### PR TITLE
feat: navegação correta e abas por role

### DIFF
--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -55,7 +55,7 @@ export default async function DashboardPage() {
         ) : (
           <div className="grid gap-4 md:grid-cols-2">
             {projects.map((project) => (
-              <Link key={project.id} href={`/projects/${project.id}/documents`}>
+              <Link key={project.id} href={`/projects/${project.id}`}>
                 <Card className="transition-colors hover:border-brand/50">
                   <CardHeader>
                     <CardTitle className="text-lg">{project.name}</CardTitle>

--- a/frontend/src/components/shell/ProjectTabs.tsx
+++ b/frontend/src/components/shell/ProjectTabs.tsx
@@ -12,7 +12,7 @@ interface ProjectTabsProps {
 
 const tabs = [
   { label: "Meu Progresso", href: "my-progress" },
-  { label: "Documentos", href: "documents" },
+  { label: "Documentos", href: "documents", coordinatorOnly: true },
   { label: "Atribuições", href: "assignments" },
   { label: "Codificar", href: "code" },
   { label: "Comparar", href: "compare" },


### PR DESCRIPTION
## Summary
- Cards do dashboard agora linkam para `/projects/:id` (redireciona para Meu Progresso) ao invés de `/documents`
- Aba "Documentos" agora é visível apenas para coordenadores

Closes #7
Closes #10

## Test plan
- [ ] Dashboard: clicar no card do projeto deve ir para "Meu Progresso"
- [ ] Como pesquisador: aba "Documentos" não deve aparecer
- [ ] Como coordenador: aba "Documentos" deve continuar visível
- [ ] "Ver como Pesquisador": aba "Documentos" deve sumir

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Navigation Changes**
- Updated project card navigation in the dashboard. Cards now direct to the main project page instead of the documents section, changing the initial destination when selecting a project.

**Access Control**
- The "Documentos" tab is now restricted to coordinators only. Users without coordinator status will no longer see this tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->