### PR TITLE
fix: usar clerk_uid() em vez de auth.uid() nas policies de resolução

### DIFF
--- a/frontend/supabase/migrations/20260422010000_fix_resolutions_use_clerk_uid.sql
+++ b/frontend/supabase/migrations/20260422010000_fix_resolutions_use_clerk_uid.sql
@@ -1,0 +1,31 @@
+-- Fix: replace auth.uid() with clerk_uid() in recently-added policies.
+-- Under Clerk third-party auth the JWT 'sub' claim is the Clerk ID
+-- (user_...), which auth.uid() casts to UUID and fails with
+-- "invalid input syntax for type uuid: 'user_...'". clerk_uid() reads
+-- the custom 'supabase_uid' claim instead (convention from
+-- 20260401100000_clerk_uid_rls.sql).
+
+-- note_resolutions
+DROP POLICY IF EXISTS "Coordinators insert note_resolutions" ON note_resolutions;
+DROP POLICY IF EXISTS "Coordinators delete note_resolutions" ON note_resolutions;
+
+CREATE POLICY "Coordinators insert note_resolutions" ON note_resolutions FOR INSERT WITH CHECK (
+  project_id IN (SELECT auth_user_coordinator_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+);
+CREATE POLICY "Coordinators delete note_resolutions" ON note_resolutions FOR DELETE USING (
+  project_id IN (SELECT auth_user_coordinator_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+);
+
+-- verdict_acknowledgments
+DROP POLICY IF EXISTS "Coordinators can update verdict_acknowledgments" ON verdict_acknowledgments;
+
+CREATE POLICY "Coordinators can update verdict_acknowledgments" ON verdict_acknowledgments
+  FOR UPDATE USING (
+    review_id IN (
+      SELECT id FROM reviews
+      WHERE project_id IN (SELECT auth_user_coordinator_project_ids())
+         OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+    )
+  );


### PR DESCRIPTION
## Summary

Fix do erro `invalid input syntax for type uuid: \"user_3Bjcgp...\"` que voltou após o PR #54. As policies novas de `note_resolutions` e `verdict_acknowledgments` usavam `auth.uid()` no branch OR, que sob Clerk third-party auth falha com o Clerk ID (`user_...`) não-castável a UUID.

Convenção do schema (`20260401100000_clerk_uid_rls.sql`) é usar `clerk_uid()`, que lê o claim custom `supabase_uid` como UUID.

## Migrations

Antes do merge, rodar:

\`\`\`bash
cd frontend && export SUPABASE_ACCESS_TOKEN=\$(grep SUPABASE_ACCESS_TOKEN .env.local | cut -d= -f2) && npx supabase db push
\`\`\`

Adiciona:
- \`20260422010000_fix_resolutions_use_clerk_uid.sql\` — drop & recreate das 3 policies com \`clerk_uid()\`.

## Test plan

- [ ] Coordenador resolve nota (✓) na aba Comentários → sem erro de UUID
- [ ] Coordenador reabre nota (↺) → sem erro
- [ ] Coordenador resolve dúvida do gabarito (✓) → sem erro
- [ ] Coordenador reabre dúvida (↺) → sem erro
- [ ] Respondente ainda consegue atualizar o próprio acknowledgment em Meu Gabarito (policy existente não foi tocada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)