### PR TITLE
fix(compare): rastrear parecer atual por ID em vez de índice

### DIFF
--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -94,6 +94,16 @@ export function ComparePage({
     documentsRef.current = documents;
   }, [documents]);
 
+  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    return () => {
+      if (advanceTimerRef.current) {
+        clearTimeout(advanceTimerRef.current);
+        advanceTimerRef.current = null;
+      }
+    };
+  }, []);
+
   // O parecer atual é derivado de `pinnedDocId` (última escolha explícita do
   // usuário). `documents` é reordenado pelo Server Component a cada
   // `revalidatePath` (sort por pendências); rastrear por índice numérico
@@ -107,6 +117,24 @@ export function ComparePage({
     }
     return 0;
   }, [documents, pinnedDocId]);
+
+  // Avisa quando o doc pinado some da lista (ex.: foi excluído). O
+  // `docIndex` memo já cai para `documents[0]` automaticamente; aqui só
+  // disparamos o toast uma vez, na transição "estava lá → sumiu".
+  const lastValidPinnedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pinnedDocId || documents.length === 0) {
+      lastValidPinnedRef.current = pinnedDocId;
+      return;
+    }
+    const exists = documents.some((d) => d.id === pinnedDocId);
+    if (exists) {
+      lastValidPinnedRef.current = pinnedDocId;
+    } else if (lastValidPinnedRef.current === pinnedDocId) {
+      toast.info("Documento removido da fila — voltando ao topo.");
+      lastValidPinnedRef.current = null;
+    }
+  }, [pinnedDocId, documents]);
 
   const currentDoc = documents[docIndex];
   const allDocDivergent = currentDoc ? (divergentFields[currentDoc.id] || []) : [];
@@ -190,16 +218,17 @@ export function ComparePage({
 
       const verdictComment = comment || undefined;
 
+      const nextDocReviews = {
+        ...localReviews[currentDoc.id],
+        [currentFieldName]: {
+          verdict,
+          chosenResponseId: chosenResponseId ?? null,
+          comment: verdictComment ?? null,
+        },
+      };
       setLocalReviews((prev) => ({
         ...prev,
-        [currentDoc.id]: {
-          ...prev[currentDoc.id],
-          [currentFieldName]: {
-            verdict,
-            chosenResponseId: chosenResponseId ?? null,
-            comment: verdictComment ?? null,
-          },
-        },
+        [currentDoc.id]: { ...prev[currentDoc.id], ...nextDocReviews },
       }));
 
       const snapshot: ResponseSnapshotEntry[] = fieldResponses
@@ -217,15 +246,16 @@ export function ComparePage({
       setComment("");
       toast.success("Veredito salvo!");
 
-      const allFieldsReviewed = allDocDivergent.every((fn) => {
-        if (fn === currentFieldName) return true;
-        return !!localReviews[currentDoc.id]?.[fn];
-      });
+      // Usa `nextDocReviews` (já contém o veredito recém-emitido) em vez de
+      // `localReviews`, que ainda reflete o estado pré-setState neste closure.
+      const allFieldsReviewed = allDocDivergent.every((fn) => !!nextDocReviews[fn]);
 
       if (allFieldsReviewed) {
         toast.success("Revisão do documento concluída!");
         const completedDocId = currentDoc.id;
-        setTimeout(() => {
+        if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
+        advanceTimerRef.current = setTimeout(() => {
+          advanceTimerRef.current = null;
           const docs = documentsRef.current;
           const idx = docs.findIndex((d) => d.id === completedDocId);
           if (idx >= 0 && idx < docs.length - 1) {

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { DocumentReader } from "../coding/DocumentReader";
 import { FullscreenNav } from "../coding/FullscreenNav";
 import {
@@ -78,7 +78,7 @@ export function ComparePage({
   latestMajorLabel,
   currentProjectVersion,
 }: ComparePageProps) {
-  const [docIndex, setDocIndex] = useState(0);
+  const [pinnedDocId, setPinnedDocId] = useState<string | null>(null);
   const [fieldIndex, setFieldIndex] = useState(0);
   const [filter, setFilter] = useState("all");
   const [comment, setComment] = useState("");
@@ -88,6 +88,25 @@ export function ComparePage({
   const [localReviews, setLocalReviews] = useState<
     Record<string, Record<string, ExistingVerdictInfo>>
   >(existingReviews);
+
+  const documentsRef = useRef(documents);
+  useEffect(() => {
+    documentsRef.current = documents;
+  }, [documents]);
+
+  // O parecer atual é derivado de `pinnedDocId` (última escolha explícita do
+  // usuário). `documents` é reordenado pelo Server Component a cada
+  // `revalidatePath` (sort por pendências); rastrear por índice numérico
+  // faria o parecer mudar sob o usuário a cada veredito. Quando o ID atual
+  // some da lista (filtro mudou, etc.) caímos para `documents[0]`.
+  const docIndex = useMemo(() => {
+    if (documents.length === 0) return 0;
+    if (pinnedDocId) {
+      const i = documents.findIndex((d) => d.id === pinnedDocId);
+      if (i >= 0) return i;
+    }
+    return 0;
+  }, [documents, pinnedDocId]);
 
   const currentDoc = documents[docIndex];
   const allDocDivergent = currentDoc ? (divergentFields[currentDoc.id] || []) : [];
@@ -205,26 +224,30 @@ export function ComparePage({
 
       if (allFieldsReviewed) {
         toast.success("Revisão do documento concluída!");
-        if (docIndex < documents.length - 1) {
-          setTimeout(() => {
-            setDocIndex(docIndex + 1);
+        const completedDocId = currentDoc.id;
+        setTimeout(() => {
+          const docs = documentsRef.current;
+          const idx = docs.findIndex((d) => d.id === completedDocId);
+          if (idx >= 0 && idx < docs.length - 1) {
+            setPinnedDocId(docs[idx + 1].id);
             setFieldIndex(0);
-          }, 1500);
-        }
+          }
+        }, 1500);
       } else if (fieldIndex < docFields.length - 1) {
         setFieldIndex(fieldIndex + 1);
       }
     },
-    [projectId, currentDoc, currentFieldName, isCurrentFieldDivergent, fieldIndex, docFields, allDocDivergent, docIndex, documents.length, localReviews, comment, fieldResponses]
+    [projectId, currentDoc, currentFieldName, isCurrentFieldDivergent, fieldIndex, docFields, allDocDivergent, localReviews, comment, fieldResponses]
   );
 
   const handleDocNavigate = useCallback(
     (newIndex: number) => {
+      if (documents.length === 0) return;
       const clamped = Math.max(0, Math.min(newIndex, documents.length - 1));
-      setDocIndex(clamped);
+      setPinnedDocId(documents[clamped].id);
       setFieldIndex(0);
     },
-    [documents.length]
+    [documents]
   );
 
   const toggleFullscreen = useCallback(() => setIsFullscreen((prev) => !prev), []);


### PR DESCRIPTION
## Summary
- Bug observado: ao clicar em uma resposta na aba Revisar, o parecer atual pulava sozinho — às vezes mais de uma posição.
- Causa raiz: `ComparePage` trackeava o parecer por `docIndex` numérico, mas o Server Component em `analyze/compare/page.tsx:424-430` reordena `documents` por nº de pendências a cada `revalidatePath` disparado pelo `submitVerdict`. Após cada veredito o índice fixo passava a apontar para um doc diferente. O `setTimeout` de auto-advance amplificava (capturava índice antigo numa lista já reordenada).
- Fix: troca para `pinnedDocId` — o `docIndex` é derivado via `findIndex`, e o auto-advance lê `documentsRef.current` para usar a ordenação vigente.

## Test plan
- [ ] Abrir um projeto com 3+ pareceres com nº de divergências variado (ex.: 1, 2, 2 pendências) e ir para a aba Revisar
- [ ] Posicionar-se no parecer com 1 pendência (no topo da lista)
- [ ] Clicar numa resposta — verificar que o parecer continua o mesmo (até o auto-advance de 1.5s); a pergunta NÃO pula sozinha
- [ ] Após o auto-advance, conferir que avança para o próximo parecer da ordenação atual
- [ ] Clicar várias vezes em sequência rápida — não deve haver saltos múltiplos
- [ ] `npx tsc --noEmit` passa
- [ ] `npx eslint src/components/compare/ComparePage.tsx` não introduz novos erros (apenas o pré-existente em `setComment` no effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)