### PR TITLE
feat: pydantic_code como fonte de verdade completa do schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Browser  →  Next.js 16 (Vercel)  ←→  Supabase (Postgres + RLS)
 - Supabase client: `lib/supabase/server.ts` (server, autenticado via Clerk JWT) e `lib/supabase/admin.ts` (service key)
 - **FastAPI** so para LLM e Pydantic (nao para CRUD)
 - **EditFieldDialog**: toda config de schema acessivel na aba Schema deve ser igualmente acessivel via `EditFieldDialog` inline (Comentarios e LLM Insights). Ao adicionar um campo novo a `PydanticField`, garantir que ambos os editores (FieldCard e EditFieldDialog) o exponham.
+- **Pydantic = fonte de verdade do schema**: toda propriedade de `PydanticField` (definida em `frontend/src/lib/types.ts`) deve ser transportada no codigo Pydantic gerado — via annotation, `Field(...)` ou `json_schema_extra={...}`. E proibido depender apenas do JSON em `projects.pydantic_fields` para reconstruir um campo. Motivo: permitir que coordenadores editem o codigo Pydantic direto sem perder informacao, alem de garantir round-trip completo `UI -> pydantic_code -> compile_pydantic -> UI`. Ao adicionar um campo novo a `PydanticField`, atualize (a) `generatePydanticCode()` em `frontend/src/lib/schema-utils.ts` para emitir a propriedade e (b) `compile_pydantic()` em `backend/services/pydantic_compiler.py` para le-la de volta.
 - Testes: **Vitest** (frontend), **pytest** (backend)
 
 ## Estrutura

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,3 +19,7 @@ dependencies = [
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -12,7 +12,7 @@ from collections import Counter
 
 import pandas as pd
 from services.supabase_client import get_supabase
-from services.pydantic_compiler import compile_pydantic
+from services.pydantic_compiler import compile_pydantic, find_root_model
 
 # In-memory job tracking
 _jobs: dict[str, dict] = {}
@@ -49,16 +49,7 @@ def _compile_model(pydantic_code: str):
     namespace: dict = {}
     compiled = compile(pydantic_code, "<pydantic_schema>", "exec")  # noqa: S102
     _run_compiled(compiled, namespace)
-
-    from pydantic import BaseModel
-    # Pick the last BaseModel subclass: by convention (and by how the frontend
-    # generates code), nested subfield classes are defined before the main
-    # Analysis model, so the root class is always the last one in namespace.
-    model_class = None
-    for obj in namespace.values():
-        if isinstance(obj, type) and issubclass(obj, BaseModel) and obj is not BaseModel:
-            model_class = obj
-    return model_class
+    return find_root_model(namespace)
 
 
 def _run_compiled(compiled_code: object, namespace: dict) -> None:

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -51,10 +51,14 @@ def _compile_model(pydantic_code: str):
     _run_compiled(compiled, namespace)
 
     from pydantic import BaseModel
+    # Pick the last BaseModel subclass: by convention (and by how the frontend
+    # generates code), nested subfield classes are defined before the main
+    # Analysis model, so the root class is always the last one in namespace.
+    model_class = None
     for obj in namespace.values():
         if isinstance(obj, type) and issubclass(obj, BaseModel) and obj is not BaseModel:
-            return obj
-    return None
+            model_class = obj
+    return model_class
 
 
 def _run_compiled(compiled_code: object, namespace: dict) -> None:

--- a/backend/services/pydantic_compiler.py
+++ b/backend/services/pydantic_compiler.py
@@ -29,7 +29,10 @@ def compile_pydantic(code: str) -> dict:
     except Exception as e:
         return {"valid": False, "fields": [], "model_name": None, "errors": [str(e)]}
 
-    # Find the BaseModel subclass
+    # Find the "main" BaseModel subclass. The frontend-generated code defines
+    # nested BaseModel classes (for subfields) before the main class, so we
+    # iterate all candidates and pick the last one — which matches the
+    # convention of defining the root model after its dependencies.
     from pydantic import BaseModel
 
     model_class = None
@@ -40,7 +43,6 @@ def compile_pydantic(code: str) -> dict:
             and obj is not BaseModel
         ):
             model_class = obj
-            break
 
     if model_class is None:
         return {
@@ -58,15 +60,25 @@ def compile_pydantic(code: str) -> dict:
         extra = field_info.json_schema_extra or {}
         if callable(extra):
             extra = {}
-        target = extra.get("target", "all") if isinstance(extra, dict) else "all"
+        is_dict_extra = isinstance(extra, dict)
+        target = extra.get("target", "all") if is_dict_extra else "all"
         # Allow json_schema_extra to override the inferred field type (e.g. date)
-        explicit_type = extra.get("field_type") if isinstance(extra, dict) else None
+        explicit_type = extra.get("field_type") if is_dict_extra else None
         if explicit_type:
             field_type = explicit_type
         description = field_info.description or field_name
         allow_other = (
-            bool(extra.get("allowOther", False)) if isinstance(extra, dict) else False
+            bool(extra.get("allowOther", False)) if is_dict_extra else False
         )
+        help_text = extra.get("help_text") if is_dict_extra else None
+        subfield_rule = extra.get("subfield_rule") if is_dict_extra else None
+
+        # If help_text was carried structurally, strip the ". Instrucoes: ..."
+        # suffix from description so the returned description is the pure form.
+        if help_text:
+            suffix = f". Instrucoes: {help_text}"
+            if description.endswith(suffix):
+                description = description[: -len(suffix)]
 
         field_dict: dict = {
             "name": field_name,
@@ -77,6 +89,9 @@ def compile_pydantic(code: str) -> dict:
             "hash": _field_hash(field_name, field_type, options, description),
         }
 
+        if help_text:
+            field_dict["help_text"] = help_text
+
         if allow_other and field_type in ("single", "multi"):
             field_dict["allow_other"] = True
 
@@ -84,6 +99,7 @@ def compile_pydantic(code: str) -> dict:
         subfields = _extract_subfields(annotation)
         if subfields:
             field_dict["subfields"] = subfields
+            field_dict["subfield_rule"] = subfield_rule or "all"
 
         fields.append(field_dict)
 

--- a/backend/services/pydantic_compiler.py
+++ b/backend/services/pydantic_compiler.py
@@ -29,20 +29,7 @@ def compile_pydantic(code: str) -> dict:
     except Exception as e:
         return {"valid": False, "fields": [], "model_name": None, "errors": [str(e)]}
 
-    # Find the "main" BaseModel subclass. The frontend-generated code defines
-    # nested BaseModel classes (for subfields) before the main class, so we
-    # iterate all candidates and pick the last one — which matches the
-    # convention of defining the root model after its dependencies.
-    from pydantic import BaseModel
-
-    model_class = None
-    for name, obj in namespace.items():
-        if (
-            isinstance(obj, type)
-            and issubclass(obj, BaseModel)
-            and obj is not BaseModel
-        ):
-            model_class = obj
+    model_class = find_root_model(namespace)
 
     if model_class is None:
         return {
@@ -70,8 +57,14 @@ def compile_pydantic(code: str) -> dict:
         allow_other = (
             bool(extra.get("allowOther", False)) if is_dict_extra else False
         )
-        help_text = extra.get("help_text") if is_dict_extra else None
-        subfield_rule = extra.get("subfield_rule") if is_dict_extra else None
+        help_text_raw = extra.get("help_text") if is_dict_extra else None
+        help_text = help_text_raw.strip() if isinstance(help_text_raw, str) else None
+        if not help_text:
+            help_text = None
+        subfield_rule_raw = extra.get("subfield_rule") if is_dict_extra else None
+        subfield_rule = (
+            subfield_rule_raw.strip() if isinstance(subfield_rule_raw, str) else None
+        ) or None
 
         # If help_text was carried structurally, strip the ". Instrucoes: ..."
         # suffix from description so the returned description is the pure form.
@@ -109,6 +102,51 @@ def compile_pydantic(code: str) -> dict:
         "model_name": model_class.__name__,
         "errors": errors,
     }
+
+
+def find_root_model(namespace: dict):
+    """Return the "main" BaseModel subclass in a namespace, or None.
+
+    Selection rules, in order:
+      1. A class explicitly named "Analysis" (the convention of the frontend
+         generator) — chosen even if not last, so manually-edited code that
+         declares helper classes after the root still works.
+      2. A BaseModel that is not referenced by any other BaseModel's fields —
+         i.e. the "root" of the type graph. Robust against arbitrary class
+         ordering.
+      3. Fallback to the last BaseModel defined, matching the generator's
+         convention of declaring nested classes before the root.
+    """
+    from pydantic import BaseModel
+
+    candidates = [
+        obj
+        for obj in namespace.values()
+        if isinstance(obj, type) and issubclass(obj, BaseModel) and obj is not BaseModel
+    ]
+    if not candidates:
+        return None
+
+    analysis = namespace.get("Analysis")
+    if analysis in candidates:
+        return analysis
+
+    referenced: set[type] = set()
+    for cls in candidates:
+        for field_info in cls.model_fields.values():
+            ann = field_info.annotation
+            if (
+                isinstance(ann, type)
+                and issubclass(ann, BaseModel)
+                and ann is not BaseModel
+                and ann is not cls
+            ):
+                referenced.add(ann)
+    roots = [c for c in candidates if c not in referenced]
+    if len(roots) == 1:
+        return roots[0]
+
+    return candidates[-1]
 
 
 def _field_hash(name: str, field_type: str, options: list[str] | None, description: str) -> str:

--- a/backend/tests/test_pydantic_compiler.py
+++ b/backend/tests/test_pydantic_compiler.py
@@ -1,0 +1,300 @@
+"""Round-trip and robustness tests for services.pydantic_compiler."""
+from pydantic import BaseModel, Field
+
+from services.pydantic_compiler import compile_pydantic, find_root_model
+
+
+def _field(result: dict, name: str) -> dict:
+    for f in result["fields"]:
+        if f["name"] == name:
+            return f
+    raise AssertionError(
+        f"field {name!r} not found in {[f['name'] for f in result['fields']]}"
+    )
+
+
+def test_single_literal_field_round_trip():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    topic: Literal["a", "b"] = Field(description="Topic of the decision")
+'''
+    result = compile_pydantic(code)
+    assert result["valid"], result["errors"]
+    f = _field(result, "topic")
+    assert f["type"] == "single"
+    assert f["options"] == ["a", "b"]
+    assert f["description"] == "Topic of the decision"
+    assert f["target"] == "all"
+    assert "help_text" not in f
+
+
+def test_multi_literal_field_round_trip():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    tags: list[Literal["x", "y", "z"]] = Field(description="Tags")
+'''
+    result = compile_pydantic(code)
+    assert result["valid"], result["errors"]
+    f = _field(result, "tags")
+    assert f["type"] == "multi"
+    assert f["options"] == ["x", "y", "z"]
+
+
+def test_help_text_is_stripped_from_description():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    verdict: Literal["yes", "no"] = Field(
+        description="Outcome. Instrucoes: Considere apenas o dispositivo",
+        json_schema_extra={"help_text": "Considere apenas o dispositivo"},
+    )
+'''
+    result = compile_pydantic(code)
+    f = _field(result, "verdict")
+    assert f["description"] == "Outcome"
+    assert f["help_text"] == "Considere apenas o dispositivo"
+
+
+def test_help_text_whitespace_is_ignored():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    verdict: Literal["yes", "no"] = Field(
+        description="Outcome",
+        json_schema_extra={"help_text": "   "},
+    )
+'''
+    result = compile_pydantic(code)
+    f = _field(result, "verdict")
+    assert f["description"] == "Outcome"
+    assert "help_text" not in f
+
+
+def test_subfield_rule_defaults_to_all():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class _doc_fields(BaseModel):
+    part_a: str = Field(description="Part A")
+    part_b: Optional[str] = Field(default=None, description="Part B")
+
+class Analysis(BaseModel):
+    doc: _doc_fields = Field(description="Document breakdown")
+'''
+    result = compile_pydantic(code)
+    f = _field(result, "doc")
+    assert f["type"] == "text"
+    assert f["subfields"] == [
+        {"key": "part_a", "label": "Part A", "required": True},
+        {"key": "part_b", "label": "Part B", "required": False},
+    ]
+    assert f["subfield_rule"] == "all"
+
+
+def test_subfield_rule_at_least_one_preserved():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class _doc_fields(BaseModel):
+    part_a: Optional[str] = Field(default=None, description="Part A")
+    part_b: Optional[str] = Field(default=None, description="Part B")
+
+class Analysis(BaseModel):
+    doc: _doc_fields = Field(
+        description="Doc",
+        json_schema_extra={"subfield_rule": "at_least_one"},
+    )
+'''
+    result = compile_pydantic(code)
+    f = _field(result, "doc")
+    assert f["subfield_rule"] == "at_least_one"
+
+
+def test_allow_other_preserved_for_single():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    court: Literal["STF", "STJ"] = Field(
+        description="Court",
+        json_schema_extra={"allowOther": True},
+    )
+'''
+    result = compile_pydantic(code)
+    f = _field(result, "court")
+    assert f.get("allow_other") is True
+
+
+def test_date_field_type_override():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    judged_on: str = Field(
+        description="Judgment date. Formato: DD/MM/AAAA (use XX para partes desconhecidas)",
+        json_schema_extra={"field_type": "date"},
+    )
+'''
+    result = compile_pydantic(code)
+    f = _field(result, "judged_on")
+    assert f["type"] == "date"
+
+
+def test_target_preserved():
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class Analysis(BaseModel):
+    headline: str = Field(
+        description="Ementa",
+        json_schema_extra={"target": "ementa"},
+    )
+'''
+    result = compile_pydantic(code)
+    f = _field(result, "headline")
+    assert f["target"] == "ementa"
+
+
+def test_field_hash_stable_across_whitespace_help_text_and_none():
+    """Hash should stay the same whether help_text is absent or empty/whitespace,
+    because in both cases the effective description is identical."""
+    plain = '''from pydantic import BaseModel, Field
+from typing import Literal
+
+class Analysis(BaseModel):
+    x: Literal["a"] = Field(description="Pure description")
+'''
+    whitespace = '''from pydantic import BaseModel, Field
+from typing import Literal
+
+class Analysis(BaseModel):
+    x: Literal["a"] = Field(
+        description="Pure description",
+        json_schema_extra={"help_text": "   "},
+    )
+'''
+    h1 = _field(compile_pydantic(plain), "x")["hash"]
+    h2 = _field(compile_pydantic(whitespace), "x")["hash"]
+    assert h1 == h2
+
+
+def test_field_hash_matches_description_without_suffix():
+    """When help_text is emitted structurally, description returned is pure,
+    and hash is computed over the pure description (not the ". Instrucoes: ..." form)."""
+    with_help = '''from pydantic import BaseModel, Field
+from typing import Literal
+
+class Analysis(BaseModel):
+    x: Literal["a"] = Field(
+        description="Pure. Instrucoes: extra",
+        json_schema_extra={"help_text": "extra"},
+    )
+'''
+    without_help = '''from pydantic import BaseModel, Field
+from typing import Literal
+
+class Analysis(BaseModel):
+    x: Literal["a"] = Field(description="Pure")
+'''
+    h1 = _field(compile_pydantic(with_help), "x")["hash"]
+    h2 = _field(compile_pydantic(without_help), "x")["hash"]
+    assert h1 == h2
+
+
+def test_find_root_model_prefers_analysis_class():
+    class Analysis(BaseModel):
+        pass
+
+    class Helper(BaseModel):
+        pass
+
+    ns = {"Analysis": Analysis, "Helper": Helper}
+    root = find_root_model(ns)
+    assert root is Analysis
+
+
+def test_find_root_model_picks_root_by_graph():
+    """No class named Analysis — the root is the one referencing others."""
+
+    class Leaf(BaseModel):
+        pass
+
+    class Root(BaseModel):
+        child: Leaf = Field(description="x")
+
+    ns = {"Leaf": Leaf, "Root": Root}
+    root = find_root_model(ns)
+    assert root is Root
+
+
+def test_find_root_model_falls_back_to_last_when_ambiguous():
+    """Two independent models — falls back to last-defined."""
+
+    class A(BaseModel):
+        pass
+
+    class B(BaseModel):
+        pass
+
+    ns = {"A": A, "B": B}
+    root = find_root_model(ns)
+    assert root is B
+
+
+def test_find_root_model_analysis_wins_even_when_helpers_defined_after():
+    """Manually edited code: Analysis first, helpers after. Old "last" heuristic
+    would pick the helper; new logic picks Analysis."""
+
+    class Analysis(BaseModel):
+        pass
+
+    class HelperA(BaseModel):
+        pass
+
+    class HelperB(BaseModel):
+        pass
+
+    ns = {"Analysis": Analysis, "HelperA": HelperA, "HelperB": HelperB}
+    root = find_root_model(ns)
+    assert root is Analysis
+
+
+def test_empty_namespace_returns_none():
+    assert find_root_model({}) is None
+
+
+def test_invalid_code_returns_error():
+    result = compile_pydantic("this is not python {{{")
+    assert result["valid"] is False
+    assert result["errors"]
+    assert result["fields"] == []
+
+
+def test_no_basemodel_returns_error():
+    result = compile_pydantic("x = 1\n")
+    assert result["valid"] is False
+    assert "BaseModel" in result["errors"][0]
+
+
+def test_multiline_help_text_round_trips():
+    """compile_pydantic must strip a multi-line suffix correctly when
+    help_text contains newlines."""
+    code = (
+        "from pydantic import BaseModel, Field\n"
+        "from typing import Literal\n\n"
+        "class Analysis(BaseModel):\n"
+        '    x: Literal["a"] = Field(\n'
+        '        description="linha1\\nlinha2. Instrucoes: ins1\\nins2",\n'
+        '        json_schema_extra={"help_text": "ins1\\nins2"},\n'
+        "    )\n"
+    )
+    result = compile_pydantic(code)
+    f = _field(result, "x")
+    assert f["description"] == "linha1\nlinha2"
+    assert f["help_text"] == "ins1\nins2"

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -3,7 +3,12 @@ import type { PydanticField } from "@/lib/types";
 // ---------- Geração de código Pydantic (pure, client-safe) ----------
 
 function escapeString(s: string): string {
-  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
 }
 
 function subfieldClassName(fieldName: string): string {

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -34,6 +34,17 @@ function fieldExtra(field: PydanticField): string {
   if ((field.type === "single" || field.type === "multi") && field.allow_other) {
     extras.push(`"allowOther": True`);
   }
+  if (
+    field.subfields &&
+    field.subfields.length > 0 &&
+    field.subfield_rule &&
+    field.subfield_rule !== "all"
+  ) {
+    extras.push(`"subfield_rule": "${field.subfield_rule}"`);
+  }
+  if (field.help_text?.trim()) {
+    extras.push(`"help_text": "${escapeString(field.help_text.trim())}"`);
+  }
   if (extras.length === 0) return "";
   return `, json_schema_extra={${extras.join(", ")}}`;
 }


### PR DESCRIPTION
## Summary

- `subfield_rule` e `help_text` agora são emitidos no `json_schema_extra` do código Pydantic gerado, além de permanecerem no JSON salvo em `projects.pydantic_fields`. Assim o `pydantic_code` contém todas as propriedades editáveis na UI e permite edição manual do schema + round-trip `UI → pydantic_code → compile_pydantic → UI` sem perda.
- `CLAUDE.md` recebe a regra arquitetural: toda nova propriedade de `PydanticField` deve ser transportada no código Pydantic gerado (via annotation, `Field(...)` ou `json_schema_extra`), mantendo o Pydantic como fonte de verdade.
- Correção de bug latente: `compile_pydantic()` e `_compile_model()` (llm_runner) selecionavam a **primeira** `BaseModel` do namespace. Com subfields, o gerador define a classe nested antes da `Analysis`, então a classe errada era escolhida — o LLM roda contra o schema errado e o Code→GUI devolvia os campos dos subfields. Passam a pegar a **última** `BaseModel`, alinhado com a convenção do gerador.

## Design notes

- `help_text` continua sendo concatenado na `description` (`". Instrucoes: ..."`) para que o LLM siga recebendo a instrução no prompt — a presença estruturada em `json_schema_extra` é adicional e garante reconstrução limpa. O compilador remove o sufixo da `description` quando `help_text` está em `json_schema_extra`.
- `subfield_rule` só é emitido quando diferente do default `"all"`, mantendo o código Pydantic enxuto no caso comum.
- `hash` continua sendo regenerado determinísticamente no backend — intencional para evitar divergência se alguém editar o código sem recalcular.

## Test plan

- [x] `npx tsc --noEmit` no frontend
- [x] `npm run lint` — sem novos warnings/errors em `schema-utils.ts`
- [x] Round-trip manual: `generatePydanticCode()` → `compile_pydantic()` retorna `subfield_rule`, `help_text`, `description` limpa, `model_name="Analysis"`
- [ ] QA manual na UI: criar projeto com subfields + `subfield_rule=at_least_one` + `help_text`, salvar, recarregar aba Schema, confirmar que valores persistem
- [ ] QA manual: alterar `pydantic_code` via SQL (mudar `subfield_rule`) e confirmar que a UI reflete a mudança após reload
- [ ] Rodar um LLM run em projeto de teste e conferir que o prompt continua incluindo `". Instrucoes: ..."` na descrição

🤖 Generated with [Claude Code](https://claude.com/claude-code)