### PR TITLE
refactor: fluxo único Revisar para sugestões de schema

### DIFF
--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -292,7 +292,7 @@ export function CommentCard({
                   variant="default"
                   size="sm"
                   className="h-6 text-xs"
-                  disabled={suggestionPending}
+                  disabled={suggestionPending || isPending}
                   onClick={onResolve}
                   title="Abre editor para revisar antes de aprovar"
                 >

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -281,7 +281,9 @@ export function CommentCard({
             />
           )}
 
-        {/* Suggestion actions (coordinator: approve/reject) */}
+        {/* Suggestion actions (coordinator: review/reject)
+            "Revisar" abre EditFieldDialog pré-preenchido (via onResolve);
+            salvar lá aprova com os valores finais editados. */}
         {comment.source === "sugestao" && comment.suggestionId && (
           <div className="flex items-center gap-2">
             {comment.suggestionStatus === "pending" && isCoordinator && (
@@ -291,15 +293,10 @@ export function CommentCard({
                   size="sm"
                   className="h-6 text-xs"
                   disabled={suggestionPending}
-                  onClick={() => {
-                    startSuggestionAction(async () => {
-                      const result = await resolveSchemaSuggestion(comment.suggestionId!, projectId, "approved");
-                      if (result.error) toast.error(result.error);
-                      else { toast.success("Sugestão aprovada e aplicada"); router.refresh(); }
-                    });
-                  }}
+                  onClick={onResolve}
+                  title="Abre editor para revisar antes de aprovar"
                 >
-                  Aprovar
+                  Revisar
                 </Button>
                 <Button
                   variant="outline"
@@ -413,8 +410,7 @@ export function CommentCard({
             )}
           </p>
           <div className="flex gap-1">
-            {comment.source === "sugestao" &&
-            comment.suggestionStatus !== "pending" ? null : isResolved ? (
+            {comment.source === "sugestao" ? null : isResolved ? (
               <Button
                 variant="ghost"
                 size="sm"
@@ -430,11 +426,7 @@ export function CommentCard({
                 size="sm"
                 disabled={isPending}
                 onClick={onResolve}
-                title={
-                  comment.source === "sugestao"
-                    ? "Editar e aprovar"
-                    : "Resolver"
-                }
+                title="Resolver"
               >
                 <CheckCircle2 className="h-3.5 w-3.5" />
               </Button>

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -160,7 +160,7 @@ export function EditFieldDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            {pendingSuggestion ? "Aprovar sugestão (com edições)" : "Editar campo"}
+            {pendingSuggestion ? "Revisar sugestão" : "Editar campo"}
             <code className="text-sm font-mono text-muted-foreground">
               {fieldName}
             </code>


### PR DESCRIPTION
## Summary
- Substitui Aprovar/Rejeitar por **Revisar**/Rejeitar no card de sugestão.
- Revisar abre o \`EditFieldDialog\` pré-preenchido com a proposta — coordenador clica Salvar para aprovar como está ou ajusta antes (já existia via \`approveSchemaSuggestionWithEdits\`, só não era descobrível).
- Remove o ícone redundante "Editar e aprovar" do rodapé do card.

## Motivação
O fluxo anterior tinha 2 caminhos para aprovar (botão "Aprovar" + ícone tooltip "Editar e aprovar") e o ícone era invisível. Era fácil clicar Aprovar sem ler o diff. Agora o diff inline serve como preview consciente, e Revisar é o único caminho de aprovação.

## Test plan
- [ ] Como coordenador em sugestão pendente, clicar **Revisar** → abre o dialog com descrição/help_text/options propostos pré-preenchidos; clicar Salvar aprova; toast e refresh ok.
- [ ] No mesmo dialog, ajustar um campo antes de salvar → sugestão é aprovada com o valor editado (não com o proposto original).
- [ ] Clicar **Rejeitar** → mantém comportamento anterior (badge "Rejeitada").
- [ ] Sugestão já aprovada/rejeitada → mostra apenas o badge, sem botões.
- [ ] Comentários não-sugestão (review, nota, anotação, dúvida) → ícone CheckCircle2 de Resolver continua aparecendo no rodapé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)