### PR TITLE
feat(filters): feedback visual ao aplicar filtros

### DIFF
--- a/frontend/src/components/compare/CompareFilters.tsx
+++ b/frontend/src/components/compare/CompareFilters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -18,7 +18,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Badge } from "@/components/ui/badge";
-import { SlidersHorizontal, X } from "lucide-react";
+import { Loader2, SlidersHorizontal, X } from "lucide-react";
 import {
   DEFAULT_COMPARE_FILTERS,
   readCompareFilters,
@@ -39,6 +39,7 @@ export function CompareFilters({
   const router = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  const [isPending, startTransition] = useTransition();
 
   const current = readCompareFilters(searchParams);
 
@@ -64,13 +65,17 @@ export function CompareFilters({
           sp.set(urlKey, String(value));
         }
       }
-      router.push(`${pathname}?${sp.toString()}`);
+      startTransition(() => {
+        router.push(`${pathname}?${sp.toString()}`);
+      });
     },
     [current, pathname, router, searchParams],
   );
 
   const reset = useCallback(() => {
-    router.push(pathname);
+    startTransition(() => {
+      router.push(pathname);
+    });
   }, [pathname, router]);
 
   const activeCount = [
@@ -90,8 +95,13 @@ export function CompareFilters({
           size="sm"
           className="h-7 gap-1.5 text-xs"
           title="Filtros da fila de comparação"
+          aria-busy={isPending}
         >
-          <SlidersHorizontal className="h-3.5 w-3.5" />
+          {isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+          )}
           Filtros
           {activeCount > 0 && (
             <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-[10px]">
@@ -110,6 +120,7 @@ export function CompareFilters({
                 size="sm"
                 className="h-6 gap-1 px-2 text-xs"
                 onClick={reset}
+                disabled={isPending}
               >
                 <X className="h-3 w-3" />
                 Limpar
@@ -117,11 +128,19 @@ export function CompareFilters({
             )}
           </div>
 
+          {isPending && (
+            <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Aplicando filtros…
+            </div>
+          )}
+
           <div className="space-y-1.5">
             <Label className="text-xs">Desde a versão</Label>
             <Select
               value={current.version}
               onValueChange={(v) => update({ version: v })}
+              disabled={isPending}
             >
               <SelectTrigger className="h-8 text-xs">
                 <SelectValue />
@@ -153,6 +172,7 @@ export function CompareFilters({
                 onValueChange={(v) =>
                   update({ minHumans: Number.parseInt(v, 10) })
                 }
+                disabled={isPending}
               >
                 <SelectTrigger className="h-8 text-xs">
                   <SelectValue />
@@ -172,6 +192,7 @@ export function CompareFilters({
                 onValueChange={(v) =>
                   update({ minTotal: Number.parseInt(v, 10) })
                 }
+                disabled={isPending}
               >
                 <SelectTrigger className="h-8 text-xs">
                   <SelectValue />
@@ -193,6 +214,7 @@ export function CompareFilters({
               onValueChange={(v) =>
                 update({ minAssignedPct: Number.parseInt(v, 10) })
               }
+              disabled={isPending}
             >
               <SelectTrigger className="h-8 text-xs">
                 <SelectValue />
@@ -213,6 +235,7 @@ export function CompareFilters({
               value={current.since}
               onChange={(e) => update({ since: e.target.value })}
               className="h-8 text-xs"
+              disabled={isPending}
             />
           </div>
 
@@ -222,6 +245,7 @@ export function CompareFilters({
               <Select
                 value={current.respondent}
                 onValueChange={(v) => update({ respondent: v })}
+                disabled={isPending}
               >
                 <SelectTrigger className="h-8 text-xs">
                   <SelectValue />

--- a/frontend/src/components/compare/CompareFilters.tsx
+++ b/frontend/src/components/compare/CompareFilters.tsx
@@ -46,7 +46,7 @@ export function CompareFilters({
   const update = useCallback(
     (patch: Partial<CompareFiltersValue>) => {
       const sp = new URLSearchParams(searchParams.toString());
-      const apply = { ...current, ...patch };
+      const apply = { ...readCompareFilters(searchParams), ...patch };
       const map: Record<keyof CompareFiltersValue, string> = {
         version: "version",
         minHumans: "min_humans",
@@ -69,7 +69,7 @@ export function CompareFilters({
         router.push(`${pathname}?${sp.toString()}`);
       });
     },
-    [current, pathname, router, searchParams],
+    [pathname, router, searchParams],
   );
 
   const reset = useCallback(() => {

--- a/frontend/src/components/llm/LlmResponsesPane.tsx
+++ b/frontend/src/components/llm/LlmResponsesPane.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { Loader2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -46,7 +47,7 @@ export function LlmResponsesPane({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const [, startTransition] = useTransition();
+  const [isPending, startTransition] = useTransition();
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
   const [search, setSearch] = useState("");
@@ -106,11 +107,15 @@ export function LlmResponsesPane({
       </header>
 
       <div className="flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-2">
-          <label className="text-xs text-muted-foreground">Execução</label>
+        <div className="flex items-center gap-2" aria-busy={isPending}>
+          <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            Execução
+            {isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+          </label>
           <Select
             value={activeJobId ?? "all"}
             onValueChange={setJobFilter}
+            disabled={isPending}
           >
             <SelectTrigger className="h-8 w-64 text-xs">
               <SelectValue />

--- a/frontend/src/components/reviews/DateSinceFilter.tsx
+++ b/frontend/src/components/reviews/DateSinceFilter.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useTransition } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -30,6 +32,7 @@ export function DateSinceFilter() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
   const current = searchParams.get("since");
 
   const activeDays: number | null | "custom" = (() => {
@@ -48,12 +51,17 @@ export function DateSinceFilter() {
       params.set("since", isoDaysAgo(days));
     }
     const qs = params.toString();
-    router.push(qs ? `${pathname}?${qs}` : pathname);
+    startTransition(() => {
+      router.push(qs ? `${pathname}?${qs}` : pathname);
+    });
   };
 
   return (
-    <div className="flex items-center gap-2 text-xs">
-      <span className="text-muted-foreground">Desde:</span>
+    <div className="flex items-center gap-2 text-xs" aria-busy={isPending}>
+      <span className="flex items-center gap-1.5 text-muted-foreground">
+        Desde:
+        {isPending && <Loader2 className="h-3 w-3 animate-spin" />}
+      </span>
       <div className="flex items-center gap-1">
         {PRESETS.map((p) => {
           const isActive =
@@ -65,6 +73,7 @@ export function DateSinceFilter() {
               variant={isActive ? "default" : "outline"}
               size="xs"
               onClick={() => setSince(p.days)}
+              disabled={isPending}
               className={cn(!isActive && "text-muted-foreground")}
             >
               {p.label}

--- a/frontend/src/components/reviews/MyVerdictsView.tsx
+++ b/frontend/src/components/reviews/MyVerdictsView.tsx
@@ -239,7 +239,9 @@ export function MyVerdictsView({
       params.delete("viewAsUser");
     }
     const qs = params.toString();
-    router.push(`${pathname}${qs ? `?${qs}` : ""}`);
+    startTransition(() => {
+      router.push(`${pathname}${qs ? `?${qs}` : ""}`);
+    });
   };
 
   if (totalItems === 0) {
@@ -281,6 +283,7 @@ export function MyVerdictsView({
               <Select
                 value={currentViewUserId || "_self"}
                 onValueChange={(v) => selectRespondent(v === "_self" ? null : v)}
+                disabled={isPending}
               >
                 <SelectTrigger className="w-40 h-8 text-xs">
                   <SelectValue />


### PR DESCRIPTION
## Summary
- Em `analisar/comparar`, mudar qualquer filtro (ex.: data) disparava re-fetch pesado no servidor sem nenhum indicativo visual; o usuário ficava achando que o clique não fez nada.
- Envolve `router.push()` em `useTransition` no `CompareFilters` e no `DateSinceFilter` (mesmo problema, usado em `reviews/difficulty` e `reviews/respondents`).
- Trigger do popover troca o ícone por `Loader2` enquanto pende, exibe linha "Aplicando filtros…" e desabilita todos os controles (selects, input de data, botão Limpar) durante o pending.
- Mesmo padrão estendido para a troca de respondente em `MyVerdictsView` (reusando o `useTransition` já existente para `acknowledgeVerdict`) e para a troca de execução em `LlmResponsesPane` (passando a consumir o `isPending` que já estava sendo computado).
- Limpeza: `update` em `CompareFilters` deriva `current` inline em vez de mantê-lo redundante na dep array.

## Test plan
- [ ] `cd frontend && npm run dev`
- [ ] Abrir `/projects/<id>/analyze/compare` em projeto com volume razoável de respostas
- [ ] Mexer no input "Desde a data" e confirmar spinner imediato no botão "Filtros" e controles desabilitados
- [ ] Repetir com "Desde a versão", "Mín. humanos", "Mín. respostas" e "% atribuídos que responderam"
- [ ] Trocar o select "Respondente" e confirmar spinner + controles disabled
- [ ] Clicar "Limpar" e confirmar que o popover continua aberto, com a linha "Aplicando filtros…" visível e demais controles desabilitados durante o pending
- [ ] Em `/projects/<id>/reviews/difficulty`, clicar `7d` / `30d` / `Tudo` e confirmar spinner no rótulo "Desde:" e botões desabilitados durante pending
- [ ] Como coordenador em `/projects/<id>/reviews/my-verdicts`, trocar o select "Minhas respostas" para outro respondente e confirmar select disabled durante o pending
- [ ] Em `/projects/<id>/llm`, trocar o select "Execução" e confirmar `Loader2` ao lado do label + select disabled durante pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)