### PR TITLE
feat: fila em fullscreen + backfill de versões pelo histórico

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,14 @@ Para aplicar migrations pendentes: `npx supabase db push`
 
 ## Deploy
 
-Vercel faz deploy automatico a partir de push no branch `main`. Sempre que terminar uma tarefa, commitar e pushar para `main` para que o deploy aconteca. A unica excecao e quando o usuario **explicitamente pedir para criar uma branch separada** no inicio da tarefa — nesse caso, deixar na branch sem merge para main.
+Vercel faz deploy automatico a partir de merge no branch `main`. A partir de 2026-04-20, **sempre criar branch + PR** em vez de push direto na main. Fluxo:
+
+1. Criar branch descritiva (`feat/...`, `fix/...`) no inicio da tarefa
+2. Commitar nela
+3. Ao final, abrir PR contra `main` via `gh pr create`
+4. Deixar o usuario revisar e fazer o merge
+
+Nunca fazer push direto para `main`, nem fazer merge do PR pelo Claude — so o usuario faz merge.
 
 ## Como rodar
 

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -286,6 +286,148 @@ export async function saveSchemaFromGUI(
   }
 }
 
+// ---------- Backfill retroativo usando schema_change_log ----------
+// Reconstrói a versão do projeto a partir do histórico de mudanças já registradas.
+// Útil em projetos que existem desde antes do versionamento ter sido introduzido.
+// Idempotente: respeitar entries já classificadas como 'major', reclassificar as demais.
+
+export async function backfillSchemaVersionHistory(projectId: string) {
+  const user = await getAuthUser();
+  if (!user) throw new Error("Não autenticado");
+
+  const supabase = await createSupabaseServer();
+
+  const { data: log, error: logErr } = await supabase
+    .from("schema_change_log")
+    .select("id, field_name, before_value, after_value, created_at, change_type")
+    .eq("project_id", projectId)
+    .order("created_at", { ascending: true });
+  if (logErr) throw new Error(logErr.message);
+
+  let current = { major: 0, minor: 1, patch: 0 };
+  const logUpdates: Array<{
+    id: string;
+    change_type: ChangeType;
+    version_major: number;
+    version_minor: number;
+    version_patch: number;
+  }> = [];
+  const versionByTimestamp: Array<{ createdAt: number; version: typeof current }> = [];
+
+  for (const entry of log ?? []) {
+    let type: ChangeType;
+    if (entry.change_type === "major") {
+      type = "major";
+    } else {
+      // Infer from before/after payload
+      const before = (entry.before_value ?? {}) as Record<string, unknown>;
+      const after = (entry.after_value ?? {}) as Record<string, unknown>;
+      const bOpts = before.options;
+      const aOpts = after.options;
+      const optsTouched = bOpts !== undefined || aOpts !== undefined;
+
+      let structural = false;
+      if (optsTouched) {
+        const bArr = Array.isArray(bOpts) ? (bOpts as unknown[]) : [];
+        const aArr = Array.isArray(aOpts) ? (aOpts as unknown[]) : [];
+        const bSet = new Set(bArr);
+        const aSet = new Set(aArr);
+        const sameSet =
+          bSet.size === aSet.size && [...bSet].every((x) => aSet.has(x));
+        if (!sameSet) structural = true;
+      }
+      type = structural ? "minor" : "patch";
+    }
+
+    current = bumpVersion(current, type);
+    logUpdates.push({
+      id: entry.id as string,
+      change_type: type,
+      version_major: current.major,
+      version_minor: current.minor,
+      version_patch: current.patch,
+    });
+    versionByTimestamp.push({
+      createdAt: new Date(entry.created_at as string).getTime(),
+      version: { ...current },
+    });
+  }
+
+  // Update each log entry (idempotent)
+  for (const u of logUpdates) {
+    await supabase
+      .from("schema_change_log")
+      .update({
+        change_type: u.change_type,
+        version_major: u.version_major,
+        version_minor: u.version_minor,
+        version_patch: u.version_patch,
+      })
+      .eq("id", u.id);
+  }
+
+  // Set project current version
+  await supabase
+    .from("projects")
+    .update({
+      schema_version_major: current.major,
+      schema_version_minor: current.minor,
+      schema_version_patch: current.patch,
+    })
+    .eq("id", projectId);
+
+  // Set response versions based on timestamps.
+  const { data: responses } = await supabase
+    .from("responses")
+    .select("id, created_at")
+    .eq("project_id", projectId);
+
+  // Sort versionByTimestamp desc for lookup
+  const versionByTsDesc = [...versionByTimestamp].sort(
+    (a, b) => b.createdAt - a.createdAt,
+  );
+
+  const byVersionKey = new Map<string, string[]>();
+  for (const r of responses ?? []) {
+    const ts = new Date(r.created_at as string).getTime();
+    let version = { major: 0, minor: 1, patch: 0 };
+    for (const v of versionByTsDesc) {
+      if (v.createdAt <= ts) {
+        version = v.version;
+        break;
+      }
+    }
+    const key = `${version.major}.${version.minor}.${version.patch}`;
+    if (!byVersionKey.has(key)) byVersionKey.set(key, []);
+    byVersionKey.get(key)!.push(r.id as string);
+  }
+
+  for (const [key, ids] of byVersionKey) {
+    const [maj, min, pat] = key.split(".").map((v) => Number.parseInt(v, 10));
+    for (let i = 0; i < ids.length; i += 100) {
+      const chunk = ids.slice(i, i + 100);
+      await supabase
+        .from("responses")
+        .update({
+          schema_version_major: maj,
+          schema_version_minor: min,
+          schema_version_patch: pat,
+        })
+        .in("id", chunk);
+    }
+  }
+
+  revalidatePath(`/projects/${projectId}/analyze/compare`);
+  revalidatePath(`/projects/${projectId}/config/schema`);
+  revalidatePath(`/projects/${projectId}/reviews`);
+
+  return {
+    finalVersion: current,
+    logEntriesUpdated: logUpdates.length,
+    responsesUpdated: (responses ?? []).length,
+  };
+}
+
 // ---------- MAJOR version bump (manual) ----------
 
 export async function publishMajorVersion(projectId: string) {

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -362,15 +362,13 @@ export function ComparePage({
       )}
 
       <div className="flex flex-1 overflow-hidden">
-        {!isFullscreen && (
-          <CompareDocList
-            docs={docListEntries}
-            currentIndex={docIndex}
-            onSelect={handleDocNavigate}
-            collapsed={listCollapsed}
-            onToggle={() => setListCollapsed((v) => !v)}
-          />
-        )}
+        <CompareDocList
+          docs={docListEntries}
+          currentIndex={docIndex}
+          onSelect={handleDocNavigate}
+          collapsed={listCollapsed}
+          onToggle={() => setListCollapsed((v) => !v)}
+        />
 
         <ResizablePanelGroup className="flex-1">
           <ResizablePanel defaultSize={50} minSize={25}>

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -20,10 +20,11 @@ import {
   saveSchema,
   saveSchemaFromGUI,
   publishMajorVersion,
+  backfillSchemaVersionHistory,
 } from "@/actions/schema";
 import { validateGUIFields, generatePydanticCode } from "@/lib/schema-utils";
 import { toast } from "sonner";
-import { LayoutGrid, Code, Rocket, Info, X } from "lucide-react";
+import { LayoutGrid, Code, Rocket, Info, X, History } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SchemaBuilderGUI } from "./SchemaBuilderGUI";
 import type { PydanticField } from "@/lib/types";
@@ -64,6 +65,7 @@ export function SchemaEditor({
   const [errors, setErrors] = useState<string[]>([]);
   const [isPending, startTransition] = useTransition();
   const [majorDialogOpen, setMajorDialogOpen] = useState(false);
+  const [backfillDialogOpen, setBackfillDialogOpen] = useState(false);
   const [helpDismissed, setHelpDismissed] = useState(() => {
     if (typeof window === "undefined") return true;
     return window.localStorage.getItem(VERSIONING_HELP_KEY) === "1";
@@ -85,6 +87,23 @@ export function SchemaEditor({
         router.refresh();
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Erro ao publicar MAJOR";
+        toast.error(msg);
+      }
+    });
+  };
+
+  const handleBackfill = () => {
+    startTransition(async () => {
+      try {
+        const result = await backfillSchemaVersionHistory(projectId);
+        const v = result.finalVersion;
+        toast.success(
+          `Versão reconstruída: v${v.major}.${v.minor}.${v.patch} (${result.logEntriesUpdated} entradas, ${result.responsesUpdated} respostas)`,
+        );
+        setBackfillDialogOpen(false);
+        router.refresh();
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : "Erro ao reconstruir";
         toast.error(msg);
       }
     });
@@ -232,6 +251,17 @@ export function SchemaEditor({
             </Badge>
           )}
           <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5 text-xs text-muted-foreground"
+            onClick={() => setBackfillDialogOpen(true)}
+            disabled={isPending}
+            title="Reconstruir versão a partir do histórico de mudanças"
+          >
+            <History className="h-3.5 w-3.5" />
+            Reconstruir histórico
+          </Button>
+          <Button
             variant="outline"
             size="sm"
             className="h-7 gap-1.5 text-xs"
@@ -320,6 +350,28 @@ export function SchemaEditor({
           </Badge>
         )}
       </div>
+
+      <AlertDialog open={backfillDialogOpen} onOpenChange={setBackfillDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reconstruir versão pelo histórico?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Isso percorre todas as entradas do histórico de mudanças do schema em
+              ordem cronológica e reatribui change_type (MINOR quando houve adição/remoção
+              de opções; PATCH quando só texto foi alterado; MAJOR preservado se já existir).
+              A versão do projeto e as versões das respostas existentes são recalculadas
+              com base nos timestamps. Útil em projetos antigos que começaram antes do
+              versionamento. Idempotente — pode rodar de novo sem problemas.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleBackfill} disabled={isPending}>
+              Reconstruir
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog open={majorDialogOpen} onOpenChange={setMajorDialogOpen}>
         <AlertDialogContent>


### PR DESCRIPTION
## Summary
- CompareDocList visível também em modo tela cheia (só o header troca para FullscreenNav)
- Nova action `backfillSchemaVersionHistory`: reconstrói versão do projeto pelo `schema_change_log` — útil em projetos antigos como Zolgensma que começaram antes do semver. Classifica MINOR quando add/remove opções, PATCH quando só texto; respeita MAJOR já setado. Idempotente.
- Botão "Reconstruir histórico" no SchemaEditor ao lado do "Publicar MAJOR", com AlertDialog explicativo
- CLAUDE.md: a partir de agora sempre abrir PR em vez de push direto na main

## Test plan
- [ ] Em `/analyze/compare`, entrar em fullscreen (Ctrl+Shift+F) e verificar que a lista lateral de documentos continua aparecendo
- [ ] Em `/config/schema`, clicar "Reconstruir histórico" no projeto Zolgensma → confirmar que versão final reflete a quantidade de mudanças registradas
- [ ] Conferir que responses antigas passam a ter `schema_version_*` preenchidas corretamente
- [ ] Aba Comparar com filtro "Desde a versão" mostra opções atualizadas após backfill
- [ ] Rodar novamente o backfill: resultado idêntico (idempotência)

🤖 Generated with [Claude Code](https://claude.com/claude-code)