### PR TITLE
fix: React error #310 em /projects/[id]/my-progress

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,7 +28,7 @@
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^4.7.3",
-        "recharts": "^3.7.0",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "svix": "^1.89.0",
         "tailwind-merge": "^3.5.0",
@@ -11454,9 +11454,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
+      "integrity": "sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==",
       "license": "MIT"
     },
     "node_modules/react-markdown": {
@@ -11606,15 +11606,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.7.0.tgz",
-      "integrity": "sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
       "license": "MIT",
       "workspaces": [
         "www"
       ],
       "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,11 +29,14 @@
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.7.3",
-    "recharts": "^3.7.0",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "svix": "^1.89.0",
     "tailwind-merge": "^3.5.0",
     "xlsx": "^0.18.5"
+  },
+  "overrides": {
+    "react-is": "19.2.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/frontend/src/components/progress/ActivityCalendar.tsx
+++ b/frontend/src/components/progress/ActivityCalendar.tsx
@@ -79,7 +79,7 @@ export function ActivityCalendar({ activityMap }: ActivityCalendarProps) {
               {Array.from({ length: 7 }, (_, di) => {
                 const entry = week[di];
                 if (!entry || entry.count === -1) {
-                  return <div key={di} className="h-3 w-3" />;
+                  return <div key={`pad-${wi}-${di}`} className="h-3 w-3" />;
                 }
                 const d = new Date(entry.date + "T00:00:00");
                 const formatted = d.toLocaleDateString("pt-BR", {
@@ -87,7 +87,7 @@ export function ActivityCalendar({ activityMap }: ActivityCalendarProps) {
                   month: "short",
                 });
                 return (
-                  <Tooltip key={di}>
+                  <Tooltip key={entry.date}>
                     <TooltipTrigger asChild>
                       <div
                         className={cn(

--- a/frontend/src/components/progress/DailyPaceChart.tsx
+++ b/frontend/src/components/progress/DailyPaceChart.tsx
@@ -61,19 +61,25 @@ const DailyPaceChartInner = dynamic(
                 dot={{ r: 3 }}
                 activeDot={{ r: 5 }}
               />
-              {requiredPace !== null && requiredPace > 0 && (
-                <ReferenceLine
-                  y={requiredPace}
-                  stroke="hsl(var(--destructive))"
-                  strokeDasharray="5 5"
-                  label={{
-                    value: `Meta: ${requiredPace}/dia`,
-                    position: "insideTopRight",
-                    fontSize: 11,
-                    fill: "hsl(var(--destructive))",
-                  }}
-                />
-              )}
+              <ReferenceLine
+                y={requiredPace !== null && requiredPace > 0 ? requiredPace : 0}
+                stroke={
+                  requiredPace !== null && requiredPace > 0
+                    ? "hsl(var(--destructive))"
+                    : "transparent"
+                }
+                strokeDasharray="5 5"
+                label={
+                  requiredPace !== null && requiredPace > 0
+                    ? {
+                        value: `Meta: ${requiredPace}/dia`,
+                        position: "insideTopRight",
+                        fontSize: 11,
+                        fill: "hsl(var(--destructive))",
+                      }
+                    : undefined
+                }
+              />
             </LineChart>
           </ResponsiveContainer>
         );


### PR DESCRIPTION
## Summary

Ao carregar a aba **Meu Progresso** o browser disparava `Minified React error #310` ("Rendered more hooks than during the previous render"), quebrando a renderização do `DailyPaceChart`.

**Causa raiz:** `recharts@3.7.0` trazia transitivo `react-is@16.13.1`, incompatível com React 19.2.3 — `react-is` v16 não reconhece alguns symbols internos do React 19, então recharts classifica os children do `<LineChart>` de forma diferente entre SSR e hydration. O `<ReferenceLine>` renderizado **condicionalmente** em `DailyPaceChart.tsx:64-76` amplificava o descompasso no número de hooks.

## Changes

- `frontend/package.json`: `overrides.react-is = "19.2.3"` + bump `recharts ^3.7.0 → ^3.8.1`.
- `frontend/src/components/progress/DailyPaceChart.tsx`: `<ReferenceLine>` agora é sempre renderizado — quando não há `requiredPace`, fica com `stroke="transparent"` e sem label. Shape de children do `<LineChart>` estável entre renders.
- `frontend/src/components/progress/ActivityCalendar.tsx`: key por `entry.date` (e `pad-${wi}-${di}` para células vazias) em vez de índice, evitando remontagem de `Tooltip` Radix quando o `activityMap` mudar.

`npm ls react-is` agora retorna só `19.2.3` em todas as árvores, e `recharts@3.8.1` dedup dessa versão.

## Test plan

- [ ] `cd frontend && npm run build` — passou localmente.
- [ ] Abrir `/projects/<id>/my-progress` em um projeto com deadline e conferir que a linha tracejada vermelha de "Meta" aparece.
- [ ] Abrir em um projeto sem deadline e conferir que o chart renderiza (sem linha de meta) e não há erro no console.
- [ ] Conferir tooltips do calendário de atividade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)