### PR TITLE
feat(schema): nova aba Histórico com timeline de mudanças

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,7 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
-        "@types/node": "^20",
+        "@types/node": "^20.19.39",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -45,7 +45,8 @@
         "shadcn": "^3.8.5",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -828,21 +829,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -850,9 +851,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2088,6 +2089,16 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3623,6 +3634,282 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4164,6 +4451,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -4236,6 +4534,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4290,9 +4595,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
-      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4946,6 +5251,126 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5289,6 +5714,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -5594,6 +6029,16 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -6681,6 +7126,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -7225,6 +7677,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -7299,6 +7761,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -7651,6 +8123,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -10773,6 +11260,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -11079,6 +11577,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11119,9 +11624,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -11829,6 +12334,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -12340,6 +12886,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -12415,6 +12968,13 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
     },
@@ -12832,6 +13392,13 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
@@ -12843,14 +13410,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -12878,9 +13445,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12888,6 +13455,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -12934,9 +13511,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -13564,6 +14141,468 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -13677,6 +14716,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wmf": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
     "@clerk/localizations": "^4.2.4",
@@ -40,7 +41,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
+    "@types/node": "^20.19.39",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -49,6 +50,7 @@
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/src/app/(app)/projects/[id]/config/history/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/history/page.tsx
@@ -14,6 +14,8 @@ export default async function SchemaHistoryPage({
   const { id } = await params;
   const supabase = await createSupabaseServer();
 
+  const HISTORY_LIMIT = 200;
+
   const [{ data: project }, { data: changes }] = await Promise.all([
     supabase
       .from("projects")
@@ -23,11 +25,11 @@ export default async function SchemaHistoryPage({
     supabase
       .from("schema_change_log")
       .select(
-        "id, field_name, change_summary, before_value, after_value, created_at, change_type, version_major, version_minor, version_patch, profiles(first_name, last_name, email)",
+        "id, field_name, change_summary, before_value, after_value, created_at, change_type, version_major, version_minor, version_patch, changed_by, profiles(first_name, last_name, email)",
       )
       .eq("project_id", id)
       .order("created_at", { ascending: false })
-      .limit(200),
+      .limit(HISTORY_LIMIT),
   ]);
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];
@@ -59,15 +61,23 @@ export default async function SchemaHistoryPage({
       beforeValue: (c.before_value as Record<string, unknown>) ?? {},
       afterValue: (c.after_value as Record<string, unknown>) ?? {},
       changedBy,
+      userId: (c.changed_by as string | null) ?? "",
       createdAt: c.created_at as string,
       changeType: (c.change_type as SchemaChangeType | null) ?? null,
       version,
     };
   });
 
+  const truncated = entries.length >= HISTORY_LIMIT;
+
   return (
     <div className="flex h-[calc(100vh-148px)] flex-col">
-      <SchemaHistoryView entries={entries} fieldOptions={fieldOptions} />
+      <SchemaHistoryView
+        entries={entries}
+        fieldOptions={fieldOptions}
+        truncated={truncated}
+        limit={HISTORY_LIMIT}
+      />
     </div>
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/config/history/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/history/page.tsx
@@ -1,0 +1,73 @@
+import { createSupabaseServer } from "@/lib/supabase/server";
+import { SchemaHistoryView } from "@/components/schema/SchemaHistoryView";
+import type {
+  PydanticField,
+  SchemaChangeEntry,
+  SchemaChangeType,
+} from "@/lib/types";
+
+export default async function SchemaHistoryPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createSupabaseServer();
+
+  const [{ data: project }, { data: changes }] = await Promise.all([
+    supabase
+      .from("projects")
+      .select("pydantic_fields")
+      .eq("id", id)
+      .single(),
+    supabase
+      .from("schema_change_log")
+      .select(
+        "id, field_name, change_summary, before_value, after_value, created_at, change_type, version_major, version_minor, version_patch, profiles(first_name, last_name, email)",
+      )
+      .eq("project_id", id)
+      .order("created_at", { ascending: false })
+      .limit(200),
+  ]);
+
+  const fields = (project?.pydantic_fields || []) as PydanticField[];
+  const fieldOptions = fields.map((f) => ({
+    name: f.name,
+    description: f.description || f.name,
+  }));
+
+  const entries: SchemaChangeEntry[] = (changes || []).map((c) => {
+    const p = c.profiles as unknown as {
+      first_name: string | null;
+      last_name: string | null;
+      email: string | null;
+    } | null;
+    const fullName = [p?.first_name, p?.last_name].filter(Boolean).join(" ");
+    const changedBy =
+      fullName || p?.email?.split("@")[0] || "Anônimo";
+    const major = c.version_major as number | null;
+    const minor = c.version_minor as number | null;
+    const patch = c.version_patch as number | null;
+    const version =
+      major !== null && minor !== null && patch !== null
+        ? { major, minor, patch }
+        : null;
+    return {
+      id: c.id as string,
+      fieldName: c.field_name as string,
+      changeSummary: (c.change_summary as string) ?? "",
+      beforeValue: (c.before_value as Record<string, unknown>) ?? {},
+      afterValue: (c.after_value as Record<string, unknown>) ?? {},
+      changedBy,
+      createdAt: c.created_at as string,
+      changeType: (c.change_type as SchemaChangeType | null) ?? null,
+      version,
+    };
+  });
+
+  return (
+    <div className="flex h-[calc(100vh-148px)] flex-col">
+      <SchemaHistoryView entries={entries} fieldOptions={fieldOptions} />
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/projects/[id]/config/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/layout.tsx
@@ -8,6 +8,7 @@ const configTabs = [
   { label: "Geral", href: "general" },
   { label: "Documentos", href: "documents" },
   { label: "Schema", href: "schema" },
+  { label: "Histórico", href: "history" },
   { label: "Membros", href: "members" },
   { label: "Regras", href: "rules" },
 ];

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -19,7 +19,6 @@ export default async function CommentsPage({
     { data: documents },
     { data: membership },
     { data: responsesWithNotes },
-    { data: schemaChanges },
     { data: suggestions },
     { data: llmResponses },
     { data: difficultyResolutions },
@@ -58,12 +57,6 @@ export default async function CommentsPage({
       .eq("project_id", id)
       .eq("respondent_type", "humano")
       .not("justifications", "is", null),
-    supabase
-      .from("schema_change_log")
-      .select("id, field_name, change_summary, before_value, after_value, created_at, profiles(first_name, last_name)")
-      .eq("project_id", id)
-      .order("created_at", { ascending: false })
-      .limit(50),
     supabase
       .from("schema_suggestions")
       .select("id, field_name, suggested_changes, reason, status, resolved_at, created_at, profiles!suggested_by(email)")
@@ -332,19 +325,6 @@ export default async function CommentsPage({
   );
   const comments = [...pendingSuggestions, ...restComments];
 
-  const schemaLog = (schemaChanges || []).map((c) => {
-    const p = c.profiles as unknown as { first_name: string | null; last_name: string | null } | null;
-    return {
-      id: c.id as string,
-      fieldName: c.field_name as string,
-      changeSummary: c.change_summary as string,
-      beforeValue: c.before_value as Record<string, unknown>,
-      afterValue: c.after_value as Record<string, unknown>,
-      changedBy: [p?.first_name, p?.last_name].filter(Boolean).join(" ") || "Anônimo",
-      createdAt: c.created_at as string,
-    };
-  });
-
   const totalLlmDocs = llmResponses?.length ?? 0;
   const llmDocsWithoutAmbiguities = (llmResponses ?? []).filter((r) => {
     const amb = (r.answers as Record<string, unknown>)?.llm_ambiguidades;
@@ -358,7 +338,6 @@ export default async function CommentsPage({
         comments={comments}
         fields={fields}
         isCoordinator={isCoordinator}
-        schemaLog={schemaLog}
         totalLlmDocs={totalLlmDocs}
         llmDocsWithoutAmbiguities={llmDocsWithoutAmbiguities}
       />

--- a/frontend/src/components/schema/FieldChangeDiff.tsx
+++ b/frontend/src/components/schema/FieldChangeDiff.tsx
@@ -1,0 +1,463 @@
+"use client";
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { ChevronDown, Plus, Minus, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  detectFieldChangeKind,
+  diffPydanticField,
+  formatCondition,
+  formatTarget,
+  formatType,
+  propertyLabel,
+  type FieldChangeKind,
+  type FieldPropertyDiff,
+} from "@/lib/schema-change-utils";
+import type { SchemaChangeEntry, FieldCondition, SubfieldDef } from "@/lib/types";
+
+interface FieldChangeDiffProps {
+  entry: SchemaChangeEntry;
+  defaultExpanded?: boolean;
+}
+
+export function FieldChangeDiff({ entry, defaultExpanded = true }: FieldChangeDiffProps) {
+  const kind = detectFieldChangeKind(entry);
+  const diffs = diffPydanticField(entry.beforeValue, entry.afterValue);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  const beforeName =
+    (entry.beforeValue?.name as string | undefined) ?? entry.fieldName;
+  const afterName =
+    (entry.afterValue?.name as string | undefined) ?? entry.fieldName;
+
+  const displayName =
+    kind === "renamed" ? (
+      <span className="font-mono text-xs">
+        <span className="text-muted-foreground line-through">{beforeName}</span>
+        <ArrowRight className="mx-1 inline h-3 w-3 text-muted-foreground" />
+        <span className="font-medium text-foreground">{afterName}</span>
+      </span>
+    ) : (
+      <span className="font-mono text-xs font-medium text-foreground">
+        {kind === "added" ? afterName : beforeName}
+      </span>
+    );
+
+  const bodyVisible = expanded && (diffs.length > 0 || kind === "added" || kind === "removed");
+
+  return (
+    <div className="group">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-muted/40"
+      >
+        <KindIcon kind={kind} />
+        {displayName}
+        <div className="flex flex-1 flex-wrap items-center gap-1">
+          {diffs.map((d) => (
+            <Badge
+              key={d.property}
+              variant="outline"
+              className="h-4 px-1.5 py-0 text-[10px] font-normal"
+            >
+              {propertyLabel(d.property)}
+            </Badge>
+          ))}
+          {kind === "added" && diffs.length === 0 && (
+            <Badge variant="outline" className="h-4 px-1.5 py-0 text-[10px] font-normal">
+              novo campo
+            </Badge>
+          )}
+          {kind === "removed" && diffs.length === 0 && (
+            <Badge variant="outline" className="h-4 px-1.5 py-0 text-[10px] font-normal">
+              removido
+            </Badge>
+          )}
+        </div>
+        <ChevronDown
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform",
+            expanded && "rotate-180",
+          )}
+        />
+      </button>
+
+      {bodyVisible && (
+        <div className="ml-6 mt-1 space-y-2 rounded-md border bg-muted/20 px-3 py-2 text-xs">
+          {kind === "added" && (
+            <FieldSnapshot data={entry.afterValue} variant="added" />
+          )}
+          {kind === "removed" && (
+            <FieldSnapshot data={entry.beforeValue} variant="removed" />
+          )}
+          {diffs.map((d) => (
+            <PropertyDiff key={d.property} diff={d} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function KindIcon({ kind }: { kind: FieldChangeKind }) {
+  if (kind === "added") {
+    return (
+      <span
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full",
+          "bg-green-500/15 text-green-700",
+        )}
+        aria-label="Campo novo"
+      >
+        <Plus className="h-3 w-3" />
+      </span>
+    );
+  }
+  if (kind === "removed") {
+    return (
+      <span
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full",
+          "bg-red-500/15 text-red-700",
+        )}
+        aria-label="Campo removido"
+      >
+        <Minus className="h-3 w-3" />
+      </span>
+    );
+  }
+  if (kind === "renamed") {
+    return (
+      <span
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full",
+          "bg-blue-500/15 text-blue-700",
+        )}
+        aria-label="Campo renomeado"
+      >
+        <ArrowRight className="h-3 w-3" />
+      </span>
+    );
+  }
+  return (
+    <span
+      className="flex h-4 w-4 shrink-0 items-center justify-center text-muted-foreground"
+      aria-label="Campo modificado"
+    >
+      •
+    </span>
+  );
+}
+
+function PropertyDiff({ diff }: { diff: FieldPropertyDiff }) {
+  const label = propertyLabel(diff.property);
+
+  if (diff.property === "options") {
+    return (
+      <DiffSection label={label}>
+        <OptionsListDiff
+          before={diff.before as string[] | null}
+          after={diff.after as string[] | null}
+        />
+      </DiffSection>
+    );
+  }
+  if (diff.property === "subfields") {
+    return (
+      <DiffSection label={label}>
+        <SubfieldsDiff
+          before={diff.before as SubfieldDef[] | null}
+          after={diff.after as SubfieldDef[] | null}
+        />
+      </DiffSection>
+    );
+  }
+  if (diff.property === "help_text") {
+    return (
+      <DiffSection label={label}>
+        <HelpTextDiff
+          before={(diff.before as string | null) ?? ""}
+          after={(diff.after as string | null) ?? ""}
+        />
+      </DiffSection>
+    );
+  }
+  if (diff.property === "condition") {
+    return (
+      <DiffSection label={label}>
+        <InlineDiff
+          before={formatCondition(diff.before as FieldCondition | null)}
+          after={formatCondition(diff.after as FieldCondition | null)}
+        />
+      </DiffSection>
+    );
+  }
+  if (diff.property === "type") {
+    return (
+      <DiffSection label={label}>
+        <PillDiff before={formatType(diff.before)} after={formatType(diff.after)} />
+      </DiffSection>
+    );
+  }
+  if (diff.property === "target") {
+    return (
+      <DiffSection label={label}>
+        <PillDiff before={formatTarget(diff.before)} after={formatTarget(diff.after)} />
+      </DiffSection>
+    );
+  }
+  if (diff.property === "required" || diff.property === "allow_other") {
+    return (
+      <DiffSection label={label}>
+        <PillDiff
+          before={diff.before ? "Sim" : "Não"}
+          after={diff.after ? "Sim" : "Não"}
+        />
+      </DiffSection>
+    );
+  }
+  if (diff.property === "subfield_rule") {
+    const map: Record<string, string> = {
+      all: "Todos obrigatórios",
+      at_least_one: "Pelo menos um",
+    };
+    return (
+      <DiffSection label={label}>
+        <PillDiff
+          before={map[diff.before as string] ?? "—"}
+          after={map[diff.after as string] ?? "—"}
+        />
+      </DiffSection>
+    );
+  }
+  // name, description (texto curto)
+  return (
+    <DiffSection label={label}>
+      <InlineDiff
+        before={String(diff.before ?? "")}
+        after={String(diff.after ?? "")}
+      />
+    </DiffSection>
+  );
+}
+
+function DiffSection({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function emptyMark(value: string): string {
+  return value.length > 0 ? value : "(vazio)";
+}
+
+function InlineDiff({ before, after }: { before: string; after: string }) {
+  return (
+    <div className="leading-relaxed break-words">
+      <del className="text-muted-foreground">{emptyMark(before)}</del>
+      <span className="mx-1.5 text-muted-foreground">→</span>
+      <ins className="font-medium text-foreground no-underline">
+        {emptyMark(after)}
+      </ins>
+    </div>
+  );
+}
+
+function HelpTextDiff({ before, after }: { before: string; after: string }) {
+  return (
+    <div className="grid gap-1">
+      <div className="rounded border border-dashed bg-background/40 px-2 py-1">
+        <span className="text-[10px] font-medium text-muted-foreground">Antes</span>
+        <del className="block whitespace-pre-wrap break-words text-muted-foreground">
+          {emptyMark(before)}
+        </del>
+      </div>
+      <div className="rounded border border-dashed border-brand/40 bg-brand/5 px-2 py-1">
+        <span className="text-[10px] font-medium text-brand">Depois</span>
+        <ins className="block whitespace-pre-wrap break-words font-medium text-foreground no-underline">
+          {emptyMark(after)}
+        </ins>
+      </div>
+    </div>
+  );
+}
+
+function PillDiff({ before, after }: { before: string; after: string }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <Badge
+        variant="outline"
+        className="h-5 px-1.5 py-0 text-[10px] font-normal text-muted-foreground"
+      >
+        <del className="no-underline">{before}</del>
+      </Badge>
+      <ArrowRight className="h-3 w-3 text-muted-foreground" />
+      <Badge className="h-5 bg-brand/10 px-1.5 py-0 text-[10px] font-medium text-brand hover:bg-brand/10">
+        {after}
+      </Badge>
+    </div>
+  );
+}
+
+function OptionsListDiff({
+  before,
+  after,
+}: {
+  before: string[] | null;
+  after: string[] | null;
+}) {
+  const beforeArr = before ?? [];
+  const afterArr = after ?? [];
+  const afterSet = new Set(afterArr);
+  const beforeSet = new Set(beforeArr);
+  const removed = beforeArr.filter((o) => !afterSet.has(o));
+  const added = afterArr.filter((o) => !beforeSet.has(o));
+  const kept = beforeArr.filter((o) => afterSet.has(o));
+
+  if (removed.length === 0 && added.length === 0 && kept.length === 0) {
+    return <span className="italic text-muted-foreground">(sem opções)</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {kept.map((o) => (
+        <Badge
+          key={`kept-${o}`}
+          variant="outline"
+          className="text-[10px] px-1.5 py-0 font-normal break-all"
+        >
+          {o}
+        </Badge>
+      ))}
+      {removed.map((o) => (
+        <Badge
+          key={`rem-${o}`}
+          aria-label={`Opção removida: ${o}`}
+          className={cn(
+            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "bg-red-500/10 text-red-700 hover:bg-red-500/10",
+          )}
+        >
+          <del className="no-underline">− {o}</del>
+        </Badge>
+      ))}
+      {added.map((o) => (
+        <Badge
+          key={`add-${o}`}
+          aria-label={`Opção adicionada: ${o}`}
+          className={cn(
+            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "bg-green-500/10 text-green-700 hover:bg-green-500/10",
+          )}
+        >
+          <ins className="no-underline">+ {o}</ins>
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function SubfieldsDiff({
+  before,
+  after,
+}: {
+  before: SubfieldDef[] | null;
+  after: SubfieldDef[] | null;
+}) {
+  const beforeArr = before ?? [];
+  const afterArr = after ?? [];
+  const afterMap = new Map(afterArr.map((s) => [s.key, s]));
+  const beforeMap = new Map(beforeArr.map((s) => [s.key, s]));
+  const removed = beforeArr.filter((s) => !afterMap.has(s.key));
+  const added = afterArr.filter((s) => !beforeMap.has(s.key));
+  const kept = beforeArr.filter((s) => afterMap.has(s.key));
+
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {kept.map((s) => (
+        <Badge
+          key={`kept-${s.key}`}
+          variant="outline"
+          className="text-[10px] px-1.5 py-0 font-normal break-all"
+        >
+          {s.label || s.key}
+        </Badge>
+      ))}
+      {removed.map((s) => (
+        <Badge
+          key={`rem-${s.key}`}
+          className={cn(
+            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "bg-red-500/10 text-red-700 hover:bg-red-500/10",
+          )}
+        >
+          <del className="no-underline">− {s.label || s.key}</del>
+        </Badge>
+      ))}
+      {added.map((s) => (
+        <Badge
+          key={`add-${s.key}`}
+          className={cn(
+            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "bg-green-500/10 text-green-700 hover:bg-green-500/10",
+          )}
+        >
+          <ins className="no-underline">+ {s.label || s.key}</ins>
+        </Badge>
+      ))}
+    </div>
+  );
+}
+
+function FieldSnapshot({
+  data,
+  variant,
+}: {
+  data: Record<string, unknown>;
+  variant: "added" | "removed";
+}) {
+  const tone =
+    variant === "added"
+      ? "border-green-500/30 bg-green-500/5"
+      : "border-red-500/30 bg-red-500/5";
+
+  const rows: { label: string; value: string }[] = [];
+  if (data.description)
+    rows.push({ label: "descrição", value: String(data.description) });
+  if (data.type) rows.push({ label: "tipo", value: formatType(data.type) });
+  if (data.target) rows.push({ label: "alvo", value: formatTarget(data.target) });
+  if (typeof data.required === "boolean")
+    rows.push({ label: "obrigatório", value: data.required ? "Sim" : "Não" });
+  if (data.help_text)
+    rows.push({ label: "instruções", value: String(data.help_text) });
+  if (Array.isArray(data.options) && (data.options as string[]).length > 0)
+    rows.push({
+      label: "opções",
+      value: (data.options as string[]).join(", "),
+    });
+  if (data.condition)
+    rows.push({
+      label: "condição",
+      value: formatCondition(data.condition as FieldCondition),
+    });
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className={cn("space-y-0.5 rounded border px-2 py-1.5", tone)}>
+      {rows.map((r) => (
+        <div key={r.label} className="flex gap-2 text-[11px] leading-snug">
+          <span className="shrink-0 text-muted-foreground">{r.label}:</span>
+          <span className="break-words text-foreground">{r.value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/schema/FieldChangeDiff.tsx
+++ b/frontend/src/components/schema/FieldChangeDiff.tsx
@@ -331,7 +331,7 @@ function OptionsListDiff({
         <Badge
           key={`kept-${o}`}
           variant="outline"
-          className="text-[10px] px-1.5 py-0 font-normal break-all"
+          className="text-[10px] px-1.5 py-0 font-normal break-words"
         >
           {o}
         </Badge>
@@ -341,7 +341,7 @@ function OptionsListDiff({
           key={`rem-${o}`}
           aria-label={`Opção removida: ${o}`}
           className={cn(
-            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "text-[10px] px-1.5 py-0 font-normal break-words",
             "bg-red-500/10 text-red-700 hover:bg-red-500/10",
           )}
         >
@@ -353,7 +353,7 @@ function OptionsListDiff({
           key={`add-${o}`}
           aria-label={`Opção adicionada: ${o}`}
           className={cn(
-            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "text-[10px] px-1.5 py-0 font-normal break-words",
             "bg-green-500/10 text-green-700 hover:bg-green-500/10",
           )}
         >
@@ -385,7 +385,7 @@ function SubfieldsDiff({
         <Badge
           key={`kept-${s.key}`}
           variant="outline"
-          className="text-[10px] px-1.5 py-0 font-normal break-all"
+          className="text-[10px] px-1.5 py-0 font-normal break-words"
         >
           {s.label || s.key}
         </Badge>
@@ -394,7 +394,7 @@ function SubfieldsDiff({
         <Badge
           key={`rem-${s.key}`}
           className={cn(
-            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "text-[10px] px-1.5 py-0 font-normal break-words",
             "bg-red-500/10 text-red-700 hover:bg-red-500/10",
           )}
         >
@@ -405,7 +405,7 @@ function SubfieldsDiff({
         <Badge
           key={`add-${s.key}`}
           className={cn(
-            "text-[10px] px-1.5 py-0 font-normal break-all",
+            "text-[10px] px-1.5 py-0 font-normal break-words",
             "bg-green-500/10 text-green-700 hover:bg-green-500/10",
           )}
         >

--- a/frontend/src/components/schema/SchemaChangeGroup.tsx
+++ b/frontend/src/components/schema/SchemaChangeGroup.tsx
@@ -37,7 +37,7 @@ const DOT_COLOR: Record<SchemaChangeType, string> = {
 
 export function SchemaChangeGroup({ group }: SchemaChangeGroupProps) {
   const fieldCount = group.entries.length;
-  const hasType = group.changeType !== null;
+  const { changeType } = group;
 
   // Expandir por padrão se commit pequeno
   const defaultExpanded = fieldCount <= 3;
@@ -52,7 +52,7 @@ export function SchemaChangeGroup({ group }: SchemaChangeGroupProps) {
       <span
         className={cn(
           "absolute left-0 top-[6px] h-3.5 w-3.5 rounded-full ring-4 ring-background",
-          hasType ? DOT_COLOR[group.changeType!] : "bg-muted-foreground/30",
+          changeType ? DOT_COLOR[changeType] : "bg-muted-foreground/30",
         )}
         aria-hidden
       />
@@ -69,14 +69,14 @@ export function SchemaChangeGroup({ group }: SchemaChangeGroupProps) {
         >
           {formatVersion(group.version)}
         </Badge>
-        {hasType && (
+        {changeType && (
           <Badge
             className={cn(
               "h-5 border px-1.5 py-0 text-[10px] font-medium",
-              TYPE_BADGE[group.changeType!],
+              TYPE_BADGE[changeType],
             )}
           >
-            {TYPE_LABEL[group.changeType!]}
+            {TYPE_LABEL[changeType]}
           </Badge>
         )}
         <span className="text-xs text-muted-foreground">

--- a/frontend/src/components/schema/SchemaChangeGroup.tsx
+++ b/frontend/src/components/schema/SchemaChangeGroup.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { FieldChangeDiff } from "./FieldChangeDiff";
+import {
+  formatRelativeDate,
+  formatVersion,
+  type ChangeGroup,
+} from "@/lib/schema-change-utils";
+import type { SchemaChangeType } from "@/lib/types";
+
+interface SchemaChangeGroupProps {
+  group: ChangeGroup;
+}
+
+const TYPE_BADGE: Record<SchemaChangeType, string> = {
+  major: "bg-brand/15 text-brand border-brand/30",
+  minor: "bg-blue-500/10 text-blue-700 border-blue-500/30",
+  patch: "bg-muted text-muted-foreground border-muted-foreground/20",
+  initial: "bg-violet-500/10 text-violet-700 border-violet-500/30",
+};
+
+const TYPE_LABEL: Record<SchemaChangeType, string> = {
+  major: "MAJOR",
+  minor: "MINOR",
+  patch: "PATCH",
+  initial: "INITIAL",
+};
+
+const DOT_COLOR: Record<SchemaChangeType, string> = {
+  major: "bg-brand",
+  minor: "bg-blue-500",
+  patch: "bg-muted-foreground/40",
+  initial: "bg-violet-500",
+};
+
+export function SchemaChangeGroup({ group }: SchemaChangeGroupProps) {
+  const fieldCount = group.entries.length;
+  const hasType = group.changeType !== null;
+
+  // Expandir por padrão se commit pequeno
+  const defaultExpanded = fieldCount <= 3;
+
+  return (
+    <div className="relative pl-6">
+      {/* Linha + dot da timeline */}
+      <span
+        className="absolute left-[7px] top-0 bottom-0 w-px bg-border"
+        aria-hidden
+      />
+      <span
+        className={cn(
+          "absolute left-0 top-[6px] h-3.5 w-3.5 rounded-full ring-4 ring-background",
+          hasType ? DOT_COLOR[group.changeType!] : "bg-muted-foreground/30",
+        )}
+        aria-hidden
+      />
+
+      <div className="flex flex-wrap items-center gap-2 pb-1">
+        <Badge
+          variant="outline"
+          className="h-5 px-1.5 py-0 font-mono text-[11px]"
+          title={
+            group.version
+              ? `${formatVersion(group.version)} após esta mudança`
+              : "Sem versão"
+          }
+        >
+          {formatVersion(group.version)}
+        </Badge>
+        {hasType && (
+          <Badge
+            className={cn(
+              "h-5 border px-1.5 py-0 text-[10px] font-medium",
+              TYPE_BADGE[group.changeType!],
+            )}
+          >
+            {TYPE_LABEL[group.changeType!]}
+          </Badge>
+        )}
+        <span className="text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">{group.changedBy}</span>
+          <span className="mx-1.5">·</span>
+          <span title={new Date(group.createdAt).toLocaleString("pt-BR")}>
+            {formatRelativeDate(group.createdAt)}
+          </span>
+        </span>
+        <span className="ml-auto text-[11px] text-muted-foreground">
+          {fieldCount} {fieldCount === 1 ? "campo" : "campos"}
+        </span>
+      </div>
+
+      <div className="space-y-1 pb-6">
+        {group.entries.map((entry) => (
+          <FieldChangeDiff
+            key={entry.id}
+            entry={entry}
+            defaultExpanded={defaultExpanded}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/schema/SchemaHistoryView.tsx
+++ b/frontend/src/components/schema/SchemaHistoryView.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { History } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { SchemaChangeGroup } from "./SchemaChangeGroup";
+import {
+  groupChangesByCommit,
+  type ChangeGroup,
+} from "@/lib/schema-change-utils";
+import type { SchemaChangeEntry, SchemaChangeType } from "@/lib/types";
+
+interface SchemaHistoryViewProps {
+  entries: SchemaChangeEntry[];
+  fieldOptions: { name: string; description: string }[];
+}
+
+type TypeFilter = "all" | SchemaChangeType;
+
+const TYPE_BUTTONS: { value: TypeFilter; label: string }[] = [
+  { value: "all", label: "Todos" },
+  { value: "major", label: "Major" },
+  { value: "minor", label: "Minor" },
+  { value: "patch", label: "Patch" },
+  { value: "initial", label: "Initial" },
+];
+
+export function SchemaHistoryView({
+  entries,
+  fieldOptions,
+}: SchemaHistoryViewProps) {
+  const [search, setSearch] = useState("");
+  const [fieldFilter, setFieldFilter] = useState("all");
+  const [authorFilter, setAuthorFilter] = useState("all");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+
+  const authors = useMemo(() => {
+    const set = new Set<string>();
+    for (const e of entries) {
+      if (e.changedBy) set.add(e.changedBy);
+    }
+    return Array.from(set).sort();
+  }, [entries]);
+
+  const fieldDescriptionMap = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const f of fieldOptions) m.set(f.name, f.description || f.name);
+    return m;
+  }, [fieldOptions]);
+
+  const filtered: SchemaChangeEntry[] = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return entries.filter((e) => {
+      if (fieldFilter !== "all" && e.fieldName !== fieldFilter) return false;
+      if (authorFilter !== "all" && e.changedBy !== authorFilter) return false;
+      if (typeFilter !== "all" && e.changeType !== typeFilter) return false;
+      if (!q) return true;
+      const haystackParts = [
+        e.fieldName,
+        e.changeSummary,
+        fieldDescriptionMap.get(e.fieldName) ?? "",
+        JSON.stringify(e.beforeValue ?? {}),
+        JSON.stringify(e.afterValue ?? {}),
+        e.changedBy,
+      ];
+      return haystackParts.join(" ").toLowerCase().includes(q);
+    });
+  }, [entries, search, fieldFilter, authorFilter, typeFilter, fieldDescriptionMap]);
+
+  const groups: ChangeGroup[] = useMemo(
+    () => groupChangesByCommit(filtered),
+    [filtered],
+  );
+
+  const totalEntries = entries.length;
+  const filteredEntries = filtered.length;
+  const activeFilters =
+    search.trim() !== "" ||
+    fieldFilter !== "all" ||
+    authorFilter !== "all" ||
+    typeFilter !== "all";
+
+  if (totalEntries === 0) {
+    return <EmptyState reason="empty" />;
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="sticky top-0 z-10 space-y-2 border-b bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            placeholder="Buscar por campo, autor ou conteúdo..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="h-8 w-64"
+          />
+          <Select value={fieldFilter} onValueChange={setFieldFilter}>
+            <SelectTrigger className="h-8 w-44 text-xs">
+              <SelectValue placeholder="Campo" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os campos</SelectItem>
+              {fieldOptions.map((f) => (
+                <SelectItem key={f.name} value={f.name}>
+                  {f.description || f.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={authorFilter} onValueChange={setAuthorFilter}>
+            <SelectTrigger className="h-8 w-44 text-xs">
+              <SelectValue placeholder="Autor" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todos os autores</SelectItem>
+              {authors.map((a) => (
+                <SelectItem key={a} value={a}>
+                  {a}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <div className="flex items-center gap-0.5 rounded-md border bg-muted/40 p-0.5">
+            {TYPE_BUTTONS.map((b) => (
+              <Button
+                key={b.value}
+                variant="ghost"
+                size="sm"
+                onClick={() => setTypeFilter(b.value)}
+                className={cn(
+                  "h-7 px-2 text-xs",
+                  typeFilter === b.value && "bg-background shadow-sm",
+                )}
+              >
+                {b.label}
+              </Button>
+            ))}
+          </div>
+          <span className="ml-auto text-xs text-muted-foreground">
+            {filteredEntries} {filteredEntries === 1 ? "mudança" : "mudanças"}
+            {" em "}
+            {groups.length} {groups.length === 1 ? "commit" : "commits"}
+            {activeFilters && filteredEntries !== totalEntries
+              ? ` (de ${totalEntries})`
+              : ""}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 pt-4">
+        {groups.length === 0 ? (
+          <EmptyState reason={activeFilters ? "filtered" : "empty"} />
+        ) : (
+          <div className="mx-auto max-w-3xl">
+            {groups.map((g) => (
+              <SchemaChangeGroup key={g.key} group={g} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ reason }: { reason: "empty" | "filtered" }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 px-4 py-16 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+        <History className="h-6 w-6 text-muted-foreground" />
+      </div>
+      {reason === "empty" ? (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Nenhuma mudança registrada ainda</p>
+          <p className="text-xs text-muted-foreground">
+            Edite o schema para começar a versionar.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">Nenhum commit encontrado</p>
+          <p className="text-xs text-muted-foreground">
+            Tente ajustar os filtros ou a busca.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/schema/SchemaHistoryView.tsx
+++ b/frontend/src/components/schema/SchemaHistoryView.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { History } from "lucide-react";
+import { History, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SchemaChangeGroup } from "./SchemaChangeGroup";
 import {
@@ -22,6 +22,8 @@ import type { SchemaChangeEntry, SchemaChangeType } from "@/lib/types";
 interface SchemaHistoryViewProps {
   entries: SchemaChangeEntry[];
   fieldOptions: { name: string; description: string }[];
+  truncated?: boolean;
+  limit?: number;
 }
 
 type TypeFilter = "all" | SchemaChangeType;
@@ -37,6 +39,8 @@ const TYPE_BUTTONS: { value: TypeFilter; label: string }[] = [
 export function SchemaHistoryView({
   entries,
   fieldOptions,
+  truncated = false,
+  limit = 200,
 }: SchemaHistoryViewProps) {
   const [search, setSearch] = useState("");
   const [fieldFilter, setFieldFilter] = useState("all");
@@ -154,6 +158,15 @@ export function SchemaHistoryView({
               : ""}
           </span>
         </div>
+        {truncated && (
+          <div className="flex items-center gap-1.5 rounded border border-amber-500/30 bg-amber-500/5 px-2 py-1 text-[11px] text-amber-700 dark:text-amber-400">
+            <Info className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              Mostrando as últimas {limit} mudanças. Use os filtros (campo, autor, tipo) para
+              localizar entradas mais antigas.
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto px-4 pt-4">

--- a/frontend/src/components/stats/ReviewCommentsView.tsx
+++ b/frontend/src/components/stats/ReviewCommentsView.tsx
@@ -10,10 +10,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
-import { History, ChevronDown, PanelLeftClose } from "lucide-react";
+import { PanelLeftClose } from "lucide-react";
 import { CommentCard, type ReviewComment } from "./CommentCard";
 import { CommentsSplitView } from "./CommentsSplitView";
 import { EditFieldDialog, type PendingSuggestion } from "./EditFieldDialog";
@@ -34,25 +32,13 @@ import {
   reopenProjectComment,
 } from "@/actions/project-comments";
 import { toast } from "sonner";
-import { cn } from "@/lib/utils";
 import type { PydanticField } from "@/lib/types";
-
-export interface SchemaChangeEntry {
-  id: string;
-  fieldName: string;
-  changeSummary: string;
-  beforeValue: Record<string, unknown>;
-  afterValue: Record<string, unknown>;
-  changedBy: string;
-  createdAt: string;
-}
 
 interface ReviewCommentsViewProps {
   projectId: string;
   comments: ReviewComment[];
   fields: PydanticField[];
   isCoordinator: boolean;
-  schemaLog?: SchemaChangeEntry[];
   totalLlmDocs?: number;
   llmDocsWithoutAmbiguities?: number;
 }
@@ -73,7 +59,6 @@ export function ReviewCommentsView({
   comments,
   fields,
   isCoordinator,
-  schemaLog = [],
   totalLlmDocs = 0,
   llmDocsWithoutAmbiguities = 0,
 }: ReviewCommentsViewProps) {
@@ -166,8 +151,6 @@ export function ReviewCommentsView({
     });
   };
 
-  const [logOpen, setLogOpen] = useState(false);
-
   // Count unique documents with review/difficulty comments (for split view button)
   const splitSources = new Set(["review", "dificuldade"]);
   const reviewDocCount = useMemo(() => {
@@ -214,72 +197,6 @@ export function ReviewCommentsView({
             Revisar por documento
           </Button>
         )}
-        <Collapsible open={logOpen} onOpenChange={setLogOpen} className="ml-auto">
-          <CollapsibleTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-1.5 text-xs">
-              <History className="h-3.5 w-3.5" />
-              Histórico de mudanças no schema{schemaLog.length > 0 && ` (${schemaLog.length})`}
-              <ChevronDown className={cn("h-3 w-3 transition-transform", logOpen && "rotate-180")} />
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-          <div className="mt-2 divide-y rounded-md border">
-            {schemaLog.length === 0 ? (
-              <p className="py-3 text-center text-xs text-muted-foreground">
-                Nenhuma mudança registrada ainda.
-              </p>
-            ) : schemaLog.map((entry) => {
-                const changes: { label: string; before: string; after: string }[] = [];
-                if (entry.beforeValue.description !== undefined) {
-                  changes.push({
-                    label: "descrição",
-                    before: String(entry.beforeValue.description) || "(vazio)",
-                    after: String(entry.afterValue.description) || "(vazio)",
-                  });
-                }
-                if (entry.beforeValue.help_text !== undefined) {
-                  changes.push({
-                    label: "instruções",
-                    before: String(entry.beforeValue.help_text ?? "") || "(vazio)",
-                    after: String(entry.afterValue.help_text ?? "") || "(vazio)",
-                  });
-                }
-                if (entry.beforeValue.options !== undefined) {
-                  changes.push({
-                    label: "opções",
-                    before: Array.isArray(entry.beforeValue.options)
-                      ? (entry.beforeValue.options as string[]).join(", ") || "(vazio)"
-                      : "(vazio)",
-                    after: Array.isArray(entry.afterValue.options)
-                      ? (entry.afterValue.options as string[]).join(", ") || "(vazio)"
-                      : "(vazio)",
-                  });
-                }
-                return (
-                  <div key={entry.id} className="flex items-baseline gap-2 px-3 py-1.5 text-xs">
-                    <code className="shrink-0 font-mono text-muted-foreground/70">{entry.fieldName}</code>
-                    <Badge variant="outline" className="shrink-0 text-[10px] px-1 py-0">
-                      {entry.changeSummary}
-                    </Badge>
-                    <span className="min-w-0 truncate text-muted-foreground">
-                      {changes.map((c, i) => (
-                        <span key={c.label}>
-                          {i > 0 && " · "}
-                          <span className="line-through">{c.before}</span>
-                          {" → "}
-                          <span className="font-medium text-foreground">{c.after}</span>
-                        </span>
-                      ))}
-                    </span>
-                    <span className="ml-auto shrink-0 whitespace-nowrap text-muted-foreground">
-                      {entry.changedBy} · {new Date(entry.createdAt).toLocaleDateString("pt-BR")}
-                    </span>
-                  </div>
-                );
-              })}
-          </div>
-          </CollapsibleContent>
-        </Collapsible>
       </div>
       <div className="flex flex-wrap items-center gap-2">
         <Input

--- a/frontend/src/lib/__tests__/schema-change-utils.test.ts
+++ b/frontend/src/lib/__tests__/schema-change-utils.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import {
+  detectFieldChangeKind,
+  diffPydanticField,
+  formatCondition,
+  formatRelativeDate,
+  formatTarget,
+  formatType,
+  formatVersion,
+  groupChangesByCommit,
+  propertyLabel,
+} from "../schema-change-utils";
+import type { SchemaChangeEntry } from "../types";
+
+function makeEntry(overrides: Partial<SchemaChangeEntry> = {}): SchemaChangeEntry {
+  return {
+    id: overrides.id ?? "id-1",
+    fieldName: overrides.fieldName ?? "campo_x",
+    changeSummary: overrides.changeSummary ?? "edit",
+    beforeValue: overrides.beforeValue ?? { name: "campo_x", description: "antes" },
+    afterValue: overrides.afterValue ?? { name: "campo_x", description: "depois" },
+    changedBy: overrides.changedBy ?? "Alice",
+    userId: overrides.userId ?? "user-1",
+    createdAt: overrides.createdAt ?? "2026-05-04T10:00:00Z",
+    changeType: overrides.changeType ?? "minor",
+    version: overrides.version ?? { major: 0, minor: 2, patch: 0 },
+  };
+}
+
+describe("detectFieldChangeKind", () => {
+  it("retorna added quando before é vazio", () => {
+    expect(
+      detectFieldChangeKind(
+        makeEntry({ beforeValue: {}, afterValue: { name: "x" } }),
+      ),
+    ).toBe("added");
+  });
+
+  it("retorna removed quando after é vazio", () => {
+    expect(
+      detectFieldChangeKind(
+        makeEntry({ beforeValue: { name: "x" }, afterValue: {} }),
+      ),
+    ).toBe("removed");
+  });
+
+  it("retorna renamed quando o nome muda", () => {
+    expect(
+      detectFieldChangeKind(
+        makeEntry({
+          beforeValue: { name: "antigo" },
+          afterValue: { name: "novo" },
+        }),
+      ),
+    ).toBe("renamed");
+  });
+
+  it("retorna modified caso contrário", () => {
+    expect(
+      detectFieldChangeKind(
+        makeEntry({
+          beforeValue: { name: "x", description: "a" },
+          afterValue: { name: "x", description: "b" },
+        }),
+      ),
+    ).toBe("modified");
+  });
+});
+
+describe("diffPydanticField", () => {
+  it("não retorna diffs quando before === after", () => {
+    const v = { name: "x", description: "d", required: true };
+    expect(diffPydanticField(v, v)).toEqual([]);
+  });
+
+  it("captura mudança de description", () => {
+    const diffs = diffPydanticField(
+      { description: "antes" },
+      { description: "depois" },
+    );
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]).toMatchObject({ property: "description", before: "antes", after: "depois" });
+  });
+
+  it("captura mudança de required (booleana)", () => {
+    const diffs = diffPydanticField({ required: false }, { required: true });
+    expect(diffs).toEqual([
+      { property: "required", before: false, after: true },
+    ]);
+  });
+
+  it("captura mudança de options (ordem importa via arraysEqual)", () => {
+    const diffs = diffPydanticField(
+      { options: ["a", "b"] },
+      { options: ["a", "b", "c"] },
+    );
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].property).toBe("options");
+    expect(diffs[0].after).toEqual(["a", "b", "c"]);
+  });
+
+  it("não duplica diff quando help_text é null vs undefined", () => {
+    const diffs = diffPydanticField(
+      { help_text: null },
+      { help_text: undefined },
+    );
+    expect(diffs).toEqual([]);
+  });
+
+  it("captura mudança de subfields via JSON.stringify", () => {
+    const diffs = diffPydanticField(
+      { subfields: [{ key: "a", label: "A", required: true }] },
+      { subfields: [{ key: "a", label: "A", required: false }] },
+    );
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].property).toBe("subfields");
+  });
+
+  it("captura propriedades novas no SubfieldDef futuro (futureproof)", () => {
+    // Simula a adição futura de uma prop nova como `description` em SubfieldDef.
+    const diffs = diffPydanticField(
+      { subfields: [{ key: "a", label: "A", description: "old" }] },
+      { subfields: [{ key: "a", label: "A", description: "new" }] },
+    );
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].property).toBe("subfields");
+  });
+
+  it("captura mudança de condition", () => {
+    const diffs = diffPydanticField(
+      { condition: { field: "x", equals: "a" } },
+      { condition: { field: "x", equals: "b" } },
+    );
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].property).toBe("condition");
+  });
+
+  it("captura múltiplas mudanças simultâneas", () => {
+    const diffs = diffPydanticField(
+      { name: "a", description: "x", required: false },
+      { name: "b", description: "y", required: true },
+    );
+    expect(diffs.map((d) => d.property).sort()).toEqual([
+      "description",
+      "name",
+      "required",
+    ]);
+  });
+});
+
+describe("groupChangesByCommit", () => {
+  it("agrupa entries do mesmo userId dentro da janela de 5s", () => {
+    const e1 = makeEntry({ id: "1", createdAt: "2026-05-04T10:00:00Z" });
+    const e2 = makeEntry({ id: "2", createdAt: "2026-05-04T10:00:03Z" });
+    const groups = groupChangesByCommit([e1, e2]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].entries).toHaveLength(2);
+  });
+
+  it("separa por userId mesmo dentro da janela", () => {
+    const e1 = makeEntry({ id: "1", userId: "user-1", createdAt: "2026-05-04T10:00:00Z" });
+    const e2 = makeEntry({ id: "2", userId: "user-2", createdAt: "2026-05-04T10:00:01Z" });
+    const groups = groupChangesByCommit([e1, e2]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("usa janela deslizante: agrega 6 mudanças com gap de 4s cada", () => {
+    // sequência de 6 mudanças, separadas por 4s — fora da janela head-fixa, dentro da deslizante
+    const entries = Array.from({ length: 6 }, (_, i) =>
+      makeEntry({
+        id: `id-${i}`,
+        createdAt: new Date(Date.UTC(2026, 4, 4, 10, 0, i * 4)).toISOString(),
+      }),
+    );
+    const groups = groupChangesByCommit(entries);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].entries).toHaveLength(6);
+  });
+
+  it("quebra grupo quando gap entre últimas duas excede 5s", () => {
+    const e1 = makeEntry({ id: "1", createdAt: "2026-05-04T10:00:00Z" });
+    const e2 = makeEntry({ id: "2", createdAt: "2026-05-04T10:00:10Z" });
+    const groups = groupChangesByCommit([e1, e2]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("separa por versão diferente", () => {
+    const e1 = makeEntry({
+      id: "1",
+      createdAt: "2026-05-04T10:00:00Z",
+      version: { major: 0, minor: 2, patch: 0 },
+    });
+    const e2 = makeEntry({
+      id: "2",
+      createdAt: "2026-05-04T10:00:01Z",
+      version: { major: 0, minor: 1, patch: 0 },
+    });
+    const groups = groupChangesByCommit([e1, e2]);
+    expect(groups).toHaveLength(2);
+  });
+
+  it("ordena entries em DESC dentro do retorno", () => {
+    const e1 = makeEntry({ id: "old", createdAt: "2026-05-04T09:00:00Z" });
+    const e2 = makeEntry({ id: "new", createdAt: "2026-05-04T11:00:00Z" });
+    const groups = groupChangesByCommit([e1, e2]);
+    expect(groups[0].entries[0].id).toBe("new");
+  });
+});
+
+describe("formatCondition", () => {
+  it("formata equals", () => {
+    expect(formatCondition({ field: "x", equals: "a" })).toBe('x = "a"');
+  });
+
+  it("formata not_equals com número", () => {
+    expect(formatCondition({ field: "x", not_equals: 5 })).toBe("x ≠ 5");
+  });
+
+  it("formata in", () => {
+    expect(formatCondition({ field: "x", in: ["a", "b"] })).toBe('x ∈ ["a", "b"]');
+  });
+
+  it("formata not_in", () => {
+    expect(formatCondition({ field: "x", not_in: [1, 2] })).toBe("x ∉ [1, 2]");
+  });
+
+  it("formata exists true/false", () => {
+    expect(formatCondition({ field: "x", exists: true })).toBe("x existe");
+    expect(formatCondition({ field: "x", exists: false })).toBe("x ausente");
+  });
+
+  it("retorna 'sem condição' para null/undefined", () => {
+    expect(formatCondition(null)).toBe("sem condição");
+    expect(formatCondition(undefined)).toBe("sem condição");
+  });
+});
+
+describe("formatRelativeDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-04T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retorna 'agora' para diff < 60s", () => {
+    expect(formatRelativeDate("2026-05-04T11:59:30Z")).toBe("agora");
+  });
+
+  it("retorna minutos para até 60min", () => {
+    expect(formatRelativeDate("2026-05-04T11:55:00Z")).toBe("há 5 minutos");
+    expect(formatRelativeDate("2026-05-04T11:59:00Z")).toBe("há 1 minuto");
+  });
+
+  it("retorna horas para até 24h", () => {
+    expect(formatRelativeDate("2026-05-04T09:00:00Z")).toBe("há 3 horas");
+    expect(formatRelativeDate("2026-05-04T11:00:00Z")).toBe("há 1 hora");
+  });
+
+  it("retorna 'ontem' para 1 dia", () => {
+    expect(formatRelativeDate("2026-05-03T12:00:00Z")).toBe("ontem");
+  });
+
+  it("retorna 'há N dias' para 2-6 dias", () => {
+    expect(formatRelativeDate("2026-05-01T12:00:00Z")).toBe("há 3 dias");
+  });
+
+  it("retorna data formatada para >= 7 dias", () => {
+    const result = formatRelativeDate("2026-04-20T12:00:00Z");
+    // toLocaleDateString pt-BR: "20/04/2026"
+    expect(result).toMatch(/\d{2}\/\d{2}\/\d{4}/);
+  });
+});
+
+describe("formatVersion / formatTarget / formatType / propertyLabel", () => {
+  it("formatVersion", () => {
+    expect(formatVersion(null)).toBe("—");
+    expect(formatVersion({ major: 1, minor: 2, patch: 3 })).toBe("v1.2.3");
+  });
+
+  it("formatTarget cobre labels conhecidos e fallback", () => {
+    expect(formatTarget("all")).toBe("Todos");
+    expect(formatTarget("llm_only")).toBe("Só LLM");
+    expect(formatTarget("desconhecido")).toBe("desconhecido");
+    expect(formatTarget(null)).toBe("—");
+  });
+
+  it("formatType cobre labels conhecidos", () => {
+    expect(formatType("single")).toBe("Escolha única");
+    expect(formatType("multi")).toBe("Múltipla escolha");
+    expect(formatType("text")).toBe("Texto");
+    expect(formatType("date")).toBe("Data");
+  });
+
+  it("propertyLabel traduz cada propriedade", () => {
+    expect(propertyLabel("name")).toBe("nome");
+    expect(propertyLabel("description")).toBe("descrição");
+    expect(propertyLabel("subfields")).toBe("subcampos");
+    expect(propertyLabel("condition")).toBe("condição");
+  });
+});

--- a/frontend/src/lib/schema-change-utils.ts
+++ b/frontend/src/lib/schema-change-utils.ts
@@ -12,6 +12,7 @@ export interface ChangeGroup {
   changeType: SchemaChangeType | null;
   version: { major: number; minor: number; patch: number } | null;
   changedBy: string;
+  userId: string;
   createdAt: string;
   entries: SchemaChangeEntry[];
 }
@@ -68,13 +69,7 @@ function subfieldsEqual(
 ): boolean {
   if (!a && !b) return true;
   if (!a || !b) return false;
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i].key !== b[i].key) return false;
-    if (a[i].label !== b[i].label) return false;
-    if (Boolean(a[i].required) !== Boolean(b[i].required)) return false;
-  }
-  return true;
+  return JSON.stringify(a) === JSON.stringify(b);
 }
 
 function conditionEqual(
@@ -198,11 +193,15 @@ export function groupChangesByCommit(entries: SchemaChangeEntry[]): ChangeGroup[
         last.version.major === entry.version.major &&
         last.version.minor === entry.version.minor &&
         last.version.patch === entry.version.patch);
+    // Janela deslizante: compara contra a entry mais antiga já incluída.
+    // sorted está em DESC, então o último elemento de `last.entries` é o mais antigo.
+    const tail = last?.entries[last.entries.length - 1];
     if (
       last &&
-      last.changedBy === entry.changedBy &&
+      tail &&
+      last.userId === entry.userId &&
       versionMatches &&
-      Math.abs(new Date(last.createdAt).getTime() - ts) <= GROUPING_WINDOW_MS
+      Math.abs(new Date(tail.createdAt).getTime() - ts) <= GROUPING_WINDOW_MS
     ) {
       last.entries.push(entry);
     } else {
@@ -211,6 +210,7 @@ export function groupChangesByCommit(entries: SchemaChangeEntry[]): ChangeGroup[
         changeType: entry.changeType,
         version: entry.version,
         changedBy: entry.changedBy,
+        userId: entry.userId,
         createdAt: entry.createdAt,
         entries: [entry],
       });

--- a/frontend/src/lib/schema-change-utils.ts
+++ b/frontend/src/lib/schema-change-utils.ts
@@ -1,0 +1,300 @@
+import type {
+  FieldCondition,
+  SchemaChangeEntry,
+  SchemaChangeType,
+  SubfieldDef,
+} from "./types";
+
+export type FieldChangeKind = "added" | "removed" | "renamed" | "modified";
+
+export interface ChangeGroup {
+  key: string;
+  changeType: SchemaChangeType | null;
+  version: { major: number; minor: number; patch: number } | null;
+  changedBy: string;
+  createdAt: string;
+  entries: SchemaChangeEntry[];
+}
+
+export interface FieldPropertyDiff {
+  property:
+    | "name"
+    | "description"
+    | "help_text"
+    | "options"
+    | "type"
+    | "target"
+    | "required"
+    | "allow_other"
+    | "subfield_rule"
+    | "subfields"
+    | "condition";
+  before: unknown;
+  after: unknown;
+}
+
+const GROUPING_WINDOW_MS = 5_000;
+
+function isEmptySnapshot(v: Record<string, unknown> | null | undefined): boolean {
+  if (!v) return true;
+  if (typeof v !== "object") return true;
+  return Object.keys(v).length === 0;
+}
+
+export function detectFieldChangeKind(entry: SchemaChangeEntry): FieldChangeKind {
+  const beforeEmpty = isEmptySnapshot(entry.beforeValue);
+  const afterEmpty = isEmptySnapshot(entry.afterValue);
+  if (beforeEmpty && !afterEmpty) return "added";
+  if (!beforeEmpty && afterEmpty) return "removed";
+  const beforeName = (entry.beforeValue?.name as string | undefined) ?? entry.fieldName;
+  const afterName = (entry.afterValue?.name as string | undefined) ?? entry.fieldName;
+  if (beforeName !== afterName) return "renamed";
+  return "modified";
+}
+
+function arraysEqual<T>(a: T[] | null | undefined, b: T[] | null | undefined): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function subfieldsEqual(
+  a: SubfieldDef[] | null | undefined,
+  b: SubfieldDef[] | null | undefined,
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].key !== b[i].key) return false;
+    if (a[i].label !== b[i].label) return false;
+    if (Boolean(a[i].required) !== Boolean(b[i].required)) return false;
+  }
+  return true;
+}
+
+function conditionEqual(
+  a: FieldCondition | null | undefined,
+  b: FieldCondition | null | undefined,
+): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function diffPydanticField(
+  before: Record<string, unknown>,
+  after: Record<string, unknown>,
+): FieldPropertyDiff[] {
+  const diffs: FieldPropertyDiff[] = [];
+  const has = (obj: Record<string, unknown>, key: string) =>
+    Object.prototype.hasOwnProperty.call(obj ?? {}, key);
+
+  if (has(before, "name") || has(after, "name")) {
+    if (before.name !== after.name) {
+      diffs.push({ property: "name", before: before.name, after: after.name });
+    }
+  }
+  if (has(before, "description") || has(after, "description")) {
+    if (before.description !== after.description) {
+      diffs.push({
+        property: "description",
+        before: before.description,
+        after: after.description,
+      });
+    }
+  }
+  if (has(before, "help_text") || has(after, "help_text")) {
+    if ((before.help_text ?? null) !== (after.help_text ?? null)) {
+      diffs.push({
+        property: "help_text",
+        before: before.help_text ?? null,
+        after: after.help_text ?? null,
+      });
+    }
+  }
+  if (has(before, "options") || has(after, "options")) {
+    const b = (before.options as string[] | null | undefined) ?? null;
+    const a = (after.options as string[] | null | undefined) ?? null;
+    if (!arraysEqual(b, a)) {
+      diffs.push({ property: "options", before: b, after: a });
+    }
+  }
+  if (has(before, "type") || has(after, "type")) {
+    if (before.type !== after.type) {
+      diffs.push({ property: "type", before: before.type, after: after.type });
+    }
+  }
+  if (has(before, "target") || has(after, "target")) {
+    if ((before.target ?? null) !== (after.target ?? null)) {
+      diffs.push({
+        property: "target",
+        before: before.target ?? null,
+        after: after.target ?? null,
+      });
+    }
+  }
+  if (has(before, "required") || has(after, "required")) {
+    if (Boolean(before.required) !== Boolean(after.required)) {
+      diffs.push({
+        property: "required",
+        before: Boolean(before.required),
+        after: Boolean(after.required),
+      });
+    }
+  }
+  if (has(before, "allow_other") || has(after, "allow_other")) {
+    if (Boolean(before.allow_other) !== Boolean(after.allow_other)) {
+      diffs.push({
+        property: "allow_other",
+        before: Boolean(before.allow_other),
+        after: Boolean(after.allow_other),
+      });
+    }
+  }
+  if (has(before, "subfield_rule") || has(after, "subfield_rule")) {
+    if ((before.subfield_rule ?? null) !== (after.subfield_rule ?? null)) {
+      diffs.push({
+        property: "subfield_rule",
+        before: before.subfield_rule ?? null,
+        after: after.subfield_rule ?? null,
+      });
+    }
+  }
+  if (has(before, "subfields") || has(after, "subfields")) {
+    const b = (before.subfields as SubfieldDef[] | null | undefined) ?? null;
+    const a = (after.subfields as SubfieldDef[] | null | undefined) ?? null;
+    if (!subfieldsEqual(b, a)) {
+      diffs.push({ property: "subfields", before: b, after: a });
+    }
+  }
+  if (has(before, "condition") || has(after, "condition")) {
+    const b = (before.condition as FieldCondition | null | undefined) ?? null;
+    const a = (after.condition as FieldCondition | null | undefined) ?? null;
+    if (!conditionEqual(b, a)) {
+      diffs.push({ property: "condition", before: b, after: a });
+    }
+  }
+
+  return diffs;
+}
+
+export function groupChangesByCommit(entries: SchemaChangeEntry[]): ChangeGroup[] {
+  const sorted = [...entries].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+  const groups: ChangeGroup[] = [];
+  for (const entry of sorted) {
+    const ts = new Date(entry.createdAt).getTime();
+    const last = groups[groups.length - 1];
+    const versionMatches =
+      (last?.version === null && entry.version === null) ||
+      (last?.version &&
+        entry.version &&
+        last.version.major === entry.version.major &&
+        last.version.minor === entry.version.minor &&
+        last.version.patch === entry.version.patch);
+    if (
+      last &&
+      last.changedBy === entry.changedBy &&
+      versionMatches &&
+      Math.abs(new Date(last.createdAt).getTime() - ts) <= GROUPING_WINDOW_MS
+    ) {
+      last.entries.push(entry);
+    } else {
+      groups.push({
+        key: entry.id,
+        changeType: entry.changeType,
+        version: entry.version,
+        changedBy: entry.changedBy,
+        createdAt: entry.createdAt,
+        entries: [entry],
+      });
+    }
+  }
+  return groups;
+}
+
+export function formatRelativeDate(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const diffMs = now - then;
+  if (diffMs < 60_000) return "agora";
+  const minutes = Math.floor(diffMs / 60_000);
+  if (minutes < 60) return `há ${minutes} ${minutes === 1 ? "minuto" : "minutos"}`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `há ${hours} ${hours === 1 ? "hora" : "horas"}`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "ontem";
+  if (days < 7) return `há ${days} dias`;
+  return new Date(iso).toLocaleDateString("pt-BR");
+}
+
+export function formatVersion(
+  v: { major: number; minor: number; patch: number } | null,
+): string {
+  if (!v) return "—";
+  return `v${v.major}.${v.minor}.${v.patch}`;
+}
+
+export function formatCondition(c: FieldCondition | null | undefined): string {
+  if (!c) return "sem condição";
+  if ("equals" in c) return `${c.field} = ${formatScalar(c.equals)}`;
+  if ("not_equals" in c) return `${c.field} ≠ ${formatScalar(c.not_equals)}`;
+  if ("in" in c) return `${c.field} ∈ [${c.in.map(formatScalar).join(", ")}]`;
+  if ("not_in" in c) return `${c.field} ∉ [${c.not_in.map(formatScalar).join(", ")}]`;
+  if ("exists" in c) return c.exists ? `${c.field} existe` : `${c.field} ausente`;
+  return "sem condição";
+}
+
+function formatScalar(v: unknown): string {
+  if (v === null || v === undefined) return "∅";
+  if (typeof v === "string") return `"${v}"`;
+  return String(v);
+}
+
+const TARGET_LABELS: Record<string, string> = {
+  all: "Todos",
+  llm_only: "Só LLM",
+  human_only: "Só humano",
+  none: "Nenhum",
+};
+
+export function formatTarget(t: unknown): string {
+  if (typeof t !== "string") return "—";
+  return TARGET_LABELS[t] ?? t;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  single: "Escolha única",
+  multi: "Múltipla escolha",
+  text: "Texto",
+  date: "Data",
+};
+
+export function formatType(t: unknown): string {
+  if (typeof t !== "string") return "—";
+  return TYPE_LABELS[t] ?? t;
+}
+
+const PROPERTY_LABELS: Record<FieldPropertyDiff["property"], string> = {
+  name: "nome",
+  description: "descrição",
+  help_text: "instruções",
+  options: "opções",
+  type: "tipo",
+  target: "alvo",
+  required: "obrigatoriedade",
+  allow_other: "permite outro",
+  subfield_rule: "regra de subcampos",
+  subfields: "subcampos",
+  condition: "condição",
+};
+
+export function propertyLabel(p: FieldPropertyDiff["property"]): string {
+  return PROPERTY_LABELS[p];
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -132,3 +132,17 @@ export interface QuestionMeta {
   field_name: string;
   priority: "ALTA" | "MEDIA" | "BAIXA";
 }
+
+export type SchemaChangeType = "major" | "minor" | "patch" | "initial";
+
+export interface SchemaChangeEntry {
+  id: string;
+  fieldName: string;
+  changeSummary: string;
+  beforeValue: Record<string, unknown>;
+  afterValue: Record<string, unknown>;
+  changedBy: string;
+  createdAt: string;
+  changeType: SchemaChangeType | null;
+  version: { major: number; minor: number; patch: number } | null;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -142,6 +142,7 @@ export interface SchemaChangeEntry {
   beforeValue: Record<string, unknown>;
   afterValue: Record<string, unknown>;
   changedBy: string;
+  userId: string;
   createdAt: string;
   changeType: SchemaChangeType | null;
   version: { major: number; minor: number; patch: number } | null;

--- a/frontend/supabase/migrations/20260504000000_schema_change_log_composite_index.sql
+++ b/frontend/supabase/migrations/20260504000000_schema_change_log_composite_index.sql
@@ -1,0 +1,7 @@
+-- Index composto para a query da aba Histórico do schema, que filtra por
+-- project_id e ordena por created_at DESC. O index simples por project_id
+-- (idx_schema_change_log_project) continua, pois pode ser usado por outros
+-- caminhos que não precisam da ordenação.
+
+CREATE INDEX IF NOT EXISTS idx_schema_change_log_project_created
+  ON schema_change_log(project_id, created_at DESC);

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Cria nova aba **Histórico** em `/projects/[id]/config/history` com timeline de mudanças do schema, agrupada por commit (autor + versão + janela de 5s)
- Cada commit exibe badge de versão colorida pelo `change_type` (MAJOR teal, MINOR azul, PATCH cinza, INITIAL violeta), autor, tempo relativo e contagem de campos
- Diff especializado por propriedade: texto curto inline (`<del> → <ins>`), texto longo lado-a-lado, listas (options/subfields) com chips kept/removed/added, booleans/enums em pílulas, condition pretty-printed, snapshot completo para campos adicionados/removidos
- Filtros: busca textual, campo, autor, tipo de mudança (Todos/Major/Minor/Patch/Initial)
- Remove o `Collapsible` antigo da aba Comentários (visualização unificada na nova aba)

## Test plan

- [ ] Abrir `/projects/[id]/config/history` em projeto com histórico → timeline renderiza com filtros funcionais
- [ ] Editar `description` de um campo → entry aparece com diff `<del> → <ins>` na propriedade correta
- [ ] Adicionar um campo novo → badge verde "+ novo campo" + snapshot completo
- [ ] Remover um campo → badge vermelho "− removido" + snapshot do que foi
- [ ] Editar `options` → chips kept/removed/added
- [ ] Mudar `required` true ↔ false → pílula `Sim → Não`
- [ ] Confirmar que aba Comentários não tem mais o botão "Histórico de mudanças"
- [ ] Entries antigas sem `change_type` renderizam com badge "—" sem quebrar

🤖 Generated with [Claude Code](https://claude.com/claude-code)