### PR TITLE
feat: diff visual em sugestões de schema na aba Comentários

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -183,18 +183,18 @@ export default async function CommentsPage({
   const suggestionComments: ReviewComment[] = (suggestions || []).map((s) => {
     const p = s.profiles as unknown as { email: string | null } | null;
     const changes = s.suggested_changes as Record<string, unknown>;
-    const changedKeys = Object.keys(changes).join(", ");
+    const currentField = fieldMap.get(s.field_name);
     return {
       id: `sugestao-${s.id}`,
       documentId: "",
       documentTitle: "",
       fieldName: s.field_name,
-      fieldDescription: fieldMap.get(s.field_name)?.description || s.field_name,
-      fieldHelpText: fieldMap.get(s.field_name)?.help_text,
-      fieldOptions: fieldMap.get(s.field_name)?.options,
-      fieldType: fieldMap.get(s.field_name)?.type,
+      fieldDescription: currentField?.description || s.field_name,
+      fieldHelpText: currentField?.help_text,
+      fieldOptions: currentField?.options,
+      fieldType: currentField?.type,
       verdict: "sugestao",
-      comment: `${s.reason || "Sem motivo"}${changedKeys ? ` (alterações: ${changedKeys})` : ""}`,
+      comment: s.reason || "Sem motivo",
       reviewerName: p?.email?.split("@")[0] || "Anônimo",
       resolvedAt: (s.resolved_at as string | null) ?? null,
       createdAt: s.created_at,
@@ -215,6 +215,11 @@ export default async function CommentsPage({
           : changes.options === null
             ? null
             : undefined,
+      },
+      fieldSnapshot: {
+        description: currentField?.description ?? "",
+        help_text: currentField?.help_text ?? null,
+        options: currentField?.options ?? null,
       },
     };
   });

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -24,6 +24,7 @@ import {
   type GabaritoRespondentAnswer,
 } from "@/actions/stats";
 import { resolveSchemaSuggestion } from "@/actions/suggestions";
+import { SuggestionDiff } from "./SuggestionDiff";
 import { toast } from "sonner";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -71,6 +72,11 @@ export interface ReviewComment {
     description?: string;
     help_text?: string | null;
     options?: string[] | null;
+  };
+  fieldSnapshot?: {
+    description: string;
+    help_text: string | null;
+    options: string[] | null;
   };
   difficultyResponseId?: string;
   difficultyDocumentId?: string;
@@ -265,6 +271,15 @@ export function CommentCard({
         <blockquote className="border-l-2 pl-3 text-sm text-foreground">
           {comment.comment}
         </blockquote>
+
+        {comment.source === "sugestao" &&
+          comment.suggestionChanges &&
+          comment.fieldSnapshot && (
+            <SuggestionDiff
+              changes={comment.suggestionChanges}
+              current={comment.fieldSnapshot}
+            />
+          )}
 
         {/* Suggestion actions (coordinator: approve/reject) */}
         {comment.source === "sugestao" && comment.suggestionId && (

--- a/frontend/src/components/stats/SuggestionDiff.tsx
+++ b/frontend/src/components/stats/SuggestionDiff.tsx
@@ -34,14 +34,14 @@ export function SuggestionDiff({ changes, current }: SuggestionDiffProps) {
           <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
             Descrição
           </span>
-          <div className="leading-relaxed">
-            <span className="line-through text-muted-foreground">
+          <div className="leading-relaxed break-words">
+            <del className="text-muted-foreground">
               {emptyMark(current.description)}
-            </span>
+            </del>
             <span className="mx-1.5 text-muted-foreground">→</span>
-            <span className="font-medium text-foreground">
+            <ins className="font-medium text-foreground no-underline">
               {emptyMark(changes.description ?? "")}
-            </span>
+            </ins>
           </div>
         </div>
       )}
@@ -56,17 +56,17 @@ export function SuggestionDiff({ changes, current }: SuggestionDiffProps) {
               <span className="text-[10px] font-medium text-muted-foreground">
                 Atual
               </span>
-              <p className="whitespace-pre-wrap text-muted-foreground line-through">
+              <del className="block whitespace-pre-wrap break-words text-muted-foreground">
                 {emptyMark(current.help_text ?? "")}
-              </p>
+              </del>
             </div>
             <div className="rounded border border-dashed border-brand/40 bg-brand/5 px-2 py-1">
               <span className="text-[10px] font-medium text-brand">
                 Proposto
               </span>
-              <p className="whitespace-pre-wrap font-medium text-foreground">
+              <ins className="block whitespace-pre-wrap break-words font-medium text-foreground no-underline">
                 {emptyMark(changes.help_text ?? "")}
-              </p>
+              </ins>
             </div>
           </div>
         </div>
@@ -114,6 +114,7 @@ function OptionsDiff({
     <div className="flex flex-wrap items-center gap-1">
       {isClear && (
         <Badge
+          aria-label="Todas as opções serão removidas"
           className={cn(
             "text-[10px] px-1.5 py-0 font-normal",
             "bg-red-500/10 text-red-700",
@@ -126,7 +127,7 @@ function OptionsDiff({
         <Badge
           key={`kept-${o}`}
           variant="outline"
-          className="text-[10px] px-1.5 py-0 font-normal"
+          className="text-[10px] px-1.5 py-0 font-normal break-all"
         >
           {o}
         </Badge>
@@ -134,23 +135,25 @@ function OptionsDiff({
       {removed.map((o) => (
         <Badge
           key={`rem-${o}`}
+          aria-label={`Opção removida: ${o}`}
           className={cn(
-            "text-[10px] px-1.5 py-0 font-normal line-through",
+            "text-[10px] px-1.5 py-0 font-normal break-all",
             "bg-red-500/10 text-red-700",
           )}
         >
-          {o}
+          <del>{o}</del>
         </Badge>
       ))}
       {added.map((o) => (
         <Badge
           key={`add-${o}`}
+          aria-label={`Opção adicionada: ${o}`}
           className={cn(
-            "text-[10px] px-1.5 py-0 font-normal",
+            "text-[10px] px-1.5 py-0 font-normal break-all",
             "bg-green-500/10 text-green-700",
           )}
         >
-          + {o}
+          <ins className="no-underline">+ {o}</ins>
         </Badge>
       ))}
     </div>

--- a/frontend/src/components/stats/SuggestionDiff.tsx
+++ b/frontend/src/components/stats/SuggestionDiff.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface SuggestionDiffProps {
+  changes: {
+    description?: string;
+    help_text?: string | null;
+    options?: string[] | null;
+  };
+  current: {
+    description: string;
+    help_text: string | null;
+    options: string[] | null;
+  };
+}
+
+function emptyMark(value: string) {
+  return value.length > 0 ? value : "(vazio)";
+}
+
+export function SuggestionDiff({ changes, current }: SuggestionDiffProps) {
+  const hasDescription = changes.description !== undefined;
+  const hasHelpText = changes.help_text !== undefined;
+  const hasOptions = changes.options !== undefined;
+
+  if (!hasDescription && !hasHelpText && !hasOptions) return null;
+
+  return (
+    <div className="rounded-md border bg-muted/20 px-3 py-2 text-xs space-y-2">
+      {hasDescription && (
+        <div className="space-y-0.5">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Descrição
+          </span>
+          <div className="leading-relaxed">
+            <span className="line-through text-muted-foreground">
+              {emptyMark(current.description)}
+            </span>
+            <span className="mx-1.5 text-muted-foreground">→</span>
+            <span className="font-medium text-foreground">
+              {emptyMark(changes.description ?? "")}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {hasHelpText && (
+        <div className="space-y-1">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Instruções complementares
+          </span>
+          <div className="grid gap-1">
+            <div className="rounded border border-dashed bg-background/40 px-2 py-1">
+              <span className="text-[10px] font-medium text-muted-foreground">
+                Atual
+              </span>
+              <p className="whitespace-pre-wrap text-muted-foreground line-through">
+                {emptyMark(current.help_text ?? "")}
+              </p>
+            </div>
+            <div className="rounded border border-dashed border-brand/40 bg-brand/5 px-2 py-1">
+              <span className="text-[10px] font-medium text-brand">
+                Proposto
+              </span>
+              <p className="whitespace-pre-wrap font-medium text-foreground">
+                {emptyMark(changes.help_text ?? "")}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {hasOptions && (
+        <div className="space-y-1">
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+            Opções
+          </span>
+          <OptionsDiff
+            current={current.options ?? []}
+            proposed={changes.options ?? null}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function OptionsDiff({
+  current,
+  proposed,
+}: {
+  current: string[];
+  proposed: string[] | null;
+}) {
+  const isClear = proposed === null || proposed.length === 0;
+  const proposedSet = new Set(proposed ?? []);
+  const currentSet = new Set(current);
+
+  const removed = current.filter((o) => !proposedSet.has(o));
+  const added = (proposed ?? []).filter((o) => !currentSet.has(o));
+  const kept = current.filter((o) => proposedSet.has(o));
+
+  if (isClear && current.length === 0) {
+    return (
+      <p className="text-muted-foreground italic">
+        Sem opções (sem alteração visível).
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {isClear && (
+        <Badge
+          className={cn(
+            "text-[10px] px-1.5 py-0 font-normal",
+            "bg-red-500/10 text-red-700",
+          )}
+        >
+          Limpar opções
+        </Badge>
+      )}
+      {kept.map((o) => (
+        <Badge
+          key={`kept-${o}`}
+          variant="outline"
+          className="text-[10px] px-1.5 py-0 font-normal"
+        >
+          {o}
+        </Badge>
+      ))}
+      {removed.map((o) => (
+        <Badge
+          key={`rem-${o}`}
+          className={cn(
+            "text-[10px] px-1.5 py-0 font-normal line-through",
+            "bg-red-500/10 text-red-700",
+          )}
+        >
+          {o}
+        </Badge>
+      ))}
+      {added.map((o) => (
+        <Badge
+          key={`add-${o}`}
+          className={cn(
+            "text-[10px] px-1.5 py-0 font-normal",
+            "bg-green-500/10 text-green-700",
+          )}
+        >
+          + {o}
+        </Badge>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Sugestões de schema agora exibem um bloco de diff antes/depois (descrição, instruções, opções) direto no `CommentCard`, em vez de apenas `motivo (alterações: help_text)`.
- Coordenador consegue decidir Aprovar/Rejeitar sem precisar abrir o `EditFieldDialog`.
- Componente novo `SuggestionDiff.tsx` reutilizável; payload no banco (`schema_suggestions.suggested_changes`) e server actions inalterados.

## Test plan
- [ ] Como pesquisador, sugerir mudança em **somente `help_text`** com motivo "esclarecer" → como coordenador, ver bloco "Atual" (line-through) e "Proposto" (destaque) no card; clicar em Aprovar e confirmar toast + atualização de schema.
- [ ] Sugerir adicionar 2 opções e remover 1 num campo `single` → ver chips: outline neutros para mantidas, vermelho line-through para removida, verde com `+` para adicionadas.
- [ ] Sugerir mudança simultânea em `description`, `help_text` e `options` → as três seções aparecem empilhadas.
- [ ] Clicar Rejeitar e confirmar badge "Rejeitada".
- [ ] Filtrar `Resolvidos` → diff continua sendo renderizado, sem botões Aprovar/Rejeitar.
- [ ] `npm run build` passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)