### PR TITLE
fix: preserve markdown tables in document reader

### DIFF
--- a/frontend/src/components/coding/DocumentReader.tsx
+++ b/frontend/src/components/coding/DocumentReader.tsx
@@ -30,7 +30,7 @@ function normalizeExtractedText(text: string): string {
   // Restore table blocks
   let result = normalized;
   for (const block of tableBlocks) {
-    result = result.replace(TABLE_PLACEHOLDER, block);
+    result = result.replace(TABLE_PLACEHOLDER, () => block);
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- Fixed `normalizeExtractedText()` in `DocumentReader.tsx` destroying markdown table formatting by converting all newlines to spaces
- Table blocks (consecutive lines containing `|`) are now detected and preserved with placeholders before normalization, then restored after
- Non-table content continues to be normalized as before (paragraph breaks, dehyphenation, list preservation)

Closes #16

## Test plan
- [ ] Open a document containing markdown tables and verify they render correctly
- [ ] Verify non-table content (paragraphs, lists, headings) still normalizes properly
- [ ] Verify documents without tables are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text processing to properly preserve markdown table formatting when normalizing extracted document content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->