### PR TITLE
fix: todos os tipos da aba Comentários passam a ser resolvíveis

### DIFF
--- a/frontend/src/actions/stats.ts
+++ b/frontend/src/actions/stats.ts
@@ -58,6 +58,122 @@ export async function reopenReviewComment(
   }
 }
 
+export async function resolveNote(
+  projectId: string,
+  responseId: string,
+  note?: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const user = await getAuthUser();
+    if (!user) return { success: false, error: "Não autenticado" };
+
+    const supabase = await createSupabaseServer();
+
+    const { error } = await supabase.from("note_resolutions").insert({
+      project_id: projectId,
+      response_id: responseId,
+      resolved_by: user.id,
+      note: note || null,
+    });
+
+    if (error) return { success: false, error: error.message };
+
+    revalidatePath(`/projects/${projectId}/reviews`);
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Erro desconhecido" };
+  }
+}
+
+export async function reopenNote(
+  projectId: string,
+  responseId: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const user = await getAuthUser();
+    if (!user) return { success: false, error: "Não autenticado" };
+
+    const supabase = await createSupabaseServer();
+
+    const { error } = await supabase
+      .from("note_resolutions")
+      .delete()
+      .eq("project_id", projectId)
+      .eq("response_id", responseId);
+
+    if (error) return { success: false, error: error.message };
+
+    revalidatePath(`/projects/${projectId}/reviews`);
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Erro desconhecido" };
+  }
+}
+
+export async function resolveDuvida(
+  projectId: string,
+  reviewId: string,
+  respondentId: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const user = await getAuthUser();
+    if (!user) return { success: false, error: "Não autenticado" };
+
+    const supabase = await createSupabaseServer();
+
+    const { data, error } = await supabase
+      .from("verdict_acknowledgments")
+      .update({
+        resolved_at: new Date().toISOString(),
+        resolved_by: user.id,
+      })
+      .eq("review_id", reviewId)
+      .eq("respondent_id", respondentId)
+      .select("review_id");
+
+    if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0)
+      return { success: false, error: "Sem permissão para resolver esta dúvida" };
+
+    revalidatePath(`/projects/${projectId}/reviews`);
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Erro desconhecido" };
+  }
+}
+
+export async function reopenDuvida(
+  projectId: string,
+  reviewId: string,
+  respondentId: string,
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const user = await getAuthUser();
+    if (!user) return { success: false, error: "Não autenticado" };
+
+    const supabase = await createSupabaseServer();
+
+    const { data, error } = await supabase
+      .from("verdict_acknowledgments")
+      .update({
+        resolved_at: null,
+        resolved_by: null,
+      })
+      .eq("review_id", reviewId)
+      .eq("respondent_id", respondentId)
+      .select("review_id");
+
+    if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0)
+      return { success: false, error: "Sem permissão para reabrir esta dúvida" };
+
+    revalidatePath(`/projects/${projectId}/reviews`);
+    return { success: true };
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : "Erro desconhecido" };
+  }
+}
+
 export async function resolveDifficulty(
   projectId: string,
   responseId: string,

--- a/frontend/src/actions/suggestions.ts
+++ b/frontend/src/actions/suggestions.ts
@@ -91,3 +91,29 @@ export async function resolveSchemaSuggestion(
   revalidatePath(`/projects/${projectId}/reviews/comments`);
   return {};
 }
+
+export async function approveSchemaSuggestionWithEdits(
+  suggestionId: string,
+  projectId: string,
+  editedFields: PydanticField[],
+): Promise<{ error?: string }> {
+  const user = await getAuthUser();
+  if (!user) return { error: "Não autenticado" };
+
+  const supabase = await createSupabaseServer();
+
+  await saveSchemaFromGUI(projectId, editedFields);
+
+  const { error } = await supabase
+    .from("schema_suggestions")
+    .update({
+      status: "approved",
+      resolved_by: user.id,
+      resolved_at: new Date().toISOString(),
+    })
+    .eq("id", suggestionId);
+
+  if (error) return { error: error.message };
+  revalidatePath(`/projects/${projectId}/reviews/comments`);
+  return {};
+}

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -25,6 +25,7 @@ export default async function CommentsPage({
     { data: difficultyResolutions },
     { data: projectComments },
     { data: verdictQuestions },
+    { data: noteResolutions },
   ] = await Promise.all([
     supabase
       .from("projects")
@@ -65,7 +66,7 @@ export default async function CommentsPage({
       .limit(50),
     supabase
       .from("schema_suggestions")
-      .select("id, field_name, suggested_changes, reason, status, created_at, profiles!suggested_by(email)")
+      .select("id, field_name, suggested_changes, reason, status, resolved_at, created_at, profiles!suggested_by(email)")
       .eq("project_id", id)
       .order("created_at", { ascending: false }),
     supabase
@@ -87,13 +88,21 @@ export default async function CommentsPage({
     supabase
       .from("verdict_acknowledgments")
       .select(
-        "review_id, respondent_id, comment, created_at, reviews!inner(id, project_id, document_id, field_name, verdict)",
+        "review_id, respondent_id, comment, resolved_at, created_at, reviews!inner(id, project_id, document_id, field_name, verdict)",
       )
       .eq("status", "questioned")
       .not("comment", "is", null)
       .eq("reviews.project_id", id)
       .order("created_at", { ascending: false }),
+    supabase
+      .from("note_resolutions")
+      .select("response_id, resolved_at")
+      .eq("project_id", id),
   ]);
+
+  const noteResolvedMap = new Map(
+    (noteResolutions || []).map((n) => [n.response_id, n.resolved_at]),
+  );
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];
 
@@ -163,7 +172,7 @@ export default async function CommentsPage({
       verdict: "nota",
       comment: (r.justifications as Record<string, string>)._notes,
       reviewerName: r.respondent_name || "Anônimo",
-      resolvedAt: null,
+      resolvedAt: noteResolvedMap.get(r.id) ?? null,
       createdAt: r.created_at,
       chosenResponseId: null,
       source: "nota" as const,
@@ -187,13 +196,26 @@ export default async function CommentsPage({
       verdict: "sugestao",
       comment: `${s.reason || "Sem motivo"}${changedKeys ? ` (alterações: ${changedKeys})` : ""}`,
       reviewerName: p?.email?.split("@")[0] || "Anônimo",
-      resolvedAt: null,
+      resolvedAt: (s.resolved_at as string | null) ?? null,
       createdAt: s.created_at,
       chosenResponseId: null,
       source: "sugestao" as const,
       responseSnapshot: null,
       suggestionId: s.id as string,
       suggestionStatus: s.status as "pending" | "approved" | "rejected",
+      suggestionChanges: {
+        description:
+          typeof changes.description === "string" ? changes.description : undefined,
+        help_text:
+          changes.help_text === null || typeof changes.help_text === "string"
+            ? (changes.help_text as string | null)
+            : undefined,
+        options: Array.isArray(changes.options)
+          ? (changes.options as string[])
+          : changes.options === null
+            ? null
+            : undefined,
+      },
     };
   });
 
@@ -234,6 +256,7 @@ export default async function CommentsPage({
     review_id: string;
     respondent_id: string;
     comment: string;
+    resolved_at: string | null;
     created_at: string;
     reviews: {
       id: string;
@@ -256,11 +279,13 @@ export default async function CommentsPage({
       verdict: "duvida",
       comment: q.comment,
       reviewerName: reviewerMap.get(q.respondent_id) || "Anônimo",
-      resolvedAt: null,
+      resolvedAt: q.resolved_at,
       createdAt: q.created_at,
       chosenResponseId: null,
       source: "duvida" as const,
       responseSnapshot: null,
+      duvidaReviewId: q.review_id,
+      duvidaRespondentId: q.respondent_id,
     };
   });
 

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -67,8 +67,15 @@ export interface ReviewComment {
   responseSnapshot: ResponseSnapshotEntry[] | null;
   suggestionId?: string;
   suggestionStatus?: "pending" | "approved" | "rejected";
+  suggestionChanges?: {
+    description?: string;
+    help_text?: string | null;
+    options?: string[] | null;
+  };
   difficultyResponseId?: string;
   difficultyDocumentId?: string;
+  duvidaReviewId?: string;
+  duvidaRespondentId?: string;
 }
 
 interface CommentCardProps {
@@ -391,11 +398,8 @@ export function CommentCard({
             )}
           </p>
           <div className="flex gap-1">
-            {comment.source === "duvida" ? (
-              <span className="text-xs text-muted-foreground italic">
-                Resolve em Meu Gabarito
-              </span>
-            ) : isResolved ? (
+            {comment.source === "sugestao" &&
+            comment.suggestionStatus !== "pending" ? null : isResolved ? (
               <Button
                 variant="ghost"
                 size="sm"
@@ -411,7 +415,11 @@ export function CommentCard({
                 size="sm"
                 disabled={isPending}
                 onClick={onResolve}
-                title="Resolver"
+                title={
+                  comment.source === "sugestao"
+                    ? "Editar e aprovar"
+                    : "Resolver"
+                }
               >
                 <CheckCircle2 className="h-3.5 w-3.5" />
               </Button>

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -52,10 +52,19 @@ function initialFromField(
   suggestion?: PendingSuggestion | null,
 ) {
   const ch = suggestion?.changes ?? {};
+  // Distinguish "no change" (undefined) from "clear" (null) in suggestions:
+  // null in suggested_changes means the suggestion explicitly wants to empty
+  // the field, so ?? against the current field value would mask that intent.
   return {
     description: ch.description ?? field?.description ?? "",
-    helpText: (ch.help_text ?? field?.help_text ?? "") as string,
-    options: (ch.options ?? field?.options ?? []) as string[],
+    helpText:
+      ch.help_text !== undefined
+        ? (ch.help_text ?? "")
+        : (field?.help_text ?? ""),
+    options:
+      ch.options !== undefined
+        ? (ch.options ?? [])
+        : (field?.options ?? []),
   };
 }
 

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -17,6 +17,7 @@ import { Switch } from "@/components/ui/switch";
 import { AlertTriangle, Loader2, Trash2 } from "lucide-react";
 import { OptionsEditor } from "@/components/schema/OptionsEditor";
 import { saveSchemaFromGUI } from "@/actions/schema";
+import { approveSchemaSuggestionWithEdits } from "@/actions/suggestions";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import type { PydanticField, SubfieldDef } from "@/lib/types";
@@ -28,12 +29,34 @@ const TYPE_LABELS: Record<string, string> = {
   date: "Data",
 };
 
+export interface PendingSuggestion {
+  id: string;
+  changes: {
+    description?: string;
+    help_text?: string | null;
+    options?: string[] | null;
+  };
+}
+
 interface EditFieldDialogProps {
   projectId: string;
   fieldName: string;
   allFields: PydanticField[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  pendingSuggestion?: PendingSuggestion | null;
+}
+
+function initialFromField(
+  field: PydanticField | undefined,
+  suggestion?: PendingSuggestion | null,
+) {
+  const ch = suggestion?.changes ?? {};
+  return {
+    description: ch.description ?? field?.description ?? "",
+    helpText: (ch.help_text ?? field?.help_text ?? "") as string,
+    options: (ch.options ?? field?.options ?? []) as string[],
+  };
 }
 
 export function EditFieldDialog({
@@ -42,25 +65,29 @@ export function EditFieldDialog({
   allFields,
   open,
   onOpenChange,
+  pendingSuggestion,
 }: EditFieldDialogProps) {
   const router = useRouter();
   const field = allFields.find((f) => f.name === fieldName);
-  const [description, setDescription] = useState(field?.description ?? "");
-  const [helpText, setHelpText] = useState(field?.help_text ?? "");
-  const [options, setOptions] = useState<string[]>(field?.options ?? []);
+  const initial = initialFromField(field, pendingSuggestion);
+  const [description, setDescription] = useState(initial.description);
+  const [helpText, setHelpText] = useState(initial.helpText);
+  const [options, setOptions] = useState<string[]>(initial.options);
   const [allowOther, setAllowOther] = useState<boolean>(field?.allow_other ?? false);
   const [subfields, setSubfields] = useState<SubfieldDef[] | undefined>(field?.subfields);
   const [subfieldRule, setSubfieldRule] = useState<"all" | "at_least_one">(field?.subfield_rule ?? "all");
   const [isSaving, startSave] = useTransition();
 
-  // Reset state when dialog opens with a different field
-  const [prevFieldName, setPrevFieldName] = useState(fieldName);
-  if (fieldName !== prevFieldName) {
-    setPrevFieldName(fieldName);
+  // Reset state when dialog opens with a different field or suggestion
+  const resetKey = `${fieldName}::${pendingSuggestion?.id ?? ""}`;
+  const [prevKey, setPrevKey] = useState(resetKey);
+  if (resetKey !== prevKey) {
+    setPrevKey(resetKey);
     const f = allFields.find((ff) => ff.name === fieldName);
-    setDescription(f?.description ?? "");
-    setHelpText(f?.help_text ?? "");
-    setOptions(f?.options ?? []);
+    const init = initialFromField(f, pendingSuggestion);
+    setDescription(init.description);
+    setHelpText(init.helpText);
+    setOptions(init.options);
     setAllowOther(f?.allow_other ?? false);
     setSubfields(f?.subfields);
     setSubfieldRule(f?.subfield_rule ?? "all");
@@ -90,8 +117,18 @@ export function EditFieldDialog({
           : f,
       );
       try {
-        await saveSchemaFromGUI(projectId, updatedFields);
-        toast.success("Campo atualizado");
+        if (pendingSuggestion) {
+          const result = await approveSchemaSuggestionWithEdits(
+            pendingSuggestion.id,
+            projectId,
+            updatedFields,
+          );
+          if (result.error) throw new Error(result.error);
+          toast.success("Sugestão aprovada e campo atualizado");
+        } else {
+          await saveSchemaFromGUI(projectId, updatedFields);
+          toast.success("Campo atualizado");
+        }
         onOpenChange(false);
         router.refresh();
       } catch (e) {
@@ -107,12 +144,21 @@ export function EditFieldDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            Editar campo
+            {pendingSuggestion ? "Aprovar sugestão (com edições)" : "Editar campo"}
             <code className="text-sm font-mono text-muted-foreground">
               {fieldName}
             </code>
           </DialogTitle>
         </DialogHeader>
+        {pendingSuggestion && (
+          <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-amber-800">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>
+              Os campos abaixo vêm da sugestão original. Ajuste o que for
+              necessário e clique em Salvar para aprovar.
+            </span>
+          </div>
+        )}
 
         <div className="space-y-4">
           <div className="flex items-center gap-2">

--- a/frontend/src/components/stats/ReviewCommentsView.tsx
+++ b/frontend/src/components/stats/ReviewCommentsView.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { History, ChevronDown, PanelLeftClose } from "lucide-react";
 import { CommentCard, type ReviewComment } from "./CommentCard";
 import { CommentsSplitView } from "./CommentsSplitView";
-import { EditFieldDialog } from "./EditFieldDialog";
+import { EditFieldDialog, type PendingSuggestion } from "./EditFieldDialog";
 import { SuggestFieldDialog } from "./SuggestFieldDialog";
 import { AddNoteButton } from "@/components/shared/AddNoteButton";
 import {
@@ -24,6 +24,10 @@ import {
   reopenReviewComment,
   resolveDifficulty,
   reopenDifficulty,
+  resolveNote,
+  reopenNote,
+  resolveDuvida,
+  reopenDuvida,
 } from "@/actions/stats";
 import {
   resolveProjectComment,
@@ -80,6 +84,8 @@ export function ReviewCommentsView({
   const [verdictFilter, setVerdictFilter] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [editingField, setEditingField] = useState<string | null>(null);
+  const [pendingSuggestion, setPendingSuggestion] =
+    useState<PendingSuggestion | null>(null);
   const [suggestingField, setSuggestingField] = useState<string | null>(null);
   const [splitDocId, setSplitDocId] = useState<string | null>(null);
 
@@ -101,10 +107,24 @@ export function ReviewCommentsView({
   }, [comments, fieldFilter, statusFilter, verdictFilter, searchQuery]);
 
   const handleResolve = (comment: ReviewComment) => {
+    // Sugestão: abre EditFieldDialog pré-preenchido com a proposta.
+    // Ao salvar o dialog, a sugestão é marcada como aprovada.
+    if (comment.source === "sugestao" && comment.suggestionId) {
+      setPendingSuggestion({
+        id: comment.suggestionId,
+        changes: comment.suggestionChanges ?? {},
+      });
+      setEditingField(comment.fieldName);
+      return;
+    }
     startTransition(async () => {
-      let result;
+      let result: { success?: boolean; error?: string };
       if (comment.source === "anotacao") {
         result = await resolveProjectComment(comment.id.slice("anotacao-".length), projectId);
+      } else if (comment.source === "nota") {
+        result = await resolveNote(projectId, comment.id.slice("nota-".length));
+      } else if (comment.source === "duvida" && comment.duvidaReviewId && comment.duvidaRespondentId) {
+        result = await resolveDuvida(projectId, comment.duvidaReviewId, comment.duvidaRespondentId);
       } else if (comment.source === "dificuldade" && comment.difficultyResponseId) {
         result = await resolveDifficulty(
           projectId,
@@ -125,9 +145,13 @@ export function ReviewCommentsView({
 
   const handleReopen = (comment: ReviewComment) => {
     startTransition(async () => {
-      let result;
+      let result: { success?: boolean; error?: string };
       if (comment.source === "anotacao") {
         result = await reopenProjectComment(comment.id.slice("anotacao-".length), projectId);
+      } else if (comment.source === "nota") {
+        result = await reopenNote(projectId, comment.id.slice("nota-".length));
+      } else if (comment.source === "duvida" && comment.duvidaReviewId && comment.duvidaRespondentId) {
+        result = await reopenDuvida(projectId, comment.duvidaReviewId, comment.duvidaRespondentId);
       } else if (comment.source === "dificuldade" && comment.difficultyResponseId) {
         result = await reopenDifficulty(projectId, comment.difficultyResponseId);
       } else {
@@ -346,8 +370,12 @@ export function ReviewCommentsView({
           fieldName={editingField}
           allFields={fields}
           open={!!editingField}
+          pendingSuggestion={pendingSuggestion}
           onOpenChange={(open) => {
-            if (!open) setEditingField(null);
+            if (!open) {
+              setEditingField(null);
+              setPendingSuggestion(null);
+            }
           }}
         />
       )}

--- a/frontend/supabase/migrations/20260422000000_note_resolutions.sql
+++ b/frontend/supabase/migrations/20260422000000_note_resolutions.sql
@@ -1,0 +1,31 @@
+-- Table for resolving researcher notes (justifications._notes in responses)
+-- Notes live inside responses.justifications JSONB, so they have no entity of their own
+CREATE TABLE note_resolutions (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  response_id  UUID NOT NULL REFERENCES responses(id) ON DELETE CASCADE,
+  resolved_by  UUID NOT NULL REFERENCES profiles(id),
+  resolved_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  note         TEXT,
+  UNIQUE(project_id, response_id)
+);
+
+CREATE INDEX idx_note_resolutions_project ON note_resolutions(project_id);
+CREATE INDEX idx_note_resolutions_response ON note_resolutions(response_id);
+
+ALTER TABLE note_resolutions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Members view note_resolutions" ON note_resolutions
+  FOR SELECT USING (
+    project_id IN (SELECT project_id FROM project_members WHERE user_id = clerk_uid())
+  );
+
+CREATE POLICY "Members insert note_resolutions" ON note_resolutions
+  FOR INSERT WITH CHECK (
+    project_id IN (SELECT project_id FROM project_members WHERE user_id = clerk_uid())
+  );
+
+CREATE POLICY "Members delete note_resolutions" ON note_resolutions
+  FOR DELETE USING (
+    project_id IN (SELECT project_id FROM project_members WHERE user_id = clerk_uid())
+  );

--- a/frontend/supabase/migrations/20260422000000_note_resolutions.sql
+++ b/frontend/supabase/migrations/20260422000000_note_resolutions.sql
@@ -15,17 +15,19 @@ CREATE INDEX idx_note_resolutions_response ON note_resolutions(response_id);
 
 ALTER TABLE note_resolutions ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Members view note_resolutions" ON note_resolutions
-  FOR SELECT USING (
-    project_id IN (SELECT project_id FROM project_members WHERE user_id = clerk_uid())
-  );
+-- Any project member can view note resolutions
+CREATE POLICY "Members view note_resolutions" ON note_resolutions FOR SELECT USING (
+  project_id IN (SELECT auth_user_project_ids())
+);
 
-CREATE POLICY "Members insert note_resolutions" ON note_resolutions
-  FOR INSERT WITH CHECK (
-    project_id IN (SELECT project_id FROM project_members WHERE user_id = clerk_uid())
-  );
+-- Coordinators can insert note resolutions
+CREATE POLICY "Coordinators insert note_resolutions" ON note_resolutions FOR INSERT WITH CHECK (
+  project_id IN (SELECT auth_user_coordinator_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = auth.uid())
+);
 
-CREATE POLICY "Members delete note_resolutions" ON note_resolutions
-  FOR DELETE USING (
-    project_id IN (SELECT project_id FROM project_members WHERE user_id = clerk_uid())
-  );
+-- Coordinators can delete note resolutions (reopen)
+CREATE POLICY "Coordinators delete note_resolutions" ON note_resolutions FOR DELETE USING (
+  project_id IN (SELECT auth_user_coordinator_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = auth.uid())
+);

--- a/frontend/supabase/migrations/20260422000100_verdict_ack_resolutions.sql
+++ b/frontend/supabase/migrations/20260422000100_verdict_ack_resolutions.sql
@@ -1,0 +1,21 @@
+-- Allow coordinators to mark verdict acknowledgment questions as "seen/resolved"
+-- without changing the respondent's status (which only the respondent can change
+-- via "Meu Gabarito" acknowledging the verdict).
+ALTER TABLE verdict_acknowledgments
+  ADD COLUMN resolved_at TIMESTAMPTZ,
+  ADD COLUMN resolved_by UUID REFERENCES profiles(id);
+
+CREATE INDEX idx_verdict_ack_unresolved
+  ON verdict_acknowledgments(review_id)
+  WHERE resolved_at IS NULL;
+
+-- Coordinators of the project can update any row (to toggle resolved fields)
+CREATE POLICY "Coordinators can update verdict_acknowledgments" ON verdict_acknowledgments
+  FOR UPDATE USING (
+    review_id IN (
+      SELECT id FROM reviews WHERE project_id IN (
+        SELECT project_id FROM project_members
+        WHERE user_id = clerk_uid() AND role = 'coordenador'
+      )
+    )
+  );

--- a/frontend/supabase/migrations/20260422000100_verdict_ack_resolutions.sql
+++ b/frontend/supabase/migrations/20260422000100_verdict_ack_resolutions.sql
@@ -13,9 +13,8 @@ CREATE INDEX idx_verdict_ack_unresolved
 CREATE POLICY "Coordinators can update verdict_acknowledgments" ON verdict_acknowledgments
   FOR UPDATE USING (
     review_id IN (
-      SELECT id FROM reviews WHERE project_id IN (
-        SELECT project_id FROM project_members
-        WHERE user_id = clerk_uid() AND role = 'coordenador'
-      )
+      SELECT id FROM reviews
+      WHERE project_id IN (SELECT auth_user_coordinator_project_ids())
+         OR project_id IN (SELECT id FROM projects WHERE created_by = auth.uid())
     )
   );


### PR DESCRIPTION
## Summary

Corrige o erro do Postgres `invalid input syntax for type uuid: "nota-..."` e torna todos os tipos de comentário da aba **Comentários** resolvíveis ali mesmo.

- **Nota do pesquisador** (bug principal): o ID composto `nota-<uuid>` caía no `else` de `handleResolve`, que chamava `resolveReviewComment` e falhava contra a coluna `reviews.id uuid`. Agora: nova tabela `note_resolutions` + actions `resolveNote`/`reopenNote` (padrão de `difficulty_resolutions`).
- **Dúvida do gabarito**: coordenador pode fechar a dúvida sem alterar o `status` do respondente. Novas colunas `resolved_at`/`resolved_by` em `verdict_acknowledgments` + actions `resolveDuvida`/`reopenDuvida`.
- **Sugestão de campo**: clicar ✓ abre `EditFieldDialog` pré-preenchido com a proposta; salvar equivale a aprovar editado (`approveSchemaSuggestionWithEdits`). Sugestão já aprovada/rejeitada não mostra mais ✓/↺ e aparece no filtro **Resolvidos** (via `schema_suggestions.resolved_at` já existente).

## Migrations

Antes do merge, rodar:

```bash
cd frontend && export SUPABASE_ACCESS_TOKEN=$(grep SUPABASE_ACCESS_TOKEN .env.local | cut -d= -f2) && npx supabase db push
```

Adiciona:
- `20260422000000_note_resolutions.sql`
- `20260422000100_verdict_ack_resolutions.sql`

## Test plan

- [ ] **Nota**: criar nota em Codificação → aba Comentários → clicar ✓ → sem erro; alternar filtro para Resolvidos → ↺ Reabrir funciona
- [ ] **Dúvida**: criar dúvida em Meu Gabarito (respondente) → aba Comentários (coordenador) → ✓ → some de Abertos; respondente continua vendo a dúvida como `questioned`
- [ ] **Sugestão**: criar sugestão (pesquisador) → aba Comentários (coordenador) → ✓ → abre EditFieldDialog pré-preenchido → editar → Salvar → vira "Aprovada" e schema atualizado
- [ ] **Rejeitar sugestão**: botão Rejeitar continua funcionando
- [ ] **Regressão**: review, dificuldade, anotação continuam OK
- [ ] Filtros por tipo e busca permanecem funcionais

🤖 Generated with [Claude Code](https://claude.com/claude-code)