### PR TITLE
feat: precisão retroativa máxima de versão via answer_field_hashes

### DIFF
--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -64,6 +64,7 @@ export async function saveResponse(
       schema_version_major: project?.schema_version_major ?? 0,
       schema_version_minor: project?.schema_version_minor ?? 1,
       schema_version_patch: project?.schema_version_patch ?? 0,
+      version_inferred_from: "live_save",
     };
 
     if (existing) {

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -226,6 +226,43 @@ export async function saveSchemaFromGUI(
     after_value: Record<string, unknown>;
   }[] = [];
 
+  const newMap = new Map(fields.map((f) => [f.name, f]));
+
+  function snapshotOf(field: PydanticField): Record<string, unknown> {
+    return {
+      name: field.name,
+      type: field.type,
+      description: field.description,
+      help_text: field.help_text ?? null,
+      options: field.options ?? null,
+      target: field.target ?? null,
+      required: field.required ?? null,
+    };
+  }
+
+  // Campos adicionados: sem entry anterior
+  for (const f of fields) {
+    if (oldMap.has(f.name)) continue;
+    logEntries.push({
+      field_name: f.name,
+      change_summary: "campo adicionado",
+      before_value: {},
+      after_value: snapshotOf(f),
+    });
+  }
+
+  // Campos removidos: sem entry atual
+  for (const o of oldFields) {
+    if (newMap.has(o.name)) continue;
+    logEntries.push({
+      field_name: o.name,
+      change_summary: "campo removido",
+      before_value: snapshotOf(o),
+      after_value: {},
+    });
+  }
+
+  // Campos modificados: compara atributo por atributo
   for (const f of fields) {
     const old = oldMap.get(f.name);
     if (!old) continue;
@@ -249,6 +286,21 @@ export async function saveSchemaFromGUI(
       diffs.push(f.type === "text" ? "respostas padronizadas" : "opções");
       before.options = old.options;
       after.options = f.options;
+    }
+    if (old.type !== f.type) {
+      diffs.push("tipo");
+      before.type = old.type;
+      after.type = f.type;
+    }
+    if ((old.target ?? "all") !== (f.target ?? "all")) {
+      diffs.push("alvo");
+      before.target = old.target ?? null;
+      after.target = f.target ?? null;
+    }
+    if ((old.required ?? true) !== (f.required ?? true)) {
+      diffs.push("obrigatório");
+      before.required = old.required ?? null;
+      after.required = f.required ?? null;
     }
 
     if (diffs.length > 0) {
@@ -287,9 +339,46 @@ export async function saveSchemaFromGUI(
 }
 
 // ---------- Backfill retroativo usando schema_change_log ----------
-// Reconstrói a versão do projeto a partir do histórico de mudanças já registradas.
-// Útil em projetos que existem desde antes do versionamento ter sido introduzido.
-// Idempotente: respeitar entries já classificadas como 'major', reclassificar as demais.
+// Reconstrói a versão do projeto a partir do histórico já registrado.
+// - Classifica entries não classificadas (minor/patch), respeita majors já setados.
+// - Reconstrói snapshots do schema em cada versão (reverter diffs do atual).
+// - Atribui versão a cada resposta usando answer_field_hashes quando disponível;
+//   cai em created_at quando não (responses pré-hash).
+// - Rastreia o método em responses.version_inferred_from.
+// Idempotente.
+
+type FieldSnapshot = Partial<PydanticField> & { name: string };
+
+function cloneFieldSnapshot(f: FieldSnapshot): FieldSnapshot {
+  return {
+    ...f,
+    options: f.options ? [...f.options] : f.options,
+  };
+}
+
+function cloneSnapshotMap(snap: Map<string, FieldSnapshot>): Map<string, FieldSnapshot> {
+  const out = new Map<string, FieldSnapshot>();
+  for (const [k, v] of snap) out.set(k, cloneFieldSnapshot(v));
+  return out;
+}
+
+function versionKey(v: { major: number; minor: number; patch: number }) {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+function computeHashesFromSnapshot(snap: Map<string, FieldSnapshot>): Record<string, string> {
+  const hashes: Record<string, string> = {};
+  for (const [name, field] of snap) {
+    if (!field.type || field.description == null) continue;
+    hashes[name] = computeFieldHash(
+      name,
+      field.type,
+      field.options ?? null,
+      field.description,
+    );
+  }
+  return hashes;
+}
 
 export async function backfillSchemaVersionHistory(projectId: string) {
   const user = await getAuthUser();
@@ -297,76 +386,93 @@ export async function backfillSchemaVersionHistory(projectId: string) {
 
   const supabase = await createSupabaseServer();
 
-  const { data: log, error: logErr } = await supabase
-    .from("schema_change_log")
-    .select("id, field_name, before_value, after_value, created_at, change_type")
-    .eq("project_id", projectId)
-    .order("created_at", { ascending: true });
+  const [{ data: project }, { data: log, error: logErr }] = await Promise.all([
+    supabase
+      .from("projects")
+      .select(
+        "pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch",
+      )
+      .eq("id", projectId)
+      .single(),
+    supabase
+      .from("schema_change_log")
+      .select("id, field_name, before_value, after_value, created_at, change_type")
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: true }),
+  ]);
+
   if (logErr) throw new Error(logErr.message);
 
+  // 1) Classify entries and compute cumulative version per entry
   let current = { major: 0, minor: 1, patch: 0 };
-  const logUpdates: Array<{
+  type EnrichedEntry = {
     id: string;
-    change_type: ChangeType;
-    version_major: number;
-    version_minor: number;
-    version_patch: number;
-  }> = [];
-  const versionByTimestamp: Array<{ createdAt: number; version: typeof current }> = [];
+    field_name: string;
+    before: Record<string, unknown>;
+    after: Record<string, unknown>;
+    createdAt: number;
+    changeType: ChangeType;
+    version: { major: number; minor: number; patch: number };
+  };
+  const enriched: EnrichedEntry[] = [];
 
   for (const entry of log ?? []) {
+    const before = (entry.before_value ?? {}) as Record<string, unknown>;
+    const after = (entry.after_value ?? {}) as Record<string, unknown>;
+
     let type: ChangeType;
     if (entry.change_type === "major") {
       type = "major";
     } else {
-      // Infer from before/after payload
-      const before = (entry.before_value ?? {}) as Record<string, unknown>;
-      const after = (entry.after_value ?? {}) as Record<string, unknown>;
-      const bOpts = before.options;
-      const aOpts = after.options;
-      const optsTouched = bOpts !== undefined || aOpts !== undefined;
-
-      let structural = false;
-      if (optsTouched) {
-        const bArr = Array.isArray(bOpts) ? (bOpts as unknown[]) : [];
-        const aArr = Array.isArray(aOpts) ? (aOpts as unknown[]) : [];
-        const bSet = new Set(bArr);
-        const aSet = new Set(aArr);
-        const sameSet =
-          bSet.size === aSet.size && [...bSet].every((x) => aSet.has(x));
-        if (!sameSet) structural = true;
+      // Estruturais: add/remove de campo (before ou after vazios), mudança de type/target/required/options
+      const isAdd = Object.keys(before).length === 0;
+      const isRemove = Object.keys(after).length === 0;
+      let structural = isAdd || isRemove;
+      if (!structural) {
+        if (before.type !== undefined || after.type !== undefined) structural = true;
+        if (before.target !== undefined || after.target !== undefined) structural = true;
+        if (before.required !== undefined || after.required !== undefined) structural = true;
+        const bOpts = before.options;
+        const aOpts = after.options;
+        if (bOpts !== undefined || aOpts !== undefined) {
+          const bArr = Array.isArray(bOpts) ? (bOpts as unknown[]) : [];
+          const aArr = Array.isArray(aOpts) ? (aOpts as unknown[]) : [];
+          const bSet = new Set(bArr);
+          const aSet = new Set(aArr);
+          const sameSet =
+            bSet.size === aSet.size && [...bSet].every((x) => aSet.has(x));
+          if (!sameSet) structural = true;
+        }
       }
       type = structural ? "minor" : "patch";
     }
 
     current = bumpVersion(current, type);
-    logUpdates.push({
+    enriched.push({
       id: entry.id as string,
-      change_type: type,
-      version_major: current.major,
-      version_minor: current.minor,
-      version_patch: current.patch,
-    });
-    versionByTimestamp.push({
+      field_name: entry.field_name as string,
+      before,
+      after,
       createdAt: new Date(entry.created_at as string).getTime(),
+      changeType: type,
       version: { ...current },
     });
   }
 
-  // Update each log entry (idempotent)
-  for (const u of logUpdates) {
+  // 2) Update each log entry with classification + version
+  for (const e of enriched) {
     await supabase
       .from("schema_change_log")
       .update({
-        change_type: u.change_type,
-        version_major: u.version_major,
-        version_minor: u.version_minor,
-        version_patch: u.version_patch,
+        change_type: e.changeType,
+        version_major: e.version.major,
+        version_minor: e.version.minor,
+        version_patch: e.version.patch,
       })
-      .eq("id", u.id);
+      .eq("id", e.id);
   }
 
-  // Set project current version
+  // 3) Set project current version
   await supabase
     .from("projects")
     .update({
@@ -376,45 +482,190 @@ export async function backfillSchemaVersionHistory(projectId: string) {
     })
     .eq("id", projectId);
 
-  // Set response versions based on timestamps.
-  const { data: responses } = await supabase
-    .from("responses")
-    .select("id, created_at")
-    .eq("project_id", projectId);
-
-  // Sort versionByTimestamp desc for lookup
-  const versionByTsDesc = [...versionByTimestamp].sort(
-    (a, b) => b.createdAt - a.createdAt,
-  );
-
-  const byVersionKey = new Map<string, string[]>();
-  for (const r of responses ?? []) {
-    const ts = new Date(r.created_at as string).getTime();
-    let version = { major: 0, minor: 1, patch: 0 };
-    for (const v of versionByTsDesc) {
-      if (v.createdAt <= ts) {
-        version = v.version;
-        break;
-      }
-    }
-    const key = `${version.major}.${version.minor}.${version.patch}`;
-    if (!byVersionKey.has(key)) byVersionKey.set(key, []);
-    byVersionKey.get(key)!.push(r.id as string);
+  // 4) Reconstruct snapshots at each version, walking log in reverse.
+  // Current project fields = snapshot of the "current" version after all entries applied.
+  const currentSnap = new Map<string, FieldSnapshot>();
+  for (const f of (project?.pydantic_fields as PydanticField[]) ?? []) {
+    currentSnap.set(f.name, cloneFieldSnapshot({ ...f }));
   }
 
-  for (const [key, ids] of byVersionKey) {
-    const [maj, min, pat] = key.split(".").map((v) => Number.parseInt(v, 10));
-    for (let i = 0; i < ids.length; i += 100) {
-      const chunk = ids.slice(i, i + 100);
+  // Map: versionKey -> snapshot map (fieldName -> snapshot)
+  const snapByVersion = new Map<string, Map<string, FieldSnapshot>>();
+  snapByVersion.set(versionKey(current), cloneSnapshotMap(currentSnap));
+
+  // Group entries by version so we revert all at once per version-change
+  const versionsDesc: Array<{ key: string; version: typeof current }> = [];
+  const entriesByVersion = new Map<string, EnrichedEntry[]>();
+  for (const e of enriched) {
+    const k = versionKey(e.version);
+    if (!entriesByVersion.has(k)) {
+      entriesByVersion.set(k, []);
+      versionsDesc.push({ key: k, version: e.version });
+    }
+    entriesByVersion.get(k)!.push(e);
+  }
+  // Sort desc so we revert from latest → earliest
+  versionsDesc.sort((a, b) => {
+    if (a.version.major !== b.version.major) return b.version.major - a.version.major;
+    if (a.version.minor !== b.version.minor) return b.version.minor - a.version.minor;
+    return b.version.patch - a.version.patch;
+  });
+
+  const workingSnap = cloneSnapshotMap(currentSnap);
+  for (let idx = 0; idx < versionsDesc.length; idx++) {
+    const { key, version } = versionsDesc[idx];
+    // Snapshot at version `version` (before reverting) — if not already stored
+    if (!snapByVersion.has(key)) {
+      snapByVersion.set(key, cloneSnapshotMap(workingSnap));
+    }
+    // Revert all entries at this version
+    const group = entriesByVersion.get(key)!;
+    for (const e of group) {
+      // Skip project-level entries (publishMajorVersion)
+      if (e.field_name === "(projeto)") continue;
+      const isAdd = Object.keys(e.before).length === 0;
+      const isRemove = Object.keys(e.after).length === 0;
+      if (isAdd) {
+        // Pré-E: o campo não existia
+        workingSnap.delete(e.field_name);
+      } else if (isRemove) {
+        // Pré-E: o campo existia como `before`
+        const snap = { name: e.field_name, ...(e.before as Partial<PydanticField>) };
+        workingSnap.set(e.field_name, snap);
+      } else {
+        // Campo modificado: reverte atributos listados em `before`
+        const existing = workingSnap.get(e.field_name) ?? { name: e.field_name };
+        workingSnap.set(e.field_name, {
+          ...existing,
+          ...(e.before as Partial<PydanticField>),
+          name: e.field_name,
+        });
+      }
+    }
+    // Após reverter, workingSnap representa a versão anterior
+    const prev = versionsDesc[idx + 1];
+    if (!prev) {
+      // 0.1.0 inicial (pré-primeira entry)
+      snapByVersion.set(versionKey({ major: 0, minor: 1, patch: 0 }), cloneSnapshotMap(workingSnap));
+    }
+  }
+
+  // Compute hashes per version
+  const hashesByVersion = new Map<string, Record<string, string>>();
+  for (const [k, snap] of snapByVersion) {
+    hashesByVersion.set(k, computeHashesFromSnapshot(snap));
+  }
+
+  // 5) Assign versions to responses
+  const { data: responses } = await supabase
+    .from("responses")
+    .select("id, created_at, answer_field_hashes, version_inferred_from")
+    .eq("project_id", projectId);
+
+  const allVersionKeys = [...hashesByVersion.keys()];
+  const versionByKey = new Map<string, { major: number; minor: number; patch: number }>();
+  for (const k of allVersionKeys) {
+    const [mj, mn, pt] = k.split(".").map((n) => Number.parseInt(n, 10));
+    versionByKey.set(k, { major: mj, minor: mn, patch: pt });
+  }
+  // Timestamp of each version (from entries; initial version = 0)
+  const versionTs = new Map<string, number>();
+  for (const e of enriched) {
+    const k = versionKey(e.version);
+    if (!versionTs.has(k)) versionTs.set(k, e.createdAt);
+  }
+  versionTs.set(versionKey({ major: 0, minor: 1, patch: 0 }), 0);
+
+  // Bucket updates by (version, method)
+  const updates = new Map<
+    string, // versionKey + "|" + method
+    { version: { major: number; minor: number; patch: number }; method: string; ids: string[] }
+  >();
+
+  let countLiveSave = 0;
+
+  for (const r of responses ?? []) {
+    // Preserve live_save entries as-is (precisão total)
+    if (r.version_inferred_from === "live_save") {
+      countLiveSave++;
+      continue;
+    }
+
+    const rHashes = (r.answer_field_hashes as Record<string, string> | null) ?? null;
+    const ts = new Date(r.created_at as string).getTime();
+
+    let chosenKey: string | null = null;
+    let chosenMethod: "hashes" | "created_at" | "fallback_created_at" = "created_at";
+
+    if (rHashes && Object.keys(rHashes).length > 0) {
+      // Score each version
+      let bestScore = -1;
+      let bestKey: string | null = null;
+      let bestTieTs = Infinity;
+      for (const [k, vHashes] of hashesByVersion) {
+        let score = 0;
+        for (const [fn, h] of Object.entries(rHashes)) {
+          if (vHashes[fn] === h) score++;
+        }
+        if (score === 0) continue;
+        const kTs = versionTs.get(k) ?? 0;
+        const tieMetric = Math.abs(kTs - ts);
+        if (
+          score > bestScore ||
+          (score === bestScore && tieMetric < bestTieTs)
+        ) {
+          bestScore = score;
+          bestKey = k;
+          bestTieTs = tieMetric;
+        }
+      }
+      if (bestKey) {
+        chosenKey = bestKey;
+        chosenMethod = "hashes";
+      }
+    }
+
+    if (!chosenKey) {
+      // Fallback timestamp
+      const candidates = [...versionTs.entries()]
+        .filter(([, t]) => t <= ts)
+        .sort((a, b) => b[1] - a[1]);
+      chosenKey = candidates.length > 0
+        ? candidates[0][0]
+        : versionKey({ major: 0, minor: 1, patch: 0 });
+      chosenMethod = rHashes && Object.keys(rHashes).length > 0
+        ? "fallback_created_at"
+        : "created_at";
+    }
+
+    const v = versionByKey.get(chosenKey) ?? { major: 0, minor: 1, patch: 0 };
+    const bucketKey = `${chosenKey}|${chosenMethod}`;
+    if (!updates.has(bucketKey)) {
+      updates.set(bucketKey, { version: v, method: chosenMethod, ids: [] });
+    }
+    updates.get(bucketKey)!.ids.push(r.id as string);
+  }
+
+  let countHashes = 0;
+  let countCreatedAt = 0;
+  let countFallback = 0;
+
+  for (const [, bucket] of updates) {
+    for (let i = 0; i < bucket.ids.length; i += 100) {
+      const chunk = bucket.ids.slice(i, i + 100);
       await supabase
         .from("responses")
         .update({
-          schema_version_major: maj,
-          schema_version_minor: min,
-          schema_version_patch: pat,
+          schema_version_major: bucket.version.major,
+          schema_version_minor: bucket.version.minor,
+          schema_version_patch: bucket.version.patch,
+          version_inferred_from: bucket.method,
         })
         .in("id", chunk);
     }
+    if (bucket.method === "hashes") countHashes += bucket.ids.length;
+    else if (bucket.method === "created_at") countCreatedAt += bucket.ids.length;
+    else if (bucket.method === "fallback_created_at") countFallback += bucket.ids.length;
   }
 
   revalidatePath(`/projects/${projectId}/analyze/compare`);
@@ -423,8 +674,14 @@ export async function backfillSchemaVersionHistory(projectId: string) {
 
   return {
     finalVersion: current,
-    logEntriesUpdated: logUpdates.length,
+    logEntriesUpdated: enriched.length,
     responsesUpdated: (responses ?? []).length,
+    byMethod: {
+      hashes: countHashes,
+      created_at: countCreatedAt,
+      fallback_created_at: countFallback,
+      live_save: countLiveSave,
+    },
   };
 }
 

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -136,6 +136,11 @@ function classifyChange(
     if (o.type !== n.type) hasStructural = true;
     if ((o.target ?? "all") !== (n.target ?? "all")) hasStructural = true;
     if ((o.required ?? true) !== (n.required ?? true)) hasStructural = true;
+    if ((o.subfield_rule ?? null) !== (n.subfield_rule ?? null)) hasStructural = true;
+    if ((o.allow_other ?? false) !== (n.allow_other ?? false)) hasStructural = true;
+    if (JSON.stringify(o.subfields ?? null) !== JSON.stringify(n.subfields ?? null)) {
+      hasStructural = true;
+    }
 
     const optsOld = o.options ?? [];
     const optsNew = n.options ?? [];
@@ -188,6 +193,37 @@ function bumpVersion(
   return { major: current.major, minor: current.minor, patch: current.patch + 1 };
 }
 
+// Classifica um diff de schema_change_log (before/after por campo) como estrutural (minor)
+// ou textual (patch). Add/remove são sempre estruturais.
+function fieldDiffIsStructural(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): boolean {
+  if (Object.keys(before).length === 0 || Object.keys(after).length === 0) return true;
+
+  for (const k of ["type", "target", "required", "subfield_rule", "allow_other"]) {
+    if (before[k] !== undefined || after[k] !== undefined) return true;
+  }
+
+  if (before.subfields !== undefined || after.subfields !== undefined) {
+    if (JSON.stringify(before.subfields ?? null) !== JSON.stringify(after.subfields ?? null)) {
+      return true;
+    }
+  }
+
+  const bOpts = before.options;
+  const aOpts = after.options;
+  if (bOpts !== undefined || aOpts !== undefined) {
+    const bArr = Array.isArray(bOpts) ? (bOpts as unknown[]) : [];
+    const aArr = Array.isArray(aOpts) ? (aOpts as unknown[]) : [];
+    const bSet = new Set(bArr);
+    const aSet = new Set(aArr);
+    const sameSet = bSet.size === aSet.size && [...bSet].every((x) => aSet.has(x));
+    if (!sameSet) return true;
+  }
+  return false;
+}
+
 // ---------- Save from GUI ----------
 
 export async function saveSchemaFromGUI(
@@ -237,6 +273,9 @@ export async function saveSchemaFromGUI(
       options: field.options ?? null,
       target: field.target ?? null,
       required: field.required ?? null,
+      subfields: field.subfields ?? null,
+      subfield_rule: field.subfield_rule ?? null,
+      allow_other: field.allow_other ?? null,
     };
   }
 
@@ -301,6 +340,23 @@ export async function saveSchemaFromGUI(
       diffs.push("obrigatório");
       before.required = old.required ?? null;
       after.required = f.required ?? null;
+    }
+    if ((old.subfield_rule ?? null) !== (f.subfield_rule ?? null)) {
+      diffs.push("regra de subcampos");
+      before.subfield_rule = old.subfield_rule ?? null;
+      after.subfield_rule = f.subfield_rule ?? null;
+    }
+    if ((old.allow_other ?? false) !== (f.allow_other ?? false)) {
+      diffs.push("permite outro");
+      before.allow_other = old.allow_other ?? false;
+      after.allow_other = f.allow_other ?? false;
+    }
+    const oldSubs = JSON.stringify(old.subfields ?? null);
+    const newSubs = JSON.stringify(f.subfields ?? null);
+    if (oldSubs !== newSubs) {
+      diffs.push("subcampos");
+      before.subfields = old.subfields ?? null;
+      after.subfields = f.subfields ?? null;
     }
 
     if (diffs.length > 0) {
@@ -402,6 +458,7 @@ export async function backfillSchemaVersionHistory(projectId: string) {
   ]);
 
   if (logErr) throw new Error(logErr.message);
+  if (!project) throw new Error("Projeto não encontrado ou sem permissão");
 
   // 1) Classify entries and compute cumulative version per entry
   let current = { major: 0, minor: 1, patch: 0 };
@@ -424,27 +481,7 @@ export async function backfillSchemaVersionHistory(projectId: string) {
     if (entry.change_type === "major") {
       type = "major";
     } else {
-      // Estruturais: add/remove de campo (before ou after vazios), mudança de type/target/required/options
-      const isAdd = Object.keys(before).length === 0;
-      const isRemove = Object.keys(after).length === 0;
-      let structural = isAdd || isRemove;
-      if (!structural) {
-        if (before.type !== undefined || after.type !== undefined) structural = true;
-        if (before.target !== undefined || after.target !== undefined) structural = true;
-        if (before.required !== undefined || after.required !== undefined) structural = true;
-        const bOpts = before.options;
-        const aOpts = after.options;
-        if (bOpts !== undefined || aOpts !== undefined) {
-          const bArr = Array.isArray(bOpts) ? (bOpts as unknown[]) : [];
-          const aArr = Array.isArray(aOpts) ? (aOpts as unknown[]) : [];
-          const bSet = new Set(bArr);
-          const aSet = new Set(aArr);
-          const sameSet =
-            bSet.size === aSet.size && [...bSet].every((x) => aSet.has(x));
-          if (!sameSet) structural = true;
-        }
-      }
-      type = structural ? "minor" : "patch";
+      type = fieldDiffIsStructural(before, after) ? "minor" : "patch";
     }
 
     current = bumpVersion(current, type);
@@ -460,17 +497,19 @@ export async function backfillSchemaVersionHistory(projectId: string) {
   }
 
   // 2) Update each log entry with classification + version
-  for (const e of enriched) {
-    await supabase
-      .from("schema_change_log")
-      .update({
-        change_type: e.changeType,
-        version_major: e.version.major,
-        version_minor: e.version.minor,
-        version_patch: e.version.patch,
-      })
-      .eq("id", e.id);
-  }
+  await Promise.all(
+    enriched.map((e) =>
+      supabase
+        .from("schema_change_log")
+        .update({
+          change_type: e.changeType,
+          version_major: e.version.major,
+          version_minor: e.version.minor,
+          version_patch: e.version.patch,
+        })
+        .eq("id", e.id),
+    ),
+  );
 
   // 3) Set project current version
   await supabase
@@ -556,11 +595,26 @@ export async function backfillSchemaVersionHistory(projectId: string) {
     hashesByVersion.set(k, computeHashesFromSnapshot(snap));
   }
 
-  // 5) Assign versions to responses
-  const { data: responses } = await supabase
-    .from("responses")
-    .select("id, created_at, answer_field_hashes, version_inferred_from")
-    .eq("project_id", projectId);
+  // 5) Assign versions to responses (paginate to avoid implicit 1000-row cap)
+  const RESPONSES_PAGE = 500;
+  type ResponseRow = {
+    id: string;
+    created_at: string;
+    answer_field_hashes: Record<string, string> | null;
+    version_inferred_from: string | null;
+  };
+  const responses: ResponseRow[] = [];
+  for (let from = 0; ; from += RESPONSES_PAGE) {
+    const { data: page, error: pageErr } = await supabase
+      .from("responses")
+      .select("id, created_at, answer_field_hashes, version_inferred_from")
+      .eq("project_id", projectId)
+      .range(from, from + RESPONSES_PAGE - 1);
+    if (pageErr) throw new Error(pageErr.message);
+    if (!page || page.length === 0) break;
+    responses.push(...(page as unknown as ResponseRow[]));
+    if (page.length < RESPONSES_PAGE) break;
+  }
 
   const allVersionKeys = [...hashesByVersion.keys()];
   const versionByKey = new Map<string, { major: number; minor: number; patch: number }>();
@@ -584,7 +638,7 @@ export async function backfillSchemaVersionHistory(projectId: string) {
 
   let countLiveSave = 0;
 
-  for (const r of responses ?? []) {
+  for (const r of responses) {
     // Preserve live_save entries as-is (precisão total)
     if (r.version_inferred_from === "live_save") {
       countLiveSave++;
@@ -650,23 +704,28 @@ export async function backfillSchemaVersionHistory(projectId: string) {
   let countCreatedAt = 0;
   let countFallback = 0;
 
-  for (const [, bucket] of updates) {
-    for (let i = 0; i < bucket.ids.length; i += 100) {
-      const chunk = bucket.ids.slice(i, i + 100);
-      await supabase
-        .from("responses")
-        .update({
-          schema_version_major: bucket.version.major,
-          schema_version_minor: bucket.version.minor,
-          schema_version_patch: bucket.version.patch,
-          version_inferred_from: bucket.method,
-        })
-        .in("id", chunk);
-    }
+  const updatePromises = [];
+  for (const bucket of updates.values()) {
     if (bucket.method === "hashes") countHashes += bucket.ids.length;
     else if (bucket.method === "created_at") countCreatedAt += bucket.ids.length;
     else if (bucket.method === "fallback_created_at") countFallback += bucket.ids.length;
+
+    for (let i = 0; i < bucket.ids.length; i += 100) {
+      const chunk = bucket.ids.slice(i, i + 100);
+      updatePromises.push(
+        supabase
+          .from("responses")
+          .update({
+            schema_version_major: bucket.version.major,
+            schema_version_minor: bucket.version.minor,
+            schema_version_patch: bucket.version.patch,
+            version_inferred_from: bucket.method,
+          })
+          .in("id", chunk),
+      );
+    }
   }
+  await Promise.all(updatePromises);
 
   revalidatePath(`/projects/${projectId}/analyze/compare`);
   revalidatePath(`/projects/${projectId}/config/schema`);
@@ -675,7 +734,7 @@ export async function backfillSchemaVersionHistory(projectId: string) {
   return {
     finalVersion: current,
     logEntriesUpdated: enriched.length,
-    responsesUpdated: (responses ?? []).length,
+    responsesProcessed: responses.length,
     byMethod: {
       hashes: countHashes,
       created_at: countCreatedAt,

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -97,8 +97,10 @@ export function SchemaEditor({
       try {
         const result = await backfillSchemaVersionHistory(projectId);
         const v = result.finalVersion;
+        const m = result.byMethod;
         toast.success(
-          `Versão reconstruída: v${v.major}.${v.minor}.${v.patch} (${result.logEntriesUpdated} entradas, ${result.responsesUpdated} respostas)`,
+          `v${v.major}.${v.minor}.${v.patch} · ${result.logEntriesUpdated} entradas, ${result.responsesUpdated} respostas — hashes: ${m.hashes}, created_at: ${m.created_at}, fallback: ${m.fallback_created_at}, live_save: ${m.live_save}`,
+          { duration: 10000 },
         );
         setBackfillDialogOpen(false);
         router.refresh();
@@ -356,12 +358,13 @@ export function SchemaEditor({
           <AlertDialogHeader>
             <AlertDialogTitle>Reconstruir versão pelo histórico?</AlertDialogTitle>
             <AlertDialogDescription>
-              Isso percorre todas as entradas do histórico de mudanças do schema em
-              ordem cronológica e reatribui change_type (MINOR quando houve adição/remoção
-              de opções; PATCH quando só texto foi alterado; MAJOR preservado se já existir).
-              A versão do projeto e as versões das respostas existentes são recalculadas
-              com base nos timestamps. Útil em projetos antigos que começaram antes do
-              versionamento. Idempotente — pode rodar de novo sem problemas.
+              Percorre o histórico de mudanças em ordem cronológica, classifica cada
+              entrada (MINOR em mudanças estruturais; PATCH em texto; MAJOR preservado)
+              e reconstrói o schema em cada versão. Para atribuir versão a cada resposta,
+              tenta match por <strong>answer_field_hashes</strong> (hashes gravados a cada
+              save); se não bater, cai em <strong>created_at</strong>. Respostas salvas
+              diretamente na plataforma (live_save) preservam a versão original.
+              Idempotente — pode rodar de novo sem problemas.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -99,7 +99,7 @@ export function SchemaEditor({
         const v = result.finalVersion;
         const m = result.byMethod;
         toast.success(
-          `v${v.major}.${v.minor}.${v.patch} · ${result.logEntriesUpdated} entradas, ${result.responsesUpdated} respostas — hashes: ${m.hashes}, created_at: ${m.created_at}, fallback: ${m.fallback_created_at}, live_save: ${m.live_save}`,
+          `v${v.major}.${v.minor}.${v.patch} · ${result.logEntriesUpdated} entradas, ${result.responsesProcessed} respostas — hashes: ${m.hashes}, created_at: ${m.created_at}, fallback: ${m.fallback_created_at}, live_save: ${m.live_save}`,
           { duration: 10000 },
         );
         setBackfillDialogOpen(false);

--- a/frontend/src/lib/supabase/database.types.ts
+++ b/frontend/src/lib/supabase/database.types.ts
@@ -581,6 +581,7 @@ export type Database = {
           schema_version_major: number | null
           schema_version_minor: number | null
           schema_version_patch: number | null
+          version_inferred_from: string | null
         }
         Insert: {
           answer_field_hashes?: Json | null
@@ -598,6 +599,7 @@ export type Database = {
           schema_version_major?: number | null
           schema_version_minor?: number | null
           schema_version_patch?: number | null
+          version_inferred_from?: string | null
         }
         Update: {
           answer_field_hashes?: Json | null
@@ -615,6 +617,7 @@ export type Database = {
           schema_version_major?: number | null
           schema_version_minor?: number | null
           schema_version_patch?: number | null
+          version_inferred_from?: string | null
         }
         Relationships: [
           {

--- a/frontend/supabase/migrations/20260421000000_response_version_inferred_from.sql
+++ b/frontend/supabase/migrations/20260421000000_response_version_inferred_from.sql
@@ -1,0 +1,14 @@
+-- Rastreia como a versão de cada resposta foi inferida.
+-- 'live_save': gravada diretamente em saveResponse (precisão total).
+-- 'hashes':    inferida por match de answer_field_hashes contra snapshots reconstruídos.
+-- 'created_at': inferida por timestamp de criação (resposta sem answer_field_hashes).
+-- 'fallback_created_at': tentou hashes, não bateu, caiu pra timestamp.
+
+ALTER TABLE responses
+  ADD COLUMN version_inferred_from TEXT
+  CHECK (version_inferred_from IN ('live_save', 'hashes', 'created_at', 'fallback_created_at'));
+
+-- Backfill preliminar: respostas existentes ficam como 'created_at' até o backfill rodar.
+UPDATE responses
+  SET version_inferred_from = 'created_at'
+  WHERE version_inferred_from IS NULL;


### PR DESCRIPTION
## Summary
Refatora o botão "Reconstruir histórico" para identificar em que versão cada resposta foi gravada usando `answer_field_hashes` (hashes por campo salvos a cada save), em vez de depender apenas de `created_at`.

## Por que
`saveResponse` faz UPDATE em respostas humanas existentes do mesmo `(user, doc)`, e `created_at` é imutável. Uma resposta editada após o schema mudar recebia uma versão defasada no backfill anterior. Com este PR, a versão é inferida pelos hashes — o que a resposta de fato salvou.

## Mudanças
- **Migration** `20260421000000_response_version_inferred_from.sql`: coluna `version_inferred_from` em `responses` (`live_save` | `hashes` | `created_at` | `fallback_created_at`)
- **`saveResponse`**: grava `version_inferred_from='live_save'` (precisão total para futuras respostas)
- **`saveSchemaFromGUI`**: amplia o log — registra add/remove de campos e mudanças em `type`/`target`/`required` (antes só `description`/`help_text`/`options`)
- **`backfillSchemaVersionHistory`**: reconstrói snapshots por versão aplicando diffs em reverso; para cada resposta faz match por maior score de hashes, desempatando por proximidade temporal; fallback para `created_at` quando não há hashes ou não bate
- **SchemaEditor**: modal explicativo atualizado; toast mostra breakdown por método

## Limitações conhecidas
- Respostas pré-23/03/2026 não têm `answer_field_hashes` → caem em `created_at`
- Mudanças históricas em `type`/`name` que não foram logadas → a reconstrução usa os valores atuais, podendo gerar score menor e match parcial
- Add/remove de campos feitos antes desta melhoria não estão no log → snapshots antigos podem ter campos a mais ou a menos

## Test plan
- [ ] Aplicar migration no remoto (ainda **não aplicada** — branch só; push do DB será no merge)
- [ ] Abrir `/config/schema` de um projeto com histórico (ex: Zolgensma) → clicar "Reconstruir histórico" → conferir toast com breakdown
- [ ] Consultar `responses` no SQL Editor e conferir distribuição de `version_inferred_from`
- [ ] Editar um schema (adicionar campo, mudar `type`) → conferir que `schema_change_log` agora registra com os atributos novos
- [ ] Editar uma resposta humana via aba de codificação → `version_inferred_from='live_save'`
- [ ] `npx tsc --noEmit` e `npm run build` — ambos passaram localmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)