### PR TITLE
feat: target="none" e options em date

### DIFF
--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -162,6 +162,12 @@ def _filter_model_for_llm(model_class, pydantic_fields: list[dict]):
     A field is excluded when its ``target`` in ``pydantic_fields`` is either
     ``"none"`` (hidden from everyone) or ``"human_only"``. Returns the original
     ``model_class`` unchanged when no fields need to be excluded.
+
+    Note: the filtered model is created with ``__base__=BaseModel``, so any
+    custom ``model_config`` or validators on the original class are not
+    preserved. This is acceptable because ``dataframeit`` only inspects the
+    schema (fields + annotations). If custom validators become relevant,
+    switch to ``__base__=model_class`` and drop excluded fields differently.
     """
     from pydantic import BaseModel, create_model
 

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -156,6 +156,36 @@ def _extend_model_with_justifications(model_class):
     )
 
 
+def _filter_model_for_llm(model_class, pydantic_fields: list[dict]):
+    """Return a model class excluding fields that should not be sent to the LLM.
+
+    A field is excluded when its ``target`` in ``pydantic_fields`` is either
+    ``"none"`` (hidden from everyone) or ``"human_only"``. Returns the original
+    ``model_class`` unchanged when no fields need to be excluded.
+    """
+    from pydantic import BaseModel, create_model
+
+    excluded_names = {
+        f["name"]
+        for f in (pydantic_fields or [])
+        if f.get("target") in ("none", "human_only")
+    }
+    if not excluded_names:
+        return model_class
+
+    kept: dict = {}
+    for name, info in model_class.model_fields.items():
+        if name in excluded_names:
+            continue
+        kept[name] = (info.annotation, info)
+
+    return create_model(
+        f"{model_class.__name__}ForLLM",
+        __base__=BaseModel,
+        **kept,
+    )
+
+
 def _compile_model(pydantic_code: str):
     """Compile Pydantic code and return the model class."""
     namespace: dict = {}
@@ -305,6 +335,12 @@ async def run_llm(
         model_class = _compile_model(pydantic_code)
         if not model_class:
             raise RuntimeError("Nenhuma classe BaseModel encontrada no código Pydantic.")
+
+        # Filter out fields that should not be sent to the LLM
+        # (target="none" hides from everyone; target="human_only" hides from LLM)
+        model_class = _filter_model_for_llm(
+            model_class, project.get("pydantic_fields") or []
+        )
 
         # Optionally extend model with justification fields
         include_justifications = llm_kwargs.pop("include_justifications", False)

--- a/backend/services/pydantic_compiler.py
+++ b/backend/services/pydantic_compiler.py
@@ -82,6 +82,24 @@ def compile_pydantic(code: str) -> dict:
             if description.endswith(suffix):
                 description = description[: -len(suffix)]
 
+        # Date fields: strip suffixes added by generatePydanticCode so the
+        # description round-trips cleanly (otherwise each UI -> compile -> UI
+        # cycle accumulates the suffix).
+        if field_type == "date":
+            if options:
+                sentinel_list = ", ".join(f'"{o}"' for o in options)
+                sentinel_suffix = (
+                    f". Caso não seja possível informar a data, "
+                    f"usar um dos seguintes valores: {sentinel_list}"
+                )
+                if description.endswith(sentinel_suffix):
+                    description = description[: -len(sentinel_suffix)]
+            date_format_suffix = (
+                ". Formato: DD/MM/AAAA (use XX para partes desconhecidas)"
+            )
+            if description.endswith(date_format_suffix):
+                description = description[: -len(date_format_suffix)]
+
         field_dict: dict = {
             "name": field_name,
             "type": field_type,

--- a/backend/services/pydantic_compiler.py
+++ b/backend/services/pydantic_compiler.py
@@ -53,6 +53,12 @@ def compile_pydantic(code: str) -> dict:
         explicit_type = extra.get("field_type") if is_dict_extra else None
         if explicit_type:
             field_type = explicit_type
+        # Date fields carry options as sentinels in json_schema_extra because
+        # the annotation itself is `str`, not Literal.
+        if field_type == "date" and is_dict_extra:
+            raw_opts = extra.get("options")
+            if isinstance(raw_opts, (list, tuple)) and raw_opts:
+                options = [str(o) for o in raw_opts]
         description = field_info.description or field_name
         allow_other = (
             bool(extra.get("allowOther", False)) if is_dict_extra else False

--- a/backend/tests/test_pydantic_compiler.py
+++ b/backend/tests/test_pydantic_compiler.py
@@ -385,3 +385,47 @@ def test_multiline_help_text_round_trips():
     f = _field(result, "x")
     assert f["description"] == "linha1\nlinha2"
     assert f["help_text"] == "ins1\nins2"
+
+
+def test_target_none_round_trips():
+    """target="none" is preserved by the compiler (used to hide fields from
+    both humans and LLM while keeping them in pydantic_code as source of
+    truth)."""
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal
+
+class Analysis(BaseModel):
+    hidden_field: Literal["a", "b"] = Field(
+        description="Hidden",
+        json_schema_extra={"target": "none"},
+    )
+    visible: Literal["x"] = Field(description="Visible")
+'''
+    result = compile_pydantic(code)
+    assert result["valid"], result["errors"]
+    hidden = _field(result, "hidden_field")
+    assert hidden["target"] == "none"
+    visible = _field(result, "visible")
+    assert visible["target"] == "all"
+
+
+def test_date_field_with_sentinel_options_round_trips():
+    """Date fields carry sentinel options (ex: 'Não identificável') via
+    json_schema_extra because the annotation itself is `str`, not Literal."""
+    code = '''from pydantic import BaseModel, Field
+from typing import Literal
+
+class Analysis(BaseModel):
+    birth_date: str = Field(
+        description="Data de nascimento",
+        json_schema_extra={
+            "field_type": "date",
+            "options": ["Não identificável"],
+        },
+    )
+'''
+    result = compile_pydantic(code)
+    assert result["valid"], result["errors"]
+    f = _field(result, "birth_date")
+    assert f["type"] == "date"
+    assert f["options"] == ["Não identificável"]

--- a/backend/tests/test_pydantic_compiler.py
+++ b/backend/tests/test_pydantic_compiler.py
@@ -429,3 +429,63 @@ class Analysis(BaseModel):
     f = _field(result, "birth_date")
     assert f["type"] == "date"
     assert f["options"] == ["Não identificável"]
+
+
+def test_date_description_strips_generated_suffixes():
+    """generatePydanticCode appends ". Formato: DD/MM/AAAA..." and, when
+    options exist, ". Caso não seja possível informar a data, usar um dos
+    seguintes valores: ..." to the description. The compiler must strip
+    both suffixes so the description round-trips cleanly (otherwise each
+    UI -> compile -> UI cycle accumulates the suffix)."""
+    # Date without options: only the format suffix
+    code_no_opts = '''from pydantic import BaseModel, Field
+
+class Analysis(BaseModel):
+    d: str = Field(
+        description="Data da decisão. Formato: DD/MM/AAAA (use XX para partes desconhecidas)",
+        json_schema_extra={"field_type": "date"},
+    )
+'''
+    result = compile_pydantic(code_no_opts)
+    assert result["valid"], result["errors"]
+    f = _field(result, "d")
+    assert f["description"] == "Data da decisão"
+    assert f["type"] == "date"
+
+    # Date with options: both suffixes, stripped in reverse order
+    code_with_opts = '''from pydantic import BaseModel, Field
+
+class Analysis(BaseModel):
+    d: str = Field(
+        description='Data da decisão. Formato: DD/MM/AAAA (use XX para partes desconhecidas). Caso não seja possível informar a data, usar um dos seguintes valores: "Não identificável", "Não aplicável"',
+        json_schema_extra={
+            "field_type": "date",
+            "options": ["Não identificável", "Não aplicável"],
+        },
+    )
+'''
+    result = compile_pydantic(code_with_opts)
+    assert result["valid"], result["errors"]
+    f = _field(result, "d")
+    assert f["description"] == "Data da decisão"
+    assert f["options"] == ["Não identificável", "Não aplicável"]
+
+    # Date with options AND help_text: all three suffixes combined
+    code_full = '''from pydantic import BaseModel, Field
+
+class Analysis(BaseModel):
+    d: str = Field(
+        description='Data da decisão. Formato: DD/MM/AAAA (use XX para partes desconhecidas). Caso não seja possível informar a data, usar um dos seguintes valores: "Não identificável". Instrucoes: Use a data da publicação',
+        json_schema_extra={
+            "field_type": "date",
+            "options": ["Não identificável"],
+            "help_text": "Use a data da publicação",
+        },
+    )
+'''
+    result = compile_pydantic(code_full)
+    assert result["valid"], result["errors"]
+    f = _field(result, "d")
+    assert f["description"] == "Data da decisão"
+    assert f["help_text"] == "Use a data da publicação"
+    assert f["options"] == ["Não identificável"]

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -339,7 +339,7 @@ export async function getDocumentForCoding(
   // Sanitize answers against current schema options
   if (rawAnswers && project?.pydantic_fields) {
     const fields = (project.pydantic_fields as { name: string; type: string; options: string[] | null; target?: string }[])
-      .filter((f) => f.target !== "llm_only");
+      .filter((f) => f.target !== "llm_only" && f.target !== "none");
     const clean: Record<string, unknown> = {};
     for (const field of fields) {
       const val = rawAnswers[field.name];

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -101,6 +101,7 @@ export async function saveResponse(
       const humanFields = fields.filter(
         (f) =>
           (f.target || "all") !== "llm_only" &&
+          f.target !== "none" &&
           f.required !== false &&
           isFieldVisible(f, sanitizedAnswers),
       );

--- a/frontend/src/actions/reviews.ts
+++ b/frontend/src/actions/reviews.ts
@@ -70,7 +70,12 @@ async function syncCompareAssignment(
 
   const divergentFields: string[] = [];
   for (const field of fields) {
-    if (field.target === "llm_only" || field.target === "human_only") continue;
+    if (
+      field.target === "llm_only" ||
+      field.target === "human_only" ||
+      field.target === "none"
+    )
+      continue;
 
     const applicable = field.condition
       ? activeResponses.filter((r) =>

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -68,7 +68,7 @@ export default async function CodePage({
 
   // Sanitize: remove answers whose values don't match current schema options
   const fields = ((project?.pydantic_fields || []) as PydanticField[]).filter(
-    (f) => f.target !== "llm_only"
+    (f) => f.target !== "llm_only" && f.target !== "none"
   );
   const existingAnswers: Record<string, Record<string, unknown>> = {};
   for (const [docId, answers] of Object.entries(rawAnswers)) {

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -287,7 +287,7 @@ export default async function ComparePageRoute({
     // Compute divergence on qualified responses
     const divergent: string[] = [];
     for (const field of fields) {
-      if (field.target === "llm_only" || field.target === "human_only") continue;
+      if (field.target === "llm_only" || field.target === "human_only" || field.target === "none") continue;
 
       // For conditional fields, a response that never triggered the condition
       // legitimately has no value — don't treat that absence as divergence.

--- a/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
@@ -47,7 +47,9 @@ export default async function ExportPage({
   const fields = (project?.pydantic_fields || []) as PydanticField[];
   const minResponses = project?.min_responses_for_comparison || 2;
 
-  const exportableFields = fields.filter((f) => f.target !== "llm_only");
+  const exportableFields = fields.filter(
+    (f) => f.target !== "llm_only" && f.target !== "none",
+  );
 
   // --- Dataset 1: Individual responses ---
   const individualHeaders = [

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -163,7 +163,9 @@ export default async function LlmInsightsPage({
       <LlmInsightsView
         projectId={id}
         errors={errors}
-        fields={fields.filter((f) => f.target !== "llm_only")}
+        fields={fields.filter(
+          (f) => f.target !== "llm_only" && f.target !== "none",
+        )}
         allFields={allFields}
         isCoordinator={isCoordinator}
         summary={{ totalLlmDocs, totalErrors, errorRate, unreviewedLlmDocs }}

--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -65,7 +65,7 @@ function DateFieldRenderer({
   onChange: (v: string) => void;
   options?: string[] | null;
 }) {
-  const sentinels = options ?? [];
+  const sentinels = (options ?? []).filter((o) => o !== NOT_INFORMED);
   const activeSentinel = sentinels.find((o) => value === o);
   const isNotInformed = value === NOT_INFORMED;
   const isSentinelActive = Boolean(activeSentinel) || isNotInformed;

--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -59,12 +59,19 @@ function isValidDatePart(
 function DateFieldRenderer({
   value,
   onChange,
+  options,
 }: {
   value: string;
   onChange: (v: string) => void;
+  options?: string[] | null;
 }) {
-  const [day, month, year] = parseDateParts(value);
+  const sentinels = options ?? [];
+  const activeSentinel = sentinels.find((o) => value === o);
   const isNotInformed = value === NOT_INFORMED;
+  const isSentinelActive = Boolean(activeSentinel) || isNotInformed;
+  const [day, month, year] = parseDateParts(
+    isSentinelActive ? "" : value,
+  );
   const monthRef = useRef<HTMLInputElement>(null);
   const yearRef = useRef<HTMLInputElement>(null);
 
@@ -88,7 +95,7 @@ function DateFieldRenderer({
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5 flex-wrap">
         <Button
           type="button"
           variant="outline"
@@ -102,6 +109,25 @@ function DateFieldRenderer({
           {isNotInformed && <Check className="mr-1 h-3 w-3" />}
           Não informada
         </Button>
+        {sentinels.map((opt) => {
+          const active = value === opt;
+          return (
+            <Button
+              key={opt}
+              type="button"
+              variant="outline"
+              size="sm"
+              className={cn(
+                "h-7 text-xs",
+                active && "bg-brand-muted text-brand border-brand",
+              )}
+              onClick={() => onChange(active ? "" : opt)}
+            >
+              {active && <Check className="mr-1 h-3 w-3" />}
+              {opt}
+            </Button>
+          );
+        })}
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -117,7 +143,7 @@ function DateFieldRenderer({
           </Tooltip>
         </TooltipProvider>
       </div>
-      {!isNotInformed && (
+      {!isSentinelActive && (
         <div className="flex items-center gap-1">
           <Input
             className="w-14 text-center text-sm font-mono"
@@ -263,6 +289,7 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
       <DateFieldRenderer
         value={(value as string) || ""}
         onChange={(v) => onChange(v)}
+        options={field.options}
       />
     );
   }

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -44,7 +44,10 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
   }, [fields]);
 
   const visibleFields = useMemo(
-    () => fields.filter((f) => isFieldVisible(f, answers)),
+    () =>
+      fields.filter(
+        (f) => f.target !== "none" && isFieldVisible(f, answers),
+      ),
     [fields, answers],
   );
   const visibleNames = useMemo(

--- a/frontend/src/components/schema/FieldCard.tsx
+++ b/frontend/src/components/schema/FieldCard.tsx
@@ -47,6 +47,7 @@ const TYPE_COLORS: Record<string, string> = {
 const TARGET_LABELS: Record<string, string> = {
   llm_only: "Apenas LLM",
   human_only: "Apenas humano",
+  none: "Oculto",
 };
 
 export function FieldCard({
@@ -66,8 +67,12 @@ export function FieldCard({
   };
 
   const handleTypeChange = (type: PydanticField["type"]) => {
-    if (type === "text" || type === "date") {
+    if (type === "text") {
       updateField({ type, options: null });
+    } else if (type === "date") {
+      // Preserve existing options when switching to date — they become
+      // sentinels rendered alongside the date picker (ex: "Não identificável").
+      updateField({ type });
     } else if (!field.options || field.options.length === 0) {
       updateField({ type, options: ["Opção 1"] });
     } else {
@@ -217,12 +222,13 @@ export function FieldCard({
             {/* Destino */}
             <div className="space-y-1.5">
               <Label className="text-xs">Quem responde</Label>
-              <div className="flex gap-1">
+              <div className="flex gap-1 flex-wrap">
                 {(
                   [
                     ["all", "Todos"],
                     ["llm_only", "Apenas LLM"],
                     ["human_only", "Apenas humano"],
+                    ["none", "Oculto (ninguém vê)"],
                   ] as const
                 ).map(([value, label]) => (
                   <Button
@@ -267,6 +273,20 @@ export function FieldCard({
                 <OptionsEditor
                   options={field.options || []}
                   onChange={(opts) => updateField({ options: opts })}
+                />
+              </div>
+            )}
+            {field.type === "date" && (
+              <div className="space-y-1.5">
+                <Label className="text-xs">Valores sentinela (opcional)</Label>
+                <p className="text-xs text-muted-foreground">
+                  Aparecem como botões ao lado do campo de data (ex: &quot;Não identificável&quot;).
+                </p>
+                <OptionsEditor
+                  options={field.options || []}
+                  onChange={(opts) =>
+                    updateField({ options: opts.length > 0 ? opts : null })
+                  }
                 />
               </div>
             )}

--- a/frontend/src/components/schema/FieldCard.tsx
+++ b/frontend/src/components/schema/FieldCard.tsx
@@ -248,8 +248,8 @@ export function FieldCard({
               </div>
             </div>
 
-            {/* Obrigatório (não faz sentido para llm_only) */}
-            {(field.target || "all") !== "llm_only" && (
+            {/* Obrigatório (não faz sentido para llm_only nem oculto) */}
+            {(field.target || "all") !== "llm_only" && field.target !== "none" && (
               <div className="flex items-center justify-between">
                 <div>
                   <Label className="text-xs">Obrigatório</Label>

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -233,6 +233,16 @@ export function EditFieldDialog({
             </div>
           )}
 
+          {field.type === "date" && (
+            <div className="space-y-1.5">
+              <Label className="text-xs">Valores sentinela (opcional)</Label>
+              <p className="text-xs text-muted-foreground">
+                Aparecem como botões ao lado do campo de data (ex: &quot;Não identificável&quot;).
+              </p>
+              <OptionsEditor options={options} onChange={setOptions} />
+            </div>
+          )}
+
           {field.type === "text" && (
             <div className="space-y-3">
               <div className="flex items-center gap-2">

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -451,6 +451,7 @@ export function computeRespondentProfiles(
       if (review.verdict === "ambiguo" || review.verdict === "pular") continue;
       const field = ctx.fieldMap.get(review.field_name);
       if (!field) continue;
+      if (field.target === "none") continue;
       if (field.target === "llm_only" && info.type === "humano") continue;
       if (field.target === "human_only" && info.type === "llm") continue;
 
@@ -530,6 +531,7 @@ export function computeHardestDocuments(
       if (review.verdict === "ambiguo" || review.verdict === "pular") continue;
       const field = ctx.fieldMap.get(review.field_name);
       if (!field) continue;
+      if (field.target === "none") continue;
 
       for (const resp of docResps) {
         if (field.target === "llm_only" && resp.respondent_type === "humano")

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -71,6 +71,15 @@ function fieldExtra(field: PydanticField): string {
   }
   if (field.type === "date") {
     extras.push(`"field_type": "date"`);
+    // Date fields carry options as sentinel values (ex: "Não identificável")
+    // rendered alongside the date picker. They must be carried in
+    // json_schema_extra because the annotation itself is `str`, not Literal.
+    if (field.options && field.options.length > 0) {
+      const opts = field.options
+        .map((o) => `"${escapeString(o)}"`)
+        .join(", ");
+      extras.push(`"options": [${opts}]`);
+    }
   }
   if ((field.type === "single" || field.type === "multi") && field.allow_other) {
     extras.push(`"allowOther": True`);
@@ -103,7 +112,11 @@ export function generatePydanticCode(
     "",
   ];
 
-  // Generate nested BaseModel classes for composite text fields
+  // Generate nested BaseModel classes for composite text fields.
+  // Note: fields with target="none" are emitted in the Pydantic code
+  // (to preserve round-trip with pydantic_code as source of truth) but
+  // are filtered out in the backend before the LLM run and in the UI
+  // renderers that show fields to humans.
   for (const field of fields) {
     if (field.subfields && field.subfields.length > 0) {
       lines.push("");
@@ -131,6 +144,16 @@ export function generatePydanticCode(
     let desc = escapeString(field.description);
     if (field.type === "date") {
       desc += ". Formato: DD/MM/AAAA (use XX para partes desconhecidas)";
+    }
+    if (
+      field.type === "date" &&
+      field.options &&
+      field.options.length > 0
+    ) {
+      const sentinelList = field.options
+        .map((o) => `\\"${escapeString(o)}\\"`)
+        .join(", ");
+      desc += `. Caso não seja possível informar a data, usar um dos seguintes valores: ${sentinelList}`;
     }
     if (field.help_text?.trim()) {
       desc += `. Instrucoes: ${escapeString(field.help_text.trim())}`;
@@ -177,10 +200,6 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
 
     if (!f.description.trim()) {
       errors.push(`${label}: descrição não pode ser vazia`);
-    }
-
-    if (f.type === "date" && f.options && f.options.length > 0) {
-      errors.push(`${label}: campo de data não deve ter opções`);
     }
 
     if (f.subfields && f.subfields.length > 0) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -45,7 +45,7 @@ export interface PydanticField {
   options: string[] | null;
   description: string;
   help_text?: string;
-  target?: "all" | "llm_only" | "human_only";
+  target?: "all" | "llm_only" | "human_only" | "none";
   required?: boolean;
   hash?: string;
   subfields?: SubfieldDef[];


### PR DESCRIPTION
## Summary

Duas extensões do modelo de schema necessárias para destravar os itens acionáveis de `docs/comentarios/Encaminhamentos.md` (projeto Zolgensma):

- **`target: "none"`**: novo valor do enum `target` que oculta o field de humanos **e** do LLM, mantendo-o em `pydantic_code`/`pydantic_fields` como fonte de verdade (nada é deletado). Todos os consumidores foram atualizados (`QuestionsPanel`, `reviews/queries`, páginas de code/compare/export/llm-insights). O backend também ganhou `_filter_model_for_llm` em `llm_runner.py` que remove `target="none"` **e** `target="human_only"` do model class antes de passar para `dataframeit` — corrige de quebra um drift pré-existente onde fields `human_only` estavam sendo enviados ao LLM.
- **Options em field `date`**: removida a validação que proibia options em campos `date`. Options agora são renderizadas como botões sentinela (ex: "Não identificável") ao lado do date picker e transportadas em `json_schema_extra` (porque a annotation é `str`, não `Literal`) para sobreviver ao round-trip `UI → pydantic_code → compile → UI`.

Round-trip de ambos os casos coberto por testes em `backend/tests/test_pydantic_compiler.py` (43 testes passam).

Ref: `docs/comentarios/Encaminhamentos.md` (itens 2 e 7). Edições do schema do projeto Zolgensma (add help_text em q3/q9/q10/q11, option "Não aplicável" em q11, option "Não identificável" em q6, `target: "none"` em q13/q15/q16) serão feitas pela aba Schema **após merge**.

## Test plan

- [ ] Revisar diff e confirmar que nenhum consumidor de `target` ficou de fora (buscar `f.target` / `field.target` no repo inteiro).
- [ ] Local: `cd frontend && npm run build` passa.
- [ ] Local: `cd backend && uv run --no-project pytest` passa (43 testes).
- [ ] Smoke test após merge no Zolgensma:
  - Aba Schema mostra "Oculto (ninguém vê)" no seletor de target.
  - Em date fields, seção "Valores sentinela" aparece no FieldCard.
  - UI de coding não renderiza field marcado como oculto.
  - Date field com option renderiza botão sentinela e grava a string da option como valor.
- [ ] Rerun LLM no Zolgensma confirma que o código efetivamente enviado não inclui os fields ocultos (inspecionar via `llm_runs.pydantic_code` não mostra mudança — a filtragem é só na hora de compilar o model class; isso é intencional para manter a fonte de verdade intacta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)