### PR TITLE
feat: incorporar skill comentarios-relatorio e eliminar drift do Pydantic

### DIFF
--- a/.claude/skills/comentarios-relatorio/SKILL.md
+++ b/.claude/skills/comentarios-relatorio/SKILL.md
@@ -1,0 +1,281 @@
+---
+name: comentarios-relatorio
+description: Gerar relatório .md dos comentários abertos de um projeto dataframeitGUI, organizado por pergunta Pydantic, e depois aplicar as decisões do usuário ao schema + marcar comentários como resolvidos. Use esta skill quando o usuário pedir "gerar relatório de comentários", "compilar comentários abertos", "revisar feedback do projeto", "aplicar decisões do relatório", "resolver comentários em lote", "revisar anotações de pesquisadores", "consolidar dúvidas", "processar sugestões de schema", ou mencionar explicitamente esta skill. Também acionar quando o usuário quiser iterar sobre o .md anotado para aplicar mudanças em massa no schema Pydantic de um projeto.
+---
+
+# Skill: comentarios-relatorio
+
+Fluxo em dois passos para revisar e responder a comentários abertos de pesquisadores/LLM/coordenadores no dataframeitGUI. Organiza tudo por pergunta, faz dedup, e aplica em lote as decisões do usuário.
+
+## Quando usar
+
+- Usuário quer consolidar feedback antes de uma revisão de schema
+- Muitos comentários abertos acumulados e precisa priorizar
+- Após um batch de codificação, triar notas/dúvidas/ambiguidades
+- Aplicar em lote decisões já tomadas offline (no .md)
+
+**Não use** para:
+- Criar um comentário novo (use a UI)
+- Resolver um comentário específico avulso (use a UI ou server action direto)
+- Refatorar schema do zero sem feedback existente (use a aba Schema)
+
+## Pré-requisitos
+
+1. Estar num repo com estrutura do dataframeitGUI
+2. `frontend/.env.local` contendo `NEXT_PUBLIC_SUPABASE_URL` e `SUPABASE_SERVICE_ROLE_KEY`
+3. `frontend/node_modules` instalado (`cd frontend && npm install`)
+4. Se estiver trabalhando em worktree: verificar se `.env.local` e `node_modules` existem — se não, criar symlinks para o main branch:
+   ```bash
+   cd frontend
+   [ ! -e node_modules ] && ln -s ../../../frontend/node_modules node_modules
+   [ ! -e .env.local ] && ln -s ../../../frontend/.env.local .env.local
+   ```
+   (Ajustar `../../../frontend` conforme profundidade do worktree.)
+
+## Passo 1 — Gerar o relatório
+
+### 1.1 Identificar o projeto
+
+Se o usuário mencionou um nome:
+```bash
+cd frontend
+npx tsx scripts/comentarios-relatorio/fetch-open-comments.ts --project-name "Zolgensma"
+```
+
+Se não: listar e perguntar via AskUserQuestion:
+```bash
+cd frontend
+npx tsx scripts/comentarios-relatorio/fetch-open-comments.ts --list
+```
+
+Se preferir passar id direto:
+```bash
+npx tsx scripts/comentarios-relatorio/fetch-open-comments.ts --project-id <uuid>
+```
+
+### 1.2 Gerar o .md
+
+O script `fetch-open-comments.ts` imprime JSON; em seguida, o script `generate-report.py` transforma esse JSON no .md final (fazendo agrupamento por campo, dedup por texto e inferência cruzada de notas gerais).
+
+Pipeline padrão:
+
+```bash
+mkdir -p docs/comentarios
+cd frontend
+npx tsx scripts/comentarios-relatorio/fetch-open-comments.ts \
+  --project-name "Zolgensma" > /tmp/comments.json
+python3 scripts/comentarios-relatorio/generate-report.py \
+  /tmp/comments.json ../docs/comentarios/Zolgensma-$(date +%Y%m%d).md
+```
+
+Estrutura do JSON produzido por `fetch-open-comments.ts`:
+- `project`: `{ id, name, version }`
+- `fields`: `PydanticField[]`
+- `stats.bySource`: contagem por fonte
+- `comments`: `OpenComment[]` com `id`, `source`, `rawId`, `fieldName`, `documentId`, `documentTitle`, `text`, `author`, `createdAt`, `extra`
+
+O script Python faz automaticamente:
+- Agrupa comentários por `fieldName` (seções na ordem dos `fields`)
+- **Clusters por reviewId**: quando múltiplos pesquisadores contestam o mesmo veredito (`duvida` com mesmo `extra.reviewId`), ficam num único bloco de decisão junto com o review original (`rawId` igual ao `reviewId`) e anotações do mesmo documento
+- **Dúvidas órfãs**: dúvidas cujo review não aparece nos abertos (já resolvido) viram um cluster próprio por `reviewId`
+- Cria seção "Notas gerais" para `fieldName === "(geral)"` — cada nota/dificuldade vira um bloco
+- Vereditos multi-select (JSON dict) são resumidos em "A, B, C e mais N" — não aparecem crus
+
+### 1.3 Quando fugir do pipeline padrão
+
+Use o pipeline padrão na maioria dos casos. Só pule o Python se o usuário pediu um formato diferente (ex: resumo executivo curto, priorização por urgência). Nesses casos, gere o .md diretamente a partir do JSON no fluxo conversacional.
+
+### 1.4 Estrutura do .md (formato conversacional)
+
+O parser (passo 2) identifica blocos pelo heading `###` e extrai os `rawId`s do comentário HTML `<!-- ids: ... -->` no rodapé do bloco. Headings são prosa livre — não há parsing por regex de id no título.
+
+```markdown
+# Comentários em aberto — {projectName}
+
+Projeto `{projectId}` na versão do schema `{version}`. Gerado em {YYYY-MM-DD}.
+
+Há **{N} comentários em aberto** — {M} perguntas com comentários específicos e {P} nota(s) geral(is). Por fonte: ...
+
+Para cada bloco, preencha `Decisão:` dentro do comentário HTML (`<!-- ... -->`).
+
+---
+
+## `{fieldName}`
+
+**Pergunta:** {description}
+**Orientação aos pesquisadores:** {help_text} (se houver)
+**Opções:** A · B · C (se houver)
+**Subcampos:** key (label), ... (regra) (se houver)
+
+### Review de **{reviewer}** em *{doc}* — contestado por {N} pesquisadores
+
+Em {date}, **{reviewer}** revisou este documento e escolheu o veredito **"{verdict}"**, deixando a seguinte observação:
+
+> {review comment}
+
+{N} pesquisadores manifestaram dúvida sobre esse veredito:
+
+- **{nome}** — {texto}
+- **{nome}** — {texto}
+
+Além disso, {N} anotações no mesmo documento:
+
+- **{nome}** — {texto}
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional -->
+
+<!-- ids: review-<uuid>; duvida-<reviewId>-<resp1>; duvida-<reviewId>-<resp2>; anotacao-<uuid> -->
+
+### Anotação de **{autor}** em *{doc}* ({date})
+
+> {texto}
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- ... -->
+**Nota ao resolver:** <!-- ... -->
+
+<!-- ids: anotacao-<uuid> -->
+
+---
+
+## Notas gerais
+
+### Nota de pesquisador de **{autor}** ao codificar *{doc}* ({date})
+
+> {texto}
+
+**Campos mencionados:** <!-- ex: q2, q14 -->
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- ... -->
+**Nota ao resolver:** <!-- ... -->
+
+<!-- ids: nota-<response-uuid> -->
+```
+
+Tipos de heading de bloco (úteis ao gerar/parsear):
+- `### Review de **X** em *doc*` (com ou sem " — contestado por N pesquisadores")
+- `### Dúvidas em *doc* sobre o veredito "Y" (N pesquisadores)` (dúvidas órfãs)
+- `### Anotação de **X** em *doc* (date)` (anotação única)
+- `### N anotações em *doc*` (anotações agrupadas por documento)
+- `### Sugestão de schema por **X** (date)`
+- `### Nota de pesquisador de **X** ao codificar *doc* (date)` (seção Notas gerais)
+- `### Ambiguidade reportada pelo LLM em *doc* (date)` (seção Notas gerais)
+
+### 1.5 Salvar e informar
+
+O pipeline padrão já salva em `docs/comentarios/{projectName}-{YYYYMMDD}.md`. Avise o caminho completo ao usuário e explique como editar as diretivas dentro dos `<!-- ... -->`.
+
+## Passo 2 — Aplicar as decisões
+
+Quando o usuário devolver o .md anotado:
+
+### 2.1 Parsear o .md anotado
+
+O .md atual usa formato conversacional. Parse assim:
+
+1. **Seções por campo**: split por `^## ` (H2). O heading `## \`{fieldName}\`` indica o field. A seção `## Notas gerais` concentra notas/dificuldades do `(geral)`.
+2. **Blocos por cluster**: dentro de cada seção, split por `^### ` (H3). O heading é prosa livre — não tenta extrair id dele.
+3. **IDs do bloco**: extrair do comentário HTML `<!-- ids: id1; id2; ... -->` no fim do bloco. Cada id tem formato `{source}-{rawId}` (para `duvida`, o rawId é `{reviewId}-{respondentId}`).
+4. **Diretivas**: extrair conteúdo entre `<!--` e `-->` de cada linha `**Decisão:**`, `**Mudança no schema:**`, `**Nota ao resolver:**`, `**Campos mencionados:**` (se aplicável).
+5. **Uma decisão se aplica a todos os ids do bloco** — ex: cluster com 1 review + 4 dúvidas fecha os 5 de uma vez. O texto de "Mudança no schema" e "Nota ao resolver" também é único para o bloco.
+6. **Aceitar variantes de escrita humana em `Decisão:`**: o usuário pode escrever "aprovar", "Ignorar e resolver.", "ok, resolver sem mudar", etc. Interpretar semanticamente:
+   - Se menciona "resolver"/"fechar"/"ok" e NÃO tem texto em "Mudança no schema" → trata como `rejeitar` (fecha sem mudar).
+   - Se "aprovar"/"sim" com texto em "Mudança no schema" preenchido → `aprovar` (aplica + fecha).
+   - Se "reformular"/"ajustar com nota" → `reformular`.
+   - Se "ignorar"/"pular"/"depois" ou vazio → pular o bloco.
+7. Quando em dúvida sobre o texto livre do usuário, use AskUserQuestion antes de aplicar.
+
+### 2.2 Converter "Mudança no schema" em diff concreto
+
+O usuário escreve em linguagem livre. Você converte para mutações no `PydanticField[]`. Casos típicos:
+
+| Texto do usuário | Mutação |
+|---|---|
+| "adicionar opção X" | `field.options.push("X")` |
+| "remover opção Y" | `field.options = field.options.filter(o => o !== "Y")` |
+| "mudar description para ..." | `field.description = "..."` |
+| "remover help_text" | `field.help_text = undefined` |
+| "adicionar help_text: ..." | `field.help_text = "..."` |
+| "renomear para X" | `field.name = "X"` (cuidado: é mudança estrutural minor) |
+| "adicionar campo novo: ..." | push novo objeto `PydanticField` |
+| "remover campo" | `fields = fields.filter(f => f.name !== target)` |
+
+**Regras importantes:**
+- Mudanças de `description`/`help_text` → patch version (invalida responses LLM se hash mudar)
+- Mudanças em `options`, `type`, `required`, `target`, `subfields` → minor version
+- Nunca aprove "mudança no schema" sem entender o que está sendo mudado. Em caso de dúvida, use AskUserQuestion.
+
+### 2.3 Montar o decisions.json
+
+Produza um arquivo temporário com esta estrutura (definida em `scripts/comentarios-relatorio/apply-decisions.ts`):
+
+```json
+{
+  "projectId": "uuid",
+  "changedBy": "uuid-opcional",
+  "newFields": [ /* lista COMPLETA de fields após aplicar mudanças */ ],
+  "resolutions": [
+    { "source": "anotacao", "rawId": "uuid" },
+    { "source": "review",   "rawId": "uuid" },
+    { "source": "nota",     "rawId": "response-uuid", "note": "texto opcional" },
+    { "source": "dificuldade", "rawId": "response-uuid", "documentId": "doc-uuid", "note": "..." },
+    { "source": "duvida",   "reviewId": "uuid", "respondentId": "uuid" },
+    { "source": "sugestao", "rawId": "suggestion-uuid", "action": "approved" }
+  ],
+  "summaryNote": "texto opcional: resumo do que foi decidido nessa rodada"
+}
+```
+
+Salve em `/tmp/decisions-{projectName}-{timestamp}.json`.
+
+### 2.4 Rodar dry-run
+
+Sempre primeiro:
+```bash
+cd frontend
+npx tsx scripts/comentarios-relatorio/apply-decisions.ts /tmp/decisions-xxx.json --dry-run
+```
+
+Revise o output (`changeType`, `newVersion`, `logEntries`). Mostre ao usuário.
+
+### 2.5 Aplicar
+
+Após confirmação do usuário:
+```bash
+npx tsx scripts/comentarios-relatorio/apply-decisions.ts /tmp/decisions-xxx.json --yes
+```
+
+Isso:
+1. Atualiza `projects.pydantic_code`, `pydantic_hash`, `pydantic_fields`, `schema_version_*`
+2. Insere entries em `schema_change_log`
+3. Marca LLM responses antigas como `is_current=false` (se hash mudou)
+4. Resolve cada comentário via INSERT/UPDATE na tabela correta
+5. Registra `summaryNote` como um `project_comment` já resolvido (trilha de auditoria)
+
+## Referências
+
+- `references/comment-sources.md` — detalhes das 6 fontes de comentários (schema, queries, semântica)
+- `references/markdown-format.md` — gramática detalhada do .md que o usuário anota
+
+## Gotchas
+
+- **Drift de lógica**: `apply-decisions.ts` duplica `saveSchemaFromGUI` de `frontend/src/actions/schema.ts`. Quando aquela função evoluir (classificação de versão, novos campos de `PydanticField`, etc.), atualizar o script também. A duplicação é intencional (script não pode chamar server actions fora do Next runtime).
+- **Parser e gerador acoplados**: o formato do .md é definido pelo `generate-report.py`. Se alterar o gerador (heading style, onde ficam os ids, etc.), atualizar também a seção 2.1 deste SKILL.md e `references/markdown-format.md`. O gerador e o parser (Claude) precisam estar de acordo.
+- **Cluster = 1 decisão para N ids**: um bloco pode conter review + várias dúvidas + anotações. A diretiva `Decisão:` se aplica a todos os ids listados em `<!-- ids: ... -->`. Ao montar `resolutions` do JSON, produzir uma entry por id.
+- **Responses humanas não são invalidadas**: mudança de descrição marca LLM como stale (via hash), mas respostas humanas permanecem — staleness é detectada em display time via `answer_field_hashes`.
+- **Não inferir demais**: se uma nota geral menciona vários fields de forma ambígua, liste como cross-reference (não invente mudanças de schema). O usuário decide.
+- **`duvida` tem chave composta**: `(review_id, respondent_id)`, não um id único. No sintético o formato é `duvida-{reviewId}-{respondentId}` — parse com cuidado (`rawId` tem hifens internos).
+- **Sugestões**: aprovar uma sugestão com edits é equivalente a incluir as mudanças em `newFields` + adicionar `{ source: "sugestao", rawId: "...", action: "approved" }` nas resolutions. Não precisa chamar uma API separada.
+- **`changedBy`**: se omitido, o script usa `projects.created_by` como fallback. Isso garante que o audit log tenha um user_id válido mesmo rodando fora do contexto Clerk.
+
+## Invocação
+
+O usuário aciona com frases como:
+- "gera relatório de comentários do projeto Zolgensma"
+- "compila os comentários abertos"
+- "quero revisar o feedback do projeto X"
+- "/comentarios-relatorio"
+
+Ao terminar o passo 1, confirme o caminho do .md. Ao terminar o passo 2, mostre um resumo (quantos comentários resolvidos, versão bumpada de X → Y, quantos log entries inseridos).

--- a/.claude/skills/comentarios-relatorio/references/comment-sources.md
+++ b/.claude/skills/comentarios-relatorio/references/comment-sources.md
@@ -1,0 +1,158 @@
+# Fontes de comentários no dataframeitGUI
+
+O dataframeitGUI consolida feedback de 6 fontes diferentes na página `/projects/[id]/reviews/comments` (ver `frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx:35-312`). A skill replica essas queries filtrando apenas os abertos.
+
+## Visão geral
+
+| Source | Tabela | Chave | "Aberto" quando | Campo atrelado? |
+|---|---|---|---|---|
+| `anotacao` | `project_comments` | `id` | `resolved_at IS NULL AND parent_id IS NULL` | opcional (`field_name`) |
+| `review` | `reviews` | `id` | `resolved_at IS NULL AND comment IS NOT NULL` | sim (`field_name`) |
+| `nota` | `responses` (humano) + `note_resolutions` | `response.id` | tem `justifications._notes` E `response_id NOT IN note_resolutions` | não (sempre `(geral)`) |
+| `dificuldade` | `responses` (LLM) + `difficulty_resolutions` | `response.id` | tem `answers.llm_ambiguidades` E `response_id NOT IN difficulty_resolutions` E `is_current=true` | não (sempre `(geral)`) |
+| `duvida` | `verdict_acknowledgments` + `reviews` | `(review_id, respondent_id)` | `resolved_at IS NULL AND status='questioned'` | sim (via `reviews.field_name`) |
+| `sugestao` | `schema_suggestions` | `id` | `status='pending'` | sim (`field_name`) |
+
+## Detalhes por fonte
+
+### anotacao — `project_comments`
+
+Anotação livre criada via modal "Nova nota". Pode ser:
+- **Global** (sem `field_name` nem `document_id`)
+- **Por campo** (`field_name`, sem `document_id`)
+- **Por documento** (sem `field_name`, com `document_id`)
+- **Específica** (ambos)
+
+Suporta threads via `parent_id` — a skill só considera comentários raiz.
+
+Resolver: `UPDATE project_comments SET resolved_at=now(), resolved_by=<user> WHERE id=<id>`.
+
+### review — `reviews`
+
+Comentário de comparação de respostas divergentes. Gerado no fluxo `/analyze/compare`. Sempre atrelado a `(document_id, field_name)`.
+
+Campos extras carregados: `verdict`, `chosen_response_id`, `response_snapshot` (array de respondentes com suas respostas).
+
+Resolver: `UPDATE reviews SET resolved_at=now(), resolved_by=<user> WHERE id=<id>`.
+
+### nota — `responses.justifications._notes`
+
+Pesquisador escreveu um texto livre ao codificar um documento. Só aparece se `justifications._notes` está preenchido. Não está atrelado a um field específico — pode cobrir vários.
+
+Dedup especial: uma nota = um `response_id` (unique por pesquisador × documento).
+
+Resolver: `INSERT INTO note_resolutions (project_id, response_id, resolved_by, note)`.
+Reabrir: `DELETE FROM note_resolutions WHERE response_id=<id>`.
+
+### dificuldade — `responses.answers.llm_ambiguidades`
+
+Quando o projeto tem um campo especial `llm_ambiguidades` no schema, o LLM preenche com ambiguidades percebidas. Skill carrega apenas de responses com `is_current=true`.
+
+Resolver: `INSERT INTO difficulty_resolutions (project_id, response_id, document_id, resolved_by, note)`.
+Reabrir: `DELETE FROM difficulty_resolutions WHERE response_id=<id>`.
+
+### duvida — `verdict_acknowledgments`
+
+Pesquisador contestou um veredito no fluxo "Meu Gabarito". Join com `reviews` para pegar `field_name`, `document_id`, `verdict`.
+
+Chave composta: `(review_id, respondent_id)`.
+
+Resolver: `UPDATE verdict_acknowledgments SET resolved_at=now() WHERE review_id=<id> AND respondent_id=<id>`.
+
+### sugestao — `schema_suggestions`
+
+Pesquisador propôs mudança explícita no schema (via EditFieldDialog). JSONB `suggested_changes` pode conter `description`, `help_text`, `options`.
+
+Aprovar aplica as mudanças + marca como resolvido. Ver `approveSchemaSuggestionWithEdits` em `frontend/src/actions/suggestions.ts:95-119`.
+
+## Queries originais
+
+Todas as 9 queries paralelas da `page.tsx`:
+
+```ts
+// 1. project — schema fields
+supabase.from("projects").select("pydantic_fields, created_by").eq("id", id).single()
+
+// 2. reviews — comparações
+supabase.from("reviews")
+  .select("id, document_id, field_name, verdict, comment, chosen_response_id, resolved_at, reviewer_id, created_at, response_snapshot")
+  .eq("project_id", id)
+  .not("comment", "is", null)
+
+// 3. documents — para mapear title
+supabase.from("documents").select("id, title, external_id").eq("project_id", id)
+
+// 4. membership — pra saber se é coordenador
+supabase.from("project_members").select("role").eq("project_id", id).eq("user_id", user.id)
+
+// 5. responses humanas com justifications → notas
+supabase.from("responses")
+  .select("id, document_id, respondent_name, justifications, created_at")
+  .eq("project_id", id).eq("respondent_type", "humano")
+  .not("justifications", "is", null)
+
+// 6. schema_change_log — histórico
+supabase.from("schema_change_log")
+  .select("...")
+  .eq("project_id", id)
+  .order("created_at", { ascending: false })
+  .limit(50)
+
+// 7. schema_suggestions — sugestões
+supabase.from("schema_suggestions")
+  .select("id, field_name, suggested_changes, reason, status, resolved_at, created_at, profiles!suggested_by(email)")
+  .eq("project_id", id)
+
+// 8. responses LLM com llm_ambiguidades → dificuldades
+supabase.from("responses")
+  .select("id, document_id, answers, respondent_name, created_at")
+  .eq("project_id", id).eq("respondent_type", "llm").eq("is_current", true)
+
+// 9. difficulty_resolutions — já resolvidos
+supabase.from("difficulty_resolutions")
+  .select("response_id, resolved_at").eq("project_id", id)
+
+// 10. project_comments — anotações
+supabase.from("project_comments")
+  .select("id, document_id, field_name, author_id, body, parent_id, resolved_at, resolved_by, created_at, profiles!author_id(email)")
+  .eq("project_id", id).is("parent_id", null)
+
+// 11. verdict_acknowledgments — dúvidas
+supabase.from("verdict_acknowledgments")
+  .select("review_id, respondent_id, comment, resolved_at, created_at, reviews!inner(id, project_id, document_id, field_name, verdict)")
+  .eq("status", "questioned").not("comment", "is", null)
+  .eq("reviews.project_id", id)
+
+// 12. note_resolutions — notas já resolvidas
+supabase.from("note_resolutions").select("response_id, resolved_at").eq("project_id", id)
+```
+
+A skill reaproveita essas queries em `scripts/comentarios-relatorio/fetch-open-comments.ts`, mas filtra só os abertos.
+
+## Payload dos comentários no JSON
+
+Cada comentário vira um `OpenComment`:
+
+```ts
+interface OpenComment {
+  id: string;              // "review-<uuid>", "nota-<uuid>", "duvida-<reviewId>-<respondentId>"
+  source: "review" | "nota" | "sugestao" | "dificuldade" | "duvida" | "anotacao";
+  rawId: string;           // id real para mutations
+  fieldName: string;       // nome do field Pydantic ou "(geral)"
+  documentId: string | null;
+  documentTitle: string | null;
+  text: string;
+  author: string;
+  createdAt: string;       // ISO
+  extra: Record<string, unknown>;  // metadata source-específico
+}
+```
+
+### `extra` por source:
+
+- **review**: `{ verdict, chosenResponseId, responseSnapshot, fieldType, fieldOptions }`
+- **nota**: `{ responseId, respondentId }`
+- **sugestao**: `{ suggestedChanges, changedKeys, status, currentField }`
+- **dificuldade**: `{ responseId, documentId }`
+- **duvida**: `{ reviewId, respondentId, verdict, fieldType, fieldOptions }`
+- **anotacao**: `{ fieldType, fieldOptions }`

--- a/.claude/skills/comentarios-relatorio/references/markdown-format.md
+++ b/.claude/skills/comentarios-relatorio/references/markdown-format.md
@@ -1,0 +1,194 @@
+# Formato do relatório .md
+
+Gramática do .md que a skill `comentarios-relatorio` gera (passo 1, via `generate-report.py`) e parseia de volta (passo 2, via Claude).
+
+## Princípios
+
+1. **Conversacional, não formulário**: headings são prosa; metadados dos campos ficam em linhas `**Label:** valor` (uma por atributo).
+2. **Cluster = 1 bloco = 1 decisão**: quando múltiplos pesquisadores contestam o mesmo veredito, vão num único H3 com a decisão aplicada a todos.
+3. **IDs invisíveis ao leitor**: os `rawId`s necessários para resolução ficam num comentário HTML `<!-- ids: ... -->` no fim do bloco.
+4. **Diretivas em HTML comments**: `<!-- aprovar | ... -->` é o placeholder. O usuário edita dentro dos `<!-- -->` ou substitui totalmente pelo valor desejado.
+
+## Estrutura
+
+```markdown
+# Comentários em aberto — {projectName}
+
+Projeto `{projectId}` na versão do schema `{version}`. Gerado em {YYYY-MM-DD}.
+
+Há **{N} comentários em aberto** — {M} perguntas com comentários específicos e {P} nota(s) geral(is). Por fonte: ...
+
+Para cada bloco, preencha `Decisão:` ...
+
+---
+
+## `{fieldName}`
+
+**Pergunta:** {description}
+**Orientação aos pesquisadores:** {help_text}     (opcional)
+**Opções:** A · B · C                              (opcional)
+**Subcampos:** key (label), ... ({regra})          (opcional)
+
+### {heading livre identificando o cluster}
+
+{corpo conversacional: prosa + citações + bullets de quem disse o quê}
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional -->
+
+<!-- ids: {source}-{rawId}; {source}-{rawId}; ... -->
+
+---
+
+## Notas gerais
+
+### {heading: Nota / Ambiguidade}
+
+{corpo}
+
+**Campos mencionados:** <!-- ex: q2, q14 -->
+**Decisão:** <!-- ... -->
+**Mudança no schema:** <!-- ... -->
+**Nota ao resolver:** <!-- ... -->
+
+<!-- ids: nota-<response-uuid> -->
+```
+
+## Tipos de cluster e seus headings
+
+Gerados por `generate-report.py`:
+
+| Tipo de cluster | Heading típico | Conteúdo |
+|---|---|---|
+| Review + dúvidas | `### Review de **{reviewer}** em *{doc}* — contestado por N pesquisadores` | Review original + todas as dúvidas com `extra.reviewId == review.rawId` + anotações do mesmo `documentId` |
+| Review sem dúvidas | `### Review de **{reviewer}** em *{doc}*` | Só o review |
+| Dúvidas órfãs | `### Dúvidas em *{doc}* sobre o veredito "{verdict}" (N pesquisadores)` | Dúvidas cujo review já foi resolvido |
+| Anotação única | `### Anotação de **{autor}** em *{doc}* ({date})` | 1 anotação avulsa |
+| Anotações múltiplas | `### N anotações em *{doc}*` | Várias anotações no mesmo documento |
+| Sugestão | `### Sugestão de schema por **{autor}** ({date})` | 1 sugestão |
+| Nota geral | `### Nota de pesquisador de **{autor}** ao codificar *{doc}* ({date})` | 1 nota livre |
+| Dificuldade LLM | `### Ambiguidade reportada pelo LLM em *{doc}* ({date})` | 1 `llm_ambiguidades` |
+
+**Vereditos multi-select** (JSON dict) são resumidos em `"opção A, opção B e mais N"` — o gerador chama `format_verdict()` em `generate-report.py`.
+
+## Diretivas
+
+Sempre estas (na ordem):
+
+```markdown
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional -->
+```
+
+Em blocos da seção "Notas gerais", adicionar também:
+
+```markdown
+**Campos mencionados:** <!-- ex: q2, q14 -->
+```
+
+### Semântica da decisão
+
+| Valor | Efeito |
+|---|---|
+| `aprovar` | Aplica "Mudança no schema" + marca **todos os ids do bloco** como resolvidos |
+| `rejeitar` | Não aplica mudança; marca todos os ids como resolvidos. Para sugestão, `status=rejected` |
+| `reformular` | Marca como resolvido + registra "Nota ao resolver" num novo `project_comment` já resolvido |
+| `ignorar` ou vazio | Pula o bloco (não resolve nada) |
+
+### Aceitar escrita humana
+
+O usuário frequentemente escreve em português livre. Interpretar semanticamente (ver também seção 2.1 do SKILL.md):
+
+- "Ignorar e resolver" / "ok, resolver sem mudar" / "fechar" → `rejeitar`
+- "Aprovar" + texto em "Mudança no schema" → `aprovar`
+- "Reformular" / "ajustar com nota" → `reformular`
+- "Ignorar" / "depois" / "pular" / vazio → pular
+
+Em caso de dúvida, usar `AskUserQuestion`.
+
+## IDs no rodapé
+
+Formato:
+
+```markdown
+<!-- ids: id1; id2; id3 -->
+```
+
+Cada id é `{source}-{rawId}`:
+- `review-{uuid}`
+- `nota-{response-uuid}`
+- `sugestao-{suggestion-uuid}`
+- `dificuldade-{response-uuid}`
+- `anotacao-{project-comment-uuid}`
+- `duvida-{reviewId}-{respondentId}` — **dois UUIDs concatenados com `-`**
+
+Ao parsear `duvida`: o id sintético tem formato `duvida-{8-4-4-4-12}-{8-4-4-4-12}`. Regex utilizável:
+
+```
+^duvida-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$
+```
+
+## Algoritmo de parse (passo 2)
+
+1. Ler o .md inteiro
+2. Split por `^## ` → cada seção é um field ou "Notas gerais"
+3. Para cada seção não-geral, capturar `fieldName` do heading `## \`{name}\``
+4. Dentro, split por `^### ` → cada bloco é um cluster
+5. Para cada bloco:
+   - Extrair `<!-- ids: ... -->` do fim
+   - Extrair diretivas entre `<!--` e `-->` de cada linha `**Decisão:**`, `**Mudança no schema:**`, `**Nota ao resolver:**`, `**Campos mencionados:**`
+   - Se `Decisão:` vazio ou "ignorar" → pular
+   - Se tem "Mudança no schema" preenchida, interpretar como mutações de `PydanticField[]`
+6. Consolidar todas as mutações em um único `newFields` (lista completa)
+7. Gerar `resolutions` com um item por id encontrado
+
+## Exemplo completo (mini)
+
+```markdown
+# Comentários em aberto — Zolgensma
+
+Projeto `0c6394da-...` na versão do schema `0.11.1`. Gerado em 2026-04-22.
+
+Há **2 comentários em aberto** — 1 pergunta com comentários específicos e 0 notas gerais. Por fonte: 1 review, 1 duvida.
+
+---
+
+## `q8_registro_anvisa`
+
+**Pergunta:** Registro na ANVISA
+**Opções:** Sim · Não · Não informado
+
+### Review de **Jacqueline** em *Parecer 123* — contestado por Um pesquisador
+
+Em 2026-03-27, **Jacqueline** revisou este documento e escolheu o veredito **"Não informado"**, deixando a seguinte observação:
+
+> Tem casos em que o documento diz "em análise". Podemos adicionar essa opção?
+
+Um pesquisador manifestou dúvida sobre esse veredito:
+
+- **Maria** — Quando o registro foi cancelado, conto como "Não"?
+
+**Decisão:** <!-- aprovar -->
+**Mudança no schema:** <!-- adicionar opção "Em análise"; help_text: "Se cancelado, marcar Não." -->
+**Nota ao resolver:** <!-- Conforme reunião 2026-04-20 -->
+
+<!-- ids: review-abc123; duvida-abc123-resp1 -->
+```
+
+Esse .md produz:
+
+```json
+{
+  "projectId": "0c6394da-...",
+  "newFields": [ /* q8 com options=[...,"Em análise"], help_text="Se cancelado, marcar Não." */ ],
+  "resolutions": [
+    { "source": "review", "rawId": "abc123" },
+    { "source": "duvida", "reviewId": "abc123", "respondentId": "resp1" }
+  ],
+  "summaryNote": "Conforme reunião 2026-04-20"
+}
+```
+
+Classificação: mudança em `options` → **minor**. Versão: `0.11.1` → `0.12.0`.

--- a/docs/comentarios/Encaminhamentos.md
+++ b/docs/comentarios/Encaminhamentos.md
@@ -1,0 +1,13 @@
+q3 - especificar que só deve ser incluido numero referente ao do paciente, não ao de qualquer processo judicial citado.
+q6 - incluir 'Não identificável'
+q9 - incluir help_text destacando que resposta deve ser específica para a condição do paciente.
+q10 - incluir help_text destacando que resposta deve ser específica para a condição do paciente.
+q11 - incluir opção 'Não aplicável'
+q11 - incluir help_text explicando relação entre a pergunta e menções ao PCDT
+Ocultar q13, q15 e q16. Não deletar, mas não apresentar nem para humanos nem para o LLM.
+
+Incluir ANS na pergunta de agencias reguladoras citadas?
+
+Rodar LLM de novo.
+
+Reorganizar q24

--- a/docs/comentarios/Zolgensma-20260422-direcionamentos.md
+++ b/docs/comentarios/Zolgensma-20260422-direcionamentos.md
@@ -1,0 +1,268 @@
+# Direcionamentos pré-coordenador — Zolgensma (2026-04-22)
+
+## Tema 1 — Categoria "Não informado / Não aplicável" e condicionalidade quando não há recomendação
+
+Este é o maior bloco. Aparece em **cinco lugares diferentes** e o núcleo é o mesmo: hoje várias perguntas têm uma opção-escape ("Não informado") que está sendo usada para cenários em que, na verdade, (a) a informação **tem que estar explícita** (caso contrário a resposta é "não"), ou (b) a pergunta simplesmente **não se aplica** (ex: NatJus nem emitiu recomendação).
+
+### Pontos agrupados
+
+- **q9 Indicação conforme Anvisa** — Wangdanielwl (anotação em NT 3672/2025 NAT-JUS/SP): *"Tirar não informado, ou foi explicitada ou nao foi"*.	
+- **q9 (comentário originalmente lançado em q2)** — Wangdanielwl, ainda em NT 3672/2025 NAT-JUS/SP, deixou também a anotação *"Não fala se foi registrado para aquela condição"*. O registro ficou no campo da q2 (id da NT), mas o conteúdo é sobre q9: ele observou que o parecer não esclarece se o medicamento tem registro Anvisa **para aquela condição específica**. Reforça o ponto de que "Não informado" está virando categoria-escape em casos em que o parecer omite a especificação.
+- **q20 Metodologia de evidência** — Wangdanielwl (anotação em Parecer NATJUS-Federal 0647/2025 - RJ): *"Não se aplica porque não houve recomendação"*.
+- **q11 Pedido conforme critérios SUS** — Leitedesouza (nota geral, ponto 1): *"Se não foi incorporado ao sus, responde não? Acredito que a pergunta poderia ser opcional."*
+- **q24 (nota geral Leitedesouza, ponto 5)** — *"É para preencher 'Justificativas utilizadas pelo NatJus para a (não) recomendação' se não houver decisão pelo Nat? Está como pergunta obrigatória"*. (Este aspecto é mencionado aqui porque é o mesmo padrão, mas o debate central sobre q24 está no doc separado.)
+- **q6 Data de nascimento do paciente** — Marianapuschel (dúvida): *"Acho que se a gente precisa padronizar o NI, não fala. Podia ficar no comentário da pergunta até terminarmos"*. É um pedido de política transversal de "NI = não identificável", que afeta potencialmente todas as perguntas com essa opção.
+
+### Estado atual das perguntas citadas
+
+**q9_indicacao_conforme_anvisa**
+- **Descrição:** "Indicação conforme registro na ANVISA"
+- **Help_text:** — (não tem)
+- **Opções** (`single`): "Sim", "Não", "Não informado"
+
+**q20_metodologia_evidencia**
+- **Descrição:** "A metodologia para o levantamento de evidência clínica foi explicitada?"
+- **Help_text:** "Como o próprio NatJus indicou que coletou e analisou as evidências sobre a tecnologia avaliada"
+- **Opções** (`single`): "Sim", "Não", "Não houve levantamento de evidência (não foram citados estudos científicos)", "Não informado"
+
+**q11_pedido_criterios_sus**
+- **Descrição:** "Pedido para uso de acordo com os critérios para incorporação ao SUS"
+- **Help_text:** — (não tem)
+- **Opções** (`single`): "Sim", "Não", "Não informado"
+
+**q21_relatorio_recomenda** (referência para condicionalidade)
+- **Descrição:** "Relatório recomenda o tratamento para o paciente"
+- **Opções** (`single`): "Sim", "Sim, mas com ressalvas", "Não", "NatJus não emitiu recomendação"
+- Observação importante: já existe o conceito "NatJus não emitiu recomendação" nessa pergunta. Ele pode servir de **gatilho canônico** para condicionar q11/q20/q24.
+
+**q6_data_nascimento_paciente**
+- **Descrição:** "Data de nascimento do paciente"
+- **Tipo:** `date`, sem help_text, sem opções especiais.
+- (O "NI" que a Marianapuschel menciona é a opção `"Não identificável"` que aparece em outras perguntas do tipo `text`, como q2, q3 e q22. A q6 é data, então "NI" aqui teria outro tratamento.)
+
+### Minhas propostas
+
+1. **Remover "Não informado" de q9.** As opções ficam apenas "Sim" e "Não". A lógica do Wangdanielwl ("ou foi explicitada ou não foi") é forte: se o parecer não indica conforme/não conforme ANVISA, a resposta é "Não" (não foi conforme explicitado). **Trade-off:** força o pesquisador em casos genuinamente ambíguos × elimina a categoria-escape que estava sendo usada para "prefiro não decidir". **Impacto retroativo:** respostas atuais marcadas "Não informado" precisam ser retomadas — são ~N casos (se você quiser, eu levanto o número exato antes de aplicar).
+
+2. **Adicionar opção "Não aplicável" em q20.** O Wangdanielwl aponta que, quando o parecer nem chega a emitir recomendação, a pergunta sobre metodologia de evidência perde sentido. **Trade-off:** "Não aplicável" é uma categoria mais honesta que "Não informado" nesse cenário × adiciona complexidade para o codificador decidir entre os quatro ou cinco valores. **Alternativa mais clean:** tornar q20 **condicional** a `q21 != "NatJus não emitiu recomendação"` (ou seja, só aparece quando houve recomendação). Se a pergunta não aparece, não precisa de opção "Não aplicável".
+
+3. **Tornar q11 condicional a q10.** Só perguntar "pedido conforme critérios SUS" quando `q10_tratamento_incorporado_sus` for "Sim" (ou similar). Quando o tratamento nem é incorporado, a pergunta vira vazia mesmo. **Trade-off:** mais elegante × perde-se o registro de "o pedido seguia alguma outra lógica de incorporação?" em casos raros.
+
+4. **Tornar q24 condicional a q21** — faz parte do doc separado de q24, mas menciono aqui para você ver que o padrão é o mesmo: quando `q21 == "NatJus não emitiu recomendação"`, q24 não faz sentido.
+
+5. **Política geral de "NI".** Acho que vale uma decisão metodológica de projeto que valha para **todas as perguntas com `"Não identificável"` como opção** (hoje: q2, q3, q22). Opções que enxergo:
+   - (a) "NI" só quando o dado existe no parecer mas está ilegível/ininteligível (ex: campo rasurado, parcial).
+   - (b) "NI" sempre que o pesquisador não consegue extrair o dado (seja porque não está, seja porque está confuso).
+   - (c) Exige distinção entre "Não consta" e "Não identificável" em perguntas de texto — aí provavelmente adicionamos uma opção nova ("Não consta no parecer").
+
+### Perguntas para você
+
+- Aprova remover "Não informado" de q9? O que fazemos com respostas passadas?
+- Prefere **opção "Não aplicável" em q20** ou **tornar q20 condicional a q21 ≠ sem recomendação**? (Eu voto na segunda, mais limpa.)
+- Aprova tornar q11 condicional a q10?
+- Qual das três leituras de "NI" é a oficial? Precisa virar uma nota metodológica no topo do projeto?
+
+---
+
+## Tema 2 — Distinção "caso geral do tratamento" vs. "caso específico do paciente"
+
+Duas perguntas têm o mesmo problema estrutural: elas coletam uma resposta binária, mas o parecer pode dizer algo diferente no plano geral (o tratamento existe / está incorporado) e no plano do caso individual (não para este paciente específico). Hoje não há como registrar os dois planos.
+
+### Pontos agrupados
+
+- **q3 Número do processo judicial** — Wangdanielwl (anotação em NT 451549 - TRF4/RS): *"Daniel: marca sim aqui e informa na questão seguinte que não para o caso do paciente"*. É uma orientação de codificação, mas deixa claro que a estrutura atual não distingue "há processo vinculado ao parecer mas não é o do paciente" de "há processo do paciente".
+- **q10 Tratamento incorporado ao SUS** — Leitedesouza (review em NT 451549 - TRF4/RS, 2026-03-27, veredito "Sim"): *"O parecer fala não, mas entendo que está, só não para o caso do paciente. Como lidamos com isso?"*
+
+### Estado atual
+
+**q3_numero_processo_judicial**
+- **Descrição:** "Número processo judicial"
+- **Tipo:** `text` (captura o número)
+- **Help_text:** — (não tem)
+- **Opções especiais:** "Não identificável"
+
+**q10_tratamento_incorporado_sus**
+- **Descrição:** "Tratamento incorporado ao SUS"
+- **Help_text:** — (não tem)
+- **Opções** (`single`): "Sim", "Não", "Não informado"
+
+### Minhas propostas
+
+1. **Para q3 — acrescentar opção especial.** Como você sugeriu: adicionar uma opção ao nível de `options` tipo *"Há apenas número de processo não relacionado ao paciente"*. O campo continua sendo `text`, mas essa opção serve de sinalizador quando se marca sem preencher o número. **Trade-off:** pesquisador ganha categoria precisa × adiciona a responsabilidade de lembrar quando usar ("mas e se for parcialmente relacionado?"). **Alternativa:** deixar como está e adicionar help_text: *"Se houver processo mencionado no parecer que não é do paciente em análise, informar como 'Há apenas nº de processo não relacionado ao paciente'."* — mas sem a opção no enum fica vago.
+
+2. **Para q10 — dois desenhos possíveis.**
+   - **(a) Dividir em duas perguntas.** Uma: *"Tratamento incorporado ao SUS (em geral)?"* — Sim/Não. Outra: *"Incorporado para o quadro clínico do paciente?"* — Sim/Não/Não aplicável.
+     - **Trade-off:** capta com precisão o caso do Leitedesouza. Aumenta o formulário em uma pergunta. Torna análise cruzada mais rica (dá pra cruzar "incorporado em geral mas não para o paciente" × veredito final).
+   - **(b) Acrescentar opção à pergunta atual.** "Sim", "Não", "Sim, mas não para o caso do paciente", "Não informado".
+     - **Trade-off:** não quebra a estrutura da pergunta. Categoria "sim mas não para o caso" pode virar bucket guarda-chuva (vai ter casos genuinamente sim e casos onde é "sim na teoria"). Comparações entre respostas ficam mais fracas (um pesquisador marca "Sim", outro "Sim mas não para o caso" para o mesmo parecer — isso aparece como divergência).
+
+### Perguntas para você
+
+- Para q3, aprova a nova opção *"Há apenas número de processo não relacionado ao paciente"*? Outra redação que prefira?
+- Para q10, **(a)** dividir em duas perguntas ou **(b)** acrescentar opção?
+- Se for (a), seria boa hora de pensar se **q11** (critérios SUS) deve se referir à dimensão geral ou à específica do paciente.
+
+---
+
+## Tema 3 — Ajuste de redação com PCDT (q11)
+
+Só um ponto nesse tema, mas conecta com Tema 1 (condicionalidade).
+
+### Ponto
+
+**q11** — Leitedesouza (review em NT 451549 - TRF4/RS, 2026-03-27, veredito "Não"): *"Mudaria a redação da pergunta para incluir PDCT"*. Traduzindo: PCDT (Protocolo Clínico e Diretrizes Terapêuticas) é o documento do SUS que rege o uso de tecnologias incorporadas. Para uma parte dos pareceres, o que existe é um PCDT específico — não uma "incorporação" genérica.
+
+### Estado atual
+
+**q11_pedido_criterios_sus**
+- **Descrição:** "Pedido para uso de acordo com os critérios para incorporação ao SUS"
+- **Help_text:** — (não tem)
+- **Opções** (`single`): "Sim", "Não", "Não informado"
+
+### Minha proposta
+
+Mudar a descrição para algo como:
+
+> "Pedido para uso de acordo com os critérios para incorporação ao SUS / PCDT"
+
+ou, mais explícito:
+
+> "Pedido para uso conforme critérios de incorporação ao SUS ou PCDT (Protocolo Clínico e Diretrizes Terapêuticas)"
+
+**Trade-off:** segunda opção é mais didática, mas pesada; primeira é seca mas depende do pesquisador saber o que é PCDT (provavelmente já sabe). Em ambos os casos, pode-se **adicionar help_text** explicando: *"Marcar 'Sim' se o pedido seguir tanto os critérios de incorporação do SUS (via Conitec) quanto eventuais PCDT específicos para a patologia."*
+
+Junto disso, cabe discutir a condicionalidade já mencionada no Tema 1 (q11 só aparece quando `q10 != Não` ou similar).
+
+### Perguntas para você
+
+- Qual redação prefere?
+- Adicionar help_text explicando PCDT?
+- Aprova a condicionalidade `q11 depende de q10`?
+
+---
+
+## Tema 4 — Escopo da pergunta q20 ("incluir ANS" — ambíguo)
+
+### Ponto
+
+**q20** — Wangdanielwl (anotação em NT 3672/2025 NAT-JUS/SP): *"Considerar apenas a justificação da conclusão: mudar a questão para incluir ANS"*.
+
+Aqui eu genuinamente não sei o que ele quis dizer. Há duas leituras plausíveis:
+
+- **(a)** A q20 trata de metodologia de evidência. A ANS (Agência Nacional de Saúde Suplementar) também emite notas técnicas sobre tecnologias — talvez o Wangdanielwl esteja sugerindo que a pergunta não é só sobre NatJus, mas também sobre pareceres de ANS (expandindo escopo).
+- **(b)** "Mudar a questão para incluir ANS" pode ser uma referência ambígua a limitar o escopo textual (tipo "na parte da Análise de Síntese"? — forçado, mas possível), ou a incluir alguma sigla nova no rol.
+
+### Estado atual
+
+**q20_metodologia_evidencia** — já citado no Tema 1. Reproduzindo:
+- **Descrição:** "A metodologia para o levantamento de evidência clínica foi explicitada?"
+- **Help_text:** "Como o próprio NatJus indicou que coletou e analisou as evidências sobre a tecnologia avaliada"
+- **Opções** (`single`): "Sim", "Não", "Não houve levantamento de evidência (não foram citados estudos científicos)", "Não informado"
+
+### Pergunta para você (ou para o Wangdanielwl diretamente)
+
+- O que ele quis dizer com "incluir ANS"? Vale pedir clarificação antes de mexer.
+- Se for leitura (a) — estender para pareceres de ANS —, o escopo do projeto vai além de NatJus mesmo? Isso é uma mudança de **escopo da pesquisa**, não só de redação da pergunta.
+
+---
+
+## Tema 5 — Perguntas q15 e q16 (outras agências e outros países)
+
+### Ponto
+
+Leitedesouza (nota geral, ponto 2): *"'Menção a avaliação de tecnologia em outros países, especificar quais' e 'Menção a registro em outras agências, especificar quais'. Acredito que ambas as perguntas poderiam ser respondidas com regex"*.
+
+### Estado atual
+
+**q15_registro_outras_agencias**
+
+- **Descrição:** "Menção a registro em outras agências, especificar quais"
+- **Tipo:** `multi`, com `allow_other: true`
+- **Opções:** "FDA (EUA)", "EMA (União Europeia)", "MHRA (Reino Unido)", "PMDA (Japão)", "Não houve"
+
+**q16_avaliacao_tecnologia_outros_paises**
+- **Descrição:** "Menção a avaliação de tecnologia em outros países, especificar quais"
+- **Tipo:** `multi`, com `allow_other: true`
+- **Opções:** "NICE (Inglaterra)", "CADTH (Canadá)", "PBAC (Austrália)", "IQWiG (Alemanha)", "HAS (França)", "Não houve"
+
+### Observação importante
+
+O schema atual **já não é texto livre** — é `multi` com as principais agências listadas e `allow_other: true` para quem não estiver na lista. Então a sugestão de "responder via regex" talvez venha da expectativa de que essas perguntas sejam de texto livre, o que não é o caso hoje (talvez o Leitedesouza tenha codificado numa versão antiga do schema onde era `text`? Pelo log do banco, houve mudanças de opções dessas perguntas em 2026-04-10).
+
+### Minhas propostas
+
+1. **Manter como está** — o desenho atual com lista fechada + `allow_other` já cumpre o papel que "regex" cumpriria (padronizar entradas frequentes). **Resposta sugerida ao Leitedesouza:** *"Já migramos para multi-select com as principais agências — pode ajudar checar se na sua última codificação você viu o formato de texto livre, pois nesse caso o schema estava atrasado."*
+
+2. **Se o ponto dele é "a lista está incompleta"** — aí vale perguntar: quais agências ele viu aparecerem no corpus que ainda não estão nas opções? Adicionamos.
+
+3. **Se o ponto é "queria validação automática do texto livre em `allow_other`"** — aí é uma feature de aplicação, não de schema. Pode virar follow-up.
+
+### Perguntas para você
+
+- Confirma que o design atual (multi + allow_other) é o que queremos?
+- Conhece agência/país que não está no rol e aparece com frequência?
+
+---
+
+## Tema 6 — "Não coletamos mais outras opções de tratamento?" (Leitedesouza ponto 3)
+
+### Ponto
+
+Leitedesouza (nota geral, ponto 3): *"Não vamos mais coletar se há outras opções de tratamento?"*
+
+Interpretação: parece sugerir que em algum momento havia uma pergunta sobre alternativas terapêuticas disponíveis ao paciente e que hoje sumiu.
+
+### O que achei no histórico
+
+Consultei o `schema_change_log` do projeto: **nenhum campo foi removido** ao longo das 19 alterações registradas desde 2026-04-01. Todas as mudanças foram em campos existentes (ajuste de instruções, opções ou descrição). Ou seja, **não há uma pergunta "outras opções de tratamento" que tenha sido excluída deste projeto**.
+
+### Três possibilidades
+
+1. **O Leitedesouza está pensando em outro projeto.** Pode ser confusão com outro estudo.
+2. **Ele está propondo incluir essa pergunta.** Nesse caso, a redação deveria ser algo tipo: *"O parecer menciona outras opções terapêuticas disponíveis para a condição do paciente?"* e, se sim, quais.
+3. **Ele está se referindo a q24 (justificativas)**, que tem a opção "(Não) Há alternativa terapêutica adequada disponível". A alternativa é **citada como justificativa**, não codificada separadamente.
+
+### Minhas propostas
+
+- Responder ao Leitedesouza pedindo esclarecimento antes de mudar algo.
+- Se for (2), considerar adicionar uma pergunta nova — mas isso é uma mudança maior, que impacta o gabarito e a paridade com codificações já feitas. Precisa decisão sua.
+- Se for (3), explicar que a alternativa terapêutica está capturada em q24.
+
+### Pergunta para você
+
+- Acha que vale uma pergunta nova sobre alternativas de tratamento, ou a informação já está suficientemente coberta em q24?
+
+---
+
+## Resumo rápido das decisões pedidas
+
+| Tema | Decisão | Complexidade |
+|---|---|---|
+| 1. q9: remover "Não informado" | sim/não | baixa, mas impacta retroativo |
+| 1. q20: "Não aplicável" ou condicional a q21 | escolha entre duas | baixa |
+| 1. q11: condicional a q10 | sim/não | baixa |
+| 1. Política de "NI" | escolher entre (a)(b)(c) | média (decisão transversal) |
+| 2. q3: adicionar opção | aprovar/ajustar | baixa |
+| 2. q10: dividir em duas ou acrescentar opção | escolher entre (a)(b) | **alta** (muda estrutura) |
+| 3. q11 PCDT: redação | escolher entre duas | baixa |
+| 4. q20 "incluir ANS" | desambiguar com Wangdanielwl | depende do que ele quis dizer |
+| 5. q15/q16 "regex" | confirmar que o design atual basta | baixa |
+| 6. Alternativas de tratamento | pergunta nova, ou não | média |
+
+---
+
+## Comentários já fechados offline (só registro)
+
+Esses 3 blocos não precisam da sua revisão — a ação é apenas fechar o ciclo:
+
+1. **q14 (review do Leitedesouza "Não é experimental" + 4 dúvidas de pesquisadores + review "Não há menção" do Wangdanielwl)** — o help_text de q14 já é *"Marcar 'não é experimental' apenas se isso for dito expressamente."* — exatamente a regra que os 4 pesquisadores defenderam nos comentários. O review antigo do Leitedesouza foi aplicação incorreta da regra, não problema de schema. Fechar todos como rejeitar, mantendo a regra.
+2. **q22 (dúvida da Naomi sobre padronizar reescrita)** — marcado pelo próprio usuário no relatório: "Ignorar e resolver".
+3. **Nota geral da Naomi sobre dificuldade em identificar a recomendação do NatJus** — marcado pelo próprio usuário: "Ignorar e resolver".
+
+> A anotação do Wangdanielwl originalmente lançada em q2 ("Não fala se foi registrado para aquela condição") foi reposicionada para o Tema 1 (debate de q9) acima — é sobre registro do medicamento para a condição específica, não sobre o id da NT.
+
+---
+
+Quando você quiser responder, pode ser direto aqui por cima (marcando escolhas) ou em reunião. Depois de definirmos, a aplicação no schema é automática com os scripts existentes — bumpa versão, marca as codificações LLM antigas como stale e re-avalia o que for necessário.
+
+**Próximo doc:** `Zolgensma-20260422-q24-justificativas.md` (debate metodológico da q24 em separado).

--- a/docs/comentarios/Zolgensma-20260422-q24-justificativas.md
+++ b/docs/comentarios/Zolgensma-20260422-q24-justificativas.md
@@ -1,0 +1,219 @@
+# Direcionamentos pré-coordenador — q24 Justificativas (Zolgensma, 2026-04-22)
+
+> **Status (2026-04-23):** decisões aplicadas no schema (projeto Zolgensma, versão 0.12.0 → 0.13.0).
+> - **Tema A:** adotada leitura estrita (A1) — help_text foca no tópico conclusivo.
+> - **Tema B:** dividida em duas perguntas por polaridade (B1) — `q24a_justificativas_favoraveis` e `q24b_justificativas_desfavoraveis`.
+> - **Tema C:** condicionalidade aplicada — q24a aparece se `q21 ∈ {Sim, Sim com ressalvas}`; q24b aparece se `q21 ∈ {Sim com ressalvas, Não}`. Nenhuma aparece quando `q21 = NatJus não emitiu recomendação`.
+> - **Tema D:** opção 10 unificada para "Uso de acordo com protocolo clínico do SUS / PCDT" (polaridade correspondente em cada pergunta).
+> - Help_text inclui notas adicionais sobre (i) "evidência genérica vs. evidência para o grupo do paciente" (caso Matheuscadedi/NT 451549) e (ii) pareceres sem seção conclusiva clara (caso Matheuscadedi/NATJUS-Federal 0647/2025).
+> - 11 dúvidas em q24 + 1 anotação reclassificada de q10 (Wangdanielwl) foram resolvidas. Respostas LLM anteriores ficaram automaticamente invalidadas via `pydantic_hash`; respostas humanas não foram migradas (ficarão sinalizadas para re-codificação).
+
+
+Pergunta **q24 (Justificativas utilizadas pelo NatJus para a (não) recomendação)** foi separada do documento principal porque foi o campo que gerou mais debate na rodada: 10 comentários de 4 pesquisadores em 4 documentos distintos, mais duas referências cruzadas em notas gerais. O problema de fundo é **metodológico** e retrodepende de decisões que afetam codificações já feitas — por isso vale dedicar atenção específica.
+
+---
+
+## Estado atual da pergunta
+
+### q24_justificativas_recomendacao
+
+- **Descrição:** "Justificativas utilizadas pelo NatJus para a (não) recomendação"
+- **Tipo:** `multi` (o pesquisador pode marcar mais de uma)
+- **Help_text atual:**
+  > "Marcar apenas aquilo que serve para fundamentar a recomendação, não as ressalvas.
+  > Incluir apenas o que de fato justifica a conclusão, o que o parecer destaca como fundamental para a decisão."
+- **11 opções atuais** (literais, na ordem do schema):
+  1. "(Não) Há evidência segura de benefício clínico"
+  2. "(Não) Há alternativa terapêutica adequada disponível"
+  3. "(Riscos à) Segurança (efeitos colaterais e eventos adversos)"
+  4. "(Não) possui registro na Anvisa"
+  5. "Uso (não) de acordo com bula (on/off label)"
+  6. "(Alto) Impacto orçamentário/custo/custo-efetividade (QALY)"
+  7. "Conitec (não) recomendou tratamento"
+  8. "Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec"
+  9. "Tratamento (não) está incorporado ao SUS"
+  10. "Uso (não) de acordo com protocolo clínico do SUS"
+  11. "Ausência de documentos necessários para elaboração do parecer"
+
+### q21_relatorio_recomenda (referência importante)
+
+- **Descrição:** "Relatório recomenda o tratamento para o paciente"
+- **Tipo:** `single`
+- **Opções:** "Sim", "Sim, mas com ressalvas", "Não", "NatJus não emitiu recomendação"
+
+Observação: q21 **já registra** o caso "NatJus não emitiu recomendação", o que facilita amarrar a lógica de condicionalidade para q24.
+
+---
+
+## Tema A — Escopo de leitura: só conclusão ou parecer inteiro?
+
+### O problema
+
+O help_text atual diz *"Incluir apenas o que de fato justifica a conclusão"*, mas isso é **ambíguo**: "justificar a conclusão" pode ser lido como (a) *"aparece literalmente no tópico de conclusão do parecer"* (ex: seção 3.11 das notas do NAT-JUS/SP), ou (b) *"qualquer coisa que, no parecer inteiro, sustenta a conclusão final"*. Os pesquisadores se dividiram nessa leitura, com impactos concretos em como codificaram cada documento.
+
+### Quem defende cada lado
+
+**Lado "só conclusão" (leitura estrita)**
+
+- **Wangdanielwl** — consistente em três documentos:
+  - NT 3672/2025 NAT-JUS/SP: *"Eu colocaria apenas 'Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec'. Na conclusão não há menção a evidência"*.
+  - NT 451549 TRF4/RS: *"Com relação ao gabarito, acho que o correto é tirar referência ao protocolo e incluir 'Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec'"*.
+  - NT NatJus - DF - AME tipo I: *"Considerar apenas o que está no 3.11: (Não) possui registro na Anvisa; (Não) Há evidência segura de benefício clínico; Impacto orçamentário/custo/custo-efetividade (QALY); Conitec (não) recomendou tratamento; Uso (não) de acordo com protocolo clínico do SUS"*.
+- **Matheuscadedi** — manifesta pelo menos ambivalência em favor dessa leitura: *"Para a resposta eu havia considerado, somente, o tópico da 'conclusão justificada'. Nesse sentido, o tópico não citou, expressamente, a presença ou ausência de evidência segura de benefício clínico. Mantemos essa lógica ou olhamos para outras partes do parecer?"*
+
+**Lado "parecer inteiro" (leitura ampla)**
+
+- **Marianapuschel** (NT 3672/2025 NAT-JUS/SP): *"Acho que fala em custo-efetividade na conclusão"* — a inclusão de custo-efetividade decorre de olhar para o corpo + conclusão.
+- **Matheuscadedi** (NT NatJus - DF): *"Confirmar se deve ser consultado somente o tópico conclusivo ou se o parecer como um todo"* — sinaliza que ele também tem dúvida, não é 100% "só conclusão".
+- **Luizscho** (NT 3672/2025 NAT-JUS/SP): *"Posso estar muito engando, mas considerando apenas a conclusão justificada, o fato do paciente não se enquadrar no grupo para a qual a tecnologia foi recomendada que foi elemento determinante para fundamentar a decisão. Me parece que, além disso, o parecer se baseia em critérios técnicos e regulatórios."* — Luizscho tenta reconciliar: na conclusão, o central é "paciente não se enquadra"; no resto, há outros critérios.
+
+### Casos-limite que apareceram
+
+- **Matheuscadedi (NT 451549)**: *"existem situações em que os pareceres mencionam existir evidências gerais de benefício, mas que estes benefícios não são comprovados para o grupo em que o paciente se enquadra. Nessas hipóteses a alternativa deve ser preenchida?"*
+   → Problema: o parecer cita evidência **em abstrato**, mas **não** evidência **para o grupo do paciente**. Marcar opção 1 ou não?
+- **Matheuscadedi (Parecer NATJUS-Federal 0647/2025 - RJ)**: *"Esse parecer foi particularmente difícil, pois não há tópico de conclusões ou uma posição clara sobre a recomendação ou não ao uso do medicamento. Isso dificulta o mapeamento das justificativas. Assim, é difícil diferenciar o que é uma 'informação jogada' e o que é uma justificativa."*
+   → Problema: em pareceres sem seção conclusiva clara, a leitura "só conclusão" não se aplica — o que fazer?
+- **Naomi (NT 451549)**: *"Vi aqui e acho que a única alternativa que faltou no meu gabarito foi essa 'Uso (não) de acordo com protocolo clínico do SUS'. Dúvida leiga - protocolo clínico e PCDT são a mesma coisa?"*
+   → Problema: confusão terminológica entre "protocolo clínico do SUS" (opção 10 de q24) e PCDT (que aparece em q11 se aceitarmos a mudança).
+
+### Comentário reposicionado — Wangdanielwl originalmente em q10
+
+No relatório original, há uma anotação do **Wangdanielwl** registrada em **q10** (Tratamento incorporado ao SUS) dizendo:
+
+> *"Daniel: opções 1 (não foram estabelecidos estudos de segurança e eficácia para essa população), 6 (Cabe considerar o custo e a custo-efetividade do tratamento.) e 8 (O uso do medicamento fora das condições especificadas pela CONITEC — isto é, para pacientes com AME tipo 1, com mais de 6 meses de idade na data da solicitação — poderia comprometer uma parte significativa dos recursos públicos)"*
+
+As "opções 1, 6 e 8" descritas são, palavra por palavra, o conteúdo das opções de **q24**:
+- **Opção 1:** "(Não) Há evidência segura de benefício clínico"
+- **Opção 6:** "(Alto) Impacto orçamentário/custo/custo-efetividade (QALY)"
+- **Opção 8:** "Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec"
+
+O que parece ter acontecido é que o Wangdanielwl usou o campo de anotação da q10 para justificar seu voto de **q24** naquele documento. Ou seja: para **NT 451549 TRF4/RS**, a sugestão dele é marcar as opções 1, 6 e 8 de q24 — o que conecta diretamente com o comentário dele em q24 do mesmo documento (citado acima no "lado só conclusão").
+
+### Propostas para o Tema A
+
+**Proposta A1 — Consagrar "só conclusão" no help_text (endossar a leitura estrita).**
+- Nova redação do help_text:
+  > "Marcar apenas as justificativas explicitamente usadas no tópico conclusivo do parecer (ex: seção 3.11 em notas do NAT-JUS/SP, ou o bloco equivalente em outros pareceres). Não inferir justificativas a partir do corpo geral do documento. Em pareceres sem seção conclusiva clara, anotar no campo 'nota do pesquisador' e optar por 'Não aplicável' via q21."
+- **Trade-off:** reprodutibilidade alta (dois pesquisadores lendo o mesmo parecer chegam ao mesmo resultado) × perde nuances do corpo (um parecer que fundamenta no corpo mas é seco na conclusão ficaria subcodificado).
+- **Impacto retroativo:** respostas codificadas com a leitura ampla precisam ser retomadas em todos os 4 documentos citados (pelo menos).
+
+**Proposta A2 — Consagrar "parecer inteiro" no help_text (endossar a leitura ampla).**
+- Nova redação:
+  > "Considerar todas as justificativas que fundamentam a recomendação, mesmo que apareçam fora do tópico conclusivo. O critério é funcional: se o argumento sustenta a conclusão (mesmo que apenas implicitamente), marcar a opção correspondente."
+- **Trade-off:** captura mais informação × depende de julgamento do pesquisador, então respostas variam mais entre codificadores. Comparações humanas ficam mais ruidosas.
+- **Impacto retroativo:** o oposto de A1.
+
+**Proposta A3 — Híbrida: dois níveis de peso.**
+- Manter a leitura ampla, mas acrescentar uma **questão ou subcampo** tipo "qual dessas justificativas aparece no tópico conclusivo?" — capturando a hierarquia (corpo vs. conclusão) sem descartar nada.
+- **Trade-off:** análise mais rica × dobra trabalho do pesquisador; exige desenho novo.
+- **Conecta com Proposta B** (dividir a pergunta).
+
+### Pergunta para você
+
+Antes de avançar para as outras sub-questões: **qual leitura deve ser oficial?** (A1, A2 ou A3). Sugiro **A1** — é a que o Wangdanielwl e o Matheuscadedi estão defendendo com mais consistência, e é mais reprodutível para o tipo de análise empírica que esse projeto alimenta. Mas isso tem custo retroativo.
+
+---
+
+## Tema B — Dividir q24 em duas perguntas (proposta do Leitedesouza)
+
+### Ponto
+
+Leitedesouza (nota geral, ponto 4): *"Não íamos dividir essa pergunta em dois? 'Justificativas utilizadas pelo NatJus para a (não) recomendação'"*.
+
+Como está, a pergunta mistura justificativas **pró-recomendação** e **contra-recomendação** num único multi-select (note como todas as opções começam com "(Não)..."). Na hora da análise, é possível inferir o sentido pela combinação com q21 (se q21="Sim", o "(Não)" das opções lê-se como "Há"; se q21="Não", lê-se como "Não há"), mas isso é fonte comprovada de erro.
+
+### Três desenhos possíveis
+
+**Proposta B1 — Dividir por polaridade.**
+- q24a: *"Justificativas utilizadas pelo NatJus para **recomendar** o tratamento"* — opções sem "(Não)" na frente, formuladas positivamente.
+- q24b: *"Justificativas utilizadas pelo NatJus para **não recomendar** o tratamento"* — opções com "(Não)" ou "Riscos" explícitos.
+- **Trade-off:** elimina a ambiguidade da dupla leitura × codificador tem que marcar em duas listas longas.
+
+**Proposta B2 — Dividir por escopo de leitura** (conecta com Tema A).
+- q24a: *"Justificativas utilizadas no tópico conclusivo do parecer"* — lista única de justificativas, mas restrita ao que aparece explícito na conclusão.
+- q24b: *"Justificativas mencionadas no corpo do parecer (fora da conclusão)"* — lista igual, mas para o corpo.
+- **Trade-off:** captura a hierarquia corpo × conclusão (a "A3" no Tema A acima) × cada parecer ganha duas perguntas idênticas, aumentando o formulário.
+
+**Proposta B3 — Manter a pergunta única mas reformular para separar polaridade e escopo em campos internos.**
+- Ao marcar uma opção (ex: "Há evidência segura"), o codificador preenche dois sub-checkboxes: "aparece na conclusão?" (sim/não) e "peso: a favor / contra".
+- **Trade-off:** análise rica × implementação mais complexa; depende da UI suportar bem essa estrutura.
+
+### Pergunta para você
+
+A divisão é desejável, mas a forma muda a análise:
+- B1 resolve só a polaridade (dá pra fazer análises "NatJus recomendou vs. não recomendou" limpas).
+- B2 resolve só a hierarquia conclusão × corpo (dá pra medir "argumentos na conclusão têm mais peso" empiricamente).
+- B3 é mais rico, mas mais caro.
+
+Qual dessas rotas é mais alinhada com o objetivo da pesquisa?
+
+---
+
+## Tema C — Condicionalidade quando não há recomendação
+
+### Ponto
+
+Leitedesouza (nota geral, ponto 5): *"É para preencher 'Justificativas utilizadas pelo NatJus para a (não) recomendação' se não houver decisão pelo Nat? Está como pergunta obrigatória"*.
+
+### Minha proposta
+
+**Proposta C1 — Tornar q24 condicional a `q21 != "NatJus não emitiu recomendação"`.**
+- Quando q21 for "NatJus não emitiu recomendação", a q24 não aparece no formulário.
+- Tecnicamente: usar o mecanismo de `depends_on` do schema.
+- **Trade-off:** elimina o ruído de respostas forçadas em pareceres sem decisão × precisa cuidado na análise (ausência de q24 ≠ "nenhuma justificativa" — é "sem decisão").
+
+Esse ponto é **independente** do debate sobre escopo de leitura (Tema A), então pode ser aplicado primeiro mesmo antes do resto ser resolvido.
+
+### Pergunta para você
+
+Aprova a condicionalidade `q24 depende de q21 ≠ "NatJus não emitiu recomendação"`?
+
+---
+
+## Tema D — Terminologia: "protocolo clínico do SUS" × "PCDT" (dúvida da Naomi)
+
+### Ponto
+
+Naomi (NT 451549 TRF4/RS): *"Dúvida leiga - protocolo clínico e PCDT são a mesma coisa?"*
+
+A opção 10 de q24 diz *"Uso (não) de acordo com protocolo clínico do SUS"*. Se no projeto decidirmos incorporar **PCDT** em q11 (ver doc principal, Tema 3), a opção 10 de q24 fica desatualizada — ou pior, fica inconsistente com q11.
+
+### Minha proposta
+
+**Proposta D1 — Padronizar a sigla no schema.**
+Renomear a opção 10 para: *"Uso (não) de acordo com protocolo clínico do SUS / PCDT"* (ou o que decidirmos em q11).
+
+**Trade-off:** consistência terminológica × pode ser redundante se PCDT já foi citado em q11. Alternativa: deixar q24 como está e adicionar uma **nota metodológica de projeto** esclarecendo que *"protocolo clínico do SUS"* e *"PCDT"* são equivalentes.
+
+### Pergunta para você
+
+Prefere mudar a opção ou manter e esclarecer via nota?
+
+---
+
+## Resumo das decisões pedidas para q24
+
+| Tema | Decisão |
+|---|---|
+| A. Escopo de leitura | A1 (só conclusão) / A2 (parecer inteiro) / A3 (híbrido) |
+| B. Divisão da pergunta | B1 (polaridade) / B2 (conclusão × corpo) / B3 (subcampos) / manter única |
+| C. Condicionalidade a q21 | sim / não |
+| D. PCDT na opção 10 | renomear / manter com nota externa |
+
+As Temas A e B são conectados: se a decisão de A for A3 (híbrido), então B2 vira a implementação natural. Se for A1 ou A2, a divisão é menos essencial — dá pra fazer só C e D.
+
+---
+
+## Impacto retroativo
+
+**Se A1 ou A2 muda o help_text**, isso gera um novo `pydantic_hash` para q24 e **invalida automaticamente** as respostas LLM (elas são marcadas como stale e re-executadas). Respostas humanas não são invalidadas automaticamente, mas a divergência entre o que foi codificado e o novo critério fica visível na UI (via `answer_field_hashes`).
+
+**Se B divide a pergunta**, as respostas antigas não se encaixam automaticamente nas duas novas perguntas. Precisamos decidir:
+- Marcar tudo como stale e pedir re-codificação.
+- Migrar automaticamente (ex: em B1, mapear opções "pro-conclusão" e "contra" via heurística a partir de q21).
+
+Em qualquer dos cenários, vale alinhar com o coordenador **antes** de aplicar, porque o custo de re-codificação recai em pesquisadores ativos.
+
+---
+
+Quando você tiver respostas para A, B, C e D, eu monto a mudança no schema (bump de versão minor ou major dependendo do peso das mudanças), rodo `apply-decisions.ts` em dry-run, confirmo contigo, e aplico.

--- a/docs/comentarios/Zolgensma-20260422.md
+++ b/docs/comentarios/Zolgensma-20260422.md
@@ -1,0 +1,322 @@
+# Comentários em aberto — Zolgensma
+
+Projeto `0c6394da-dd2e-4ac0-af83-a107fae37ad4` na versão do schema `0.11.1`. Gerado em 2026-04-22.
+
+Há **31 comentários em aberto** — 10 perguntas com comentários específicos e 2 nota(s) geral(is). Por fonte: 7 anotacao, 18 duvida, 2 nota, 4 review.
+
+Para cada bloco, preencha `Decisão:` dentro do comentário HTML (`<!-- ... -->`). Valores: **aprovar** (aplica a mudança e fecha), **rejeitar** (fecha sem mudar), **reformular** (fecha registrando uma nota com orientação), **ignorar** (pula — não fecha nada).
+
+---
+
+## `q2_id_nota_tecnica`
+
+**Pergunta:** Id Nota Técnica - incluir apenas o número do Id
+**Orientação aos pesquisadores:** Incluir também o ano da nota técnica, se houver.
+**Opções:** Não identificável
+
+### Anotação de **Wangdanielwl** em *Nota Tecnica 3672/2025 NAT-JUS/SP - AME tipo 1 (G12.9)* (2026-04-07)
+
+> Não fala se foi registrado para aquela condição
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: anotacao-209986c1-fd16-410b-86d0-15a300448ddd -->
+
+---
+
+## `q3_numero_processo_judicial`
+
+**Pergunta:** Número processo judicial
+**Opções:** Não identificável
+
+### Anotação de **Wangdanielwl** em *Nota Tecnica 451549 - TRF4/RS - AME (G12.1)* (2026-04-07)
+
+> Daniel: marca sim aqui e informa na questão seguinte que não para o caso do paciente
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: anotacao-5fe362e7-e002-4799-b82b-fc13b361ae48 -->
+
+---
+
+## `q6_data_nascimento_paciente`
+
+**Pergunta:** Data de nascimento do paciente
+
+### Dúvidas em *Nota Tecnica 451549 - TRF4/RS - AME (G12.1)* sobre o veredito "NI" (Um pesquisador)
+
+- **Marianapuschel** (2026-04-07) — Acho que se a gente precisa padronizar o NI, não fala. Podia ficar no comentário da pergunta até terminarmos
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: duvida-5c2e0ca1-fec6-455e-8f2c-94339c690724-334390e4-358d-44bd-b04a-2bbf4bc1bdd7 -->
+
+---
+
+## `q9_indicacao_conforme_anvisa`
+
+**Pergunta:** Indicação conforme registro na ANVISA
+**Opções:** Sim · Não · Não informado
+
+### Dúvidas em *Parecer NATJUS-Federal 0647/2025 - RJ - AME tipo 1* sobre o veredito "Não informado" (Um pesquisador)
+
+- **Marianapuschel** (2026-04-07) — aqui tem escrito que é registrado pela anvisa, não faz sentido não ser informado
+
+No mesmo documento há Uma anotação:
+
+- **Wangdanielwl** — No caso, não houve levantamento de estudos cientificos
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: duvida-5e5141f4-6147-40b3-a5d8-6b08c5619b75-334390e4-358d-44bd-b04a-2bbf4bc1bdd7; anotacao-a30cd51b-3493-481c-8c61-3dac9a0a34b3 -->
+
+### Anotação de **Wangdanielwl** em *Nota Tecnica 3672/2025 NAT-JUS/SP - AME tipo 1 (G12.9)* (2026-04-07)
+
+> Tirar não informado, ou foi explicitada ou nao foi
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: anotacao-a1a0446e-16bb-41c1-8d60-26c072825365 -->
+
+---
+
+## `q10_tratamento_incorporado_sus`
+
+**Pergunta:** Tratamento incorporado ao SUS
+**Opções:** Sim · Não · Não informado
+
+### Review de **Leitedesouza** em *Nota Tecnica 451549 - TRF4/RS - AME (G12.1)*
+
+Em 2026-03-27, **Leitedesouza** revisou este documento e escolheu o veredito **"Sim"**, deixando a seguinte observação:
+
+> O parecer fala não, mas entendo que está, só não para o caso do paciente. Como lidamos com isso?
+
+Além disso, Uma anotação no mesmo documento:
+
+- **Wangdanielwl** — Daniel: opções 1 (não foram estabelecidos estudos de segurança e eficácia para essa população), 6 (Cabe considerar o custo e a custo-efetividade do tratamento.) e 8 ( O uso do medicamento fora das condições especificadas pela CONITEC — isto é, para pacientes com AME tipo 1, com mais de 6 meses de idade na data da solicitação — poderia comprometer uma parte significativa dos recursos públicos)
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: review-61dd6a37-6662-4dfb-aa3c-c64cb13d95e8; anotacao-dd797512-aa71-4b3d-aace-92c70c123eb2 -->
+
+---
+
+## `q11_pedido_criterios_sus`
+
+**Pergunta:** Pedido para uso de acordo com os critérios para incorporação ao SUS
+**Opções:** Sim · Não · Não informado
+
+### Review de **Leitedesouza** em *Nota Tecnica 451549 - TRF4/RS - AME (G12.1)*
+
+Em 2026-03-27, **Leitedesouza** revisou este documento e escolheu o veredito **"Não"**, deixando a seguinte observação:
+
+> Mudaria a redação da pergunta para incluir PDCT
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: review-3792c3d6-cfa1-431f-a799-8bc2ff13c348 -->
+
+---
+
+## `q14_tratamento_experimental`
+
+**Pergunta:** Há menção ao tratamento ser experimental?
+**Orientação aos pesquisadores:** Marcar 'não é experimental' apenas se isso for dito expressamente.
+**Opções:** Sim, é experimental · Não é experimental · Não há menção
+
+### Review de **Wangdanielwl** em *Nota Tecnica NatJus - DF - AME tipo I*
+
+Em 2026-04-07, **Wangdanielwl** revisou este documento e escolheu o veredito **"Não há menção"**, deixando a seguinte observação:
+
+> Entendo que essa pergunta pode gerar dúvidas. Discutir. Marcar como "não experimental" apenas se for mencionado que não é experimental. Se não falar nada, marca como não há menção ou NI
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: review-38770b0b-e19e-4eda-b11e-071b9d489f20 -->
+
+### Review de **Leitedesouza** em *Nota Tecnica NatJus - DF - AME tipo I* — contestado por Quatro pesquisadores
+
+Em 2026-03-27, **Leitedesouza** revisou este documento e escolheu o veredito **"Não é experimental"**, deixando a seguinte observação:
+
+> Entendo que essa pergunta pode gerar dúvidas. Discutir.
+
+Quatro pesquisadores manifestaram dúvida sobre esse veredito:
+
+- **Matheuscadedi** — Nessa pergunta eu não encontrei menção expressa no parecer (dizendo que o tratamento era experimental). Consideramos só quando houver menção expressa ou presumimos pelo contexto?
+- **Marianapuschel** — Não achei essa informação, talvez eu tenha perdido
+- **Naomi** — Acho que essa pergunta gera dúvidas mesmo. Uma possível sugestão é deixar para indicar se é experimental somente quando o relatório expressamente indicar que é experimental / não é? Pelas infos da nota, não peguei mesmo essa parte em que constata-se que não é experimental.
+- **Wangdanielwl** — Onde menciona que não é experimental? Se não fala nada, então a resposta é "nao há menção"
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: review-8b2bb91c-d6dd-4a94-abb5-e222a27e219d; duvida-8b2bb91c-d6dd-4a94-abb5-e222a27e219d-d9b22caa-ab02-41e1-9d1e-da51035663c0; duvida-8b2bb91c-d6dd-4a94-abb5-e222a27e219d-334390e4-358d-44bd-b04a-2bbf4bc1bdd7; duvida-8b2bb91c-d6dd-4a94-abb5-e222a27e219d-76b5b21c-59e7-4fbd-b080-cdfda5d4eb17; duvida-8b2bb91c-d6dd-4a94-abb5-e222a27e219d-bf71215f-9ce9-400a-8753-bc762bbf4a29 -->
+
+---
+
+## `q20_metodologia_evidencia`
+
+**Pergunta:** A metodologia para o levantamento de evidência clínica foi explicitada? 
+**Orientação aos pesquisadores:** Como o próprio NatJus indicou que coletou e analisou as evidências sobre a tecnologia avaliada
+**Opções:** Sim · Não · Não houve levantamento de evidência (não foram citados estudos científicos) · Não informado
+
+### Anotação de **Wangdanielwl** em *Parecer NATJUS-Federal 0647/2025 - RJ - AME tipo 1* (2026-04-07)
+
+> Não se aplica porque não houve recomendação
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: anotacao-4b71f67a-2fca-47b0-9854-c35cb52c2afe -->
+
+### Anotação de **Wangdanielwl** em *Nota Tecnica 3672/2025 NAT-JUS/SP - AME tipo 1 (G12.9)* (2026-04-07)
+
+> Considerar apenas a justificação da conclusão: mudar a questão para incluir ANS
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: anotacao-a6fb7d39-8758-4a10-8690-ae45a3258ab2 -->
+
+---
+
+## `q22_ressalva_qual`
+
+**Pergunta:** Onde há ressalva, qual
+**Opções:** Não aplicável · Não identificável
+
+### Dúvidas em *Nota Tecnica NatJus - DF - AME tipo I* sobre o veredito "Confirmação de que o paciente se encontra extubado e que, portanto, está apto para preencher integralmente os critérios de inclusão estabelecidos para uso da terapia gênica." (Um pesquisador)
+
+- **Naomi** (2026-04-07) — Acho que o conteúdo tá equivalente ao gabarito, só não idêntico porque copiei e colei do texto. A gente vai combinar de reescrever?
+
+**Decisão:** Ignorar e resolver. 
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: duvida-3960c112-318a-4d69-8041-8e1a1ce49747-76b5b21c-59e7-4fbd-b080-cdfda5d4eb17 -->
+
+---
+
+## `q24_justificativas_recomendacao`
+
+**Pergunta:** Justificativas utilizadas pelo NatJus para a (não) recomendação
+**Orientação aos pesquisadores:** Marcar apenas aquilo que serve para fundamentar a recomendação, não as ressalvas.
+Incluir apenas o que de fato justifica a conclusão, o que o parecer destaca como fundamental para a decisão.
+**Opções:** (Não) Há evidência segura de benefício clínico · (Não) Há alternativa terapêutica adequada disponível · (Riscos à) Segurança (efeitos colaterais e eventos adversos) · (Não) possui registro na Anvisa · Uso (não) de acordo com bula (on/off label) · (Alto) Impacto orçamentário/custo/custo-efetividade (QALY) · Conitec (não) recomendou tratamento · Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec · Tratamento (não) está incorporado ao SUS · Uso (não) de acordo com protocolo clínico do SUS · Ausência de documentos necessários para elaboração do parecer
+
+### Dúvidas em *Nota Tecnica NatJus - DF - AME tipo I* sobre o veredito "(Não) Há evidência segura de benefício clínico, (Não) possui registro na Anvisa, Uso (não) de acordo com bula (on/off label) e mais 5" (Três pesquisadores)
+
+- **Matheuscadedi** (2026-04-09) — confirmar se deve ser consultado somente o tópico conclusivo ou se o parecer como um todo
+- **Naomi** (2026-04-07) — Só não entendi onde entra Uso (não) de acordo com bula (on/off label) - é na parte de ser aprovado pela ANVISA para tal uso? PCDT = protocolo clínico do SUS?
+- **Wangdanielwl** (2026-04-07) — Considerar apenas o que está no 3.11: (Não) possui registro na Anvisa; (Não) Há evidência segura de benefício clínico; Impacto orçamentário/custo/custo-efetividade (QALY); Conitec (não) recomendou tratamento; Uso (não) de acordo com protocolo clínico do SUS
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: duvida-841be49a-181f-4cc1-8c22-8b665fd1b60a-d9b22caa-ab02-41e1-9d1e-da51035663c0; duvida-841be49a-181f-4cc1-8c22-8b665fd1b60a-76b5b21c-59e7-4fbd-b080-cdfda5d4eb17; duvida-841be49a-181f-4cc1-8c22-8b665fd1b60a-bf71215f-9ce9-400a-8753-bc762bbf4a29 -->
+
+### Dúvidas em *Nota Tecnica 3672/2025 NAT-JUS/SP - AME tipo 1 (G12.9)* sobre o veredito "(Não) Há evidência segura de benefício clínico, Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec" (Quatro pesquisadores)
+
+- **Matheuscadedi** (2026-04-09) — Para a resposta eu havia considerado, somente, o tópico da "conclusão justificada". Nesse sentido, o tópico não citou, expressamente, a presença ou ausência de evidência segura de benefício clínico. Mantemos essa lógica ou olhamos para outras partes do parecer?
+- **Luizscho** (2026-04-08) — Posso estar muito engando, mas considerando apenas a conclusão justificada, o fato do paciente não se enquadrar no grupo para a qual a tecnologia foi recomendada que foi elemento determinante para fundamentar a decisão. Me parece que, além disso, o parecer se baseia em critérios técnicos e regulatórios.
+- **Marianapuschel** (2026-04-07) — Acho que fala em custo-efetividade na conclusão
+- **Wangdanielwl** (2026-04-07) — Eu colocaria apenas Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec. Na conclusão não há menção a evidencia
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: duvida-e493e7a6-ac56-4816-a5b5-fa3a8ba5f4c8-d9b22caa-ab02-41e1-9d1e-da51035663c0; duvida-e493e7a6-ac56-4816-a5b5-fa3a8ba5f4c8-dcbc9803-6efb-469b-892f-25e029d47424; duvida-e493e7a6-ac56-4816-a5b5-fa3a8ba5f4c8-334390e4-358d-44bd-b04a-2bbf4bc1bdd7; duvida-e493e7a6-ac56-4816-a5b5-fa3a8ba5f4c8-bf71215f-9ce9-400a-8753-bc762bbf4a29 -->
+
+### Dúvidas em *Parecer NATJUS-Federal 0647/2025 - RJ - AME tipo 1* sobre o veredito "(Não) Há alternativa terapêutica adequada disponível, Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec, Uso (não) de acordo com protocolo clínico do SUS" (Um pesquisador)
+
+- **Matheuscadedi** (2026-04-09) — Esse parecer foi particularmente difícil, pois não há tópico de conclusões ou uma posição clara sobre a recomendação ou não ao uso do medicamento. Isso dificulta o mapeamento das justificativas. Assim, é difícil diferenciar o que é uma "informação jogada" e o que é uma justificativa
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: duvida-506d112a-5850-49de-b38e-3e55ee338b41-d9b22caa-ab02-41e1-9d1e-da51035663c0 -->
+
+### Dúvidas em *Nota Tecnica 451549 - TRF4/RS - AME (G12.1)* sobre o veredito "(Não) Há evidência segura de benefício clínico, (Não) Há alternativa terapêutica adequada disponível, (Alto) Impacto orçamentário/custo/custo-efetividade (QALY) e mais 2" (Três pesquisadores)
+
+- **Matheuscadedi** (2026-04-09) — Sobre a evidência segura do benefício clínico: existem situações em que os pareceres mencionam existir evidências gerais de benefício, mas que estes benefícios não são comprovados para o grupo em que o paciente se enquadra. Nessas hipóteses a alternativa deve ser preenchida?
+- **Naomi** (2026-04-07) — Vi aqui e acho que a única alternativa que faltou no meu gabarito foi essa  "Uso (não) de acordo com protocolo clínico do SUS". Dúvida leiga - protocolo clínico e PCDT são a mesma coisa?
+- **Wangdanielwl** (2026-04-07) — Com relação ao gabarito, acho que o correto é tirar referencia ao protocolo e incluir "Paciente (não) se enquadra no grupo para a qual tecnologia foi recomendada pela Conitec"
+
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: duvida-3742f78c-b604-42d1-9f48-ece80220bea5-d9b22caa-ab02-41e1-9d1e-da51035663c0; duvida-3742f78c-b604-42d1-9f48-ece80220bea5-76b5b21c-59e7-4fbd-b080-cdfda5d4eb17; duvida-3742f78c-b604-42d1-9f48-ece80220bea5-bf71215f-9ce9-400a-8753-bc762bbf4a29 -->
+
+---
+
+## Notas gerais
+
+Comentários não atrelados a uma pergunta específica. O pesquisador pode ter mencionado mais de uma pergunta — ao anotar, liste em `Campos mencionados:` quais perguntas a nota afeta.
+
+### Nota de pesquisador de **Leitedesouza** ao codificar *ZOLGENSMA (ONASEMNOGENE ABEPARVOVEC-XIOI) / ATROFIA MUSCULAR ESPINHAL TIPO 1* (2026-04-17)
+
+> 1. "Pedido para uso de acordo com os critérios para incorporação ao SUS". Se não foi incorporado ao sus, responde não? Acredito que a pergunta poderia ser opcional.
+>
+> 2. "Menção a avaliação de tecnologia em outros países, especificar quais" e "Menção a registro em outras agências, especificar quais". Acredito que ambas as perguntas poderiam ser respondidas com regex
+>
+> 3. Não vamos mais coletar se há outras opções de tratamento?
+>
+> 4. Não íamos dividir essa pergunta em dois? "Justificativas utilizadas pelo NatJus para a (não) recomendação"
+>
+> 5. É para preencher "Justificativas utilizadas pelo NatJus para a (não) recomendação" se não houver decisão pelo Nat? Está como pergunta obrigatória
+
+**Campos mencionados:** <!-- ex: q2, q14 -->
+
+**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: nota-361883d6-87b4-4079-83c2-6a5b2ce0366d -->
+
+### Nota de pesquisador de **Naomi** ao codificar *ZOLGENSMA (ONASEMNOGENE ABEPARVOVEC-XIOI)/ATROFIA MUSCULAR ESPINHAL TIPO 1* (2026-04-16)
+
+> Não fica claro, na NT, qual é a recomendação do NATJUS. Parece que há uma inclinação no sentido de conceder o medicamento, mas não existe um campo afirmativo em que essa informação se confirma. Por esse motivo, apesar de o parecer mencionar comparativo de custo efetividade Zol x Nusinersena, sugerindo que o Zol pode vir a ter menor custo, a longo prazo, eu não indiquei como justificativa para concessão ou não, já que não fica claro em que sentido essa informação está sendo mobilizada. Sobre uso de acordo com a bula, evidência clínica e alternativa terapêutica disponível está mais claro no texto que estão sendo usadas como justificativas.
+
+**Campos mencionados:** <!-- ex: q2, q14 -->
+
+**Decisão:** Ignorar e resolver o comentário.
+**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->
+**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->
+
+<!-- ids: nota-5fad256c-0c67-4cd8-9868-12cf2db977fa -->
+
+---
+

--- a/frontend/scripts/comentarios-relatorio/apply-decisions.ts
+++ b/frontend/scripts/comentarios-relatorio/apply-decisions.ts
@@ -1,0 +1,618 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * apply-decisions.ts
+ *
+ * Lê um arquivo JSON com a lista estruturada de decisões (produzido pelo Claude
+ * a partir do .md anotado pelo usuário) e aplica:
+ *   1. Mudanças no schema Pydantic (replicando primitivas de saveSchemaFromGUI):
+ *      - update projects.{pydantic_code, pydantic_hash, pydantic_fields, schema_version_*}
+ *      - insert schema_change_log entries
+ *      - invalidar responses LLM com hash antigo
+ *   2. Resolução dos comentários via INSERT/UPDATE nas tabelas corretas.
+ *
+ * Uso:
+ *   cd frontend
+ *   npx tsx scripts/comentarios-relatorio/apply-decisions.ts <decisions.json> [--dry-run] [--yes]
+ *
+ * Formato esperado do JSON: ver references/decisions-format.md
+ *
+ * Observação: `generatePydanticCode` é importado diretamente de
+ * `src/lib/schema-utils` (pure, client-safe) para manter paridade com a UI
+ * e evitar drift. A lógica de classificação de versão e persistência duplica
+ * `saveSchemaFromGUI` de `src/actions/schema.ts` porque server actions não
+ * são chamáveis fora do Next runtime.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { generatePydanticCode } from "../../src/lib/schema-utils";
+import type { FieldCondition, PydanticField as LibPydanticField } from "../../src/lib/types";
+
+// ----------------------- Env loading -----------------------
+
+function loadEnv() {
+  const cwd = process.cwd();
+  const candidates = [
+    resolve(cwd, ".env.local"),
+    resolve(cwd, "frontend/.env.local"),
+    resolve(cwd, "../.env.local"),
+  ];
+  for (const path of candidates) {
+    try {
+      const content = readFileSync(path, "utf-8");
+      for (const line of content.split("\n")) {
+        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+        if (!m) continue;
+        const key = m[1];
+        if (process.env[key]) continue;
+        let val = m[2].trim();
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1);
+        }
+        process.env[key] = val;
+      }
+      return;
+    } catch {
+      /* try next */
+    }
+  }
+}
+
+loadEnv();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error(
+    "Faltam NEXT_PUBLIC_SUPABASE_URL e/ou SUPABASE_SERVICE_ROLE_KEY no .env.local",
+  );
+  process.exit(1);
+}
+
+// ----------------------- Tipos -----------------------
+
+type PydanticField = LibPydanticField;
+
+// Formato do JSON de entrada. O Claude gera esse arquivo parseando o .md anotado.
+interface DecisionsFile {
+  projectId: string;
+  // ID do usuário a registrar como changed_by / resolved_by.
+  // Se omitido, tenta pegar o created_by do projeto.
+  changedBy?: string;
+  // Nova lista completa de fields a persistir (já com add/remove/edit aplicados).
+  newFields: PydanticField[];
+  // Lista de comentários a resolver.
+  resolutions: Array<
+    | { source: "anotacao"; rawId: string }
+    | { source: "review"; rawId: string }
+    | { source: "nota"; rawId: string; note?: string } // rawId = response_id
+    | {
+        source: "dificuldade";
+        rawId: string; // response_id
+        documentId: string;
+        note?: string;
+      }
+    | {
+        source: "duvida";
+        reviewId: string;
+        respondentId: string;
+      }
+    | {
+        source: "sugestao";
+        rawId: string; // suggestion_id
+        action: "approved" | "rejected";
+        rejectionReason?: string;
+      }
+  >;
+  // Opcional: nota resumo a registrar num project_comment "meta" após aplicação.
+  summaryNote?: string;
+}
+
+// ----------------------- Funções puras -----------------------
+// `generatePydanticCode` vem de `src/lib/schema-utils` (mesma função usada pela UI).
+// Apenas utilitários específicos do script ficam aqui.
+
+function pythonListRepr(arr: string[]): string {
+  return "[" + arr.map((s) => `'${s}'`).join(", ") + "]";
+}
+
+function computeFieldHash(
+  name: string,
+  type: string,
+  options: string[] | null,
+  description: string,
+): string {
+  const optionsPart = options ? pythonListRepr([...options].sort()) : "";
+  const content = `${name}|${type}|${optionsPart}|${description}`;
+  return crypto.createHash("sha256").update(content).digest("hex").slice(0, 12);
+}
+
+type ChangeType = "major" | "minor" | "patch";
+
+function classifyChange(
+  oldFields: PydanticField[],
+  newFields: PydanticField[],
+): ChangeType | null {
+  const oldNames = new Set(oldFields.map((f) => f.name));
+  const newNames = new Set(newFields.map((f) => f.name));
+
+  const addedOrRemoved =
+    newFields.some((f) => !oldNames.has(f.name)) ||
+    oldFields.some((f) => !newNames.has(f.name));
+
+  if (addedOrRemoved) return "minor";
+
+  let hasStructural = false;
+  let hasTextual = false;
+  const oldMap = new Map(oldFields.map((f) => [f.name, f]));
+
+  for (const n of newFields) {
+    const o = oldMap.get(n.name);
+    if (!o) continue;
+
+    if (o.type !== n.type) hasStructural = true;
+    if ((o.target ?? "all") !== (n.target ?? "all")) hasStructural = true;
+    if ((o.required ?? true) !== (n.required ?? true)) hasStructural = true;
+    if ((o.subfield_rule ?? null) !== (n.subfield_rule ?? null)) hasStructural = true;
+    if ((o.allow_other ?? false) !== (n.allow_other ?? false)) hasStructural = true;
+    if (JSON.stringify(o.subfields ?? null) !== JSON.stringify(n.subfields ?? null)) {
+      hasStructural = true;
+    }
+
+    const optsOld = o.options ?? [];
+    const optsNew = n.options ?? [];
+    const setOld = new Set(optsOld);
+    const setNew = new Set(optsNew);
+    const sameSet =
+      setOld.size === setNew.size && [...setOld].every((x) => setNew.has(x));
+    if (!sameSet) {
+      hasStructural = true;
+    } else if (optsOld.length !== optsNew.length) {
+      hasStructural = true;
+    } else {
+      for (let i = 0; i < optsOld.length; i++) {
+        if (optsOld[i] !== optsNew[i]) {
+          hasTextual = true;
+          break;
+        }
+      }
+    }
+
+    if (o.description !== n.description) hasTextual = true;
+    if ((o.help_text || "") !== (n.help_text || "")) hasTextual = true;
+  }
+
+  if (!hasStructural && !hasTextual) {
+    for (let i = 0; i < newFields.length; i++) {
+      if (newFields[i].name !== oldFields[i]?.name) {
+        hasTextual = true;
+        break;
+      }
+    }
+  }
+
+  if (hasStructural) return "minor";
+  if (hasTextual) return "patch";
+  return null;
+}
+
+function bumpVersion(
+  current: { major: number; minor: number; patch: number },
+  type: ChangeType,
+): { major: number; minor: number; patch: number } {
+  if (type === "major") return { major: current.major + 1, minor: 0, patch: 0 };
+  if (type === "minor")
+    return { major: current.major, minor: current.minor + 1, patch: 0 };
+  return { major: current.major, minor: current.minor, patch: current.patch + 1 };
+}
+
+function snapshotOf(field: PydanticField): Record<string, unknown> {
+  return {
+    name: field.name,
+    type: field.type,
+    description: field.description,
+    help_text: field.help_text ?? null,
+    options: field.options ?? null,
+    target: field.target ?? null,
+    required: field.required ?? null,
+    subfields: field.subfields ?? null,
+    subfield_rule: field.subfield_rule ?? null,
+    allow_other: field.allow_other ?? null,
+  };
+}
+
+// ----------------------- Schema apply -----------------------
+
+async function applySchemaChanges(
+  supabase: SupabaseClient,
+  projectId: string,
+  newFields: PydanticField[],
+  changedBy: string,
+  dryRun: boolean,
+) {
+  const { data: project, error: projErr } = await supabase
+    .from("projects")
+    .select(
+      "pydantic_fields, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch",
+    )
+    .eq("id", projectId)
+    .single();
+  if (projErr) throw new Error(`projects select: ${projErr.message}`);
+
+  const oldFields = (project?.pydantic_fields as PydanticField[]) ?? [];
+  const oldMap = new Map(oldFields.map((f) => [f.name, f]));
+  const newMap = new Map(newFields.map((f) => [f.name, f]));
+
+  const current = {
+    major: project?.schema_version_major ?? 0,
+    minor: project?.schema_version_minor ?? 1,
+    patch: project?.schema_version_patch ?? 0,
+  };
+
+  const changeType = classifyChange(oldFields, newFields);
+  const bumped = changeType ? bumpVersion(current, changeType) : current;
+
+  // Audit entries
+  const logEntries: Array<{
+    field_name: string;
+    change_summary: string;
+    before_value: Record<string, unknown>;
+    after_value: Record<string, unknown>;
+  }> = [];
+
+  for (const f of newFields) {
+    if (oldMap.has(f.name)) continue;
+    logEntries.push({
+      field_name: f.name,
+      change_summary: "campo adicionado",
+      before_value: {},
+      after_value: snapshotOf(f),
+    });
+  }
+  for (const o of oldFields) {
+    if (newMap.has(o.name)) continue;
+    logEntries.push({
+      field_name: o.name,
+      change_summary: "campo removido",
+      before_value: snapshotOf(o),
+      after_value: {},
+    });
+  }
+  for (const f of newFields) {
+    const old = oldMap.get(f.name);
+    if (!old) continue;
+    const diffs: string[] = [];
+    const before: Record<string, unknown> = {};
+    const after: Record<string, unknown> = {};
+
+    if (old.description !== f.description) {
+      diffs.push("descrição");
+      before.description = old.description;
+      after.description = f.description;
+    }
+    if ((old.help_text || "") !== (f.help_text || "")) {
+      diffs.push("instruções");
+      before.help_text = old.help_text || null;
+      after.help_text = f.help_text || null;
+    }
+    const oldOpts = JSON.stringify(old.options ?? null);
+    const newOpts = JSON.stringify(f.options ?? null);
+    if (oldOpts !== newOpts) {
+      diffs.push(f.type === "text" ? "respostas padronizadas" : "opções");
+      before.options = old.options;
+      after.options = f.options;
+    }
+    if (old.type !== f.type) {
+      diffs.push("tipo");
+      before.type = old.type;
+      after.type = f.type;
+    }
+    if ((old.target ?? "all") !== (f.target ?? "all")) {
+      diffs.push("alvo");
+      before.target = old.target ?? null;
+      after.target = f.target ?? null;
+    }
+    if ((old.required ?? true) !== (f.required ?? true)) {
+      diffs.push("obrigatório");
+      before.required = old.required ?? null;
+      after.required = f.required ?? null;
+    }
+    if ((old.subfield_rule ?? null) !== (f.subfield_rule ?? null)) {
+      diffs.push("regra de subcampos");
+      before.subfield_rule = old.subfield_rule ?? null;
+      after.subfield_rule = f.subfield_rule ?? null;
+    }
+    if ((old.allow_other ?? false) !== (f.allow_other ?? false)) {
+      diffs.push("permite outro");
+      before.allow_other = old.allow_other ?? false;
+      after.allow_other = f.allow_other ?? false;
+    }
+    const oldSubs = JSON.stringify(old.subfields ?? null);
+    const newSubs = JSON.stringify(f.subfields ?? null);
+    if (oldSubs !== newSubs) {
+      diffs.push("subcampos");
+      before.subfields = old.subfields ?? null;
+      after.subfields = f.subfields ?? null;
+    }
+    if (diffs.length > 0) {
+      logEntries.push({
+        field_name: f.name,
+        change_summary: diffs.join(", "),
+        before_value: before,
+        after_value: after,
+      });
+    }
+  }
+
+  const code = generatePydanticCode(newFields);
+  const hash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
+  const fieldsWithHash = newFields.map((f) => ({
+    ...f,
+    hash: computeFieldHash(f.name, f.type, f.options, f.description),
+  }));
+
+  const summary = {
+    changeType,
+    currentVersion: `${current.major}.${current.minor}.${current.patch}`,
+    newVersion: `${bumped.major}.${bumped.minor}.${bumped.patch}`,
+    hashChanged: project?.pydantic_hash !== hash,
+    logEntryCount: logEntries.length,
+    logEntries,
+    pydanticCodePreview: code.split("\n").slice(0, 10).join("\n") + "\n...",
+  };
+
+  if (dryRun) {
+    return { dryRun: true, summary };
+  }
+
+  if (!changeType && logEntries.length === 0) {
+    return { dryRun: false, summary, applied: false, reason: "sem mudanças" };
+  }
+
+  // Update projects
+  const updatePayload: Record<string, unknown> = {
+    pydantic_code: code,
+    pydantic_hash: hash,
+    pydantic_fields: fieldsWithHash,
+  };
+  if (changeType) {
+    updatePayload.schema_version_major = bumped.major;
+    updatePayload.schema_version_minor = bumped.minor;
+    updatePayload.schema_version_patch = bumped.patch;
+  }
+  const { error: updErr } = await supabase
+    .from("projects")
+    .update(updatePayload)
+    .eq("id", projectId);
+  if (updErr) throw new Error(`projects update: ${updErr.message}`);
+
+  // Invalidate LLM responses if hash changed
+  if (project?.pydantic_hash && project.pydantic_hash !== hash) {
+    const { error: respErr } = await supabase
+      .from("responses")
+      .update({ is_current: false })
+      .eq("project_id", projectId)
+      .eq("respondent_type", "llm")
+      .neq("pydantic_hash", hash);
+    if (respErr) throw new Error(`responses update: ${respErr.message}`);
+  }
+
+  // Audit log
+  if (logEntries.length > 0) {
+    const { error: logErr } = await supabase.from("schema_change_log").insert(
+      logEntries.map((e) => ({
+        project_id: projectId,
+        changed_by: changedBy,
+        change_type: changeType ?? "patch",
+        version_major: bumped.major,
+        version_minor: bumped.minor,
+        version_patch: bumped.patch,
+        ...e,
+      })),
+    );
+    if (logErr) throw new Error(`schema_change_log insert: ${logErr.message}`);
+  }
+
+  return { dryRun: false, summary, applied: true };
+}
+
+// ----------------------- Comment resolution -----------------------
+
+async function resolveComment(
+  supabase: SupabaseClient,
+  projectId: string,
+  changedBy: string,
+  r: DecisionsFile["resolutions"][number],
+  dryRun: boolean,
+): Promise<{ success: boolean; error?: string; detail?: string }> {
+  if (dryRun) {
+    return { success: true, detail: `DRY RUN: would resolve ${r.source} ${JSON.stringify(r)}` };
+  }
+  const nowIso = new Date().toISOString();
+  try {
+    if (r.source === "anotacao") {
+      const { data, error } = await supabase
+        .from("project_comments")
+        .update({ resolved_at: nowIso, resolved_by: changedBy })
+        .eq("id", r.rawId)
+        .eq("project_id", projectId)
+        .select("id");
+      if (error) return { success: false, error: error.message };
+      if (!data || data.length === 0) return { success: false, error: "not found" };
+      return { success: true };
+    }
+    if (r.source === "review") {
+      const { error } = await supabase
+        .from("reviews")
+        .update({ resolved_at: nowIso, resolved_by: changedBy })
+        .eq("id", r.rawId);
+      if (error) return { success: false, error: error.message };
+      return { success: true };
+    }
+    if (r.source === "nota") {
+      const { error } = await supabase.from("note_resolutions").insert({
+        project_id: projectId,
+        response_id: r.rawId,
+        resolved_by: changedBy,
+        note: r.note || null,
+      });
+      if (error) return { success: false, error: error.message };
+      return { success: true };
+    }
+    if (r.source === "dificuldade") {
+      const { error } = await supabase.from("difficulty_resolutions").insert({
+        project_id: projectId,
+        response_id: r.rawId,
+        document_id: r.documentId,
+        resolved_by: changedBy,
+        note: r.note || null,
+      });
+      if (error) return { success: false, error: error.message };
+      return { success: true };
+    }
+    if (r.source === "duvida") {
+      const { data, error } = await supabase
+        .from("verdict_acknowledgments")
+        .update({ resolved_at: nowIso, resolved_by: changedBy })
+        .eq("review_id", r.reviewId)
+        .eq("respondent_id", r.respondentId)
+        .select("review_id");
+      if (error) return { success: false, error: error.message };
+      if (!data || data.length === 0) return { success: false, error: "not found" };
+      return { success: true };
+    }
+    if (r.source === "sugestao") {
+      const payload: Record<string, unknown> = {
+        status: r.action,
+        resolved_by: changedBy,
+        resolved_at: nowIso,
+      };
+      if (r.action === "rejected" && r.rejectionReason) {
+        payload.rejection_reason = r.rejectionReason;
+      }
+      const { error } = await supabase
+        .from("schema_suggestions")
+        .update(payload)
+        .eq("id", r.rawId);
+      if (error) return { success: false, error: error.message };
+      return { success: true };
+    }
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+  return { success: false, error: "unknown source" };
+}
+
+// ----------------------- Main -----------------------
+
+function parseArgs(argv: string[]) {
+  const out: { file?: string; dryRun: boolean; yes: boolean } = {
+    dryRun: false,
+    yes: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--yes" || a === "-y") out.yes = true;
+    else if (!a.startsWith("-")) out.file = a;
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!args.file) {
+    console.error(
+      "Uso: npx tsx apply-decisions.ts <decisions.json> [--dry-run] [--yes]",
+    );
+    process.exit(1);
+  }
+  const decisionsPath = resolve(process.cwd(), args.file);
+  const raw = readFileSync(decisionsPath, "utf-8");
+  const decisions = JSON.parse(raw) as DecisionsFile;
+
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Resolve changedBy
+  let changedBy = decisions.changedBy;
+  if (!changedBy) {
+    const { data: proj } = await supabase
+      .from("projects")
+      .select("created_by")
+      .eq("id", decisions.projectId)
+      .single();
+    changedBy = proj?.created_by as string;
+  }
+  if (!changedBy) {
+    console.error("Não foi possível resolver changedBy. Forneça decisions.changedBy.");
+    process.exit(1);
+  }
+
+  console.log(
+    `Projeto: ${decisions.projectId}\nchangedBy: ${changedBy}\nNovos fields: ${decisions.newFields.length}\nResoluções: ${decisions.resolutions.length}\ndry-run: ${args.dryRun}\n`,
+  );
+
+  // Step 1: schema
+  const schemaResult = await applySchemaChanges(
+    supabase,
+    decisions.projectId,
+    decisions.newFields,
+    changedBy,
+    args.dryRun,
+  );
+  console.log("---- SCHEMA ----");
+  console.log(JSON.stringify(schemaResult, null, 2));
+
+  // Step 2: confirmação antes de resolver comentários (se não dry-run e não --yes)
+  if (!args.dryRun && !args.yes) {
+    console.log(
+      "\n[info] Para prosseguir com a resolução dos comentários, rode novamente com --yes.",
+    );
+    return;
+  }
+
+  // Step 3: resolutions
+  console.log("\n---- RESOLUÇÕES ----");
+  const results: Array<{ item: unknown; result: unknown }> = [];
+  for (const r of decisions.resolutions) {
+    const res = await resolveComment(
+      supabase,
+      decisions.projectId,
+      changedBy,
+      r,
+      args.dryRun,
+    );
+    results.push({ item: r, result: res });
+  }
+  console.log(JSON.stringify(results, null, 2));
+
+  // Step 4: summaryNote (opcional)
+  if (decisions.summaryNote && !args.dryRun) {
+    const { error } = await supabase.from("project_comments").insert({
+      project_id: decisions.projectId,
+      author_id: changedBy,
+      body: decisions.summaryNote,
+      resolved_at: new Date().toISOString(),
+      resolved_by: changedBy,
+    });
+    if (error) {
+      console.error(`summary note insert: ${error.message}`);
+    } else {
+      console.log("\n[info] summaryNote registrada em project_comments.");
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(`ERRO: ${err?.message ?? err}`);
+  process.exit(1);
+});

--- a/frontend/scripts/comentarios-relatorio/fetch-open-comments.ts
+++ b/frontend/scripts/comentarios-relatorio/fetch-open-comments.ts
@@ -1,0 +1,543 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * fetch-open-comments.ts
+ *
+ * Lê comentários ABERTOS de um projeto dataframeitGUI e imprime JSON estruturado
+ * no stdout para ser consumido pela skill comentarios-relatorio.
+ *
+ * Uso:
+ *   cd frontend
+ *   npx tsx ../.claude/skills/comentarios-relatorio/scripts/fetch-open-comments.ts \
+ *     [--project-id <uuid>] [--project-name <fragmento>] [--list]
+ *
+ * Sem argumentos: imprime lista de projetos disponíveis (JSON).
+ * Com --project-id ou --project-name (match case-insensitive contém): busca os comentários.
+ *
+ * Espelha a lógica de frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+ * mas filtrando apenas abertos. Requer SUPABASE_SERVICE_ROLE_KEY no .env.local.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function loadEnv() {
+  // Carrega frontend/.env.local se variáveis não vierem do ambiente
+  const cwd = process.cwd();
+  const candidates = [
+    resolve(cwd, ".env.local"),
+    resolve(cwd, "frontend/.env.local"),
+    resolve(cwd, "../.env.local"),
+  ];
+  for (const path of candidates) {
+    try {
+      const content = readFileSync(path, "utf-8");
+      for (const line of content.split("\n")) {
+        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+        if (!m) continue;
+        const key = m[1];
+        if (process.env[key]) continue;
+        let val = m[2].trim();
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1);
+        }
+        process.env[key] = val;
+      }
+      return;
+    } catch {
+      /* try next */
+    }
+  }
+}
+
+loadEnv();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error(
+    JSON.stringify({
+      error:
+        "Faltam NEXT_PUBLIC_SUPABASE_URL e/ou SUPABASE_SERVICE_ROLE_KEY. Rode de dentro de frontend/ ou defina as vars manualmente.",
+    }),
+  );
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// ----------------------- Tipos -----------------------
+
+interface PydanticField {
+  name: string;
+  type: "single" | "multi" | "text" | "date";
+  options: string[] | null;
+  description: string;
+  help_text?: string;
+  target?: "all" | "llm_only" | "human_only";
+  required?: boolean;
+  hash?: string;
+  subfields?: Array<{ key: string; label: string; required?: boolean }>;
+  subfield_rule?: "all" | "at_least_one";
+  allow_other?: boolean;
+}
+
+interface OpenComment {
+  id: string;
+  source: "review" | "nota" | "sugestao" | "dificuldade" | "duvida" | "anotacao";
+  rawId: string;
+  fieldName: string;
+  documentId: string | null;
+  documentTitle: string | null;
+  text: string;
+  author: string;
+  createdAt: string;
+  extra: Record<string, unknown>;
+}
+
+// ----------------------- CLI parsing -----------------------
+
+function parseArgs(argv: string[]) {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--list") {
+      out.list = true;
+    } else if (a === "--project-id" || a === "--id") {
+      out.projectId = argv[++i];
+    } else if (a === "--project-name" || a === "--name") {
+      out.projectName = argv[++i];
+    } else if (a === "--help" || a === "-h") {
+      out.help = true;
+    }
+  }
+  return out;
+}
+
+async function listProjects() {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, name, created_at, schema_version_major, schema_version_minor, schema_version_patch")
+    .order("created_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+async function resolveProject(args: Record<string, string | boolean>) {
+  if (typeof args.projectId === "string") {
+    const { data, error } = await supabase
+      .from("projects")
+      .select(
+        "id, name, created_by, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch",
+      )
+      .eq("id", args.projectId)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) throw new Error(`Projeto ${args.projectId} não encontrado`);
+    return data;
+  }
+  if (typeof args.projectName === "string") {
+    const { data, error } = await supabase
+      .from("projects")
+      .select(
+        "id, name, created_by, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch",
+      )
+      .ilike("name", `%${args.projectName}%`)
+      .order("created_at", { ascending: false });
+    if (error) throw new Error(error.message);
+    if (!data || data.length === 0)
+      throw new Error(`Nenhum projeto corresponde a "${args.projectName}"`);
+    if (data.length > 1) {
+      throw new Error(
+        `Múltiplos projetos correspondem a "${args.projectName}": ${data
+          .map((p) => `${p.name} (${p.id})`)
+          .join(", ")}. Use --project-id.`,
+      );
+    }
+    return data[0];
+  }
+  return null;
+}
+
+// ----------------------- Fetching -----------------------
+
+async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
+  const [
+    { data: reviews },
+    { data: documents },
+    { data: responsesWithNotes },
+    { data: suggestions },
+    { data: llmResponses },
+    { data: difficultyResolutions },
+    { data: projectComments },
+    { data: verdictQuestions },
+    { data: noteResolutions },
+  ] = await Promise.all([
+    // Reviews abertos (com comentário e não resolvidos)
+    supabase
+      .from("reviews")
+      .select(
+        "id, document_id, field_name, verdict, comment, chosen_response_id, resolved_at, reviewer_id, created_at, response_snapshot",
+      )
+      .eq("project_id", projectId)
+      .not("comment", "is", null)
+      .is("resolved_at", null)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("documents")
+      .select("id, title, external_id")
+      .eq("project_id", projectId),
+    // Notas de pesquisador (humano)
+    supabase
+      .from("responses")
+      .select("id, document_id, respondent_id, respondent_name, justifications, created_at")
+      .eq("project_id", projectId)
+      .eq("respondent_type", "humano")
+      .not("justifications", "is", null),
+    // Sugestões pendentes
+    supabase
+      .from("schema_suggestions")
+      .select(
+        "id, field_name, suggested_changes, reason, status, resolved_at, created_at, suggested_by, profiles!suggested_by(email)",
+      )
+      .eq("project_id", projectId)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false }),
+    // Respostas LLM ativas (para extrair llm_ambiguidades)
+    supabase
+      .from("responses")
+      .select("id, document_id, answers, respondent_name, created_at")
+      .eq("project_id", projectId)
+      .eq("respondent_type", "llm")
+      .eq("is_current", true),
+    // Dificuldades já resolvidas → filtrar fora
+    supabase
+      .from("difficulty_resolutions")
+      .select("response_id")
+      .eq("project_id", projectId),
+    // project_comments abertos (root, não resolvidos)
+    supabase
+      .from("project_comments")
+      .select(
+        "id, document_id, field_name, author_id, body, parent_id, resolved_at, created_at, profiles!author_id(email)",
+      )
+      .eq("project_id", projectId)
+      .is("parent_id", null)
+      .is("resolved_at", null)
+      .order("created_at", { ascending: false }),
+    // Dúvidas abertas
+    supabase
+      .from("verdict_acknowledgments")
+      .select(
+        "review_id, respondent_id, comment, resolved_at, created_at, reviews!inner(id, project_id, document_id, field_name, verdict)",
+      )
+      .eq("status", "questioned")
+      .is("resolved_at", null)
+      .not("comment", "is", null)
+      .eq("reviews.project_id", projectId)
+      .order("created_at", { ascending: false }),
+    // Notas já resolvidas → filtrar fora
+    supabase
+      .from("note_resolutions")
+      .select("response_id")
+      .eq("project_id", projectId),
+  ]);
+
+  const fieldMap = new Map(fields.map((f) => [f.name, f]));
+  const docMap = new Map(
+    (documents ?? []).map((d) => [d.id, d.title || d.external_id || d.id]),
+  );
+  const resolvedNoteIds = new Set(
+    (noteResolutions ?? []).map((n) => n.response_id),
+  );
+  const resolvedDiffIds = new Set(
+    (difficultyResolutions ?? []).map((d) => d.response_id),
+  );
+
+  // Coletar ids de profiles para resolver nomes
+  const profileIds = new Set<string>();
+  (reviews ?? []).forEach((r) => r.reviewer_id && profileIds.add(r.reviewer_id));
+  (responsesWithNotes ?? []).forEach(
+    (r) => r.respondent_id && profileIds.add(r.respondent_id),
+  );
+  (verdictQuestions ?? []).forEach(
+    (q) => q.respondent_id && profileIds.add(q.respondent_id),
+  );
+
+  const profileMap = new Map<string, string>();
+  if (profileIds.size > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, email, first_name, last_name")
+      .in("id", Array.from(profileIds));
+    (profiles ?? []).forEach((p) => {
+      const name =
+        [p.first_name, p.last_name].filter(Boolean).join(" ") ||
+        p.email?.split("@")[0] ||
+        "Anônimo";
+      profileMap.set(p.id as string, name);
+    });
+  }
+
+  const comments: OpenComment[] = [];
+
+  // review
+  for (const r of reviews ?? []) {
+    const field = fieldMap.get(r.field_name as string);
+    comments.push({
+      id: `review-${r.id}`,
+      source: "review",
+      rawId: r.id as string,
+      fieldName: r.field_name as string,
+      documentId: r.document_id as string,
+      documentTitle: docMap.get(r.document_id as string) ?? null,
+      text: (r.comment as string) ?? "",
+      author: r.reviewer_id
+        ? profileMap.get(r.reviewer_id as string) ?? "Anônimo"
+        : "Anônimo",
+      createdAt: r.created_at as string,
+      extra: {
+        verdict: r.verdict,
+        chosenResponseId: r.chosen_response_id,
+        responseSnapshot: r.response_snapshot,
+        fieldType: field?.type,
+        fieldOptions: field?.options,
+      },
+    });
+  }
+
+  // nota (humano, não resolvida)
+  for (const r of responsesWithNotes ?? []) {
+    if (resolvedNoteIds.has(r.id as string)) continue;
+    const j = r.justifications as Record<string, string> | null;
+    const note = j && typeof j._notes === "string" ? j._notes.trim() : "";
+    if (!note) continue;
+    comments.push({
+      id: `nota-${r.id}`,
+      source: "nota",
+      rawId: r.id as string,
+      fieldName: "(geral)",
+      documentId: r.document_id as string,
+      documentTitle: docMap.get(r.document_id as string) ?? null,
+      text: note,
+      author:
+        (r.respondent_id &&
+          (profileMap.get(r.respondent_id as string) ||
+            (r.respondent_name as string))) ||
+        (r.respondent_name as string) ||
+        "Anônimo",
+      createdAt: r.created_at as string,
+      extra: {
+        responseId: r.id,
+        respondentId: r.respondent_id,
+      },
+    });
+  }
+
+  // sugestao (pending)
+  for (const s of suggestions ?? []) {
+    const changes = s.suggested_changes as Record<string, unknown>;
+    const changedKeys = Object.keys(changes);
+    const p = s.profiles as unknown as { email: string | null } | null;
+    const field = fieldMap.get(s.field_name as string);
+    comments.push({
+      id: `sugestao-${s.id}`,
+      source: "sugestao",
+      rawId: s.id as string,
+      fieldName: s.field_name as string,
+      documentId: null,
+      documentTitle: null,
+      text: (s.reason as string) || "Sem motivo",
+      author: p?.email?.split("@")[0] ?? "Anônimo",
+      createdAt: s.created_at as string,
+      extra: {
+        suggestedChanges: changes,
+        changedKeys,
+        status: s.status,
+        currentField: field
+          ? {
+              description: field.description,
+              help_text: field.help_text,
+              options: field.options,
+              type: field.type,
+            }
+          : null,
+      },
+    });
+  }
+
+  // dificuldade (LLM, não resolvida)
+  for (const r of llmResponses ?? []) {
+    if (resolvedDiffIds.has(r.id as string)) continue;
+    const ambiguidades = (r.answers as Record<string, unknown>)
+      ?.llm_ambiguidades;
+    const txt =
+      typeof ambiguidades === "string" ? ambiguidades.trim() : "";
+    if (!txt) continue;
+    comments.push({
+      id: `dificuldade-${r.id}`,
+      source: "dificuldade",
+      rawId: r.id as string,
+      fieldName: "(geral)",
+      documentId: r.document_id as string,
+      documentTitle: docMap.get(r.document_id as string) ?? null,
+      text: txt,
+      author: (r.respondent_name as string) || "LLM",
+      createdAt: r.created_at as string,
+      extra: {
+        responseId: r.id,
+        documentId: r.document_id,
+      },
+    });
+  }
+
+  // duvida (verdict_acknowledgments abertas).
+  // O join !inner em many-to-one retorna um único objeto em runtime, mas os
+  // tipos gerados pelo Supabase o inferem como array. Usar `as unknown as`
+  // pelo mesmo motivo que o cast de `c.profiles` abaixo.
+  for (const q of (verdictQuestions ?? []) as unknown as Array<{
+    review_id: string;
+    respondent_id: string;
+    comment: string;
+    resolved_at: string | null;
+    created_at: string;
+    reviews: {
+      id: string;
+      document_id: string;
+      field_name: string;
+      verdict: string;
+    };
+  }>) {
+    const r = q.reviews;
+    const field = fieldMap.get(r.field_name);
+    comments.push({
+      id: `duvida-${q.review_id}-${q.respondent_id}`,
+      source: "duvida",
+      rawId: `${q.review_id}|${q.respondent_id}`,
+      fieldName: r.field_name,
+      documentId: r.document_id,
+      documentTitle: docMap.get(r.document_id) ?? null,
+      text: q.comment,
+      author: profileMap.get(q.respondent_id) ?? "Anônimo",
+      createdAt: q.created_at,
+      extra: {
+        reviewId: q.review_id,
+        respondentId: q.respondent_id,
+        verdict: r.verdict,
+        fieldType: field?.type,
+        fieldOptions: field?.options,
+      },
+    });
+  }
+
+  // anotacao (project_comments root, não resolvidos)
+  for (const c of projectComments ?? []) {
+    const p = c.profiles as unknown as { email: string | null } | null;
+    const field = c.field_name
+      ? fieldMap.get(c.field_name as string)
+      : undefined;
+    comments.push({
+      id: `anotacao-${c.id}`,
+      source: "anotacao",
+      rawId: c.id as string,
+      fieldName: (c.field_name as string | null) ?? "(geral)",
+      documentId: (c.document_id as string | null) ?? null,
+      documentTitle: c.document_id
+        ? docMap.get(c.document_id as string) ?? null
+        : null,
+      text: c.body as string,
+      author: p?.email?.split("@")[0] ?? "Anônimo",
+      createdAt: c.created_at as string,
+      extra: {
+        fieldType: field?.type,
+        fieldOptions: field?.options,
+      },
+    });
+  }
+
+  comments.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return comments;
+}
+
+// ----------------------- Main -----------------------
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      `fetch-open-comments.ts\n\nUso:\n  npx tsx fetch-open-comments.ts [--project-id <uuid>] [--project-name <fragmento>] [--list]\n\nImprime JSON estruturado com os comentários abertos do projeto.\n`,
+    );
+    return;
+  }
+
+  if (args.list) {
+    const projects = await listProjects();
+    console.log(JSON.stringify({ projects }, null, 2));
+    return;
+  }
+
+  const project = await resolveProject(args);
+  if (!project) {
+    // Sem id nem name → lista projetos para escolher
+    const projects = await listProjects();
+    console.log(
+      JSON.stringify(
+        {
+          message:
+            "Nenhum projeto identificado. Use --project-id ou --project-name.",
+          projects,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const fields = (project.pydantic_fields as PydanticField[]) ?? [];
+  const comments = await fetchOpenComments(project.id as string, fields);
+
+  const version = {
+    major: project.schema_version_major ?? 0,
+    minor: project.schema_version_minor ?? 1,
+    patch: project.schema_version_patch ?? 0,
+  };
+
+  console.log(
+    JSON.stringify(
+      {
+        project: {
+          id: project.id,
+          name: project.name,
+          version: `${version.major}.${version.minor}.${version.patch}`,
+        },
+        fields,
+        stats: {
+          totalOpen: comments.length,
+          bySource: comments.reduce<Record<string, number>>((acc, c) => {
+            acc[c.source] = (acc[c.source] ?? 0) + 1;
+            return acc;
+          }, {}),
+        },
+        comments,
+        generatedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ error: err?.message ?? String(err) }));
+  process.exit(1);
+});

--- a/frontend/scripts/comentarios-relatorio/generate-report.py
+++ b/frontend/scripts/comentarios-relatorio/generate-report.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+generate-report.py
+
+Transforma o JSON produzido por fetch-open-comments.ts em um relatório .md
+em formato conversacional, destacando a redação exata de cada pergunta e
+agrupando discussões relacionadas (ex: múltiplos pesquisadores contestando
+o mesmo veredito).
+
+Uso:
+    python3 generate-report.py <comments.json> <output.md>
+
+O .md gerado tem blocos com diretivas em HTML comments; o apply-decisions.ts
+consome esse mesmo formato (via JSON intermediário produzido pelo Claude).
+
+Agrupamento (clusters por campo):
+1. Cada `review` vira um cluster — arrasta junto todas as `duvida` com
+   `extra.reviewId` igual ao `rawId` do review + `anotacao` do mesmo documento.
+2. `duvida` órfãs (sem review correspondente no aberto) → cluster por reviewId.
+3. `anotacao` restantes → cluster por documentId dentro do campo.
+4. `sugestao` → um cluster por sugestão.
+
+Para `(geral)` (notas e dificuldades): cada item um bloco; nota humana vira
+"Nota de pesquisador", dificuldade LLM vira "Ambiguidade reportada pelo LLM".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s.strip().lower())
+
+
+def pretty_author(email_local: str) -> str:
+    """Tenta extrair um primeiro nome do email local part. Heurística."""
+    if not email_local or email_local == "Anônimo":
+        return email_local or "Anônimo"
+    if "." in email_local:
+        parts = [p for p in email_local.split(".") if p]
+        alpha = [p for p in parts if p.isalpha()]
+        if alpha:
+            return max(alpha, key=len).capitalize()
+    return email_local.capitalize()
+
+
+NUMERO_EXTENSO_MASC = {
+    1: "Um", 2: "Dois", 3: "Três", 4: "Quatro", 5: "Cinco",
+    6: "Seis", 7: "Sete", 8: "Oito", 9: "Nove", 10: "Dez",
+}
+NUMERO_EXTENSO_FEM = {
+    1: "Uma", 2: "Duas", 3: "Três", 4: "Quatro", 5: "Cinco",
+    6: "Seis", 7: "Sete", 8: "Oito", 9: "Nove", 10: "Dez",
+}
+
+
+def n_palavras(n: int, singular: str, plural: str, fem: bool = False) -> str:
+    tbl = NUMERO_EXTENSO_FEM if fem else NUMERO_EXTENSO_MASC
+    extenso = tbl.get(n, str(n))
+    return f"{extenso} {singular if n == 1 else plural}"
+
+
+def format_verdict(v) -> str:
+    """Vereditos de multi-select vêm como JSON dict. Resume em lista legível."""
+    if v is None:
+        return "—"
+    if isinstance(v, str):
+        s = v.strip()
+        # Se for JSON serializado, tenta parsear
+        if s.startswith("{") and s.endswith("}"):
+            try:
+                parsed = json.loads(s)
+                return format_verdict(parsed)
+            except Exception:
+                pass
+        return s or "—"
+    if isinstance(v, dict):
+        marcados = [k for k, val in v.items() if val is True]
+        if not marcados:
+            return "(nenhuma opção marcada)"
+        if len(marcados) <= 3:
+            return ", ".join(marcados)
+        return f"{', '.join(marcados[:3])} e mais {len(marcados) - 3}"
+    if isinstance(v, list):
+        return ", ".join(str(x) for x in v) or "—"
+    return str(v)
+
+
+def render_field_header(f: dict) -> list[str]:
+    lines: list[str] = []
+    lines.append(f"## `{f['name']}`")
+    lines.append("")
+    lines.append(f"**Pergunta:** {f['description']}")
+    if f.get("help_text"):
+        help_clean = f["help_text"].strip()
+        lines.append(f"**Orientação aos pesquisadores:** {help_clean}")
+    if f.get("options"):
+        opts = " · ".join(f["options"])
+        lines.append(f"**Opções:** {opts}")
+    if f.get("subfields"):
+        sub_lines = [f"{s['key']} ({s['label']})" for s in f["subfields"]]
+        rule = f.get("subfield_rule") or "all"
+        regra_txt = "todos obrigatórios" if rule == "all" else "pelo menos um"
+        lines.append(f"**Subcampos:** {', '.join(sub_lines)} ({regra_txt})")
+    lines.append("")
+    return lines
+
+
+def render_decision_block(heading: str, body_lines: list[str], ids: list[str]) -> list[str]:
+    out: list[str] = []
+    out.append(f"### {heading}")
+    out.append("")
+    out.extend(body_lines)
+    out.append("")
+    out.append("**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->")
+    out.append("**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->")
+    out.append("**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->")
+    out.append("")
+    out.append(f"<!-- ids: {'; '.join(ids)} -->")
+    out.append("")
+    return out
+
+
+def build_clusters(field_comments: list[dict]) -> list[dict]:
+    clusters: list[dict] = []
+    consumed: set[str] = set()
+
+    reviews = [c for c in field_comments if c["source"] == "review"]
+    duvidas = [c for c in field_comments if c["source"] == "duvida"]
+    anotacoes = [c for c in field_comments if c["source"] == "anotacao"]
+    sugestoes = [c for c in field_comments if c["source"] == "sugestao"]
+
+    # 1. Cluster por review
+    for r in reviews:
+        if r["id"] in consumed:
+            continue
+        duvs = [
+            d for d in duvidas
+            if d["id"] not in consumed
+            and d.get("extra", {}).get("reviewId") == r["rawId"]
+        ]
+        anots = [
+            a for a in anotacoes
+            if a["id"] not in consumed and a.get("documentId") == r.get("documentId")
+        ]
+        clusters.append({
+            "type": "review",
+            "anchor": r,
+            "duvidas": duvs,
+            "anotacoes": anots,
+        })
+        consumed.update([r["id"], *(d["id"] for d in duvs), *(a["id"] for a in anots)])
+
+    # 2. Dúvidas órfãs — por reviewId
+    by_review: dict[str, list[dict]] = {}
+    for d in duvidas:
+        if d["id"] in consumed:
+            continue
+        rid = d.get("extra", {}).get("reviewId") or d["rawId"]
+        by_review.setdefault(rid, []).append(d)
+    for rid, group in by_review.items():
+        anots = [
+            a for a in anotacoes
+            if a["id"] not in consumed and a.get("documentId") == group[0].get("documentId")
+        ]
+        clusters.append({
+            "type": "duvidas-orphans",
+            "duvidas": group,
+            "anotacoes": anots,
+            "reviewId": rid,
+        })
+        consumed.update([*(d["id"] for d in group), *(a["id"] for a in anots)])
+
+    # 3. Anotações avulsas — por documentId
+    anot_by_doc: dict[str, list[dict]] = {}
+    for a in anotacoes:
+        if a["id"] in consumed:
+            continue
+        key = a.get("documentId") or f"solo-{a['id']}"
+        anot_by_doc.setdefault(key, []).append(a)
+    for group in anot_by_doc.values():
+        clusters.append({"type": "anotacoes", "anotacoes": group})
+        consumed.update(a["id"] for a in group)
+
+    # 4. Sugestões
+    for s in sugestoes:
+        clusters.append({"type": "sugestao", "sugestao": s})
+
+    return clusters
+
+
+def render_review_cluster(cl: dict) -> list[str]:
+    r = cl["anchor"]
+    duvs = cl["duvidas"]
+    anots = cl["anotacoes"]
+    doc = r.get("documentTitle") or "(documento)"
+    date = r["createdAt"][:10]
+    verdict = format_verdict((r.get("extra") or {}).get("verdict"))
+    reviewer = pretty_author(r.get("author"))
+
+    n_q = len(duvs)
+    n_a = len(anots)
+    if n_q > 0:
+        heading = (
+            f"Review de **{reviewer}** em *{doc}* — contestado por "
+            f"{n_palavras(n_q, 'pesquisador', 'pesquisadores')}"
+        )
+    else:
+        heading = f"Review de **{reviewer}** em *{doc}*"
+
+    body: list[str] = []
+    body.append(
+        f"Em {date}, **{reviewer}** revisou este documento e escolheu o veredito "
+        f"**\"{verdict}\"**, deixando a seguinte observação:"
+    )
+    body.append("")
+    for ln in r["text"].splitlines():
+        body.append(f"> {ln}" if ln.strip() else ">")
+    body.append("")
+
+    if duvs:
+        body.append(
+            f"{n_palavras(n_q, 'pesquisador manifestou dúvida', 'pesquisadores manifestaram dúvida')} "
+            f"sobre esse veredito:"
+        )
+        body.append("")
+        for d in duvs:
+            nm = pretty_author(d.get("author"))
+            txt = d["text"].strip().replace("\n", " ")
+            body.append(f"- **{nm}** — {txt}")
+        body.append("")
+
+    if anots:
+        body.append(
+            f"Além disso, {n_palavras(n_a, 'anotação', 'anotações', fem=True)} "
+            f"no mesmo documento:"
+        )
+        body.append("")
+        for a in anots:
+            nm = pretty_author(a.get("author"))
+            txt = a["text"].strip().replace("\n", " ")
+            body.append(f"- **{nm}** — {txt}")
+        body.append("")
+
+    ids = [r["id"], *(d["id"] for d in duvs), *(a["id"] for a in anots)]
+    return render_decision_block(heading, body, ids)
+
+
+def render_duvidas_orphan_cluster(cl: dict) -> list[str]:
+    duvs = cl["duvidas"]
+    anots = cl.get("anotacoes", [])
+    doc = duvs[0].get("documentTitle") or "(documento)"
+    verdict = format_verdict((duvs[0].get("extra") or {}).get("verdict"))
+
+    n_q = len(duvs)
+    heading = (
+        f"Dúvidas em *{doc}* sobre o veredito \"{verdict}\" "
+        f"({n_palavras(n_q, 'pesquisador', 'pesquisadores')})"
+    )
+
+    body: list[str] = []
+    for d in duvs:
+        nm = pretty_author(d.get("author"))
+        date = d["createdAt"][:10]
+        txt = d["text"].strip().replace("\n", " ")
+        body.append(f"- **{nm}** ({date}) — {txt}")
+    body.append("")
+
+    if anots:
+        body.append(
+            f"No mesmo documento há {n_palavras(len(anots), 'anotação', 'anotações', fem=True)}:"
+        )
+        body.append("")
+        for a in anots:
+            nm = pretty_author(a.get("author"))
+            txt = a["text"].strip().replace("\n", " ")
+            body.append(f"- **{nm}** — {txt}")
+        body.append("")
+
+    ids = [*(d["id"] for d in duvs), *(a["id"] for a in anots)]
+    return render_decision_block(heading, body, ids)
+
+
+def render_anotacoes_cluster(cl: dict) -> list[str]:
+    anots = cl["anotacoes"]
+    doc = anots[0].get("documentTitle") or "—"
+    n = len(anots)
+
+    if n == 1:
+        a = anots[0]
+        nm = pretty_author(a.get("author"))
+        date = a["createdAt"][:10]
+        heading = f"Anotação de **{nm}** em *{doc}* ({date})"
+        body = [f"> {ln}" if ln.strip() else ">" for ln in a["text"].splitlines()]
+        return render_decision_block(heading, body, [a["id"]])
+
+    heading = f"{n_palavras(n, 'anotação', 'anotações', fem=True)} em *{doc}*"
+    body: list[str] = []
+    for a in anots:
+        nm = pretty_author(a.get("author"))
+        date = a["createdAt"][:10]
+        txt = a["text"].strip().replace("\n", " ")
+        body.append(f"- **{nm}** ({date}) — {txt}")
+    body.append("")
+    ids = [a["id"] for a in anots]
+    return render_decision_block(heading, body, ids)
+
+
+def render_sugestao_cluster(cl: dict) -> list[str]:
+    s = cl["sugestao"]
+    nm = pretty_author(s.get("author"))
+    date = s["createdAt"][:10]
+    changes = (s.get("extra") or {}).get("suggestedChanges") or {}
+    changed_keys = (s.get("extra") or {}).get("changedKeys") or []
+    current = (s.get("extra") or {}).get("currentField") or {}
+
+    heading = f"Sugestão de schema por **{nm}** ({date})"
+    body: list[str] = []
+    body.append(f"Motivo: {s['text'].strip() or '(sem motivo)'}")
+    body.append("")
+    body.append(f"Alterações propostas em: {', '.join(changed_keys) or '(nenhuma)'}")
+    body.append("")
+    if changes:
+        body.append("```json")
+        body.append(json.dumps(changes, ensure_ascii=False, indent=2))
+        body.append("```")
+        body.append("")
+    if current:
+        body.append(
+            f"Estado atual: description=\"{current.get('description','')}\"; "
+            f"help_text=\"{current.get('help_text') or ''}\"; options={current.get('options')}"
+        )
+        body.append("")
+    return render_decision_block(heading, body, [s["id"]])
+
+
+def render_field_section(f: dict, field_comments: list[dict]) -> list[str]:
+    lines = render_field_header(f)
+    clusters = build_clusters(field_comments)
+    for cl in clusters:
+        if cl["type"] == "review":
+            lines.extend(render_review_cluster(cl))
+        elif cl["type"] == "duvidas-orphans":
+            lines.extend(render_duvidas_orphan_cluster(cl))
+        elif cl["type"] == "anotacoes":
+            lines.extend(render_anotacoes_cluster(cl))
+        elif cl["type"] == "sugestao":
+            lines.extend(render_sugestao_cluster(cl))
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def render_geral(comments: list[dict]) -> list[str]:
+    lines: list[str] = []
+    lines.append("## Notas gerais")
+    lines.append("")
+    lines.append(
+        "Comentários não atrelados a uma pergunta específica. O pesquisador "
+        "pode ter mencionado mais de uma pergunta — ao anotar, liste em "
+        "`Campos mencionados:` quais perguntas a nota afeta."
+    )
+    lines.append("")
+
+    for c in comments:
+        nm = pretty_author(c.get("author"))
+        date = c["createdAt"][:10]
+        doc = c.get("documentTitle") or "—"
+        if c["source"] == "nota":
+            heading = f"Nota de pesquisador de **{nm}** ao codificar *{doc}* ({date})"
+        elif c["source"] == "dificuldade":
+            heading = f"Ambiguidade reportada pelo LLM em *{doc}* ({date})"
+        else:
+            heading = f"[{c['source']}] **{nm}** em *{doc}* ({date})"
+        body = [f"> {ln}" if ln.strip() else ">" for ln in c["text"].splitlines()]
+        body.append("")
+        body.append("**Campos mencionados:** <!-- ex: q2, q14 -->")
+        lines.extend(render_decision_block(heading, body, [c["id"]]))
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def render(data: dict) -> str:
+    project = data["project"]
+    fields = data["fields"]
+    comments = data["comments"]
+    stats = data["stats"]
+
+    by_field: dict[str, list[dict]] = {}
+    for c in comments:
+        by_field.setdefault(c["fieldName"], []).append(c)
+
+    lines: list[str] = []
+    lines.append(f"# Comentários em aberto — {project['name']}")
+    lines.append("")
+    n_fields = len([f for f in by_field if f != "(geral)"])
+    n_geral = len(by_field.get("(geral)", []))
+    src_summary = ", ".join(f"{v} {k}" for k, v in sorted(stats["bySource"].items()))
+    lines.append(
+        f"Projeto `{project['id']}` na versão do schema `{project['version']}`. "
+        f"Gerado em {data['generatedAt'][:10]}."
+    )
+    lines.append("")
+    lines.append(
+        f"Há **{stats['totalOpen']} comentários em aberto** — "
+        f"{n_fields} perguntas com comentários específicos e {n_geral} "
+        f"nota(s) geral(is). Por fonte: {src_summary}."
+    )
+    lines.append("")
+    lines.append(
+        "Para cada bloco, preencha `Decisão:` dentro do comentário HTML "
+        "(`<!-- ... -->`). Valores: **aprovar** (aplica a mudança e fecha), "
+        "**rejeitar** (fecha sem mudar), **reformular** (fecha registrando uma "
+        "nota com orientação), **ignorar** (pula — não fecha nada)."
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    for f in fields:
+        if f["name"] not in by_field:
+            continue
+        lines.extend(render_field_section(f, by_field[f["name"]]))
+
+    if "(geral)" in by_field:
+        lines.extend(render_geral(by_field["(geral)"]))
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(
+            "Uso: python3 generate-report.py <comments.json> <output.md>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    md = render(data)
+    Path(sys.argv[2]).write_text(md, encoding="utf-8")
+    print(f"Relatório gerado: {sys.argv[2]} ({len(md)} bytes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Versiona a skill `comentarios-relatorio` (SKILL.md + references + 3 scripts + docs de uso), que estava só em `.git/info/exclude` local.
- Refatora `apply-decisions.ts` para importar `generatePydanticCode` de `src/lib/schema-utils.ts` — remove ~160 linhas duplicadas e elimina o drift que causou o gap de perguntas condicionais (#58) não serem emitidas pelo script.
- Inclui os docs da rodada Zolgensma 2026-04-22 (direcionamentos, comentários consolidados, debate do q24) como referência real de uso.

## Contexto

Na rodada de revisão do projeto Zolgensma, ao aplicar a divisão de q24 em q24a/q24b condicionais, o script silenciosamente omitia o campo `condition` no código Pydantic emitido — porque tinha sua própria cópia desatualizada de `generatePydanticCode`. A função canônica em `src/lib/schema-utils.ts` já era `client-safe` desde o #57 (pydantic_code como fonte de verdade), então dá para importar direto sem precisar de contexto Next.

O schema do Zolgensma no Supabase já foi atualizado para 0.13.0 via a versão local corrigida; este PR garante que futuros usos do script fiquem em paridade automática com a UI.

## Test plan

- [ ] Rodar `npx tsx frontend/scripts/comentarios-relatorio/apply-decisions.ts <decisions.json> --dry-run` em um projeto com `condition` e confirmar que o `pydantic_code` gerado contém `json_schema_extra={..., "condition": {...}}` para campos condicionais.
- [ ] Confirmar que um campo com `condition` é emitido como `Optional[...]` com `default=None` (obrigatório em Pydantic v2).
- [ ] Round-trip: gerar via script → compilar via `backend/services/pydantic_compiler.py` → verificar que `condition` sobrevive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)