### PR TITLE
feat: LLM como aba principal com filtros de execução

### DIFF
--- a/backend/routes/llm_routes.py
+++ b/backend/routes/llm_routes.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Literal
 from fastapi import APIRouter, BackgroundTasks
 from pydantic import BaseModel
 
@@ -10,6 +11,9 @@ router = APIRouter()
 class RunRequest(BaseModel):
     project_id: str
     document_ids: list[str] | None = None
+    filter_mode: Literal["all", "pending", "max_responses", "random_sample"] = "all"
+    max_response_count: int | None = None
+    sample_size: int | None = None
 
 
 class RunFieldRequest(BaseModel):
@@ -32,7 +36,15 @@ class StatusResponse(BaseModel):
 @router.post("/run", response_model=RunResponse)
 async def run(req: RunRequest, background_tasks: BackgroundTasks):
     job_id = str(uuid.uuid4())
-    background_tasks.add_task(run_llm, job_id, req.project_id, req.document_ids)
+    background_tasks.add_task(
+        run_llm,
+        job_id,
+        req.project_id,
+        req.document_ids,
+        req.filter_mode,
+        req.max_response_count,
+        req.sample_size,
+    )
     return {"job_id": job_id}
 
 

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -6,6 +6,9 @@ This is intentional — only authenticated coordinators can define schemas.
 The backend runs in an isolated container.
 """
 import hashlib
+import random
+from collections import Counter
+
 import pandas as pd
 from services.supabase_client import get_supabase
 from services.pydantic_compiler import compile_pydantic
@@ -53,19 +56,69 @@ def _compile_model(pydantic_code: str):
 
 def _run_compiled(compiled_code: object, namespace: dict) -> None:
     """Execute pre-compiled code. Separated for clarity."""
-    exec(compiled_code, namespace)  # noqa: S102
+    # noqa: S102 — intentional exec of coordinator-provided Pydantic code in isolated container
+    exec(compiled_code, namespace)
+
+
+def _filter_docs(
+    sb,
+    docs: list[dict],
+    project_id: str,
+    filter_mode: str,
+    max_response_count: int | None,
+    sample_size: int | None,
+) -> list[dict]:
+    """Apply filtering to the document list based on filter_mode."""
+    if filter_mode == "all":
+        return docs
+
+    if filter_mode in ("pending", "max_responses"):
+        # Fetch current LLM responses to count per document
+        existing = (
+            sb.table("responses")
+            .select("document_id")
+            .eq("project_id", project_id)
+            .eq("respondent_type", "llm")
+            .eq("is_current", True)
+            .execute()
+            .data
+        )
+        counts = Counter(r["document_id"] for r in existing)
+
+        if filter_mode == "pending":
+            docs = [d for d in docs if counts.get(d["id"], 0) == 0]
+        elif filter_mode == "max_responses" and max_response_count is not None:
+            docs = [d for d in docs if counts.get(d["id"], 0) <= max_response_count]
+
+    if filter_mode == "random_sample" and sample_size is not None:
+        if len(docs) > sample_size:
+            docs = random.sample(docs, sample_size)
+
+    return docs
 
 
 async def run_llm(
-    job_id: str, project_id: str, document_ids: list[str] | None = None
+    job_id: str,
+    project_id: str,
+    document_ids: list[str] | None = None,
+    filter_mode: str = "all",
+    max_response_count: int | None = None,
+    sample_size: int | None = None,
 ):
-    """Run dataframeit on all (or specified) documents."""
+    """Run dataframeit on all (or filtered) documents."""
     sb = get_supabase()
     _jobs[job_id] = {"status": "running", "progress": 0, "total": 0, "errors": []}
 
     try:
-        # Load project
-        project = sb.table("projects").select("*").eq("id", project_id).single().execute().data
+        # Load project (only needed columns)
+        project = (
+            sb.table("projects")
+            .select("pydantic_code, prompt_template, llm_provider, llm_model, llm_kwargs, pydantic_fields")
+            .eq("id", project_id)
+            .single()
+            .execute()
+            .data
+        )
         pydantic_code = project["pydantic_code"]
         prompt_template = project["prompt_template"]
         llm_provider = project["llm_provider"]
@@ -73,13 +126,27 @@ async def run_llm(
         llm_kwargs = project["llm_kwargs"] or {}
         pydantic_hash = hashlib.sha256(pydantic_code.encode()).hexdigest()[:16]
 
+        # Build per-field hash snapshot for staleness detection
+        answer_field_hashes = {
+            f["name"]: f["hash"]
+            for f in (project.get("pydantic_fields") or [])
+            if f.get("hash")
+        }
+
         # Load documents
         query = sb.table("documents").select("id, text, title, external_id").eq("project_id", project_id)
         if document_ids:
             query = query.in_("id", document_ids)
         docs = query.execute().data
 
+        # Apply filtering
+        docs = _filter_docs(sb, docs, project_id, filter_mode, max_response_count, sample_size)
+
         _jobs[job_id]["total"] = len(docs)
+
+        if not docs:
+            _jobs[job_id]["status"] = "completed"
+            return
 
         # Compile Pydantic model
         model_class = _compile_model(pydantic_code)
@@ -142,6 +209,7 @@ async def run_llm(
                 "justifications": justifications if justifications else None,
                 "is_current": True,
                 "pydantic_hash": pydantic_hash,
+                "answer_field_hashes": answer_field_hashes,
             }).execute()
 
             _jobs[job_id]["progress"] = i + 1

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -176,9 +176,15 @@ async def run_llm(
             **llm_kwargs,
         )
 
-        # Save responses
+        # Mark all old LLM responses as not current in one batch
+        doc_ids = [d["id"] for d in docs]
+        sb.table("responses").update({"is_current": False}).eq(
+            "project_id", project_id
+        ).in_("document_id", doc_ids).eq("respondent_type", "llm").execute()
+
+        # Save responses — use row["id"] (not index correlation) for safety
         for i, (_, row) in enumerate(result_df.iterrows()):
-            doc_id = docs[i]["id"]
+            doc_id = row["id"]
             answers = {}
             justifications = {}
 
@@ -193,11 +199,6 @@ async def run_llm(
                 just_col = f"{field_name}_justification"
                 if just_col in row and row[just_col]:
                     justifications[field_name] = str(row[just_col])
-
-            # Mark old LLM responses as not current
-            sb.table("responses").update({"is_current": False}).eq(
-                "project_id", project_id
-            ).eq("document_id", doc_id).eq("respondent_type", "llm").execute()
 
             # Insert new response
             sb.table("responses").insert({

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -113,7 +113,7 @@ async def run_llm(
         # Load project (only needed columns)
         project = (
             sb.table("projects")
-            .select("pydantic_code, prompt_template, llm_provider, llm_model, llm_kwargs, pydantic_fields")
+            .select("pydantic_code, prompt_template, llm_provider, llm_model, llm_kwargs")
             .eq("id", project_id)
             .single()
             .execute()
@@ -125,13 +125,6 @@ async def run_llm(
         llm_model = project["llm_model"]
         llm_kwargs = project["llm_kwargs"] or {}
         pydantic_hash = hashlib.sha256(pydantic_code.encode()).hexdigest()[:16]
-
-        # Build per-field hash snapshot for staleness detection
-        answer_field_hashes = {
-            f["name"]: f["hash"]
-            for f in (project.get("pydantic_fields") or [])
-            if f.get("hash")
-        }
 
         # Load documents
         query = sb.table("documents").select("id, text, title, external_id").eq("project_id", project_id)
@@ -210,7 +203,6 @@ async def run_llm(
                 "justifications": justifications if justifications else None,
                 "is_current": True,
                 "pydantic_hash": pydantic_hash,
-                "answer_field_hashes": answer_field_hashes,
             }).execute()
 
             _jobs[job_id]["progress"] = i + 1

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -1,0 +1,51 @@
+"use server";
+
+import { createSupabaseServer } from "@/lib/supabase/server";
+
+export async function getEligibleDocCount(
+  projectId: string,
+  filterMode: "all" | "pending" | "max_responses" | "random_sample",
+  maxResponseCount?: number
+): Promise<{ total: number; eligible: number }> {
+  const supabase = await createSupabaseServer();
+
+  const [{ count: total }, { data: llmResponses }] = await Promise.all([
+    supabase
+      .from("documents")
+      .select("*", { count: "exact", head: true })
+      .eq("project_id", projectId),
+    supabase
+      .from("responses")
+      .select("document_id")
+      .eq("project_id", projectId)
+      .eq("respondent_type", "llm")
+      .eq("is_current", true),
+  ]);
+
+  const totalDocs = total ?? 0;
+
+  if (filterMode === "all" || filterMode === "random_sample") {
+    return { total: totalDocs, eligible: totalDocs };
+  }
+
+  // Count LLM responses per document
+  const counts = new Map<string, number>();
+  for (const r of llmResponses ?? []) {
+    counts.set(r.document_id, (counts.get(r.document_id) ?? 0) + 1);
+  }
+
+  if (filterMode === "pending") {
+    const docsWithLlm = counts.size;
+    return { total: totalDocs, eligible: totalDocs - docsWithLlm };
+  }
+
+  if (filterMode === "max_responses" && maxResponseCount != null) {
+    // Docs with <= maxResponseCount LLM responses (including 0)
+    const docsExceeding = [...counts.values()].filter(
+      (c) => c > maxResponseCount
+    ).length;
+    return { total: totalDocs, eligible: totalDocs - docsExceeding };
+  }
+
+  return { total: totalDocs, eligible: totalDocs };
+}

--- a/frontend/src/app/(app)/projects/[id]/config/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/layout.tsx
@@ -5,9 +5,8 @@ import { usePathname, useParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 const configTabs = [
+  { label: "Documentos", href: "documents" },
   { label: "Schema", href: "schema" },
-  { label: "Prompt", href: "prompt" },
-  { label: "LLM", href: "llm" },
   { label: "Membros", href: "members" },
   { label: "Regras", href: "rules" },
 ];

--- a/frontend/src/app/(app)/projects/[id]/config/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/layout.tsx
@@ -5,7 +5,6 @@ import { usePathname, useParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 const configTabs = [
-  { label: "Documentos", href: "documents" },
   { label: "Schema", href: "schema" },
   { label: "Membros", href: "members" },
   { label: "Regras", href: "rules" },

--- a/frontend/src/app/(app)/projects/[id]/config/llm/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/llm/page.tsx
@@ -1,30 +1,10 @@
-import { createSupabaseServer } from "@/lib/supabase/server";
-import { LlmControl } from "@/components/schema/LlmControl";
-import type { PydanticField } from "@/lib/types";
+import { redirect } from "next/navigation";
 
-export default async function LlmPage({
+export default async function LlmConfigRedirect({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const supabase = await createSupabaseServer();
-
-  const { data: project } = await supabase
-    .from("projects")
-    .select("llm_provider, llm_model, llm_kwargs, pydantic_fields")
-    .eq("id", id)
-    .single();
-
-  return (
-    <LlmControl
-      projectId={id}
-      config={{
-        llm_provider: project?.llm_provider || "google_genai",
-        llm_model: project?.llm_model || "gemini-3-flash-preview",
-        llm_kwargs: (project?.llm_kwargs as Record<string, unknown>) || { temperature: 1.0, thinking_level: "medium" },
-      }}
-      pydanticFields={(project?.pydantic_fields as PydanticField[]) || null}
-    />
-  );
+  redirect(`/projects/${id}/llm`);
 }

--- a/frontend/src/app/(app)/projects/[id]/config/prompt/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/prompt/page.tsx
@@ -1,21 +1,10 @@
-import { createSupabaseServer } from "@/lib/supabase/server";
-import { PromptEditor } from "@/components/schema/PromptEditor";
+import { redirect } from "next/navigation";
 
-export default async function PromptPage({
+export default async function PromptConfigRedirect({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const supabase = await createSupabaseServer();
-
-  const { data: project } = await supabase
-    .from("projects")
-    .select("prompt_template")
-    .eq("id", id)
-    .single();
-
-  return (
-    <PromptEditor projectId={id} initialPrompt={project?.prompt_template} />
-  );
+  redirect(`/projects/${id}/llm`);
 }

--- a/frontend/src/app/(app)/projects/[id]/llm/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/page.tsx
@@ -1,0 +1,55 @@
+import { createSupabaseServer } from "@/lib/supabase/server";
+import { LlmTab } from "@/components/llm/LlmTab";
+import type { PydanticField } from "@/lib/types";
+
+export default async function LlmPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createSupabaseServer();
+
+  const [{ data: project }, { count: totalDocs }, { data: llmResponses }] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select(
+          "prompt_template, llm_provider, llm_model, llm_kwargs, pydantic_fields"
+        )
+        .eq("id", id)
+        .single(),
+      supabase
+        .from("documents")
+        .select("*", { count: "exact", head: true })
+        .eq("project_id", id),
+      supabase
+        .from("responses")
+        .select("document_id")
+        .eq("project_id", id)
+        .eq("respondent_type", "llm")
+        .eq("is_current", true),
+    ]);
+
+  // Count unique documents with LLM responses
+  const docsWithLlm = new Set(llmResponses?.map((r) => r.document_id)).size;
+
+  return (
+    <LlmTab
+      projectId={id}
+      promptTemplate={project?.prompt_template ?? ""}
+      config={{
+        llm_provider: project?.llm_provider || "google_genai",
+        llm_model: project?.llm_model || "gemini-3-flash-preview",
+        llm_kwargs:
+          (project?.llm_kwargs as Record<string, unknown>) || {
+            temperature: 1.0,
+            thinking_level: "medium",
+          },
+      }}
+      pydanticFields={(project?.pydantic_fields as PydanticField[]) || null}
+      totalDocs={totalDocs ?? 0}
+      docsWithLlm={docsWithLlm}
+    />
+  );
+}

--- a/frontend/src/components/llm/LlmTab.tsx
+++ b/frontend/src/components/llm/LlmTab.tsx
@@ -71,8 +71,16 @@ export function LlmTab({
   const [isPending, startTransition] = useTransition();
 
   const includeJustifications = !!(config.llm_kwargs.include_justifications);
-  const hasAmbiguities =
-    pydanticFields?.some((f) => f.name === "llm_ambiguidades") ?? false;
+  const [hasAmbiguities, setHasAmbiguities] = useState(
+    pydanticFields?.some((f) => f.name === "llm_ambiguidades") ?? false
+  );
+  const [isStartingRun, setIsStartingRun] = useState(false);
+
+  useEffect(() => {
+    setHasAmbiguities(
+      pydanticFields?.some((f) => f.name === "llm_ambiguidades") ?? false
+    );
+  }, [pydanticFields]);
 
   useEffect(() => {
     return () => {
@@ -93,7 +101,7 @@ export function LlmTab({
     }
     fetch();
     return () => { cancelled = true; };
-  }, [projectId, filterMode, maxResponseCount]);
+  }, [projectId, filterMode, maxResponseCount, status]);
 
   // Computed eligible display
   const displayEligible = (() => {
@@ -126,10 +134,14 @@ export function LlmTab({
   };
 
   const handleRun = async () => {
+    if (isStartingRun || status === "running") return;
+    setIsStartingRun(true);
     try {
       // Save config before running
-      await saveLlmConfig(projectId, config);
-      await savePrompt(projectId, prompt);
+      await Promise.all([
+        saveLlmConfig(projectId, config),
+        savePrompt(projectId, prompt),
+      ]);
 
       const body: Record<string, unknown> = {
         project_id: projectId,
@@ -148,6 +160,8 @@ export function LlmTab({
       pollProgress(res.job_id);
     } catch (e: any) {
       toast.error(e.message);
+    } finally {
+      setIsStartingRun(false);
     }
   };
 
@@ -171,9 +185,11 @@ export function LlmTab({
           if (res.status === "error")
             toast.error(res.errors[0] || "Erro na execução");
         }
-      } catch {
+      } catch (e: any) {
         if (intervalRef.current) clearInterval(intervalRef.current);
         intervalRef.current = null;
+        setStatus("error");
+        toast.error(e?.message ?? "Não foi possível atualizar o progresso");
       }
     }, 2000);
   };
@@ -186,6 +202,7 @@ export function LlmTab({
   };
 
   const handleToggleAmbiguities = (checked: boolean) => {
+    setHasAmbiguities(checked);
     startTransition(async () => {
       try {
         await toggleLlmField(projectId, LLM_AMBIGUITIES_FIELD, checked);
@@ -238,7 +255,7 @@ export function LlmTab({
         <h2 className="text-lg font-semibold">Configuração do Modelo</h2>
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-1.5">
-            <Label className="text-sm">Provider</Label>
+            <Label className="text-sm">Provedor</Label>
             <Select
               value={config.llm_provider}
               onValueChange={(v) =>
@@ -271,7 +288,7 @@ export function LlmTab({
               step={0.1}
               min={0}
               max={2}
-              value={config.llm_kwargs.temperature || 1.0}
+              value={config.llm_kwargs.temperature ?? 1.0}
               onChange={(e) =>
                 setConfig((c) => ({
                   ...c,
@@ -284,9 +301,9 @@ export function LlmTab({
             />
           </div>
           <div className="space-y-1.5">
-            <Label className="text-sm">Thinking Level</Label>
+            <Label className="text-sm">Nível de raciocínio</Label>
             <Select
-              value={config.llm_kwargs.thinking_level || "medium"}
+              value={config.llm_kwargs.thinking_level ?? "medium"}
               onValueChange={(v) =>
                 setConfig((c) => ({
                   ...c,
@@ -298,9 +315,9 @@ export function LlmTab({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="low">Low</SelectItem>
-                <SelectItem value="medium">Medium</SelectItem>
-                <SelectItem value="high">High</SelectItem>
+                <SelectItem value="low">Baixo</SelectItem>
+                <SelectItem value="medium">Médio</SelectItem>
+                <SelectItem value="high">Alto</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -436,12 +453,12 @@ export function LlmTab({
             onClick={handleSaveConfig}
             disabled={status === "running"}
           >
-            Salvar Config
+            Salvar configuração
           </Button>
           <Button
             onClick={handleRun}
             className="bg-brand hover:bg-brand/90 text-brand-foreground"
-            disabled={status === "running" || displayEligible === 0}
+            disabled={isStartingRun || status === "running" || displayEligible === 0}
           >
             Rodar LLM
           </Button>

--- a/frontend/src/components/llm/LlmTab.tsx
+++ b/frontend/src/components/llm/LlmTab.tsx
@@ -1,0 +1,461 @@
+"use client";
+
+import { useState, useRef, useEffect, useTransition } from "react";
+import dynamic from "next/dynamic";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Separator } from "@/components/ui/separator";
+import { Progress } from "@/components/ui/progress";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { saveLlmConfig, savePrompt, toggleLlmField } from "@/actions/schema";
+import { getEligibleDocCount } from "@/actions/llm";
+import { fetchFastAPI } from "@/lib/api";
+import { LLM_AMBIGUITIES_FIELD } from "@/lib/standard-questions";
+import { toast } from "sonner";
+import type { PydanticField } from "@/lib/types";
+
+const MonacoEditor = dynamic(
+  () => import("@monaco-editor/react").then((m) => m.default),
+  { ssr: false }
+);
+
+type FilterMode = "all" | "pending" | "max_responses" | "random_sample";
+
+interface LlmTabProps {
+  projectId: string;
+  promptTemplate: string;
+  config: {
+    llm_provider: string;
+    llm_model: string;
+    llm_kwargs: Record<string, any>;
+  };
+  pydanticFields: PydanticField[] | null;
+  totalDocs: number;
+  docsWithLlm: number;
+}
+
+export function LlmTab({
+  projectId,
+  promptTemplate: initialPrompt,
+  config: initialConfig,
+  pydanticFields,
+  totalDocs,
+  docsWithLlm,
+}: LlmTabProps) {
+  // Prompt state
+  const [prompt, setPrompt] = useState(initialPrompt);
+  const [savingPrompt, setSavingPrompt] = useState(false);
+
+  // Config state
+  const [config, setConfig] = useState(initialConfig);
+
+  // Run state
+  const [filterMode, setFilterMode] = useState<FilterMode>("all");
+  const [sampleSize, setSampleSize] = useState(10);
+  const [maxResponseCount, setMaxResponseCount] = useState(0);
+  const [eligibleCount, setEligibleCount] = useState<number | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [status, setStatus] = useState<string>("idle");
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const includeJustifications = !!(config.llm_kwargs.include_justifications);
+  const hasAmbiguities =
+    pydanticFields?.some((f) => f.name === "llm_ambiguidades") ?? false;
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  // Fetch eligible count when filter mode changes
+  useEffect(() => {
+    let cancelled = false;
+    async function fetch() {
+      const result = await getEligibleDocCount(
+        projectId,
+        filterMode,
+        filterMode === "max_responses" ? maxResponseCount : undefined
+      );
+      if (!cancelled) setEligibleCount(result.eligible);
+    }
+    fetch();
+    return () => { cancelled = true; };
+  }, [projectId, filterMode, maxResponseCount]);
+
+  // Computed eligible display
+  const displayEligible = (() => {
+    if (filterMode === "random_sample") {
+      return Math.min(sampleSize, eligibleCount ?? totalDocs);
+    }
+    return eligibleCount ?? totalDocs;
+  })();
+
+  // --- Handlers ---
+
+  const handleSavePrompt = async () => {
+    setSavingPrompt(true);
+    try {
+      await savePrompt(projectId, prompt);
+      toast.success("Prompt salvo!");
+    } catch (e: any) {
+      toast.error(e.message);
+    }
+    setSavingPrompt(false);
+  };
+
+  const handleSaveConfig = async () => {
+    try {
+      await saveLlmConfig(projectId, config);
+      toast.success("Configuração salva!");
+    } catch (e: any) {
+      toast.error(e.message);
+    }
+  };
+
+  const handleRun = async () => {
+    try {
+      // Save config before running
+      await saveLlmConfig(projectId, config);
+      await savePrompt(projectId, prompt);
+
+      const body: Record<string, unknown> = {
+        project_id: projectId,
+        filter_mode: filterMode,
+      };
+      if (filterMode === "random_sample") body.sample_size = sampleSize;
+      if (filterMode === "max_responses")
+        body.max_response_count = maxResponseCount;
+
+      const res = await fetchFastAPI<{ job_id: string }>("/api/llm/run", {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      setJobId(res.job_id);
+      setStatus("running");
+      pollProgress(res.job_id);
+    } catch (e: any) {
+      toast.error(e.message);
+    }
+  };
+
+  const pollProgress = (id: string) => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = setInterval(async () => {
+      try {
+        const res = await fetchFastAPI<{
+          status: string;
+          progress: number;
+          total: number;
+          errors: string[];
+        }>(`/api/llm/status/${id}`);
+        setProgress(res.progress);
+        setTotal(res.total);
+        setStatus(res.status);
+        if (res.status !== "running") {
+          if (intervalRef.current) clearInterval(intervalRef.current);
+          intervalRef.current = null;
+          if (res.status === "completed") toast.success("LLM concluído!");
+          if (res.status === "error")
+            toast.error(res.errors[0] || "Erro na execução");
+        }
+      } catch {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }, 2000);
+  };
+
+  const handleToggleJustifications = (checked: boolean) => {
+    setConfig((c) => ({
+      ...c,
+      llm_kwargs: { ...c.llm_kwargs, include_justifications: checked },
+    }));
+  };
+
+  const handleToggleAmbiguities = (checked: boolean) => {
+    startTransition(async () => {
+      try {
+        await toggleLlmField(projectId, LLM_AMBIGUITIES_FIELD, checked);
+        toast.success(
+          checked
+            ? "Campo de ambiguidades adicionado"
+            : "Campo de ambiguidades removido"
+        );
+      } catch (e: any) {
+        toast.error(e.message);
+      }
+    });
+  };
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-6">
+      {/* --- Prompt --- */}
+      <section className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Prompt</h2>
+          <Button
+            size="sm"
+            onClick={handleSavePrompt}
+            disabled={savingPrompt}
+            className="bg-brand hover:bg-brand/90 text-brand-foreground"
+          >
+            Salvar Prompt
+          </Button>
+        </div>
+        <div className="h-80 rounded-md border overflow-hidden">
+          <MonacoEditor
+            height="100%"
+            language="plaintext"
+            theme="vs-light"
+            value={prompt}
+            onChange={(val) => setPrompt(val || "")}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 14,
+              wordWrap: "on",
+            }}
+          />
+        </div>
+      </section>
+
+      <Separator />
+
+      {/* --- Configuração do Modelo --- */}
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Configuração do Modelo</h2>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-1.5">
+            <Label className="text-sm">Provider</Label>
+            <Select
+              value={config.llm_provider}
+              onValueChange={(v) =>
+                setConfig((c) => ({ ...c, llm_provider: v }))
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="google_genai">Google GenAI</SelectItem>
+                <SelectItem value="openai">OpenAI</SelectItem>
+                <SelectItem value="anthropic">Anthropic</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Modelo</Label>
+            <Input
+              value={config.llm_model}
+              onChange={(e) =>
+                setConfig((c) => ({ ...c, llm_model: e.target.value }))
+              }
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Temperatura</Label>
+            <Input
+              type="number"
+              step={0.1}
+              min={0}
+              max={2}
+              value={config.llm_kwargs.temperature || 1.0}
+              onChange={(e) =>
+                setConfig((c) => ({
+                  ...c,
+                  llm_kwargs: {
+                    ...c.llm_kwargs,
+                    temperature: parseFloat(e.target.value),
+                  },
+                }))
+              }
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-sm">Thinking Level</Label>
+            <Select
+              value={config.llm_kwargs.thinking_level || "medium"}
+              onValueChange={(v) =>
+                setConfig((c) => ({
+                  ...c,
+                  llm_kwargs: { ...c.llm_kwargs, thinking_level: v },
+                }))
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="low">Low</SelectItem>
+                <SelectItem value="medium">Medium</SelectItem>
+                <SelectItem value="high">High</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        {/* Behavior toggles */}
+        <div className="space-y-3 pt-2">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label className="text-sm">
+                Pedir justificativas para cada resposta
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                O LLM explicará o raciocínio por trás de cada classificação.
+              </p>
+            </div>
+            <Switch
+              checked={includeJustifications}
+              onCheckedChange={handleToggleJustifications}
+            />
+          </div>
+
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label className="text-sm">
+                Registrar ambiguidades e dificuldades
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                O LLM reportará incertezas nas instruções e dificuldades na
+                classificação. (campo llm_only)
+              </p>
+            </div>
+            <Switch
+              checked={hasAmbiguities}
+              onCheckedChange={handleToggleAmbiguities}
+              disabled={isPending}
+            />
+          </div>
+        </div>
+      </section>
+
+      <Separator />
+
+      {/* --- Execução --- */}
+      <section className="space-y-4">
+        <h2 className="text-lg font-semibold">Execução</h2>
+
+        <RadioGroup
+          value={filterMode}
+          onValueChange={(v) => setFilterMode(v as FilterMode)}
+          className="gap-3"
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="all" id="filter-all" />
+            <Label htmlFor="filter-all" className="text-sm font-normal">
+              Todos os documentos
+            </Label>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="pending" id="filter-pending" />
+            <Label htmlFor="filter-pending" className="text-sm font-normal">
+              Apenas pendentes (sem resposta LLM)
+            </Label>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <RadioGroupItem
+                value="max_responses"
+                id="filter-max-responses"
+              />
+              <Label
+                htmlFor="filter-max-responses"
+                className="text-sm font-normal"
+              >
+                Documentos com até N respostas LLM
+              </Label>
+            </div>
+            {filterMode === "max_responses" && (
+              <div className="ml-6">
+                <Input
+                  type="number"
+                  min={0}
+                  value={maxResponseCount}
+                  onChange={(e) =>
+                    setMaxResponseCount(parseInt(e.target.value) || 0)
+                  }
+                  className="w-24"
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="random_sample" id="filter-random" />
+              <Label htmlFor="filter-random" className="text-sm font-normal">
+                Amostra aleatória
+              </Label>
+            </div>
+            {filterMode === "random_sample" && (
+              <div className="ml-6 flex items-center gap-2">
+                <Label className="text-sm text-muted-foreground">
+                  Quantidade:
+                </Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={sampleSize}
+                  onChange={(e) =>
+                    setSampleSize(parseInt(e.target.value) || 1)
+                  }
+                  className="w-24"
+                />
+              </div>
+            )}
+          </div>
+        </RadioGroup>
+
+        <p className="text-sm text-muted-foreground">
+          {displayEligible} documento{displayEligible !== 1 ? "s" : ""}{" "}
+          {displayEligible !== 1 ? "serão" : "será"} processado
+          {displayEligible !== 1 ? "s" : ""}
+          <span className="ml-1 text-xs">
+            ({docsWithLlm}/{totalDocs} já possuem resposta LLM)
+          </span>
+        </p>
+
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={handleSaveConfig}
+            disabled={status === "running"}
+          >
+            Salvar Config
+          </Button>
+          <Button
+            onClick={handleRun}
+            className="bg-brand hover:bg-brand/90 text-brand-foreground"
+            disabled={status === "running" || displayEligible === 0}
+          >
+            Rodar LLM
+          </Button>
+        </div>
+
+        {status === "running" && (
+          <div className="space-y-2">
+            <Progress value={total > 0 ? (progress / total) * 100 : 0} />
+            <p className="text-sm text-muted-foreground">
+              {progress}/{total}
+            </p>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/ProjectTabs.tsx
+++ b/frontend/src/components/shell/ProjectTabs.tsx
@@ -12,6 +12,7 @@ interface ProjectTabsProps {
 
 const tabs = [
   { label: "Meu Progresso", href: "my-progress" },
+  { label: "Documentos", href: "documents", coordinatorOnly: true },
   { label: "Atribuições", href: "assignments" },
   { label: "Codificar", href: "code" },
   { label: "Comparar", href: "compare" },

--- a/frontend/src/components/shell/ProjectTabs.tsx
+++ b/frontend/src/components/shell/ProjectTabs.tsx
@@ -12,11 +12,11 @@ interface ProjectTabsProps {
 
 const tabs = [
   { label: "Meu Progresso", href: "my-progress" },
-  { label: "Documentos", href: "documents", coordinatorOnly: true },
   { label: "Atribuições", href: "assignments" },
   { label: "Codificar", href: "code" },
   { label: "Comparar", href: "compare" },
   { label: "Estatísticas", href: "stats" },
+  { label: "LLM", href: "llm", coordinatorOnly: true },
   { label: "Discussões", href: "discussions" },
   { label: "Configurações", href: "config", coordinatorOnly: true },
 ];


### PR DESCRIPTION
## Summary
- Promove LLM de sub-aba em Configurações para aba principal (coordinator-only)
- Unifica prompt editor + configuração do modelo + controles de execução em uma única página
- Adiciona filtros de execução: todos, pendentes, docs com até N respostas, amostra aleatória
- Corrige bug do botão "Rodar pendentes" que não filtrava nada
- Corrige `select("*")` no backend (violação de regra de performance)
- Redireciona rotas antigas (`/config/llm`, `/config/prompt`) para a nova aba

## Análise crítica do LLM anterior
1. **Bug: "Rodar pendentes" não funcionava** — `handleRun("pending")` ignorava o parâmetro e enviava payload idêntico ao "Rodar em todos"
2. **`select("*")` no backend** — violava regra de performance
3. **Prompt e Config separados** — exigiam navegação entre sub-abas apesar de serem acoplados
4. **Zero opções de filtragem** — não era possível rodar em amostra aleatória ou filtrar por quantidade de respostas

## Test plan
- [ ] Navegar para `/projects/[id]/llm` — deve mostrar prompt + config + execução
- [ ] Editar e salvar prompt
- [ ] Configurar modelo e salvar
- [ ] Verificar cada modo de filtragem (contagem de docs elegíveis atualiza)
- [ ] Rodar LLM e verificar progress bar
- [ ] Verificar que `/projects/[id]/config` não tem mais Prompt/LLM
- [ ] Verificar que `/projects/[id]/config/llm` redireciona para `/projects/[id]/llm`
- [ ] Verificar que pesquisadores não veem a aba LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add document filtering for LLM runs: all, pending, max responses, random sample.
  * Real-time eligible-document counts and a new LLM UI to edit prompt/config, start runs, and monitor progress.
  * Server-side endpoint to compute eligible totals for chosen filters.

* **Bug Fixes**
  * Improved response bookkeeping so run progress and results reflect filtered documents.

* **Refactor**
  * Simplified project config navigation by consolidating prompt/LLM routes into a dedicated LLM page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->