### PR TITLE
feat: badge de versão por resposta + filtro completo

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -154,11 +154,24 @@ export default async function ComparePageRoute({
   const minVersion = resolveMinVersion(filters.version, projectVersion);
   const sinceMs = filters.since ? new Date(filters.since).getTime() : null;
 
-  // Build distinct ordered version list desc
+  // Build distinct ordered version list desc — une versões do schema_change_log
+  // com as efetivamente gravadas em responses (cobre respostas cuja versão
+  // veio do backfill por hashes/created_at e não tem entry classificada no log).
   const versionSet = new Set<string>();
   for (const v of versionLog ?? []) {
     if (v.version_major !== null && v.version_minor !== null && v.version_patch !== null) {
       versionSet.add(`${v.version_major}.${v.version_minor}.${v.version_patch}`);
+    }
+  }
+  for (const r of allResponses ?? []) {
+    if (
+      r.schema_version_major !== null &&
+      r.schema_version_minor !== null &&
+      r.schema_version_patch !== null
+    ) {
+      versionSet.add(
+        `${r.schema_version_major}.${r.schema_version_minor}.${r.schema_version_patch}`,
+      );
     }
   }
   const availableVersions = [...versionSet].sort((a, b) => {

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -13,6 +13,15 @@ interface AgreementResponse {
   justification?: string;
   is_current: boolean;
   isFieldStale: boolean;
+  schemaVersion?: string | null;
+}
+
+function compareVersionsDesc(a: string, b: string): number {
+  const [am, an, ap] = a.split(".").map((n) => Number.parseInt(n, 10));
+  const [bm, bn, bp] = b.split(".").map((n) => Number.parseInt(n, 10));
+  if (am !== bm) return bm - am;
+  if (an !== bn) return bn - an;
+  return bp - ap;
 }
 
 interface ExistingVerdict {
@@ -81,6 +90,13 @@ export function AgreementGroup({
           const isChosen = group.responses.some(
             (r) => r.id === existingVerdict?.chosenResponseId,
           );
+          const versions = [
+            ...new Set(
+              group.responses
+                .map((r) => r.schemaVersion)
+                .filter((v): v is string => !!v),
+            ),
+          ].sort(compareVersionsDesc);
 
           return (
             <AnswerCard
@@ -93,6 +109,7 @@ export function AgreementGroup({
               llmJustification={llmResponse?.justification}
               staleCount={staleCount}
               isChosen={isChosen}
+              versions={versions}
               onVote={() => onVote(group.displayAnswer, group.responses[0].id)}
             />
           );

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -18,6 +18,7 @@ interface AnswerCardProps {
   llmJustification?: string;
   staleCount: number;
   isChosen: boolean;
+  versions: string[];
   onVote: () => void;
 }
 
@@ -30,6 +31,7 @@ export function AnswerCard({
   llmJustification,
   staleCount,
   isChosen,
+  versions,
   onVote,
 }: AnswerCardProps) {
   const [showJustification, setShowJustification] = useState(false);
@@ -79,6 +81,29 @@ export function AnswerCard({
                   ? "desatualizada"
                   : `${staleCount} de ${respondentCount} desatualizadas`}
               </span>
+            )}
+
+            {versions.length === 1 && (
+              <span
+                className="font-mono text-[10px] text-muted-foreground"
+                title="Versão do schema em que esta resposta foi salva"
+              >
+                v{versions[0]}
+              </span>
+            )}
+            {versions.length > 1 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="cursor-default font-mono text-[10px] text-muted-foreground underline decoration-dotted underline-offset-2">
+                    {versions.length} versões
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {versions.map((v) => (
+                    <div key={v}>v{v}</div>
+                  ))}
+                </TooltipContent>
+              </Tooltip>
             )}
           </div>
 

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -163,6 +163,7 @@ export function ComparisonPanel({
               justification: r.justification,
               is_current: r.is_current,
               isFieldStale: r.isFieldStale,
+              schemaVersion: r.schemaVersion,
             }))}
             existingVerdict={existingVerdict}
             onVote={(displayAnswer, chosenResponseId) =>


### PR DESCRIPTION
## Summary
- Exibe em cada `AnswerCard` a versão do schema em que cada resposta foi salva (`v0.X.Y`) ou "N versões" com tooltip quando um mesmo valor foi gravado em versões distintas.
- Filtro "Desde a versão" passa a listar todas as versões presentes em `responses` (vindas de backfill por hashes/created_at), não só as do `schema_change_log`.

## Por que
Depois do backfill do PR #49 as respostas têm versão individual no DB, mas a UI da aba Comparar descartava `schemaVersion` antes de exibir, e o dropdown só mostrava versões registradas no log — no projeto-cobaia, só havia entries dentro da MAJOR atual, então só "Todas" e "Última MAJOR" apareciam. Agora dá pra ver a versão por resposta e filtrar por qualquer versão real.

## Test plan
- [ ] Abrir Comparar de projeto com histórico → conferir badge `v0.X.Y` por card, ou "N versões" quando aplicável.
- [ ] Abrir Filtros → "Desde a versão" → conferir lista ampliada.
- [ ] Aplicar filtro numa versão antiga → fila deve reduzir (prova que backfill gravou versões distintas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)