### PR TITLE
feat: registro persistente de erros de LLM

### DIFF
--- a/backend/routes/llm_routes.py
+++ b/backend/routes/llm_routes.py
@@ -40,6 +40,10 @@ class StatusResponse(BaseModel):
     error_type: str | None = None
     error_line: int | None = None
     error_column: int | None = None
+    # Snapshot of the pydantic_code used in this run — sent with errors so the
+    # frontend can render the code window against the actual failed version,
+    # not the project's current (possibly edited) code.
+    pydantic_code: str | None = None
 
 
 @router.post("/run", response_model=RunResponse)

--- a/backend/routes/llm_routes.py
+++ b/backend/routes/llm_routes.py
@@ -35,6 +35,11 @@ class StatusResponse(BaseModel):
     eta_seconds: float | None = None
     current_batch: int = 0
     total_batches: int = 0
+    # Populated only when status == "error"
+    error_traceback: str | None = None
+    error_type: str | None = None
+    error_line: int | None = None
+    error_column: int | None = None
 
 
 @router.post("/run", response_model=RunResponse)

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _jobs: dict[str, dict] = {}
 
 
-def _error_status_from_row(row: dict) -> dict:
+def _status_from_row(row: dict) -> dict:
     """Shape a llm_runs row as a StatusResponse-compatible dict."""
     return {
         "status": row.get("status", "error"),
@@ -40,6 +40,7 @@ def _error_status_from_row(row: dict) -> dict:
         "error_type": row.get("error_type"),
         "error_line": row.get("error_line"),
         "error_column": row.get("error_column"),
+        "pydantic_code": row.get("pydantic_code"),
     }
 
 
@@ -52,14 +53,14 @@ def get_job_status(job_id: str) -> dict:
         row = (
             sb.table("llm_runs")
             .select("status, phase, progress, total, error_message, error_type, "
-                    "error_traceback, error_line, error_column")
+                    "error_traceback, error_line, error_column, pydantic_code")
             .eq("job_id", job_id)
             .maybe_single()
             .execute()
             .data
         )
         if row:
-            return _error_status_from_row(row)
+            return _status_from_row(row)
     except Exception:
         logger.exception("Failed to fetch job status from llm_runs fallback")
     return {"status": "error", "phase": "error", "progress": 0, "total": 0,
@@ -251,6 +252,7 @@ async def run_llm(
         "current_batch": 0, "total_batches": 0,
         "error_traceback": None, "error_type": None,
         "error_line": None, "error_column": None,
+        "pydantic_code": None,
     }
     _persist_run_insert(sb, job_id, project_id, filter_mode)
 
@@ -291,6 +293,7 @@ async def run_llm(
         docs = _filter_docs(sb, docs, project_id, filter_mode, max_response_count, sample_size)
 
         _jobs[job_id]["total"] = len(docs)
+        _jobs[job_id]["pydantic_code"] = pydantic_code
         _persist_run_snapshot(sb, job_id, project, len(docs))
 
         if not docs:

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -6,25 +6,135 @@ This is intentional — only authenticated coordinators can define schemas.
 The backend runs in an isolated container.
 """
 import hashlib
+import logging
 import random
+import re
 import time
+import traceback
 from collections import Counter
+from datetime import datetime, timezone
 
 import pandas as pd
 from services.condition_evaluator import evaluate_condition, extract_field_conditions
 from services.supabase_client import get_supabase
 from services.pydantic_compiler import compile_pydantic, find_root_model
 
+logger = logging.getLogger(__name__)
+
 # In-memory job tracking
 _jobs: dict[str, dict] = {}
 
 
+def _error_status_from_row(row: dict) -> dict:
+    """Shape a llm_runs row as a StatusResponse-compatible dict."""
+    return {
+        "status": row.get("status", "error"),
+        "phase": row.get("phase", "error"),
+        "progress": row.get("progress") or 0,
+        "total": row.get("total") or 0,
+        "errors": [row["error_message"]] if row.get("error_message") else [],
+        "eta_seconds": None,
+        "current_batch": 0,
+        "total_batches": 0,
+        "error_traceback": row.get("error_traceback"),
+        "error_type": row.get("error_type"),
+        "error_line": row.get("error_line"),
+        "error_column": row.get("error_column"),
+    }
+
+
 def get_job_status(job_id: str) -> dict:
-    if job_id not in _jobs:
-        return {"status": "error", "phase": "error", "progress": 0, "total": 0,
-                "errors": ["Job not found"], "eta_seconds": None,
-                "current_batch": 0, "total_batches": 0}
-    return _jobs[job_id]
+    if job_id in _jobs:
+        return _jobs[job_id]
+    # Fallback: job vanished from memory (container restart) but may exist in DB.
+    try:
+        sb = get_supabase()
+        row = (
+            sb.table("llm_runs")
+            .select("status, phase, progress, total, error_message, error_type, "
+                    "error_traceback, error_line, error_column")
+            .eq("job_id", job_id)
+            .maybe_single()
+            .execute()
+            .data
+        )
+        if row:
+            return _error_status_from_row(row)
+    except Exception:
+        logger.exception("Failed to fetch job status from llm_runs fallback")
+    return {"status": "error", "phase": "error", "progress": 0, "total": 0,
+            "errors": ["Job not found"], "eta_seconds": None,
+            "current_batch": 0, "total_batches": 0}
+
+
+def _extract_pydantic_location(exc: Exception, tb: str) -> tuple[int | None, int | None]:
+    """Best-effort line/column inside pydantic_code where the error originated."""
+    if isinstance(exc, SyntaxError) and exc.filename in (None, "<pydantic_schema>"):
+        return exc.lineno, exc.offset
+    m = re.search(r'File "<pydantic_schema>", line (\d+)', tb)
+    if m:
+        return int(m.group(1)), None
+    return None, None
+
+
+def _persist_run_insert(sb, job_id: str, project_id: str, filter_mode: str) -> None:
+    """Insert the initial 'running' row as soon as the job starts."""
+    try:
+        sb.table("llm_runs").insert({
+            "job_id": job_id,
+            "project_id": project_id,
+            "filter_mode": filter_mode,
+            "status": "running",
+            "phase": "loading",
+        }).execute()
+    except Exception:
+        logger.exception("Failed to INSERT llm_runs row for job %s", job_id)
+
+
+def _persist_run_snapshot(
+    sb, job_id: str, project: dict, doc_count: int
+) -> None:
+    """Backfill provider/model/pydantic snapshot after the project is loaded."""
+    try:
+        sb.table("llm_runs").update({
+            "llm_provider": project.get("llm_provider"),
+            "llm_model": project.get("llm_model"),
+            "document_count": doc_count,
+            "pydantic_code": project.get("pydantic_code"),
+        }).eq("job_id", job_id).execute()
+    except Exception:
+        logger.exception("Failed to UPDATE llm_runs snapshot for job %s", job_id)
+
+
+def _persist_run_completion(sb, job_id: str, progress: int, total: int) -> None:
+    try:
+        sb.table("llm_runs").update({
+            "status": "completed",
+            "phase": "completed",
+            "progress": progress,
+            "total": total,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+        }).eq("job_id", job_id).execute()
+    except Exception:
+        logger.exception("Failed to UPDATE llm_runs completion for job %s", job_id)
+
+
+def _persist_run_error(sb, job_id: str, exc: Exception, tb: str) -> tuple[int | None, int | None]:
+    line, col = _extract_pydantic_location(exc, tb)
+    try:
+        sb.table("llm_runs").update({
+            "status": "error",
+            "phase": "error",
+            "error_message": str(exc),
+            "error_type": type(exc).__name__,
+            "error_traceback": tb,
+            "error_line": line,
+            "error_column": col,
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+        }).eq("job_id", job_id).execute()
+    except Exception:
+        logger.exception("Failed to UPDATE llm_runs error for job %s", job_id)
+    return line, col
 
 
 def _extend_model_with_justifications(model_class):
@@ -139,7 +249,10 @@ async def run_llm(
         "status": "running", "phase": "loading", "progress": 0, "total": 0,
         "errors": [], "started_at": time.time(), "eta_seconds": None,
         "current_batch": 0, "total_batches": 0,
+        "error_traceback": None, "error_type": None,
+        "error_line": None, "error_column": None,
     }
+    _persist_run_insert(sb, job_id, project_id, filter_mode)
 
     try:
         # Load project (only needed columns)
@@ -178,16 +291,17 @@ async def run_llm(
         docs = _filter_docs(sb, docs, project_id, filter_mode, max_response_count, sample_size)
 
         _jobs[job_id]["total"] = len(docs)
+        _persist_run_snapshot(sb, job_id, project, len(docs))
 
         if not docs:
             _jobs[job_id]["status"] = "completed"
+            _persist_run_completion(sb, job_id, 0, 0)
             return
 
         # Compile Pydantic model
         model_class = _compile_model(pydantic_code)
         if not model_class:
-            _jobs[job_id] = {"status": "error", "progress": 0, "total": 0, "errors": ["No BaseModel found"]}
-            return
+            raise RuntimeError("Nenhuma classe BaseModel encontrada no código Pydantic.")
 
         # Optionally extend model with justification fields
         include_justifications = llm_kwargs.pop("include_justifications", False)
@@ -306,11 +420,21 @@ async def run_llm(
         sb.table("projects").update({"pydantic_hash": pydantic_hash}).eq("id", project_id).execute()
 
         _jobs[job_id].update(status="completed", phase="completed", eta_seconds=0)
+        _persist_run_completion(
+            sb, job_id, _jobs[job_id]["progress"], _jobs[job_id]["total"]
+        )
 
     except Exception as e:
+        tb = traceback.format_exc()
+        line, col = _persist_run_error(sb, job_id, e, tb)
         _jobs[job_id]["status"] = "error"
         _jobs[job_id]["phase"] = "error"
         _jobs[job_id]["errors"].append(str(e))
+        _jobs[job_id]["error_type"] = type(e).__name__
+        _jobs[job_id]["error_traceback"] = tb
+        _jobs[job_id]["error_line"] = line
+        _jobs[job_id]["error_column"] = col
+        logger.exception("LLM run %s failed", job_id)
 
 
 async def run_llm_fields(

--- a/backend/tests/test_llm_error_location.py
+++ b/backend/tests/test_llm_error_location.py
@@ -1,0 +1,36 @@
+"""Unit tests for _extract_pydantic_location in services.llm_runner."""
+from services.llm_runner import _extract_pydantic_location
+
+
+def test_syntax_error_returns_line_and_column():
+    try:
+        compile('x = "hello\n', "<pydantic_schema>", "exec")
+    except SyntaxError as e:
+        line, col = _extract_pydantic_location(e, "")
+        assert line == e.lineno
+        assert col == e.offset
+
+
+def test_traceback_with_pydantic_schema_frame_extracts_line():
+    fake_tb = (
+        'Traceback (most recent call last):\n'
+        '  File "services/llm_runner.py", line 311, in run_llm\n'
+        '    model_class = _compile_model(pydantic_code)\n'
+        '  File "<pydantic_schema>", line 7, in <module>\n'
+        '    tipo: Literal["a\\q"]\n'
+        "re.error: bad escape \\q at position 0\n"
+    )
+    line, col = _extract_pydantic_location(ValueError("bad escape"), fake_tb)
+    assert line == 7
+    assert col is None
+
+
+def test_unrelated_traceback_returns_none():
+    fake_tb = (
+        'Traceback (most recent call last):\n'
+        '  File "services/other.py", line 42, in foo\n'
+        "ValueError: unrelated\n"
+    )
+    line, col = _extract_pydantic_location(ValueError("x"), fake_tb)
+    assert line is None
+    assert col is None

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -58,47 +58,45 @@ export interface DocSelectionItem {
   llmResponseCount: number;
 }
 
-export interface LlmRunHistoryItem {
-  respondent_name: string;
-  docCount: number;
-  latestAt: string;
+export interface LlmRunRecord {
+  id: string;
+  job_id: string;
+  status: "running" | "completed" | "error";
+  phase: string | null;
+  llm_provider: string | null;
+  llm_model: string | null;
+  filter_mode: string | null;
+  document_count: number | null;
+  progress: number;
+  total: number;
+  pydantic_code: string | null;
+  error_message: string | null;
+  error_type: string | null;
+  error_traceback: string | null;
+  error_line: number | null;
+  error_column: number | null;
+  started_at: string;
+  completed_at: string | null;
 }
 
-export async function getLlmRunHistory(
-  projectId: string
-): Promise<LlmRunHistoryItem[]> {
+export async function getLlmRuns(
+  projectId: string,
+  limit = 20
+): Promise<LlmRunRecord[]> {
   const supabase = await createSupabaseServer();
 
-  const { data: responses } = await supabase
-    .from("responses")
-    .select("respondent_name, document_id, created_at")
+  const { data } = await supabase
+    .from("llm_runs")
+    .select(
+      "id, job_id, status, phase, llm_provider, llm_model, filter_mode, " +
+        "document_count, progress, total, pydantic_code, error_message, " +
+        "error_type, error_traceback, error_line, error_column, started_at, completed_at"
+    )
     .eq("project_id", projectId)
-    .eq("respondent_type", "llm")
-    .eq("is_current", true);
+    .order("started_at", { ascending: false })
+    .limit(limit);
 
-  if (!responses || responses.length === 0) return [];
-
-  const groups = new Map<
-    string,
-    { docs: Set<string>; latestAt: string }
-  >();
-  for (const r of responses) {
-    const name = r.respondent_name ?? "unknown";
-    if (!groups.has(name)) {
-      groups.set(name, { docs: new Set(), latestAt: r.created_at });
-    }
-    const g = groups.get(name)!;
-    g.docs.add(r.document_id);
-    if (r.created_at > g.latestAt) g.latestAt = r.created_at;
-  }
-
-  return [...groups.entries()]
-    .map(([name, g]) => ({
-      respondent_name: name,
-      docCount: g.docs.size,
-      latestAt: g.latestAt,
-    }))
-    .sort((a, b) => b.latestAt.localeCompare(a.latestAt));
+  return (data ?? []) as unknown as LlmRunRecord[];
 }
 
 export async function getDocumentsForSelection(

--- a/frontend/src/app/(app)/projects/[id]/config/llm/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/llm/page.tsx
@@ -1,6 +1,6 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { LlmTab } from "@/components/llm/LlmTab";
-import { getLlmRunHistory } from "@/actions/llm";
+import { getLlmRuns } from "@/actions/llm";
 import type { PydanticField } from "@/lib/types";
 
 export default async function LlmConfigPage({
@@ -11,12 +11,12 @@ export default async function LlmConfigPage({
   const { id } = await params;
   const supabase = await createSupabaseServer();
 
-  const [{ data: project }, { count: totalDocs }, { data: llmResponses }, runHistory] =
+  const [{ data: project }, { count: totalDocs }, { data: llmResponses }, runs] =
     await Promise.all([
       supabase
         .from("projects")
         .select(
-          "prompt_template, description, llm_provider, llm_model, llm_kwargs, pydantic_fields"
+          "prompt_template, description, llm_provider, llm_model, llm_kwargs, pydantic_fields, pydantic_code"
         )
         .eq("id", id)
         .single(),
@@ -30,7 +30,7 @@ export default async function LlmConfigPage({
         .eq("project_id", id)
         .eq("respondent_type", "llm")
         .eq("is_current", true),
-      getLlmRunHistory(id),
+      getLlmRuns(id),
     ]);
 
   const docsWithLlm = new Set(llmResponses?.map((r) => r.document_id)).size;
@@ -50,9 +50,10 @@ export default async function LlmConfigPage({
           },
       }}
       pydanticFields={(project?.pydantic_fields as PydanticField[]) || null}
+      pydanticCode={(project?.pydantic_code as string | null) ?? null}
       totalDocs={totalDocs ?? 0}
       docsWithLlm={docsWithLlm}
-      runHistory={runHistory}
+      runs={runs}
     />
   );
 }

--- a/frontend/src/components/llm/LlmErrorCard.tsx
+++ b/frontend/src/components/llm/LlmErrorCard.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/collapsible";
 import { AlertCircle, ChevronRight, Copy, X, Check } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 
 export interface LlmErrorInfo {
   message: string;
@@ -133,11 +134,17 @@ export function LlmErrorCard({ id, error, onDismiss }: LlmErrorCardProps) {
                       key={l.lineNumber}
                       className={
                         l.highlighted
-                          ? "bg-destructive/10"
+                          ? "bg-destructive/20"
                           : "hover:bg-muted/30"
                       }
                     >
-                      <td className="select-none border-r px-2 py-0.5 text-right text-muted-foreground">
+                      <td
+                        className={cn(
+                          "select-none border-r px-2 py-0.5 text-right text-muted-foreground",
+                          l.highlighted &&
+                            "border-l-2 border-l-destructive font-medium text-destructive"
+                        )}
+                      >
                         {l.lineNumber}
                       </td>
                       <td className="whitespace-pre px-2 py-0.5">

--- a/frontend/src/components/llm/LlmErrorCard.tsx
+++ b/frontend/src/components/llm/LlmErrorCard.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { AlertCircle, ChevronRight, Copy, X, Check } from "lucide-react";
+import { toast } from "sonner";
+
+export interface LlmErrorInfo {
+  message: string;
+  type: string | null;
+  traceback: string | null;
+  line: number | null;
+  column: number | null;
+  pydanticCode: string | null;
+}
+
+interface LlmErrorCardProps {
+  id?: string;
+  error: LlmErrorInfo;
+  onDismiss: () => void;
+}
+
+function getCodeWindow(
+  code: string,
+  targetLine: number,
+  radius = 3
+): { lineNumber: number; text: string; highlighted: boolean }[] {
+  const lines = code.split("\n");
+  const start = Math.max(1, targetLine - radius);
+  const end = Math.min(lines.length, targetLine + radius);
+  const out: { lineNumber: number; text: string; highlighted: boolean }[] = [];
+  for (let i = start; i <= end; i++) {
+    out.push({
+      lineNumber: i,
+      text: lines[i - 1] ?? "",
+      highlighted: i === targetLine,
+    });
+  }
+  return out;
+}
+
+export function LlmErrorCard({ id, error, onDismiss }: LlmErrorCardProps) {
+  const [copied, setCopied] = useState(false);
+
+  const codeWindow =
+    error.line && error.pydanticCode
+      ? getCodeWindow(error.pydanticCode, error.line)
+      : null;
+
+  const handleCopy = async () => {
+    const parts: string[] = [];
+    if (error.type) parts.push(`Tipo: ${error.type}`);
+    parts.push(`Mensagem: ${error.message}`);
+    if (error.line) {
+      parts.push(
+        `Local: linha ${error.line}${
+          error.column != null ? `, coluna ${error.column}` : ""
+        } do código Pydantic`
+      );
+    }
+    if (codeWindow) {
+      parts.push("", "Trecho:");
+      for (const l of codeWindow) {
+        parts.push(`${l.highlighted ? ">>" : "  "} ${l.lineNumber} | ${l.text}`);
+      }
+    }
+    if (error.traceback) parts.push("", "Traceback:", error.traceback);
+    try {
+      await navigator.clipboard.writeText(parts.join("\n"));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Não foi possível copiar para a área de transferência.");
+    }
+  };
+
+  return (
+    <Card
+      id={id}
+      className="border-destructive/40 bg-destructive/5"
+    >
+      <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0 pb-3">
+        <div className="flex items-start gap-2">
+          <AlertCircle className="h-5 w-5 shrink-0 text-destructive" />
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Badge variant="destructive">{error.type ?? "Erro"}</Badge>
+              {error.line != null && (
+                <span className="text-xs text-muted-foreground">
+                  linha {error.line}
+                  {error.column != null ? `, coluna ${error.column}` : ""}
+                </span>
+              )}
+            </div>
+            <p className="text-sm font-medium leading-snug">
+              Falha ao rodar o LLM
+            </p>
+          </div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onDismiss}
+          aria-label="Fechar"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </CardHeader>
+
+      <CardContent className="space-y-3">
+        <pre className="whitespace-pre-wrap rounded-md border bg-background p-3 text-xs font-mono">
+          {error.message}
+        </pre>
+
+        {codeWindow && (
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">
+              Trecho do código Pydantic
+            </p>
+            <div className="overflow-x-auto rounded-md border bg-background font-mono text-xs">
+              <table className="w-full border-collapse">
+                <tbody>
+                  {codeWindow.map((l) => (
+                    <tr
+                      key={l.lineNumber}
+                      className={
+                        l.highlighted
+                          ? "bg-destructive/10"
+                          : "hover:bg-muted/30"
+                      }
+                    >
+                      <td className="select-none border-r px-2 py-0.5 text-right text-muted-foreground">
+                        {l.lineNumber}
+                      </td>
+                      <td className="whitespace-pre px-2 py-0.5">
+                        {l.text || " "}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        {error.traceback && (
+          <Collapsible>
+            <CollapsibleTrigger className="group flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground">
+              <ChevronRight className="h-3 w-3 transition-transform group-data-[state=open]:rotate-90" />
+              Stack trace completo
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <pre className="mt-2 max-h-72 overflow-auto rounded-md border bg-background p-3 text-[11px] font-mono text-muted-foreground">
+                {error.traceback}
+              </pre>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+
+        <div className="flex gap-2 pt-1">
+          <Button size="sm" variant="outline" onClick={handleCopy}>
+            {copied ? (
+              <>
+                <Check className="mr-1.5 h-3.5 w-3.5" /> Copiado
+              </>
+            ) : (
+              <>
+                <Copy className="mr-1.5 h-3.5 w-3.5" /> Copiar diagnóstico
+              </>
+            )}
+          </Button>
+          <Button size="sm" variant="ghost" onClick={onDismiss}>
+            Fechar
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/llm/LlmRunHistory.tsx
+++ b/frontend/src/components/llm/LlmRunHistory.tsx
@@ -28,6 +28,18 @@ function formatModelOrDash(provider: string | null, model: string | null): strin
   return formatModelLabel(`${provider}/${model}`);
 }
 
+const FILTER_LABELS: Record<string, string> = {
+  all: "Todos",
+  pending: "Pendentes",
+  max_responses: "Até N respostas",
+  random_sample: "Amostra aleatória",
+};
+
+function formatFilterMode(mode: string | null): string {
+  if (!mode) return "—";
+  return FILTER_LABELS[mode] ?? mode;
+}
+
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleDateString("pt-BR", {
     day: "2-digit",
@@ -125,7 +137,7 @@ export function LlmRunHistory({
                       {formatModelOrDash(run.llm_provider, run.llm_model)}
                     </td>
                     <td className="px-3 py-2 text-muted-foreground">
-                      {run.filter_mode ?? "—"}
+                      {formatFilterMode(run.filter_mode)}
                     </td>
                     <td className="px-3 py-2 text-right text-muted-foreground">
                       {run.document_count ?? "—"}

--- a/frontend/src/components/llm/LlmRunHistory.tsx
+++ b/frontend/src/components/llm/LlmRunHistory.tsx
@@ -6,53 +6,136 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { ChevronRight, History } from "lucide-react";
-import type { LlmRunHistoryItem } from "@/actions/llm";
+import { Badge } from "@/components/ui/badge";
+import {
+  ChevronRight,
+  History,
+  CheckCircle2,
+  XCircle,
+  Loader2,
+} from "lucide-react";
+import type { LlmRunRecord } from "@/actions/llm";
+import type { LlmErrorInfo } from "./LlmErrorCard";
 
 interface LlmRunHistoryProps {
-  history: LlmRunHistoryItem[];
+  runs: LlmRunRecord[];
+  pydanticCode: string | null;
+  onOpenError: (err: LlmErrorInfo) => void;
 }
 
-export function LlmRunHistory({ history }: LlmRunHistoryProps) {
-  if (history.length === 0) return null;
+function formatModelOrDash(provider: string | null, model: string | null): string {
+  if (!provider || !model) return "—";
+  return formatModelLabel(`${provider}/${model}`);
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function StatusIcon({ status }: { status: LlmRunRecord["status"] }) {
+  if (status === "completed")
+    return (
+      <CheckCircle2
+        className="h-4 w-4 text-emerald-600"
+        aria-label="Concluído"
+      />
+    );
+  if (status === "error")
+    return <XCircle className="h-4 w-4 text-destructive" aria-label="Erro" />;
+  return (
+    <Loader2
+      className="h-4 w-4 animate-spin text-muted-foreground"
+      aria-label="Em execução"
+    />
+  );
+}
+
+export function LlmRunHistory({
+  runs,
+  pydanticCode,
+  onOpenError,
+}: LlmRunHistoryProps) {
+  if (runs.length === 0) return null;
+
+  const errorCount = runs.filter((r) => r.status === "error").length;
 
   return (
-    <Collapsible>
-      <CollapsibleTrigger className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors group">
+    <Collapsible defaultOpen={errorCount > 0}>
+      <CollapsibleTrigger className="group flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground">
         <ChevronRight className="h-3.5 w-3.5 transition-transform group-data-[state=open]:rotate-90" />
         <History className="h-3.5 w-3.5" />
-        Histórico de execuções ({history.length})
+        Histórico de execuções ({runs.length})
+        {errorCount > 0 && (
+          <Badge variant="destructive" className="ml-1 h-5 px-1.5 text-[10px]">
+            {errorCount} erro{errorCount > 1 ? "s" : ""}
+          </Badge>
+        )}
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="mt-2 rounded-md border">
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b text-left text-xs text-muted-foreground">
+                <th className="w-8 px-2 py-2 font-medium" />
                 <th className="px-3 py-2 font-medium">Modelo</th>
+                <th className="px-3 py-2 font-medium">Filtro</th>
                 <th className="px-3 py-2 font-medium text-right">Docs</th>
-                <th className="px-3 py-2 font-medium text-right">Última execução</th>
+                <th className="px-3 py-2 font-medium text-right">Data</th>
               </tr>
             </thead>
             <tbody>
-              {history.map((item) => (
-                <tr key={item.respondent_name} className="border-b last:border-0">
-                  <td className="px-3 py-2">
-                    {formatModelLabel(item.respondent_name)}
-                  </td>
-                  <td className="px-3 py-2 text-right text-muted-foreground">
-                    {item.docCount}
-                  </td>
-                  <td className="px-3 py-2 text-right text-muted-foreground">
-                    {new Date(item.latestAt).toLocaleDateString("pt-BR", {
-                      day: "2-digit",
-                      month: "2-digit",
-                      year: "numeric",
-                      hour: "2-digit",
-                      minute: "2-digit",
-                    })}
-                  </td>
-                </tr>
-              ))}
+              {runs.map((run) => {
+                const isError = run.status === "error";
+                const rowClasses = [
+                  "border-b last:border-0",
+                  isError
+                    ? "cursor-pointer hover:bg-destructive/5"
+                    : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                const handleClick = isError
+                  ? () =>
+                      onOpenError({
+                        message: run.error_message ?? "Erro sem mensagem",
+                        type: run.error_type,
+                        traceback: run.error_traceback,
+                        line: run.error_line,
+                        column: run.error_column,
+                        pydanticCode: run.pydantic_code ?? pydanticCode,
+                      })
+                  : undefined;
+                return (
+                  <tr
+                    key={run.id}
+                    className={rowClasses}
+                    onClick={handleClick}
+                    title={isError ? "Clique para ver detalhes do erro" : undefined}
+                  >
+                    <td className="px-2 py-2">
+                      <StatusIcon status={run.status} />
+                    </td>
+                    <td className="px-3 py-2">
+                      {formatModelOrDash(run.llm_provider, run.llm_model)}
+                    </td>
+                    <td className="px-3 py-2 text-muted-foreground">
+                      {run.filter_mode ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right text-muted-foreground">
+                      {run.document_count ?? "—"}
+                    </td>
+                    <td className="px-3 py-2 text-right text-muted-foreground">
+                      {formatDateTime(run.started_at)}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/frontend/src/components/llm/LlmTab.tsx
+++ b/frontend/src/components/llm/LlmTab.tsx
@@ -266,6 +266,7 @@ export function LlmTab({
           error_type: string | null;
           error_line: number | null;
           error_column: number | null;
+          pydantic_code: string | null;
         }>(`/api/llm/status/${id}`);
         setProgress(res.progress);
         setTotal(res.total);
@@ -286,7 +287,9 @@ export function LlmTab({
               traceback: res.error_traceback,
               line: res.error_line,
               column: res.error_column,
-              pydanticCode,
+              // Prefer the snapshot stored with the run — the project's current
+              // pydanticCode may have been edited between run start and failure.
+              pydanticCode: res.pydantic_code ?? pydanticCode,
             });
             toast.error(msg, {
               duration: 10000,

--- a/frontend/src/components/llm/LlmTab.tsx
+++ b/frontend/src/components/llm/LlmTab.tsx
@@ -65,7 +65,8 @@ import {
 import { ChevronRight } from "lucide-react";
 import { DocumentSelector } from "./DocumentSelector";
 import { LlmRunHistory } from "./LlmRunHistory";
-import type { LlmRunHistoryItem } from "@/actions/llm";
+import { LlmErrorCard, type LlmErrorInfo } from "./LlmErrorCard";
+import type { LlmRunRecord } from "@/actions/llm";
 
 function formatEta(seconds: number): string {
   if (seconds < 60) return `${Math.round(seconds)}s`;
@@ -89,9 +90,10 @@ interface LlmTabProps {
     llm_kwargs: Record<string, any>;
   };
   pydanticFields: PydanticField[] | null;
+  pydanticCode: string | null;
   totalDocs: number;
   docsWithLlm: number;
-  runHistory: LlmRunHistoryItem[];
+  runs: LlmRunRecord[];
 }
 
 export function LlmTab({
@@ -100,9 +102,10 @@ export function LlmTab({
   projectDescription,
   config: initialConfig,
   pydanticFields,
+  pydanticCode,
   totalDocs,
   docsWithLlm,
-  runHistory,
+  runs,
 }: LlmTabProps) {
   // Prompt state
   const [prompt, setPrompt] = useState(initialPrompt);
@@ -125,6 +128,7 @@ export function LlmTab({
   const [etaSeconds, setEtaSeconds] = useState<number | null>(null);
   const [currentBatch, setCurrentBatch] = useState(0);
   const [totalBatches, setTotalBatches] = useState(0);
+  const [errorInfo, setErrorInfo] = useState<LlmErrorInfo | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [isPending, startTransition] = useTransition();
 
@@ -208,6 +212,7 @@ export function LlmTab({
   const handleRun = async () => {
     if (isStartingRun || status === "running") return;
     setIsStartingRun(true);
+    setErrorInfo(null);
     try {
       // Save config before running
       await Promise.all([
@@ -257,6 +262,10 @@ export function LlmTab({
           eta_seconds: number | null;
           current_batch: number;
           total_batches: number;
+          error_traceback: string | null;
+          error_type: string | null;
+          error_line: number | null;
+          error_column: number | null;
         }>(`/api/llm/status/${id}`);
         setProgress(res.progress);
         setTotal(res.total);
@@ -269,15 +278,43 @@ export function LlmTab({
           if (intervalRef.current) clearInterval(intervalRef.current);
           intervalRef.current = null;
           if (res.status === "completed") toast.success("LLM concluído!");
-          if (res.status === "error")
-            toast.error(res.errors[0] || "Erro na execução");
+          if (res.status === "error") {
+            const msg = res.errors[0] || "Erro na execução";
+            setErrorInfo({
+              message: msg,
+              type: res.error_type,
+              traceback: res.error_traceback,
+              line: res.error_line,
+              column: res.error_column,
+              pydanticCode,
+            });
+            toast.error(msg, {
+              duration: 10000,
+              action: {
+                label: "Ver detalhes",
+                onClick: () =>
+                  document
+                    .getElementById("llm-error-card")
+                    ?.scrollIntoView({ behavior: "smooth", block: "center" }),
+              },
+            });
+          }
         }
       } catch (e: any) {
         if (intervalRef.current) clearInterval(intervalRef.current);
         intervalRef.current = null;
         setStatus("error");
         setPhase("error");
-        toast.error(e?.message ?? "Não foi possível atualizar o progresso");
+        const msg = e?.message ?? "Não foi possível atualizar o progresso";
+        setErrorInfo({
+          message: msg,
+          type: "NetworkError",
+          traceback: null,
+          line: null,
+          column: null,
+          pydanticCode,
+        });
+        toast.error(msg);
       }
     }, 2000);
   };
@@ -781,7 +818,26 @@ export function LlmTab({
           </div>
         )}
 
-        <LlmRunHistory history={runHistory} />
+        {errorInfo && (
+          <LlmErrorCard
+            id="llm-error-card"
+            error={errorInfo}
+            onDismiss={() => setErrorInfo(null)}
+          />
+        )}
+
+        <LlmRunHistory
+          runs={runs}
+          pydanticCode={pydanticCode}
+          onOpenError={(err) => {
+            setErrorInfo(err);
+            setTimeout(() => {
+              document
+                .getElementById("llm-error-card")
+                ?.scrollIntoView({ behavior: "smooth", block: "center" });
+            }, 50);
+          }}
+        />
         </CardContent>
       </Card>
     </div>

--- a/frontend/supabase/migrations/20260422020000_llm_runs.sql
+++ b/frontend/supabase/migrations/20260422020000_llm_runs.sql
@@ -1,0 +1,58 @@
+-- Persistent log of LLM runs (one row per job dispatched via POST /api/llm/run).
+-- Today, job status lives only in the FastAPI process memory (_jobs dict in
+-- backend/services/llm_runner.py). If the container restarts or the user
+-- closes the tab, the error message is lost. This table captures every run
+-- (completed and failed) so researchers/coordinators can review diagnostics
+-- later.
+--
+-- Writes come exclusively from the backend (service-role key, bypasses RLS).
+-- Reads are gated to project members via auth_user_project_ids().
+
+CREATE TABLE llm_runs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id      UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  job_id          TEXT NOT NULL UNIQUE,
+  started_by      UUID REFERENCES profiles(id),
+
+  -- Config snapshot for diagnosis
+  llm_provider    TEXT,
+  llm_model       TEXT,
+  filter_mode     TEXT,
+  document_count  INT,
+  pydantic_code   TEXT,
+
+  -- Status
+  status          TEXT NOT NULL CHECK (status IN ('running','completed','error')),
+  phase           TEXT,
+  progress        INT DEFAULT 0,
+  total           INT DEFAULT 0,
+
+  -- Error diagnostics (populated when status='error')
+  error_message   TEXT,
+  error_type      TEXT,
+  error_traceback TEXT,
+  error_line      INT,
+  error_column    INT,
+  dismissed_at    TIMESTAMPTZ,
+
+  started_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at    TIMESTAMPTZ
+);
+
+CREATE INDEX idx_llm_runs_project_started ON llm_runs(project_id, started_at DESC);
+CREATE INDEX idx_llm_runs_project_status ON llm_runs(project_id, status);
+
+ALTER TABLE llm_runs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Members view llm_runs" ON llm_runs FOR SELECT USING (
+  project_id IN (SELECT auth_user_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+);
+
+-- Coordinators (and project creators) can mark a failed run as "dismissed"
+-- from the UI. Writes come through a Server Action using the Clerk JWT;
+-- service-role inserts from the backend bypass RLS anyway.
+CREATE POLICY "Coordinators update llm_runs" ON llm_runs FOR UPDATE USING (
+  project_id IN (SELECT auth_user_coordinator_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+);

--- a/frontend/supabase/migrations/20260423000000_llm_runs_cleanup.sql
+++ b/frontend/supabase/migrations/20260423000000_llm_runs_cleanup.sql
@@ -1,0 +1,29 @@
+-- Cleanup of llm_runs following PR #60 review.
+--
+-- - Drop `started_by` and `dismissed_at` columns: declared in the original
+--   migration but never written anywhere in the code. No half-finished schema.
+-- - Drop the UPDATE policy for coordinators: existed only to support the
+--   unused `dismissed_at` write path.
+-- - Drop the `(project_id, status)` index: no query filters by status.
+-- - Add CHECK constraints on `filter_mode` and `phase` for parity with `status`.
+-- - Convert `job_id` from TEXT to UUID: values are UUIDs (uuid.uuid4) and UUID
+--   is cheaper to index.
+
+DROP POLICY IF EXISTS "Coordinators update llm_runs" ON llm_runs;
+
+DROP INDEX IF EXISTS idx_llm_runs_project_status;
+
+ALTER TABLE llm_runs
+  DROP COLUMN IF EXISTS started_by,
+  DROP COLUMN IF EXISTS dismissed_at;
+
+ALTER TABLE llm_runs
+  ADD CONSTRAINT llm_runs_filter_mode_check
+  CHECK (filter_mode IS NULL OR filter_mode IN ('all','pending','max_responses','random_sample'));
+
+ALTER TABLE llm_runs
+  ADD CONSTRAINT llm_runs_phase_check
+  CHECK (phase IS NULL OR phase IN ('loading','processing','saving','completed','error'));
+
+ALTER TABLE llm_runs
+  ALTER COLUMN job_id TYPE UUID USING job_id::uuid;


### PR DESCRIPTION
## Contexto

Você tentou rodar o LLM, viu um erro (algo como \"escaped literal\" do Pydantic) e o toast de 5s sumiu antes de dar pra ler. Hoje o backend só guarda a exceção em memória (`_jobs` dict), e a UI só mostra via `toast.error`, que some em poucos segundos. Se o container do backend reinicia ou você fecha a aba, o diagnóstico some.

## O que muda

### Tabela nova: `llm_runs`

Cada execução disparada por `POST /api/llm/run` passa a ter uma linha persistida: provider, model, filter_mode, snapshot do `pydantic_code`, progresso, status (`running` / `completed` / `error`) e, em caso de falha: mensagem, tipo da exceção, traceback completo, linha e coluna apontando para o código Pydantic.

### Backend

- `backend/services/llm_runner.py`:
  - `_persist_run_insert` cria a linha antes mesmo do load do projeto — erro de rede ou projeto inexistente também fica registrado.
  - `_persist_run_snapshot` preenche provider/model/pydantic_code depois que o projeto é carregado.
  - `_persist_run_completion` e `_persist_run_error` fecham o ciclo.
  - `_extract_pydantic_location` lê `SyntaxError.lineno/offset` direto e, para outras exceções, parseia o frame `File \"<pydantic_schema>\", line N` do traceback.
  - `get_job_status` mantém `_jobs` como cache e faz fallback para `llm_runs` quando o job não está em memória (útil depois de restart do container).
- `backend/routes/llm_routes.py`: `StatusResponse` ganha `error_traceback`, `error_type`, `error_line`, `error_column`.

### Frontend

- `LlmErrorCard` (novo): card com badge do tipo de erro, mensagem formatada, trecho do código Pydantic com ±3 linhas em volta da linha culpada destacada em vermelho, stack trace colapsável e botão \"Copiar diagnóstico\". Fica visível até você clicar em fechar.
- `LlmTab`: novo estado `errorInfo`, preenchido pelo polling quando `status === \"error\"`. Toast continua, agora com duração de 10s e ação \"Ver detalhes\" que scrolla pro card.
- `LlmRunHistory`: refatorado pra consumir `llm_runs` (antes derivava de `responses`). Ganha coluna de status (✓/✗/spinner) e, clicando numa linha com erro, o `LlmErrorCard` reabre com os dados daquela run — dá pra voltar dias depois e revisar o erro.
- `actions/llm.ts`: `getLlmRunHistory` (derivava de `responses`) foi substituído por `getLlmRuns` (lê direto de `llm_runs` com colunas explícitas).

### Testes

- `backend/tests/test_llm_error_location.py`: cobre `SyntaxError`, traceback com frame `<pydantic_schema>` e caso sem match.
- 38 testes existentes continuam passando.
- `npx tsc --noEmit` e `next build` verdes.

## Test plan

- [ ] Em algum projeto, editar o `pydantic_code` para conter um escape inválido (ex.: `tipo: Literal[\"a\\\\q\"]`), salvar, ir na aba LLM e clicar \"Rodar LLM\".
- [ ] Confirmar que o card de erro aparece e **não some** sozinho.
- [ ] Confirmar que o trecho do código aparece com a linha correta destacada.
- [ ] Expandir o stack trace completo e clicar em \"Copiar diagnóstico\" — colar em algum lugar pra conferir.
- [ ] Recarregar a página (F5). Abrir \"Histórico de execuções\" — a run com ✗ deve estar lá. Clicar nela → card reabre com tudo.
- [ ] Rodar um LLM que funciona e confirmar que entra no histórico como ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)