### PR TITLE
feat: add notes and suggestions field in coding

### DIFF
--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -292,7 +292,7 @@ export async function getDocumentsForBrowse(projectId: string): Promise<BrowseDo
 export async function getDocumentForCoding(
   projectId: string,
   documentId: string
-): Promise<{ document: { id: string; external_id: string | null; title: string | null; text: string }; existingAnswers: Record<string, unknown> | null }> {
+): Promise<{ document: { id: string; external_id: string | null; title: string | null; text: string }; existingAnswers: Record<string, unknown> | null; existingJustifications: Record<string, unknown> | null }> {
   const supabase = await createSupabaseServer();
   const {
     data: { user },
@@ -317,7 +317,7 @@ export async function getDocumentForCoding(
 
   const { data: response } = await supabase
     .from("responses")
-    .select("answers")
+    .select("answers, justifications")
     .eq("project_id", projectId)
     .eq("document_id", documentId)
     .eq("respondent_id", user.id)
@@ -343,10 +343,10 @@ export async function getDocumentForCoding(
         clean[field.name] = val;
       }
     }
-    return { document: doc, existingAnswers: clean };
+    return { document: doc, existingAnswers: clean, existingJustifications: (response?.justifications as Record<string, unknown>) ?? null };
   }
 
-  return { document: doc, existingAnswers: rawAnswers };
+  return { document: doc, existingAnswers: rawAnswers, existingJustifications: (response?.justifications as Record<string, unknown>) ?? null };
 }
 
 export async function deleteDocument(projectId: string, documentId: string) {

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -7,7 +7,8 @@ import type { PydanticField } from "@/lib/types";
 export async function saveResponse(
   projectId: string,
   documentId: string,
-  answers: Record<string, unknown>
+  answers: Record<string, unknown>,
+  notes?: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
     const supabase = await createSupabaseServer();
@@ -37,10 +38,12 @@ export async function saveResponse(
       .filter(Boolean)
       .join(" ") || user.email;
 
+    const justifications = notes ? { _notes: notes } : null;
+
     if (existing) {
       const { error: updateErr } = await supabase
         .from("responses")
-        .update({ answers })
+        .update({ answers, justifications })
         .eq("id", existing.id);
       if (updateErr) return { success: false, error: updateErr.message };
     } else {
@@ -51,6 +54,7 @@ export async function saveResponse(
         respondent_type: "humano",
         respondent_name: respondentName,
         answers,
+        justifications,
         is_current: true,
       });
       if (insertErr) return { success: false, error: insertErr.message };

--- a/frontend/src/app/(app)/projects/[id]/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/code/page.tsx
@@ -39,7 +39,7 @@ export default async function CodePage({
   const docIds = documents.map((d) => d.id);
   const { data: responses } = await supabase
     .from("responses")
-    .select("*")
+    .select("document_id, answers, justifications")
     .eq("project_id", id)
     .eq("respondent_id", user!.id)
     .in("document_id", docIds.length > 0 ? docIds : ["__none__"]);
@@ -47,6 +47,13 @@ export default async function CodePage({
   const rawAnswers: Record<string, Record<string, unknown>> = {};
   responses?.forEach((r) => {
     rawAnswers[r.document_id] = r.answers as Record<string, unknown>;
+  });
+
+  const existingJustifications: Record<string, Record<string, unknown>> = {};
+  responses?.forEach((r) => {
+    if (r.justifications) {
+      existingJustifications[r.document_id] = r.justifications as Record<string, unknown>;
+    }
   });
 
   // Sanitize: remove answers whose values don't match current schema options
@@ -95,6 +102,7 @@ export default async function CodePage({
       documents={documents}
       fields={fields}
       existingAnswers={existingAnswers}
+      existingJustifications={existingJustifications}
       hasAssignments={documents.length > 0}
       progress={progress}
     />

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -29,6 +29,7 @@ interface CodingPageProps {
   documents: (Document & { assignment?: Pick<Assignment, "id" | "status"> })[];
   fields: PydanticField[];
   existingAnswers: Record<string, Record<string, any>>;
+  existingJustifications?: Record<string, Record<string, unknown>>;
   hasAssignments?: boolean;
   progress?: ProgressBannerData | null;
 }
@@ -38,6 +39,7 @@ export function CodingPage({
   documents,
   fields,
   existingAnswers,
+  existingJustifications = {},
   hasAssignments = false,
   progress = null,
 }: CodingPageProps) {
@@ -63,6 +65,15 @@ export function CodingPage({
   // Assigned mode state
   const [docIndex, setDocIndex] = useState(initial.docIndex);
   const [allAnswers, setAllAnswers] = useState<Record<string, Record<string, any>>>(existingAnswers);
+  const [allNotes, setAllNotes] = useState<Record<string, string>>(() => {
+    const notes: Record<string, string> = {};
+    for (const [docId, justifications] of Object.entries(existingJustifications)) {
+      if (typeof justifications?._notes === "string") {
+        notes[docId] = justifications._notes;
+      }
+    }
+    return notes;
+  });
 
   // Mode state
   const [mode, setMode] = useState<"assigned" | "browse">(initial.mode);
@@ -110,6 +121,7 @@ export function CodingPage({
     text: string;
   } | null>(null);
   const [browseAnswers, setBrowseAnswers] = useState<Record<string, any>>({});
+  const [browseNotes, setBrowseNotes] = useState("");
   const browseFetchedRef = useRef(false);
 
   // Update URL query param without full navigation
@@ -156,6 +168,7 @@ export function CodingPage({
   // --- Assigned mode handlers ---
   const currentDoc = documents[docIndex];
   const docAnswers = allAnswers[currentDoc?.id] || {};
+  const docNotes = allNotes[currentDoc?.id] ?? "";
 
   // --- Auto-save on exit (#14) ---
   // Warn on page exit (close tab, navigate away)
@@ -175,15 +188,15 @@ export function CodingPage({
     const handleVisibilityChange = () => {
       if (document.visibilityState === "hidden") {
         if (mode === "assigned" && currentDoc && dirtyDocs.has(currentDoc.id)) {
-          saveResponse(projectId, currentDoc.id, docAnswers);
+          saveResponse(projectId, currentDoc.id, docAnswers, docNotes);
         } else if (mode === "browse" && selectedBrowseDoc && dirtyDocs.has(selectedBrowseDoc.id)) {
-          saveResponse(projectId, selectedBrowseDoc.id, browseAnswers);
+          saveResponse(projectId, selectedBrowseDoc.id, browseAnswers, browseNotes);
         }
       }
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);
     return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
-  }, [mode, currentDoc, docAnswers, selectedBrowseDoc, browseAnswers, projectId, dirtyDocs]);
+  }, [mode, currentDoc, docAnswers, docNotes, selectedBrowseDoc, browseAnswers, browseNotes, projectId, dirtyDocs]);
 
   const handleAnswer = useCallback(
     (fieldName: string, value: any) => {
@@ -196,10 +209,18 @@ export function CodingPage({
     [currentDoc?.id, markDirty]
   );
 
+  const handleNotesChange = useCallback(
+    (notes: string) => {
+      setAllNotes((prev) => ({ ...prev, [currentDoc.id]: notes }));
+      markDirty(currentDoc.id);
+    },
+    [currentDoc?.id, markDirty]
+  );
+
   const handleSubmit = useCallback(async () => {
     if (!currentDoc || Object.keys(docAnswers).length === 0) return;
     setSubmitting(true);
-    const result = await saveResponse(projectId, currentDoc.id, docAnswers);
+    const result = await saveResponse(projectId, currentDoc.id, docAnswers, docNotes);
     setSubmitting(false);
     if (result.success) {
       markClean(currentDoc.id);
@@ -212,12 +233,12 @@ export function CodingPage({
     } else {
       toast.error(result.error || "Erro ao salvar respostas");
     }
-  }, [currentDoc, docAnswers, projectId, docIndex, documents.length, markClean]);
+  }, [currentDoc, docAnswers, docNotes, projectId, docIndex, documents.length, markClean]);
 
   const handleDocNavigate = useCallback(
     (newIndex: number) => {
       if (currentDoc && dirtyDocs.has(currentDoc.id)) {
-        saveResponse(projectId, currentDoc.id, docAnswers).then((result) => {
+        saveResponse(projectId, currentDoc.id, docAnswers, docNotes).then((result) => {
           if (result.success) markClean(currentDoc.id);
           else toast.error(result.error || "Erro ao salvar respostas");
         });
@@ -226,7 +247,7 @@ export function CodingPage({
       setDocIndex(clampedIndex);
       updateDocParam(documents[clampedIndex]?.id ?? null);
     },
-    [currentDoc, docAnswers, projectId, documents, updateDocParam, dirtyDocs, markClean]
+    [currentDoc, docAnswers, docNotes, projectId, documents, updateDocParam, dirtyDocs, markClean]
   );
 
   // --- Browse mode handlers ---
@@ -237,6 +258,11 @@ export function CodingPage({
         setSelectedBrowseDoc(result.document);
         setBrowseAnswers(
           (result.existingAnswers as Record<string, any>) ?? {}
+        );
+        setBrowseNotes(
+          typeof result.existingJustifications?._notes === "string"
+            ? result.existingJustifications._notes
+            : ""
         );
         updateDocParam(docId);
       } catch (e) {
@@ -274,7 +300,7 @@ export function CodingPage({
   const handleBrowseSubmit = useCallback(async () => {
     if (!selectedBrowseDoc || Object.keys(browseAnswers).length === 0) return;
     setSubmitting(true);
-    const result = await saveResponse(projectId, selectedBrowseDoc.id, browseAnswers);
+    const result = await saveResponse(projectId, selectedBrowseDoc.id, browseAnswers, browseNotes);
     setSubmitting(false);
     if (result.success) {
       markClean(selectedBrowseDoc.id);
@@ -294,14 +320,15 @@ export function CodingPage({
       );
       setSelectedBrowseDoc(null);
       setBrowseAnswers({});
+      setBrowseNotes("");
     } else {
       toast.error(result.error || "Erro ao salvar respostas");
     }
-  }, [selectedBrowseDoc, browseAnswers, projectId, markClean]);
+  }, [selectedBrowseDoc, browseAnswers, browseNotes, projectId, markClean]);
 
   const handleBrowseBack = useCallback(() => {
     if (selectedBrowseDoc && dirtyDocs.has(selectedBrowseDoc.id)) {
-      saveResponse(projectId, selectedBrowseDoc.id, browseAnswers).then((result) => {
+      saveResponse(projectId, selectedBrowseDoc.id, browseAnswers, browseNotes).then((result) => {
         if (result.success) {
           markClean(selectedBrowseDoc.id);
           setBrowseDocuments((prev) =>
@@ -316,8 +343,9 @@ export function CodingPage({
     }
     setSelectedBrowseDoc(null);
     setBrowseAnswers({});
+    setBrowseNotes("");
     updateDocParam(null);
-  }, [selectedBrowseDoc, browseAnswers, projectId, updateDocParam, dirtyDocs, markClean]);
+  }, [selectedBrowseDoc, browseAnswers, browseNotes, projectId, updateDocParam, dirtyDocs, markClean]);
 
   const handleBrowseRandom = useCallback(() => {
     if (!browseDocuments || browseDocuments.length === 0) return;
@@ -446,11 +474,14 @@ export function CodingPage({
                 <ResizableHandle withHandle />
                 <ResizablePanel defaultSize={45} minSize={25}>
                   <QuestionsPanel
+                    key={currentDoc?.id}
                     fields={fields}
                     answers={docAnswers}
                     onAnswer={handleAnswer}
                     onSubmit={handleSubmit}
                     submitting={submitting}
+                    notes={docNotes}
+                    onNotesChange={handleNotesChange}
                   />
                 </ResizablePanel>
               </ResizablePanelGroup>
@@ -501,11 +532,14 @@ export function CodingPage({
                 <ResizableHandle withHandle />
                 <ResizablePanel defaultSize={45} minSize={25}>
                   <QuestionsPanel
+                    key={selectedBrowseDoc?.id}
                     fields={fields}
                     answers={browseAnswers}
                     onAnswer={handleBrowseAnswer}
                     onSubmit={handleBrowseSubmit}
                     submitting={submitting}
+                    notes={browseNotes}
+                    onNotesChange={setBrowseNotes}
                   />
                 </ResizablePanel>
               </ResizablePanelGroup>

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -2,8 +2,10 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FieldRenderer } from "./FieldRenderer";
-import { Check, Loader2 } from "lucide-react";
+import { Check, Loader2, MessageSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import type { PydanticField } from "@/lib/types";
@@ -14,9 +16,11 @@ interface QuestionsPanelProps {
   onAnswer: (fieldName: string, value: any) => void;
   onSubmit: () => void;
   submitting?: boolean;
+  notes?: string;
+  onNotesChange?: (notes: string) => void;
 }
 
-export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false }: QuestionsPanelProps) {
+export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange }: QuestionsPanelProps) {
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
 
@@ -108,6 +112,25 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
             />
           </div>
         ))}
+
+        {/* Notas e sugestões */}
+        {onNotesChange && (
+          <Collapsible defaultOpen={!!notes}>
+            <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
+              <MessageSquare className="h-3.5 w-3.5" />
+              Notas e sugestões (opcional)
+              {notes && <span className="h-1.5 w-1.5 rounded-full bg-brand" />}
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <Textarea
+                value={notes}
+                onChange={(e) => onNotesChange(e.target.value)}
+                placeholder="Anotações, dúvidas ou sugestões sobre este documento..."
+                className="mt-2 text-sm min-h-[80px] resize-y"
+              />
+            </CollapsibleContent>
+          </Collapsible>
+        )}
       </div>
 
       {/* Footer fixo com botão de enviar */}


### PR DESCRIPTION
## Summary
- Adds a collapsible "Notas e sugestoes" free-text field below the structured questions in the coding interface
- Notes are persisted in the existing `justifications` JSONB column (no database migration needed), stored under the `_notes` key
- Notes are loaded from existing responses on page load and when browsing documents, and auto-saved on navigation

## Test plan
- [ ] Open the coding interface with assigned documents, verify the collapsible "Notas e sugestoes" section appears below the questions
- [ ] Type notes and submit -- verify they persist on reload (check `justifications._notes` in the response row)
- [ ] Navigate between documents and verify notes are auto-saved and restored per-document
- [ ] Open browse mode, select a document, add notes, submit -- verify notes are saved and cleared on return
- [ ] Verify the dot indicator appears next to the section title when notes are non-empty

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can add optional notes/justifications when coding documents; notes are saved, loaded, and auto-saved across sessions.
  * Coding interface shows a collapsible "Notas e sugestões (opcional)" section with a textarea to view/edit notes.
  * Notes are available in both assigned and browse modes and persist per document, with seamless submit/back-navigation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->