### PR TITLE
feat(llm): diagnóstico por documento + counters ao vivo na execução

### DIFF
--- a/backend/routes/llm_routes.py
+++ b/backend/routes/llm_routes.py
@@ -3,7 +3,7 @@ from typing import Literal
 from fastapi import APIRouter, BackgroundTasks
 from pydantic import BaseModel
 
-from services.llm_runner import run_llm, run_llm_fields, get_job_status
+from services.llm_runner import init_job, run_llm, run_llm_fields, get_job_status
 
 router = APIRouter()
 
@@ -44,11 +44,22 @@ class StatusResponse(BaseModel):
     # frontend can render the code window against the actual failed version,
     # not the project's current (possibly edited) code.
     pydantic_code: str | None = None
+    # Counters ao vivo durante a fase de saving — quantos documentos saíram
+    # completos / parciais (cobertura baixa) / vazios (sem nenhum field). Default
+    # 0 e disponíveis assim que o save loop começa a inserir respostas. Vê
+    # llm_runner.py:_answers_have_content para a regra de classificação.
+    processed_complete: int = 0
+    processed_partial: int = 0
+    processed_empty: int = 0
 
 
 @router.post("/run", response_model=RunResponse)
 async def run(req: RunRequest, background_tasks: BackgroundTasks):
     job_id = str(uuid.uuid4())
+    # Síncrono: insere a row de llm_runs ANTES do background task. Se falhar
+    # (RLS, conexão, payload), a request retorna 500 e o frontend mostra o erro
+    # em vez de ficar com job fantasma que nunca aparece em Execuções.
+    init_job(job_id, req.project_id, req.filter_mode)
     background_tasks.add_task(
         run_llm,
         job_id,
@@ -64,6 +75,9 @@ async def run(req: RunRequest, background_tasks: BackgroundTasks):
 @router.post("/run-field", response_model=RunResponse)
 async def run_field(req: RunFieldRequest, background_tasks: BackgroundTasks):
     job_id = str(uuid.uuid4())
+    # filter_mode "all" porque run-field não tem semântica de subset; o
+    # subset é o conjunto de fields, não de docs.
+    init_job(job_id, req.project_id, "all")
     background_tasks.add_task(
         run_llm_fields, job_id, req.project_id, req.field_names, req.document_ids
     )

--- a/backend/routes/llm_routes.py
+++ b/backend/routes/llm_routes.py
@@ -3,7 +3,14 @@ from typing import Literal
 from fastapi import APIRouter, BackgroundTasks
 from pydantic import BaseModel
 
-from services.llm_runner import init_job, run_llm, run_llm_fields, get_job_status
+from services.llm_runner import (
+    get_job_status,
+    init_job,
+    mark_stale_runs_as_error,
+    run_llm,
+    run_llm_fields,
+)
+from services.supabase_client import get_supabase
 
 router = APIRouter()
 
@@ -87,3 +94,24 @@ async def run_field(req: RunFieldRequest, background_tasks: BackgroundTasks):
 @router.get("/status/{job_id}", response_model=StatusResponse)
 async def status(job_id: str):
     return get_job_status(job_id)
+
+
+class CleanupRequest(BaseModel):
+    project_id: str
+
+
+class CleanupResponse(BaseModel):
+    cleaned: int
+
+
+@router.post("/cleanup-stale", response_model=CleanupResponse)
+async def cleanup_stale(req: CleanupRequest):
+    """Marca runs com status='running' sem heartbeat recente como 'error'.
+
+    Idempotente. Chamado pelo frontend antes de getRunningLlmJob para evitar
+    que polling órfão (de uma run cuja máquina morreu) seja religado. Sem
+    autenticação extra: backend está atrás do JWT do frontend e a função
+    filtra por project_id (RLS via service key na supabase_client).
+    """
+    n = mark_stale_runs_as_error(get_supabase(), req.project_id)
+    return CleanupResponse(cleaned=n)

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -137,11 +137,13 @@ def mark_stale_runs_as_error(sb, project_id: str) -> int:
     Retorna o número de runs marcadas como erro. Idempotente.
     """
     now = datetime.now(timezone.utc)
-    # 5 minutos sem heartbeat = morta. O save loop renova a cada ~2s, então
-    # 5min é folgado o suficiente para evitar falsos positivos em pausas
-    # legítimas (ex.: GC do Python, latência do Supabase). 30min para runs
-    # sem heartbeat (pré-migration) — conservador.
-    heartbeat_cutoff_iso = (now - timedelta(minutes=5)).isoformat()
+    # 10 minutos sem heartbeat = morta. O save loop renova a cada ~2s, mas
+    # o heartbeat na fase de processing só dispara após cada batch retornar
+    # — uma chamada single-batch a um provider lento (Claude com thinking,
+    # OpenAI sob throttling) pode passar de 5min sem update. 10min absorve
+    # esse caso sem deixar runs zumbis pendurarem por muito tempo. 30min
+    # para runs sem heartbeat (pré-migration) — conservador.
+    heartbeat_cutoff_iso = (now - timedelta(minutes=10)).isoformat()
     started_cutoff_iso = (now - timedelta(minutes=30)).isoformat()
 
     error_msg = (
@@ -562,7 +564,14 @@ def init_job(job_id: str, project_id: str, filter_mode: str) -> None:
         # Throttle do _persist_run_progress (atualiza a cada 2s).
         "last_progress_persist": 0.0,
     }
-    _persist_run_insert(sb, job_id, project_id, filter_mode)
+    try:
+        _persist_run_insert(sb, job_id, project_id, filter_mode)
+    except Exception:
+        # Mantém _jobs limpo se o INSERT falhar — sem isso, o dict acumula
+        # entradas órfãs até o próximo restart do processo (jobs nunca
+        # consultados, já que /run retornou 500 ao usuário).
+        _jobs.pop(job_id, None)
+        raise
 
 
 async def run_llm(

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -12,7 +12,7 @@ import re
 import time
 import traceback
 from collections import Counter
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 from services.condition_evaluator import evaluate_condition, extract_field_conditions
@@ -41,12 +41,13 @@ def _status_from_row(row: dict) -> dict:
         "error_line": row.get("error_line"),
         "error_column": row.get("error_column"),
         "pydantic_code": row.get("pydantic_code"),
-        # Counters não são persistidos em llm_runs (vivem em _jobs), então no
-        # fallback ficam 0. Aceitável porque o fallback só dispara quando o
-        # container reiniciou — caso em que a run em si já não está mais rodando.
-        "processed_complete": 0,
-        "processed_partial": 0,
-        "processed_empty": 0,
+        # Counters persistidos em llm_runs pelo save loop (ver
+        # _persist_run_progress). No fallback de container reiniciado, ainda
+        # mostram o ultimo snapshot conhecido — antes desta migration ficavam
+        # zerados, o que mascarava o trabalho ja feito.
+        "processed_complete": row.get("processed_complete") or 0,
+        "processed_partial": row.get("processed_partial") or 0,
+        "processed_empty": row.get("processed_empty") or 0,
     }
 
 
@@ -59,7 +60,8 @@ def get_job_status(job_id: str) -> dict:
         row = (
             sb.table("llm_runs")
             .select("status, phase, progress, total, error_message, error_type, "
-                    "error_traceback, error_line, error_column, pydantic_code")
+                    "error_traceback, error_line, error_column, pydantic_code, "
+                    "processed_complete, processed_partial, processed_empty")
             .eq("job_id", job_id)
             .maybe_single()
             .execute()
@@ -71,7 +73,8 @@ def get_job_status(job_id: str) -> dict:
         logger.exception("Failed to fetch job status from llm_runs fallback")
     return {"status": "error", "phase": "error", "progress": 0, "total": 0,
             "errors": ["Job not found"], "eta_seconds": None,
-            "current_batch": 0, "total_batches": 0}
+            "current_batch": 0, "total_batches": 0,
+            "processed_complete": 0, "processed_partial": 0, "processed_empty": 0}
 
 
 def _extract_pydantic_location(exc: Exception, tb: str) -> tuple[int | None, int | None]:
@@ -98,7 +101,72 @@ def _persist_run_insert(sb, job_id: str, project_id: str, filter_mode: str) -> N
         "filter_mode": filter_mode,
         "status": "running",
         "phase": "loading",
+        # heartbeat inicial. O save loop renova a cada ~2s (ver
+        # _persist_run_progress); cleanup ativo (mark_stale_runs_as_error)
+        # marca como erro runs cujo heartbeat ficou velho.
+        "heartbeat_at": datetime.now(timezone.utc).isoformat(),
     }).execute()
+
+
+def _persist_run_progress(sb, job_id: str, jobs_state: dict) -> None:
+    """Persistir snapshot de counters + heartbeat em llm_runs.
+
+    Chamado periodicamente pelo save loop (throttle 2s). Erros aqui são
+    logados, não re-lançados: a run principal não deve abortar só porque uma
+    atualização de progresso falhou. O próximo tick tenta de novo.
+    """
+    try:
+        sb.table("llm_runs").update({
+            "processed_complete": jobs_state.get("processed_complete", 0),
+            "processed_partial": jobs_state.get("processed_partial", 0),
+            "processed_empty": jobs_state.get("processed_empty", 0),
+            "progress": jobs_state.get("progress", 0),
+            "heartbeat_at": datetime.now(timezone.utc).isoformat(),
+        }).eq("job_id", job_id).execute()
+    except Exception:
+        logger.exception("Failed to UPDATE llm_runs progress for job %s", job_id)
+
+
+def mark_stale_runs_as_error(sb, project_id: str) -> int:
+    """Marcar como 'error' runs órfãs do projeto (sem heartbeat recente).
+
+    Critério: status='running' e (heartbeat antigo OR heartbeat null com
+    started_at antigo). O segundo caso cobre runs criadas antes desta
+    migration que nunca terão heartbeat.
+
+    Retorna o número de runs marcadas como erro. Idempotente.
+    """
+    now = datetime.now(timezone.utc)
+    # 5 minutos sem heartbeat = morta. O save loop renova a cada ~2s, então
+    # 5min é folgado o suficiente para evitar falsos positivos em pausas
+    # legítimas (ex.: GC do Python, latência do Supabase). 30min para runs
+    # sem heartbeat (pré-migration) — conservador.
+    heartbeat_cutoff_iso = (now - timedelta(minutes=5)).isoformat()
+    started_cutoff_iso = (now - timedelta(minutes=30)).isoformat()
+
+    error_msg = (
+        "Execução abandonada (sem heartbeat — possivelmente o backend "
+        "reiniciou ou a máquina hibernou)."
+    )
+    # PostgREST .or_ syntax: separa termos por vírgula; agrupa com and(...).
+    or_clause = (
+        f"heartbeat_at.lt.{heartbeat_cutoff_iso},"
+        f"and(heartbeat_at.is.null,started_at.lt.{started_cutoff_iso})"
+    )
+    res = (
+        sb.table("llm_runs")
+        .update({
+            "status": "error",
+            "phase": "error",
+            "error_message": error_msg,
+            "completed_at": now.isoformat(),
+        })
+        .eq("project_id", project_id)
+        .eq("status", "running")
+        .or_(or_clause)
+        .execute()
+    )
+    return len(res.data or [])
 
 
 def _persist_run_snapshot(
@@ -118,13 +186,22 @@ def _persist_run_snapshot(
 
 
 def _persist_run_completion(
-    sb, job_id: str, progress: int, total: int, warnings: list[str] | None = None
+    sb,
+    job_id: str,
+    progress: int,
+    total: int,
+    warnings: list[str] | None = None,
+    counters: dict | None = None,
 ) -> None:
     """Mark the run as completed. Errors here are logged but do not re-raise.
 
     Diferente de _persist_run_insert/_snapshot: aqui a execução já terminou e o
     payload já está em responses. Ressuscitar a exception levaria a `_persist_run_error`
     em cascata e duplicaria o registro de falha. Logar é suficiente.
+
+    `counters` recebe dict com processed_complete/partial/empty para fechar
+    o snapshot final consistente — sem isso, o último update via
+    _persist_run_progress poderia ter ficado desatualizado em até 2s.
     """
     try:
         payload: dict = {
@@ -134,6 +211,10 @@ def _persist_run_completion(
             "total": total,
             "completed_at": datetime.now(timezone.utc).isoformat(),
         }
+        if counters:
+            payload["processed_complete"] = counters.get("processed_complete", 0)
+            payload["processed_partial"] = counters.get("processed_partial", 0)
+            payload["processed_empty"] = counters.get("processed_empty", 0)
         # Persistir warnings de cobertura parcial reutilizando error_message
         # (evita migration). Motivo: llm_runs.error_message é o único campo
         # livre para texto diagnóstico pós-completion.
@@ -146,10 +227,12 @@ def _persist_run_completion(
         logger.exception("Failed to UPDATE llm_runs completion for job %s", job_id)
 
 
-def _persist_run_error(sb, job_id: str, exc: Exception, tb: str) -> tuple[int | None, int | None]:
+def _persist_run_error(
+    sb, job_id: str, exc: Exception, tb: str, counters: dict | None = None
+) -> tuple[int | None, int | None]:
     line, col = _extract_pydantic_location(exc, tb)
     try:
-        sb.table("llm_runs").update({
+        payload: dict = {
             "status": "error",
             "phase": "error",
             "error_message": str(exc),
@@ -158,7 +241,12 @@ def _persist_run_error(sb, job_id: str, exc: Exception, tb: str) -> tuple[int | 
             "error_line": line,
             "error_column": col,
             "completed_at": datetime.now(timezone.utc).isoformat(),
-        }).eq("job_id", job_id).execute()
+        }
+        if counters:
+            payload["processed_complete"] = counters.get("processed_complete", 0)
+            payload["processed_partial"] = counters.get("processed_partial", 0)
+            payload["processed_empty"] = counters.get("processed_empty", 0)
+        sb.table("llm_runs").update(payload).eq("job_id", job_id).execute()
     except Exception:
         logger.exception("Failed to UPDATE llm_runs error for job %s", job_id)
     return line, col
@@ -183,6 +271,83 @@ def _answers_have_content(answers: dict) -> bool:
         else:
             return True
     return False
+
+
+def _is_nan(val) -> bool:
+    """True se val for um float NaN. Outros tipos não são considerados NaN.
+
+    Necessário porque dataframeit deixa np.nan em rows com erro, e bool(NaN)
+    é True em Python — sem essa guarda, NaN passaria como "preenchido".
+    """
+    return isinstance(val, float) and pd.isna(val)
+
+
+def _extract_answers_from_row(row, model_class) -> tuple[dict, dict]:
+    """Extrai answers e justifications de uma row do result_df.
+
+    Itera sobre `model_class.model_fields` (não sobre as colunas da row) para
+    descartar colunas internas do dataframeit (`_dataframeit_status`,
+    `_error_details`) e qualquer extra que o provider tenha incluído.
+
+    Filtra NaN explicitamente — sem isso, rows que dataframeit marcou como
+    erro (que vêm com NaN nos campos) entrariam em `answers` como "preenchido".
+    """
+    answers: dict = {}
+    justifications: dict = {}
+
+    for field_name in model_class.model_fields:
+        val = row.get(field_name)
+        if val is not None and not _is_nan(val):
+            if isinstance(val, list):
+                answers[field_name] = val
+            else:
+                answers[field_name] = str(val)
+
+        just_col = f"{field_name}_justification"
+        # `just_col in row` aceita tanto dict quanto pandas.Series; truthy
+        # check em conjunto com _is_nan cobre None, "", e NaN.
+        if just_col in row:
+            jval = row[just_col]
+            if jval and not _is_nan(jval):
+                justifications[field_name] = str(jval)
+
+    return answers, justifications
+
+
+def _build_llm_error_message(
+    *,
+    dfi_error: str | None,
+    is_empty: bool,
+    is_partial: bool,
+    dfi_status,
+    pre_prune_keys: list[str],
+    post_prune_keys: list[str],
+    answered_count: int,
+    active_expected_count: int,
+) -> str | None:
+    """Monta a mensagem para responses.llm_error a partir do diagnóstico.
+
+    Hierarquia (ordem importa):
+    1. Erro cru do dataframeit (timeout, parse, structured-output null)
+    2. answers vazio após prune (LLM trouxe os campos mas evaluate_condition
+       zerou) ou LLM trouxe vazio direto
+    3. Cobertura baixa (LLM já chega com poucos campos)
+    Retorna None quando a resposta está saudável.
+    """
+    if dfi_error:
+        return f"dataframeit: {dfi_error}"
+    if is_empty:
+        return (
+            f"answers vazio após prune; pre_prune_keys={pre_prune_keys}; "
+            f"dfi_status={dfi_status}"
+        )
+    if is_partial:
+        return (
+            f"cobertura baixa ({answered_count}/{active_expected_count}); "
+            f"pre_prune_keys={pre_prune_keys}; "
+            f"post_prune_keys={post_prune_keys}"
+        )
+    return None
 
 
 def _extend_model_with_justifications(model_class):
@@ -394,6 +559,8 @@ def init_job(job_id: str, project_id: str, filter_mode: str) -> None:
         "processed_complete": 0,
         "processed_partial": 0,
         "processed_empty": 0,
+        # Throttle do _persist_run_progress (atualiza a cada 2s).
+        "last_progress_persist": 0.0,
     }
     _persist_run_insert(sb, job_id, project_id, filter_mode)
 
@@ -534,6 +701,11 @@ async def run_llm(
 
         result_frames = []
         proc_start = time.time()
+        # Throttle de heartbeat na fase de processing. Importante porque
+        # processar pode levar minutos antes do save loop começar; sem
+        # heartbeat aqui, mark_stale_runs_as_error marcaria a run como morta
+        # mesmo estando viva.
+        last_proc_heartbeat = 0.0
         for idx, batch_df in enumerate(batches):
             _jobs[job_id]["current_batch"] = idx + 1
             batch_result = dataframeit(
@@ -557,6 +729,10 @@ async def run_llm(
                 _jobs[job_id]["eta_seconds"] = round(
                     (elapsed / processed) * (len(df) - processed), 1
                 )
+            now_ts = time.time()
+            if now_ts - last_proc_heartbeat >= 2.0:
+                _persist_run_progress(sb, job_id, _jobs[job_id])
+                last_proc_heartbeat = now_ts
 
         result_df = pd.concat(result_frames, ignore_index=True)
 
@@ -591,14 +767,19 @@ async def run_llm(
         partial_warnings: list[str] = []
         # Sample de _error_details reais por mensagem para incluir no
         # RuntimeError quando a run for marcada como comprometida. Mais útil
-        # do que só "cobertura baixa" porque diz a causa.
+        # do que só "cobertura baixa" porque diz a causa. Chave: hash MD5 da
+        # mensagem completa, evita agrupar erros distintos com prefixo igual.
         dfi_error_samples: dict[str, str] = {}
+
+        # Throttle do persist de progresso para llm_runs. Atualizar a cada row
+        # dobraria a load (já há 1 INSERT em responses por row); 2s mantém
+        # heartbeat fresco e counters próximos do real-time sem custo dobrado.
+        # last_progress_persist é inicializado em init_job.
+        progress_persist_interval_s = 2.0
 
         # Save responses — use row["id"] (not index correlation) for safety
         for _, row in result_df.iterrows():
             doc_id = row["id"]
-            answers = {}
-            justifications = {}
 
             # Diagnóstico cru do dataframeit (ver dataframeit/core.py:451-452):
             # _dataframeit_status é 'processed' ou 'error'; _error_details traz
@@ -610,23 +791,7 @@ async def run_llm(
                 str(dfi_error_raw) if dfi_error_raw is not None and pd.notna(dfi_error_raw) else None
             )
 
-            for field_name in model_class.model_fields:
-                val = row.get(field_name)
-                # pd.isna lida com np.nan que dataframeit deixa em rows com erro;
-                # `val is not None` sozinho deixaria passar NaN como "preenchido".
-                if val is not None and not (
-                    isinstance(val, float) and pd.isna(val)
-                ):
-                    if isinstance(val, list):
-                        answers[field_name] = val
-                    else:
-                        answers[field_name] = str(val)
-
-                just_col = f"{field_name}_justification"
-                if just_col in row and row[just_col] and not (
-                    isinstance(row[just_col], float) and pd.isna(row[just_col])
-                ):
-                    justifications[field_name] = str(row[just_col])
+            answers, justifications = _extract_answers_from_row(row, model_class)
 
             # Reconstruir dicts aninhados a partir dos subfields flat (ver
             # _flatten_nested_basemodels). Deve rodar ANTES do prune de
@@ -689,25 +854,16 @@ async def run_llm(
             else:
                 _jobs[job_id]["processed_complete"] += 1
 
-            # Construir mensagem para responses.llm_error. Hierarquia:
-            # 1. Erro cru do dataframeit (timeout, parse, structured-output null)
-            # 2. Diagnóstico de prune (caso mais sutil — LLM trouxe os campos
-            #    mas evaluate_condition zerou) ou de "LLM trouxe vazio"
-            # null caso a resposta esteja saudável.
-            llm_error_msg: str | None = None
-            if dfi_error:
-                llm_error_msg = f"dataframeit: {dfi_error}"
-            elif is_empty:
-                llm_error_msg = (
-                    f"answers vazio após prune; pre_prune_keys={answers_pre_prune_keys}; "
-                    f"dfi_status={dfi_status}"
-                )
-            elif is_partial:
-                llm_error_msg = (
-                    f"cobertura baixa ({len(answered)}/{len(active_expected)}); "
-                    f"pre_prune_keys={answers_pre_prune_keys}; "
-                    f"post_prune_keys={sorted(answers.keys())}"
-                )
+            llm_error_msg = _build_llm_error_message(
+                dfi_error=dfi_error,
+                is_empty=is_empty,
+                is_partial=is_partial,
+                dfi_status=dfi_status,
+                pre_prune_keys=answers_pre_prune_keys,
+                post_prune_keys=sorted(answers.keys()),
+                answered_count=len(answered),
+                active_expected_count=len(active_expected),
+            )
 
             if is_partial or is_empty or dfi_error:
                 logger.warning(
@@ -717,8 +873,12 @@ async def run_llm(
                 )
 
             if dfi_error:
-                # Agrupa por mensagem (truncada) para o RuntimeError final.
-                key = dfi_error[:120]
+                # Agrupa por hash da mensagem (não prefixo) para o RuntimeError
+                # final. Truncar 120 chars agrupava erros distintos com prefixo
+                # igual.
+                key = hashlib.md5(
+                    dfi_error.encode("utf-8", errors="replace")
+                ).hexdigest()[:16]
                 if key not in dfi_error_samples:
                     dfi_error_samples[key] = f"doc={doc_id}: {dfi_error}"
 
@@ -731,6 +891,14 @@ async def run_llm(
                 )
                 partial_warnings.append(warning_msg)
                 _jobs[job_id].setdefault("warnings", []).append(warning_msg)
+
+            # Throttle: persiste counters + heartbeat a cada 2s. Garante que
+            # mesmo após scale-to-zero o llm_runs reflete o trabalho feito,
+            # e que a UI consegue distinguir run viva de zumbi.
+            now_ts = time.time()
+            if now_ts - _jobs[job_id]["last_progress_persist"] >= progress_persist_interval_s:
+                _persist_run_progress(sb, job_id, _jobs[job_id])
+                _jobs[job_id]["last_progress_persist"] = now_ts
 
             sb.table("responses").insert({
                 "project_id": project_id,
@@ -795,11 +963,16 @@ async def run_llm(
             _jobs[job_id]["progress"],
             _jobs[job_id]["total"],
             warnings=partial_warnings or None,
+            counters=_jobs[job_id],
         )
 
     except Exception as e:
         tb = traceback.format_exc()
-        line, col = _persist_run_error(sb, job_id, e, tb)
+        # Passa counters do _jobs para fechar snapshot consistente em llm_runs
+        # mesmo quando a run falha mid-loop. Sem isso, o último _persist_run_progress
+        # poderia ter ficado até 2s atrás.
+        counters = _jobs.get(job_id) or {}
+        line, col = _persist_run_error(sb, job_id, e, tb, counters=counters)
         _jobs[job_id]["status"] = "error"
         _jobs[job_id]["phase"] = "error"
         _jobs[job_id]["errors"].append(str(e))

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -41,6 +41,12 @@ def _status_from_row(row: dict) -> dict:
         "error_line": row.get("error_line"),
         "error_column": row.get("error_column"),
         "pydantic_code": row.get("pydantic_code"),
+        # Counters não são persistidos em llm_runs (vivem em _jobs), então no
+        # fallback ficam 0. Aceitável porque o fallback só dispara quando o
+        # container reiniciou — caso em que a run em si já não está mais rodando.
+        "processed_complete": 0,
+        "processed_partial": 0,
+        "processed_empty": 0,
     }
 
 
@@ -79,37 +85,47 @@ def _extract_pydantic_location(exc: Exception, tb: str) -> tuple[int | None, int
 
 
 def _persist_run_insert(sb, job_id: str, project_id: str, filter_mode: str) -> None:
-    """Insert the initial 'running' row as soon as the job starts."""
-    try:
-        sb.table("llm_runs").insert({
-            "job_id": job_id,
-            "project_id": project_id,
-            "filter_mode": filter_mode,
-            "status": "running",
-            "phase": "loading",
-        }).execute()
-    except Exception:
-        logger.exception("Failed to INSERT llm_runs row for job %s", job_id)
+    """Insert the initial 'running' row as soon as the job starts.
+
+    Re-raise on failure: se o INSERT em llm_runs morrer silenciosamente, a run
+    fica órfã (executa em memória mas não aparece na aba Execuções), o que já
+    enganou o usuário no passado. Melhor falhar a request do /run e mostrar o
+    erro de cara em vez de seguir uma execução invisível.
+    """
+    sb.table("llm_runs").insert({
+        "job_id": job_id,
+        "project_id": project_id,
+        "filter_mode": filter_mode,
+        "status": "running",
+        "phase": "loading",
+    }).execute()
 
 
 def _persist_run_snapshot(
     sb, job_id: str, project: dict, doc_count: int
 ) -> None:
-    """Backfill provider/model/pydantic snapshot after the project is loaded."""
-    try:
-        sb.table("llm_runs").update({
-            "llm_provider": project.get("llm_provider"),
-            "llm_model": project.get("llm_model"),
-            "document_count": doc_count,
-            "pydantic_code": project.get("pydantic_code"),
-        }).eq("job_id", job_id).execute()
-    except Exception:
-        logger.exception("Failed to UPDATE llm_runs snapshot for job %s", job_id)
+    """Backfill provider/model/pydantic snapshot after the project is loaded.
+
+    Não engolir erro: se essa atualização falhar, a aba Execuções fica sem
+    metadados da run e o usuário não consegue diagnosticar nada depois.
+    """
+    sb.table("llm_runs").update({
+        "llm_provider": project.get("llm_provider"),
+        "llm_model": project.get("llm_model"),
+        "document_count": doc_count,
+        "pydantic_code": project.get("pydantic_code"),
+    }).eq("job_id", job_id).execute()
 
 
 def _persist_run_completion(
     sb, job_id: str, progress: int, total: int, warnings: list[str] | None = None
 ) -> None:
+    """Mark the run as completed. Errors here are logged but do not re-raise.
+
+    Diferente de _persist_run_insert/_snapshot: aqui a execução já terminou e o
+    payload já está em responses. Ressuscitar a exception levaria a `_persist_run_error`
+    em cascata e duplicaria o registro de falha. Logar é suficiente.
+    """
     try:
         payload: dict = {
             "status": "completed",
@@ -146,6 +162,27 @@ def _persist_run_error(sb, job_id: str, exc: Exception, tb: str) -> tuple[int | 
     except Exception:
         logger.exception("Failed to UPDATE llm_runs error for job %s", job_id)
     return line, col
+
+
+def _answers_have_content(answers: dict) -> bool:
+    """True se algum field tem valor significativo. Espelha
+    LlmResponseRow.classifyResponse no frontend para counters consistentes.
+    """
+    for v in answers.values():
+        if v is None:
+            continue
+        if isinstance(v, str):
+            if v.strip():
+                return True
+        elif isinstance(v, list):
+            if v:
+                return True
+        elif isinstance(v, dict):
+            if v:
+                return True
+        else:
+            return True
+    return False
 
 
 def _extend_model_with_justifications(model_class):
@@ -334,15 +371,14 @@ def _filter_docs(
     return docs
 
 
-async def run_llm(
-    job_id: str,
-    project_id: str,
-    document_ids: list[str] | None = None,
-    filter_mode: str = "all",
-    max_response_count: int | None = None,
-    sample_size: int | None = None,
-):
-    """Run dataframeit on all (or filtered) documents."""
+def init_job(job_id: str, project_id: str, filter_mode: str) -> None:
+    """Inicializar estado do job + INSERT em llm_runs.
+
+    Chamado sincronamente pelo endpoint /run antes do background task. Se
+    o INSERT falhar (RLS, conexão, payload malformado), a exceção sobe pro
+    handler do FastAPI e o usuário vê 500 em vez de uma run fantasma que
+    nunca aparece em Execuções.
+    """
     sb = get_supabase()
     _jobs[job_id] = {
         "status": "running", "phase": "loading", "progress": 0, "total": 0,
@@ -351,8 +387,32 @@ async def run_llm(
         "error_traceback": None, "error_type": None,
         "error_line": None, "error_column": None,
         "pydantic_code": None,
+        # Counters atualizados durante a fase de saving para o frontend
+        # mostrar feedback ao vivo de quantos documentos saíram completos /
+        # parciais / vazios (ver LlmConfigurePane). Classificação espelha
+        # LlmResponseRow.classifyResponse no frontend.
+        "processed_complete": 0,
+        "processed_partial": 0,
+        "processed_empty": 0,
     }
     _persist_run_insert(sb, job_id, project_id, filter_mode)
+
+
+async def run_llm(
+    job_id: str,
+    project_id: str,
+    document_ids: list[str] | None = None,
+    filter_mode: str = "all",
+    max_response_count: int | None = None,
+    sample_size: int | None = None,
+):
+    """Run dataframeit on all (or filtered) documents.
+
+    Pré-condição: init_job(job_id, project_id, filter_mode) já foi chamado
+    pelo handler do /run. Aqui já assumimos _jobs[job_id] populado e
+    llm_runs row existente.
+    """
+    sb = get_supabase()
 
     try:
         # Load project (only needed columns)
@@ -529,6 +589,10 @@ async def run_llm(
                 expected_llm_fields.add(name)
 
         partial_warnings: list[str] = []
+        # Sample de _error_details reais por mensagem para incluir no
+        # RuntimeError quando a run for marcada como comprometida. Mais útil
+        # do que só "cobertura baixa" porque diz a causa.
+        dfi_error_samples: dict[str, str] = {}
 
         # Save responses — use row["id"] (not index correlation) for safety
         for _, row in result_df.iterrows():
@@ -536,16 +600,32 @@ async def run_llm(
             answers = {}
             justifications = {}
 
+            # Diagnóstico cru do dataframeit (ver dataframeit/core.py:451-452):
+            # _dataframeit_status é 'processed' ou 'error'; _error_details traz
+            # a mensagem da exceção quando a row falhou. Sem ler isso, qualquer
+            # falha de provider/parse/timeout vira "resposta vazia" sem motivo.
+            dfi_status = row.get("_dataframeit_status")
+            dfi_error_raw = row.get("_error_details")
+            dfi_error: str | None = (
+                str(dfi_error_raw) if dfi_error_raw is not None and pd.notna(dfi_error_raw) else None
+            )
+
             for field_name in model_class.model_fields:
                 val = row.get(field_name)
-                if val is not None:
+                # pd.isna lida com np.nan que dataframeit deixa em rows com erro;
+                # `val is not None` sozinho deixaria passar NaN como "preenchido".
+                if val is not None and not (
+                    isinstance(val, float) and pd.isna(val)
+                ):
                     if isinstance(val, list):
                         answers[field_name] = val
                     else:
                         answers[field_name] = str(val)
 
                 just_col = f"{field_name}_justification"
-                if just_col in row and row[just_col]:
+                if just_col in row and row[just_col] and not (
+                    isinstance(row[just_col], float) and pd.isna(row[just_col])
+                ):
                     justifications[field_name] = str(row[just_col])
 
             # Reconstruir dicts aninhados a partir dos subfields flat (ver
@@ -570,6 +650,11 @@ async def run_llm(
                         f"{k}: {v}" for k, v in sub_justs.items()
                     )
 
+            # Snapshot pré-prune para diagnosticar quando o evaluate_condition
+            # zera campos. Se uma resposta sai com 1 campo só mas pre_prune
+            # tinha muitos, o problema está nas conditions — não no LLM.
+            answers_pre_prune_keys = sorted(answers.keys())
+
             # Post-process conditional fields: remove values for fields whose
             # visibility condition is not satisfied by the sibling answers.
             # dataframeit core mode doesn't evaluate conditions itself, so the
@@ -593,6 +678,50 @@ async def run_llm(
             coverage = len(answered) / len(active_expected) if active_expected else 1.0
             is_partial = coverage < partial_coverage_threshold
 
+            # Classificação para counters ao vivo. Espelha
+            # LlmResponseRow.classifyResponse no frontend: vazia se nenhum
+            # field tem conteúdo significativo; senão complete ou partial.
+            is_empty = not _answers_have_content(answers)
+            if is_empty:
+                _jobs[job_id]["processed_empty"] += 1
+            elif is_partial:
+                _jobs[job_id]["processed_partial"] += 1
+            else:
+                _jobs[job_id]["processed_complete"] += 1
+
+            # Construir mensagem para responses.llm_error. Hierarquia:
+            # 1. Erro cru do dataframeit (timeout, parse, structured-output null)
+            # 2. Diagnóstico de prune (caso mais sutil — LLM trouxe os campos
+            #    mas evaluate_condition zerou) ou de "LLM trouxe vazio"
+            # null caso a resposta esteja saudável.
+            llm_error_msg: str | None = None
+            if dfi_error:
+                llm_error_msg = f"dataframeit: {dfi_error}"
+            elif is_empty:
+                llm_error_msg = (
+                    f"answers vazio após prune; pre_prune_keys={answers_pre_prune_keys}; "
+                    f"dfi_status={dfi_status}"
+                )
+            elif is_partial:
+                llm_error_msg = (
+                    f"cobertura baixa ({len(answered)}/{len(active_expected)}); "
+                    f"pre_prune_keys={answers_pre_prune_keys}; "
+                    f"post_prune_keys={sorted(answers.keys())}"
+                )
+
+            if is_partial or is_empty or dfi_error:
+                logger.warning(
+                    "LLM row diag doc=%s status=%s error=%s pre_prune=%s post_prune=%s",
+                    doc_id, dfi_status, dfi_error,
+                    answers_pre_prune_keys, sorted(answers.keys()),
+                )
+
+            if dfi_error:
+                # Agrupa por mensagem (truncada) para o RuntimeError final.
+                key = dfi_error[:120]
+                if key not in dfi_error_samples:
+                    dfi_error_samples[key] = f"doc={doc_id}: {dfi_error}"
+
             if is_partial:
                 missing = sorted(active_expected - answered)
                 warning_msg = (
@@ -600,7 +729,6 @@ async def run_llm(
                     f"({len(answered)}/{len(active_expected)}); "
                     f"faltaram: {missing[:8]}{'...' if len(missing) > 8 else ''}"
                 )
-                logger.warning("LLM partial response — %s", warning_msg)
                 partial_warnings.append(warning_msg)
                 _jobs[job_id].setdefault("warnings", []).append(warning_msg)
 
@@ -625,6 +753,10 @@ async def run_llm(
                 # Correlaciona a resposta com a execução que a produziu para a
                 # aba LLM > Respostas (ver migration 20260424000000).
                 "llm_job_id": job_id,
+                # Diagnóstico por documento (ver migration 20260504000002).
+                # Null quando a resposta é saudável; senão traz o motivo real
+                # (erro do dataframeit, prune zerou, ou cobertura baixa).
+                "llm_error": llm_error_msg,
             }).execute()
 
         # Update project hash
@@ -638,12 +770,23 @@ async def run_llm(
             len(partial_warnings) / total_processed if total_processed else 0.0
         )
         if partial_ratio >= run_failure_threshold:
-            raise RuntimeError(
+            # Inclui exemplos de _error_details reais (quando dataframeit
+            # falhou) além dos warnings de cobertura. Mais útil que só
+            # "cobertura baixa" porque diz a causa primária.
+            error_examples = list(dfi_error_samples.values())[:3]
+            sections = [
                 f"Run comprometida: {len(partial_warnings)}/{total_processed} "
                 f"docs ({int(partial_ratio * 100)}%) com resposta parcial. "
-                f"Respostas gravadas com is_current=false. "
-                f"Exemplos: {' || '.join(partial_warnings[:3])}"
+                f"Respostas gravadas com is_current=false."
+            ]
+            if error_examples:
+                sections.append(
+                    "Erros do provider: " + " || ".join(error_examples)
+                )
+            sections.append(
+                "Exemplos de cobertura baixa: " + " || ".join(partial_warnings[:3])
             )
+            raise RuntimeError(" ".join(sections))
 
         _jobs[job_id].update(status="completed", phase="completed", eta_seconds=0)
         _persist_run_completion(

--- a/backend/tests/test_llm_runner_classify.py
+++ b/backend/tests/test_llm_runner_classify.py
@@ -1,0 +1,60 @@
+"""Tests for _answers_have_content — classifies a response as empty or not.
+
+Espelha LlmResponseRow.classifyResponse no frontend; divergencia aqui leva a
+counters live (LlmConfigurePane) inconsistentes com badges (LlmResponseRow).
+"""
+from services.llm_runner import _answers_have_content
+
+
+def test_empty_dict_has_no_content():
+    assert _answers_have_content({}) is False
+
+
+def test_only_none_values_has_no_content():
+    assert _answers_have_content({"a": None, "b": None}) is False
+
+
+def test_empty_string_is_no_content():
+    assert _answers_have_content({"a": ""}) is False
+
+
+def test_whitespace_string_is_no_content():
+    assert _answers_have_content({"a": "   \n\t"}) is False
+
+
+def test_non_empty_string_has_content():
+    assert _answers_have_content({"a": "valor"}) is True
+
+
+def test_empty_list_is_no_content():
+    assert _answers_have_content({"a": []}) is False
+
+
+def test_non_empty_list_has_content():
+    assert _answers_have_content({"a": ["x"]}) is True
+
+
+def test_empty_dict_value_is_no_content():
+    assert _answers_have_content({"a": {}}) is False
+
+
+def test_non_empty_dict_value_has_content():
+    assert _answers_have_content({"a": {"k": "v"}}) is True
+
+
+def test_zero_int_has_content():
+    # int 0 e bool False sao valores legitimos para o LLM (ex: "quantidade",
+    # "presenca booleana"). Tratar como vazio mascararia respostas validas.
+    assert _answers_have_content({"a": 0}) is True
+
+
+def test_false_bool_has_content():
+    assert _answers_have_content({"a": False}) is True
+
+
+def test_mix_of_empty_and_useful_has_content():
+    assert _answers_have_content({"a": "", "b": None, "c": "ok"}) is True
+
+
+def test_mix_of_all_empty_kinds_has_no_content():
+    assert _answers_have_content({"a": "", "b": None, "c": [], "d": {}}) is False

--- a/backend/tests/test_llm_runner_cleanup.py
+++ b/backend/tests/test_llm_runner_cleanup.py
@@ -1,0 +1,67 @@
+"""Tests for mark_stale_runs_as_error — cleanup de runs orfas.
+
+Cobertura: a query .or_() PostgREST usa sintaxe nao-trivial
+(`heartbeat_at.lt.X,and(heartbeat_at.is.null,started_at.lt.Y)`); um typo
+silencioso quebraria o cleanup sem qualquer sinal — runs morreriam em
+'running' eternamente e o frontend religaria polling. Este teste fixa a
+sintaxe e o pipeline de chamadas.
+"""
+from unittest.mock import MagicMock
+
+from services.llm_runner import mark_stale_runs_as_error
+
+
+def _build_sb_chain(returned_data):
+    """Monta um mock que imita o builder do supabase-py (table -> update ->
+    eq -> eq -> or_ -> execute) e captura os argumentos para asserts.
+    """
+    chain = MagicMock()
+    chain.table.return_value = chain
+    chain.update.return_value = chain
+    chain.eq.return_value = chain
+    chain.or_.return_value = chain
+    chain.execute.return_value = MagicMock(data=returned_data)
+    return chain
+
+
+def test_cleanup_returns_count_of_marked_runs():
+    sb = _build_sb_chain([{"job_id": "j1"}, {"job_id": "j2"}])
+    n = mark_stale_runs_as_error(sb, "proj-123")
+    assert n == 2
+
+
+def test_cleanup_returns_zero_when_no_data():
+    """data=None deve virar 0, nao explodir com TypeError."""
+    sb = _build_sb_chain(None)
+    assert mark_stale_runs_as_error(sb, "proj-123") == 0
+
+
+def test_cleanup_filters_by_project_and_running_status():
+    sb = _build_sb_chain([])
+    mark_stale_runs_as_error(sb, "proj-abc")
+    eq_calls = [tuple(c.args) for c in sb.eq.call_args_list]
+    assert ("project_id", "proj-abc") in eq_calls
+    assert ("status", "running") in eq_calls
+
+
+def test_cleanup_or_clause_includes_heartbeat_and_null_branches():
+    """Sintaxe da .or_() e o ponto frágil: validar que ambos os ramos estão
+    presentes (heartbeat antigo OR (heartbeat null AND started_at antigo)).
+    """
+    sb = _build_sb_chain([])
+    mark_stale_runs_as_error(sb, "proj-x")
+
+    or_arg = sb.or_.call_args.args[0]
+    assert "heartbeat_at.lt." in or_arg
+    assert "and(heartbeat_at.is.null,started_at.lt." in or_arg
+
+
+def test_cleanup_writes_error_status_and_message():
+    sb = _build_sb_chain([])
+    mark_stale_runs_as_error(sb, "proj-x")
+
+    payload = sb.update.call_args.args[0]
+    assert payload["status"] == "error"
+    assert payload["phase"] == "error"
+    assert "heartbeat" in payload["error_message"].lower()
+    assert "completed_at" in payload

--- a/backend/tests/test_llm_runner_error_msg.py
+++ b/backend/tests/test_llm_runner_error_msg.py
@@ -1,0 +1,72 @@
+"""Tests for _build_llm_error_message — diagnostic stored in responses.llm_error.
+
+A hierarquia importa: erro do dataframeit pode coexistir com is_empty=True
+(quando a row inteira falhou e veio so com NaN), e o message deve preferir
+o erro cru porque e mais informativo.
+"""
+from services.llm_runner import _build_llm_error_message
+
+
+def _kwargs(**overrides):
+    base = dict(
+        dfi_error=None,
+        is_empty=False,
+        is_partial=False,
+        dfi_status="processed",
+        pre_prune_keys=[],
+        post_prune_keys=[],
+        answered_count=0,
+        active_expected_count=0,
+    )
+    base.update(overrides)
+    return base
+
+
+def test_dataframeit_error_takes_precedence():
+    msg = _build_llm_error_message(**_kwargs(
+        dfi_error="rate limit exceeded",
+        is_empty=True,
+        is_partial=True,
+        dfi_status="error",
+    ))
+    assert msg is not None
+    assert msg.startswith("dataframeit:")
+    assert "rate limit exceeded" in msg
+
+
+def test_empty_after_prune_when_no_dfi_error():
+    msg = _build_llm_error_message(**_kwargs(
+        is_empty=True,
+        pre_prune_keys=["q1", "q2", "q3"],
+    ))
+    assert msg is not None
+    assert msg.startswith("answers vazio após prune")
+    assert "['q1', 'q2', 'q3']" in msg
+
+
+def test_partial_coverage_message():
+    msg = _build_llm_error_message(**_kwargs(
+        is_partial=True,
+        pre_prune_keys=["q1", "q2"],
+        post_prune_keys=["q1"],
+        answered_count=1,
+        active_expected_count=5,
+    ))
+    assert msg is not None
+    assert msg.startswith("cobertura baixa (1/5)")
+    assert "post_prune_keys=['q1']" in msg
+
+
+def test_healthy_response_returns_none():
+    """Resposta saudavel: nem erro, nem vazia, nem parcial. Mensagem fica null."""
+    assert _build_llm_error_message(**_kwargs()) is None
+
+
+def test_dfi_status_appears_in_empty_message():
+    msg = _build_llm_error_message(**_kwargs(
+        is_empty=True,
+        dfi_status="error",
+        pre_prune_keys=[],
+    ))
+    assert msg is not None
+    assert "dfi_status=error" in msg

--- a/backend/tests/test_llm_runner_extract.py
+++ b/backend/tests/test_llm_runner_extract.py
@@ -1,0 +1,106 @@
+"""Tests for _extract_answers_from_row — NaN-safe extraction from result_df.
+
+dataframeit deixa np.nan em rows que falharam no provider; bool(NaN) e True
+em Python, entao um filtro ingenuo (`if val`) deixaria NaN passar como
+"preenchido" e a resposta seria salva com lixo. Esta funcao precisa rejeitar
+NaN explicitamente.
+"""
+import math
+
+from pydantic import BaseModel
+from services.llm_runner import _extract_answers_from_row
+
+
+class _Sample(BaseModel):
+    field_a: str | None = None
+    field_b: list[str] | None = None
+    field_c: int | None = None
+
+
+def test_extract_basic_string_field():
+    row = {"field_a": "valor", "field_b": None, "field_c": None}
+    answers, justifications = _extract_answers_from_row(row, _Sample)
+    assert answers == {"field_a": "valor"}
+    assert justifications == {}
+
+
+def test_extract_skips_none_values():
+    row = {"field_a": None, "field_b": None, "field_c": None}
+    answers, _ = _extract_answers_from_row(row, _Sample)
+    assert answers == {}
+
+
+def test_extract_skips_nan_values():
+    """NaN nunca deve entrar em answers (causa raiz do bug pre-PR #77)."""
+    nan = float("nan")
+    row = {"field_a": nan, "field_b": nan, "field_c": nan}
+    answers, _ = _extract_answers_from_row(row, _Sample)
+    assert answers == {}
+
+
+def test_extract_keeps_list_as_list():
+    row = {"field_a": None, "field_b": ["x", "y"], "field_c": None}
+    answers, _ = _extract_answers_from_row(row, _Sample)
+    assert answers == {"field_b": ["x", "y"]}
+
+
+def test_extract_stringifies_int():
+    row = {"field_a": None, "field_b": None, "field_c": 42}
+    answers, _ = _extract_answers_from_row(row, _Sample)
+    assert answers == {"field_c": "42"}
+
+
+def test_extract_ignores_internal_dataframeit_columns():
+    """Colunas como _dataframeit_status nao devem aparecer em answers."""
+    row = {
+        "field_a": "ok",
+        "field_b": None,
+        "field_c": None,
+        "_dataframeit_status": "processed",
+        "_error_details": None,
+    }
+    answers, _ = _extract_answers_from_row(row, _Sample)
+    assert answers == {"field_a": "ok"}
+    assert "_dataframeit_status" not in answers
+    assert "_error_details" not in answers
+
+
+def test_extract_justifications_present():
+    row = {
+        "field_a": "ok",
+        "field_b": None,
+        "field_c": None,
+        "field_a_justification": "porque sim",
+    }
+    answers, justifications = _extract_answers_from_row(row, _Sample)
+    assert answers == {"field_a": "ok"}
+    assert justifications == {"field_a": "porque sim"}
+
+
+def test_extract_skips_nan_justification():
+    nan = float("nan")
+    row = {
+        "field_a": "ok",
+        "field_b": None,
+        "field_c": None,
+        "field_a_justification": nan,
+    }
+    answers, justifications = _extract_answers_from_row(row, _Sample)
+    assert answers == {"field_a": "ok"}
+    assert justifications == {}
+
+
+def test_extract_skips_empty_string_justification():
+    row = {
+        "field_a": "ok",
+        "field_b": None,
+        "field_c": None,
+        "field_a_justification": "",
+    }
+    answers, justifications = _extract_answers_from_row(row, _Sample)
+    assert justifications == {}
+
+
+def test_nan_check_uses_math_isnan_semantics():
+    """Sanity check: pd.isna(float('nan')) == True, mas isinstance(nan, int) e False."""
+    assert math.isnan(float("nan"))

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createSupabaseServer } from "@/lib/supabase/server";
+import { fetchFastAPI } from "@/lib/api";
 
 export async function getEligibleDocCount(
   projectId: string,
@@ -211,19 +212,54 @@ export interface RunningLlmJob {
 }
 
 /**
- * Retorna a run LLM com status='running' mais recente do projeto, ou null.
- * Usado pelo LlmConfigurePane para retomar o card de execução em andamento
- * quando o usuário recarrega a página ou volta para a aba.
+ * Marca runs do projeto sem heartbeat recente como 'error'. Idempotente.
+ * Resolve runs orfas — quando a maquina do backend morre antes de completar
+ * (scale-to-zero do Fly.io), a row de llm_runs fica eternamente como
+ * 'running'; sem cleanup, getRunningLlmJob religa o polling para sempre.
+ */
+export async function cleanupStaleLlmRuns(
+  projectId: string
+): Promise<{ cleaned: number }> {
+  try {
+    return await fetchFastAPI<{ cleaned: number }>(
+      "/api/llm/cleanup-stale",
+      {
+        method: "POST",
+        body: JSON.stringify({ project_id: projectId }),
+      }
+    );
+  } catch {
+    // Cleanup e best-effort: se o backend esta down, nao bloquear o
+    // carregamento da pagina. O filtro heartbeat em getRunningLlmJob ja
+    // evita religar polling em runs orfas.
+    return { cleaned: 0 };
+  }
+}
+
+/**
+ * Retorna a run LLM com status='running' e heartbeat recente do projeto,
+ * ou null. Usado pelo LlmConfigurePane para retomar o card de execução em
+ * andamento quando o usuário recarrega a página ou volta para a aba.
+ *
+ * Premissa: máximo uma run ativa por projeto. `.limit(1)` ignora silenciosamente
+ * runs concorrentes — a coordenação de execuções é responsabilidade do frontend
+ * (botão `Rodar` desabilita enquanto há run ativa).
+ *
+ * O filtro de heartbeat (5min) evita religar polling em runs cuja máquina
+ * morreu sem marcar a row como erro. cleanupStaleLlmRuns deve ser chamado
+ * antes para também atualizar a aba Execuções.
  */
 export async function getRunningLlmJob(
   projectId: string
 ): Promise<RunningLlmJob | null> {
   const supabase = await createSupabaseServer();
+  const heartbeatCutoff = new Date(Date.now() - 5 * 60 * 1000).toISOString();
   const { data } = await supabase
     .from("llm_runs")
-    .select("job_id, started_at")
+    .select("job_id, started_at, heartbeat_at")
     .eq("project_id", projectId)
     .eq("status", "running")
+    .gt("heartbeat_at", heartbeatCutoff)
     .order("started_at", { ascending: false })
     .limit(1)
     .maybeSingle();

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -245,15 +245,18 @@ export async function cleanupStaleLlmRuns(
  * runs concorrentes — a coordenação de execuções é responsabilidade do frontend
  * (botão `Rodar` desabilita enquanto há run ativa).
  *
- * O filtro de heartbeat (5min) evita religar polling em runs cuja máquina
- * morreu sem marcar a row como erro. cleanupStaleLlmRuns deve ser chamado
- * antes para também atualizar a aba Execuções.
+ * O filtro de heartbeat (10min) evita religar polling em runs cuja máquina
+ * morreu sem marcar a row como erro. Mantido em paralelo ao cutoff do
+ * mark_stale_runs_as_error no backend — ambos devem ser iguais para evitar
+ * janela onde uma run marcada stale ainda apareceria como running aqui (ou
+ * vice-versa). cleanupStaleLlmRuns deve ser chamado antes para também
+ * atualizar a aba Execuções.
  */
 export async function getRunningLlmJob(
   projectId: string
 ): Promise<RunningLlmJob | null> {
   const supabase = await createSupabaseServer();
-  const heartbeatCutoff = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  const heartbeatCutoff = new Date(Date.now() - 10 * 60 * 1000).toISOString();
   const { data } = await supabase
     .from("llm_runs")
     .select("job_id, started_at, heartbeat_at")

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -141,6 +141,10 @@ export interface LlmResponseRecord {
   justifications: Record<string, string> | null;
   respondent_name: string | null;
   created_at: string;
+  // Diagnostico por documento gravado pelo backend quando a resposta saiu
+  // vazia, parcial ou com erro do dataframeit. Null quando a resposta foi
+  // integra. Ver migration 20260504000002_responses_llm_error.sql.
+  llm_error: string | null;
   document: {
     id: string;
     title: string | null;
@@ -160,7 +164,7 @@ export async function getLlmResponsesForProject(
     .from("responses")
     .select(
       "id, document_id, llm_job_id, is_current, is_partial, answers, " +
-        "justifications, respondent_name, created_at, " +
+        "justifications, respondent_name, created_at, llm_error, " +
         "documents(id, title, external_id)"
     )
     .eq("project_id", projectId)
@@ -182,6 +186,7 @@ export async function getLlmResponsesForProject(
     justifications: Record<string, string> | null;
     respondent_name: string | null;
     created_at: string;
+    llm_error: string | null;
     documents:
       | { id: string; title: string | null; external_id: string | null }
       | null;
@@ -195,8 +200,35 @@ export async function getLlmResponsesForProject(
     justifications: r.justifications,
     respondent_name: r.respondent_name,
     created_at: r.created_at,
+    llm_error: r.llm_error,
     document: r.documents,
   }));
+}
+
+export interface RunningLlmJob {
+  job_id: string;
+  started_at: string;
+}
+
+/**
+ * Retorna a run LLM com status='running' mais recente do projeto, ou null.
+ * Usado pelo LlmConfigurePane para retomar o card de execução em andamento
+ * quando o usuário recarrega a página ou volta para a aba.
+ */
+export async function getRunningLlmJob(
+  projectId: string
+): Promise<RunningLlmJob | null> {
+  const supabase = await createSupabaseServer();
+  const { data } = await supabase
+    .from("llm_runs")
+    .select("job_id, started_at")
+    .eq("project_id", projectId)
+    .eq("status", "running")
+    .order("started_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!data) return null;
+  return { job_id: data.job_id, started_at: data.started_at };
 }
 
 export async function getDocumentsForSelection(

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -30,7 +30,7 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { saveLlmConfig, savePrompt, toggleLlmField } from "@/actions/schema";
-import { getEligibleDocCount } from "@/actions/llm";
+import { getEligibleDocCount, getRunningLlmJob } from "@/actions/llm";
 import { fetchFastAPI } from "@/lib/api";
 import { LLM_AMBIGUITIES_FIELD } from "@/lib/standard-questions";
 import {
@@ -127,6 +127,9 @@ export function LlmConfigurePane({
   const [etaSeconds, setEtaSeconds] = useState<number | null>(null);
   const [currentBatch, setCurrentBatch] = useState(0);
   const [totalBatches, setTotalBatches] = useState(0);
+  const [processedComplete, setProcessedComplete] = useState(0);
+  const [processedPartial, setProcessedPartial] = useState(0);
+  const [processedEmpty, setProcessedEmpty] = useState(0);
   const [errorInfo, setErrorInfo] = useState<LlmErrorInfo | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -160,6 +163,27 @@ export function LlmConfigurePane({
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, []);
+
+  // Retomar polling se houver uma run em execucao ao montar (ex.: usuario
+  // recarregou a pagina ou voltou para a aba). Sem isso, o card de execucao
+  // some quando a aba fecha e o usuario nao tem feedback algum ate ir em
+  // /llm/runs ou aguardar terminar.
+  useEffect(() => {
+    let cancelled = false;
+    async function check() {
+      const running = await getRunningLlmJob(projectId);
+      if (cancelled || !running) return;
+      setJobId(running.job_id);
+      setStatus("running");
+      setPhase("loading");
+      pollProgress(running.job_id);
+    }
+    check();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
 
   // Fetch eligible count when filter mode changes
   useEffect(() => {
@@ -240,6 +264,9 @@ export function LlmConfigurePane({
       setTotalBatches(0);
       setProgress(0);
       setTotal(0);
+      setProcessedComplete(0);
+      setProcessedPartial(0);
+      setProcessedEmpty(0);
       // Refresca o layout do projeto para o badge "LLM rodando" aparecer na aba.
       router.refresh();
       pollProgress(res.job_id);
@@ -268,6 +295,9 @@ export function LlmConfigurePane({
           error_line: number | null;
           error_column: number | null;
           pydantic_code: string | null;
+          processed_complete: number;
+          processed_partial: number;
+          processed_empty: number;
         }>(`/api/llm/status/${id}`);
         setProgress(res.progress);
         setTotal(res.total);
@@ -276,6 +306,9 @@ export function LlmConfigurePane({
         setEtaSeconds(res.eta_seconds);
         setCurrentBatch(res.current_batch);
         setTotalBatches(res.total_batches);
+        setProcessedComplete(res.processed_complete ?? 0);
+        setProcessedPartial(res.processed_partial ?? 0);
+        setProcessedEmpty(res.processed_empty ?? 0);
         if (res.status !== "running") {
           if (intervalRef.current) clearInterval(intervalRef.current);
           intervalRef.current = null;
@@ -873,6 +906,23 @@ export function LlmConfigurePane({
               {phase === "processing" && `${progress}/${total} documentos processados`}
               {phase === "saving" && "Salvando resultados..."}
             </p>
+            {/* Counters ao vivo: completas / parciais / vazias. Aparecem
+                durante a fase de saving (quando o backend comeca a inserir
+                em responses) e ate o fim da run para que o usuario tenha
+                feedback imediato de como esta saindo. */}
+            {(processedComplete > 0 || processedPartial > 0 || processedEmpty > 0) && (
+              <div className="flex flex-wrap gap-2 pt-1">
+                <Badge className="bg-emerald-600 hover:bg-emerald-600 text-white">
+                  {processedComplete} completa{processedComplete !== 1 ? "s" : ""}
+                </Badge>
+                <Badge className="bg-amber-600 hover:bg-amber-600 text-white">
+                  {processedPartial} parcia{processedPartial !== 1 ? "is" : "l"}
+                </Badge>
+                <Badge variant="destructive">
+                  {processedEmpty} vazia{processedEmpty !== 1 ? "s" : ""}
+                </Badge>
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -30,7 +30,11 @@ import {
   CommandList,
 } from "@/components/ui/command";
 import { saveLlmConfig, savePrompt, toggleLlmField } from "@/actions/schema";
-import { getEligibleDocCount, getRunningLlmJob } from "@/actions/llm";
+import {
+  cleanupStaleLlmRuns,
+  getEligibleDocCount,
+  getRunningLlmJob,
+} from "@/actions/llm";
 import { fetchFastAPI } from "@/lib/api";
 import { LLM_AMBIGUITIES_FIELD } from "@/lib/standard-questions";
 import {
@@ -168,11 +172,24 @@ export function LlmConfigurePane({
   // recarregou a pagina ou voltou para a aba). Sem isso, o card de execucao
   // some quando a aba fecha e o usuario nao tem feedback algum ate ir em
   // /llm/runs ou aguardar terminar.
+  //
+  // cleanupStaleLlmRuns roda primeiro para evitar religar polling em runs
+  // cuja maquina morreu antes de completar (scale-to-zero do Fly.io). Tambem
+  // resolve o sintoma cosmetico de runs eternamente "running" na aba
+  // Execucoes.
   useEffect(() => {
     let cancelled = false;
     async function check() {
+      await cleanupStaleLlmRuns(projectId);
+      if (cancelled) return;
       const running = await getRunningLlmJob(projectId);
       if (cancelled || !running) return;
+      // Reset counters antes de religar polling: sem isso, valores residuais
+      // de uma run anterior (encerrada nesta sessao) ficariam visiveis ate o
+      // primeiro tick do polling preencher os valores reais.
+      setProcessedComplete(0);
+      setProcessedPartial(0);
+      setProcessedEmpty(0);
       setJobId(running.job_id);
       setStatus("running");
       setPhase("loading");

--- a/frontend/src/components/llm/LlmResponseRow.tsx
+++ b/frontend/src/components/llm/LlmResponseRow.tsx
@@ -109,11 +109,27 @@ export function LlmResponseRow({
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="space-y-3 border-t px-4 py-3">
+            {/* Diagnostico do backend: aparece sempre que llm_error estiver
+                preenchido — pode ser erro real do dataframeit, prune de
+                condicionais zerou os campos, ou cobertura baixa. Substitui o
+                texto generico "Veja a aba Execucoes" anterior. */}
+            {r.llm_error && (
+              <div className="rounded-md border border-destructive/30 bg-destructive/5 p-2">
+                <p className="text-xs font-medium text-destructive">
+                  Motivo {status === "empty" ? "da resposta vazia" : "do alerta"}
+                </p>
+                <pre className="mt-1 whitespace-pre-wrap break-words text-xs text-destructive/80 font-mono">
+                  {r.llm_error}
+                </pre>
+              </div>
+            )}
             {entries.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                Resposta vazia — o LLM não retornou nenhum campo para este
-                documento. Veja a aba Execuções para o motivo.
-              </p>
+              !r.llm_error && (
+                <p className="text-sm text-muted-foreground">
+                  Resposta vazia — o LLM não retornou nenhum campo para este
+                  documento.
+                </p>
+              )
             ) : (
               <dl className="grid gap-2 text-sm">
                 {entries.map(([field, value]) => (

--- a/frontend/src/components/llm/LlmResponseRow.tsx
+++ b/frontend/src/components/llm/LlmResponseRow.tsx
@@ -10,21 +10,10 @@ import { Badge } from "@/components/ui/badge";
 import { ChevronRight, ExternalLink } from "lucide-react";
 import type { LlmResponseRecord } from "@/actions/llm";
 import { formatModelLabel } from "@/lib/model-registry";
+import { classifyResponse, type ResponseStatus } from "./classify";
 
-export type ResponseStatus = "complete" | "partial" | "empty";
-
-export function classifyResponse(r: LlmResponseRecord): ResponseStatus {
-  const entries = Object.entries(r.answers ?? {});
-  const hasValue = entries.some(([, v]) => {
-    if (v == null) return false;
-    if (typeof v === "string") return v.trim().length > 0;
-    if (Array.isArray(v)) return v.length > 0;
-    if (typeof v === "object") return Object.keys(v).length > 0;
-    return true;
-  });
-  if (!hasValue) return "empty";
-  return r.is_partial ? "partial" : "complete";
-}
+export { classifyResponse };
+export type { ResponseStatus };
 
 function StatusBadge({ status }: { status: ResponseStatus }) {
   if (status === "complete")
@@ -118,7 +107,7 @@ export function LlmResponseRow({
                 <p className="text-xs font-medium text-destructive">
                   Motivo {status === "empty" ? "da resposta vazia" : "do alerta"}
                 </p>
-                <pre className="mt-1 whitespace-pre-wrap break-words text-xs text-destructive/80 font-mono">
+                <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words text-xs text-destructive/80 font-mono">
                   {r.llm_error}
                 </pre>
               </div>

--- a/frontend/src/components/llm/__tests__/classify.test.ts
+++ b/frontend/src/components/llm/__tests__/classify.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { classifyResponse } from "../classify";
+import type { LlmResponseRecord } from "@/actions/llm";
+
+// Espelha _answers_have_content no backend (services/llm_runner.py). Se um
+// teste aqui falhar apos mudar a regra, atualize tambem o backend para
+// manter counters live consistentes com badges renderizadas.
+
+function record(
+  partial: Partial<LlmResponseRecord> & Pick<LlmResponseRecord, "answers" | "is_partial">
+): LlmResponseRecord {
+  return {
+    id: "r1",
+    document_id: "d1",
+    llm_job_id: null,
+    is_current: true,
+    justifications: null,
+    respondent_name: null,
+    created_at: "2026-05-04T00:00:00Z",
+    llm_error: null,
+    document: null,
+    ...partial,
+  };
+}
+
+describe("classifyResponse", () => {
+  it("retorna empty para answers vazio", () => {
+    expect(classifyResponse(record({ answers: {}, is_partial: false }))).toBe(
+      "empty"
+    );
+  });
+
+  it("retorna empty quando todos os valores sao null/undefined", () => {
+    expect(
+      classifyResponse(
+        record({ answers: { a: null, b: undefined }, is_partial: false })
+      )
+    ).toBe("empty");
+  });
+
+  it("retorna empty quando todas as strings sao vazias ou whitespace", () => {
+    expect(
+      classifyResponse(
+        record({ answers: { a: "", b: "   \n" }, is_partial: false })
+      )
+    ).toBe("empty");
+  });
+
+  it("retorna empty quando arrays e objetos sao vazios", () => {
+    expect(
+      classifyResponse(
+        record({ answers: { a: [], b: {} }, is_partial: false })
+      )
+    ).toBe("empty");
+  });
+
+  it("retorna complete quando ha string util e nao parcial", () => {
+    expect(
+      classifyResponse(record({ answers: { a: "valor" }, is_partial: false }))
+    ).toBe("complete");
+  });
+
+  it("retorna partial quando ha valor mas is_partial=true", () => {
+    expect(
+      classifyResponse(record({ answers: { a: "valor" }, is_partial: true }))
+    ).toBe("partial");
+  });
+
+  it("retorna complete para lista nao vazia", () => {
+    expect(
+      classifyResponse(record({ answers: { a: ["x"] }, is_partial: false }))
+    ).toBe("complete");
+  });
+
+  it("retorna complete para dict nao vazio", () => {
+    expect(
+      classifyResponse(
+        record({ answers: { a: { k: "v" } }, is_partial: false })
+      )
+    ).toBe("complete");
+  });
+
+  it("retorna complete para int 0 (valor legitimo)", () => {
+    // int 0 e bool false sao respostas validas (quantidade, presenca booleana).
+    // Tratar como vazio mascararia respostas reais.
+    expect(
+      classifyResponse(record({ answers: { a: 0 }, is_partial: false }))
+    ).toBe("complete");
+  });
+
+  it("retorna complete para bool false", () => {
+    expect(
+      classifyResponse(record({ answers: { a: false }, is_partial: false }))
+    ).toBe("complete");
+  });
+
+  it("considera mistura de vazios + 1 valor real como complete", () => {
+    expect(
+      classifyResponse(
+        record({
+          answers: { a: "", b: null, c: "ok" },
+          is_partial: false,
+        })
+      )
+    ).toBe("complete");
+  });
+
+  it("answers null/undefined caem como empty", () => {
+    expect(
+      classifyResponse(record({ answers: null as unknown as Record<string, unknown>, is_partial: false }))
+    ).toBe("empty");
+  });
+});

--- a/frontend/src/components/llm/classify.ts
+++ b/frontend/src/components/llm/classify.ts
@@ -1,0 +1,24 @@
+// Funcoes puras de classificacao de respostas LLM. Separadas de
+// LlmResponseRow.tsx (que e "use client" e importa React) para serem
+// testaveis em vitest com environment: "node".
+//
+// IMPORTANTE: a regra de classificacao espelha _answers_have_content no
+// backend (services/llm_runner.py). Divergencia aqui deixa counters live
+// inconsistentes com badges. Mudou aqui? Atualize o backend tambem.
+
+import type { LlmResponseRecord } from "@/actions/llm";
+
+export type ResponseStatus = "complete" | "partial" | "empty";
+
+export function classifyResponse(r: LlmResponseRecord): ResponseStatus {
+  const entries = Object.entries(r.answers ?? {});
+  const hasValue = entries.some(([, v]) => {
+    if (v == null) return false;
+    if (typeof v === "string") return v.trim().length > 0;
+    if (Array.isArray(v)) return v.length > 0;
+    if (typeof v === "object") return Object.keys(v).length > 0;
+    return true;
+  });
+  if (!hasValue) return "empty";
+  return r.is_partial ? "partial" : "complete";
+}

--- a/frontend/supabase/migrations/20260504000002_responses_llm_error.sql
+++ b/frontend/supabase/migrations/20260504000002_responses_llm_error.sql
@@ -1,0 +1,22 @@
+-- Diagnostico por documento da execucao LLM.
+--
+-- Antes desta migration, quando uma resposta LLM saia vazia ou com poucos
+-- campos, nao havia jeito de saber por que: o save loop em
+-- backend/services/llm_runner.py iterava so sobre model_class.model_fields e
+-- descartava as colunas internas do dataframeit (_dataframeit_status e
+-- _error_details). Resultado: respostas marcadas como "Vazia" no frontend sem
+-- nenhum vinculo com a causa real (timeout, structured-output null, parse
+-- error, prune de condicionais, cobertura baixa).
+--
+-- Esta coluna armazena por documento, on-demand:
+--  - Erro cru do dataframeit (ex.: "dataframeit: Falha no parsing do
+--    structured output: ..."), ou
+--  - Diagnostico de prune ("answers vazio apos prune; pre_prune_keys=[...]"),
+--    quando o LLM trouxe campos mas evaluate_condition zerou, ou
+--  - Cobertura baixa ("cobertura baixa (1/12); pre_prune_keys=[...];
+--    post_prune_keys=[doenca]") quando o LLM ja chega com poucos campos.
+--
+-- Null quando a resposta foi salva integra. Sem index: leitura on-demand junto
+-- com a resposta; cardinalidade alta inviabiliza index util.
+ALTER TABLE responses
+  ADD COLUMN llm_error TEXT;

--- a/frontend/supabase/migrations/20260504000003_llm_runs_counters_heartbeat.sql
+++ b/frontend/supabase/migrations/20260504000003_llm_runs_counters_heartbeat.sql
@@ -1,12 +1,12 @@
 -- Persistir counters ao vivo e heartbeat em llm_runs.
 --
--- Motivacao: o PR anterior (20260504000002) introduziu contadores
--- processed_complete/partial/empty exibidos ao vivo no LlmConfigurePane,
--- mas eles viviam apenas no dict _jobs em memoria do backend
--- (backend/services/llm_runner.py). Como o deploy roda single-worker em
--- Fly.io com min_machines_running=0 (scale-to-zero), toda vez que a maquina
--- hiberna ou reinicia esses contadores somem -- exatamente a feature recem
--- adicionada.
+-- Motivacao: o conjunto de mudancas deste PR introduz contadores
+-- processed_complete/partial/empty exibidos ao vivo no LlmConfigurePane
+-- (backend/services/llm_runner.py). Esses contadores nasceram vivendo
+-- apenas no dict _jobs em memoria do backend; como o deploy roda
+-- single-worker em Fly.io com min_machines_running=0 (scale-to-zero), toda
+-- vez que a maquina hiberna ou reinicia esses contadores somem -- exatamente
+-- a feature recem adicionada.
 --
 -- Alem disso, runs cuja maquina morreu antes de completar ficavam com
 -- status='running' eternamente: o frontend nao tinha como distinguir uma

--- a/frontend/supabase/migrations/20260504000003_llm_runs_counters_heartbeat.sql
+++ b/frontend/supabase/migrations/20260504000003_llm_runs_counters_heartbeat.sql
@@ -1,0 +1,29 @@
+-- Persistir counters ao vivo e heartbeat em llm_runs.
+--
+-- Motivacao: o PR anterior (20260504000002) introduziu contadores
+-- processed_complete/partial/empty exibidos ao vivo no LlmConfigurePane,
+-- mas eles viviam apenas no dict _jobs em memoria do backend
+-- (backend/services/llm_runner.py). Como o deploy roda single-worker em
+-- Fly.io com min_machines_running=0 (scale-to-zero), toda vez que a maquina
+-- hiberna ou reinicia esses contadores somem -- exatamente a feature recem
+-- adicionada.
+--
+-- Alem disso, runs cuja maquina morreu antes de completar ficavam com
+-- status='running' eternamente: o frontend nao tinha como distinguir uma
+-- run viva de uma run zumbi e, com a feature de retomada de polling
+-- (getRunningLlmJob), religava o card de execucao para sempre.
+--
+-- Esta migration adiciona:
+--  - 3 colunas de contadores persistidos: o save loop atualiza esses
+--    valores periodicamente (throttle 2s) e o frontend le dali quando o
+--    fallback _status_from_row e acionado (caso o _jobs em memoria nao
+--    tenha o job).
+--  - heartbeat_at: timestamp atualizado pelo save loop no mesmo throttle.
+--    Cleanup ativo (mark_stale_runs_as_error) marca como 'error' as runs
+--    com heartbeat antigo, e getRunningLlmJob filtra por heartbeat recente.
+
+ALTER TABLE llm_runs
+  ADD COLUMN processed_complete INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN processed_partial INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN processed_empty INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN heartbeat_at TIMESTAMPTZ;

--- a/frontend/supabase/migrations/20260505000000_llm_runs_heartbeat_index.sql
+++ b/frontend/supabase/migrations/20260505000000_llm_runs_heartbeat_index.sql
@@ -1,0 +1,16 @@
+-- Index parcial em llm_runs(heartbeat_at) restrito a status='running'.
+--
+-- Motivacao: getRunningLlmJob (frontend/src/actions/llm.ts) filtra por
+-- (project_id, status='running', heartbeat_at > cutoff). mark_stale_runs_as_error
+-- (backend/services/llm_runner.py) filtra por (project_id, status='running',
+-- heartbeat_at < cutoff OR null). Ambos sao chamados em mount do
+-- LlmConfigurePane e podem rodar muitas vezes por dia. Sem index, full scan
+-- em llm_runs cresce O(n) com o historico do projeto.
+--
+-- Index parcial (WHERE status='running') porque a vasta maioria das runs
+-- termina como completed/error -- so vale indexar a fatia ativa, mantendo
+-- o index pequeno e barato de manter.
+
+CREATE INDEX IF NOT EXISTS idx_llm_runs_running_heartbeat
+  ON llm_runs (project_id, heartbeat_at)
+  WHERE status = 'running';


### PR DESCRIPTION
## Contexto

Resolve o bug "há um bom tempo está com bug de sempre ficar com todas as respostas vazias" e a queixa "é bem ruim de saber o que está rolando — precisamos deixar mais claro se está tudo certo e se está rodando ou não".

## Causa-raiz das respostas vazias

`dataframeit` injeta duas colunas internas em cada linha (`dataframeit/core.py:451-452`):

- `_dataframeit_status` — `'processed'` ou `'error'`
- `_error_details` — mensagem do erro real (parse fail, structured-output null, timeout, rate limit, token cap)

O save loop em `llm_runner.py:534-628` só iterava sobre `model_class.model_fields` e **descartava essas colunas**. Resultado: qualquer falha por linha virava `answers: {}` sem rastro, exibida como "Vazia" no frontend sem motivo.

## Mudanças

### Diagnóstico por documento
- Nova coluna `responses.llm_error` (migration `20260504000002`) — TEXT nullable.
- Save loop grava ali: erro cru do dataframeit (`"dataframeit: ..."`), ou `"answers vazio após prune; pre_prune_keys=[...]"` quando `evaluate_condition` zerou os campos, ou `"cobertura baixa; pre/post_prune_keys=..."` quando o LLM já trouxe pouco.
- Snapshot dos `answers` antes do prune permite distinguir os casos.
- `LlmResponseRow` renderiza a mensagem em `<pre>` no lugar do antigo "Veja a aba Execuções".

### Counters ao vivo
- `_jobs[job_id]` ganha `processed_complete/partial/empty` atualizados durante o save loop, com a mesma regra de classificação que o frontend já usa em `LlmResponseRow.classifyResponse`.
- `/api/llm/status` os expõe; `LlmConfigurePane` renderiza 3 badges abaixo da progress bar (verde / âmbar / vermelho) atualizando a cada tick.

### Retomada de polling
- Nova action `getRunningLlmJob(projectId)`.
- `LlmConfigurePane` consulta na montagem; se há run "running", reativa o card de execução e o polling. Resolve "fechei a aba e perdi o card".

### INSERT silencioso de `llm_runs` (caso "rodei agorinha mas não aparece em Execuções")
- `_persist_run_insert` antes engolia exceções (`try/except: logger.exception(...)`) → run rodava em memória mas ficava órfã.
- Movido pra `init_job()`, chamado **síncrono** pelo handler `/run` antes do `BackgroundTasks.add_task`. Falha agora vira 500 com a causa em vez de run fantasma.

### RuntimeError de "run comprometida" com causa real
- Antes: só dizia "cobertura baixa". Agora inclui até 3 exemplos de `_error_details` agrupados por mensagem (`"Erros do provider: ..."`).

## Test plan

- [x] Backend: 49/49 testes pytest passam (`backend/tests/`).
- [x] Frontend: `tsc --noEmit` sem erros novos (apenas vitest typings pré-existentes em arquivos `*.test.ts`).
- [ ] **Aplicar migration**: `cd frontend && export SUPABASE_ACCESS_TOKEN=$(grep SUPABASE_ACCESS_TOKEN .env.local | cut -d= -f2) && npx supabase db push`
- [ ] Smoke test do path feliz: rodar com schema válido, ver counter de "completas" crescer, `llm_error` ficar null nas respostas íntegras.
- [ ] Reproduzir "só doença aparece" e verificar com `select document_id, jsonb_object_keys(answers), llm_error from responses where llm_job_id = '...'` — agora dá pra distinguir prune zerando vs LLM trouxe pouco.
- [ ] Forçar erro (API key inválida, schema malformado): respostas afetadas devem mostrar `llm_error` real em vez de "Vazia" sem motivo.
- [ ] Fechar aba durante execução, voltar — card "Em execução" deve reaparecer com estado atual.
- [ ] Simular falha no INSERT de `llm_runs` (ex: service_key errada) → `/api/llm/run` deve retornar 500 em vez de aceitar e sumir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)