### PR TITLE
feat(llm-insights): filtros de data/versão, ordenação e marcar equivalentes

### DIFF
--- a/frontend/src/actions/equivalences.ts
+++ b/frontend/src/actions/equivalences.ts
@@ -91,6 +91,49 @@ export async function confirmEquivalentVerdict(
   revalidatePath(`/projects/${projectId}/analyze/assignments`);
 }
 
+// Lightweight variant for the "Erros LLM" tab: registers that the LLM
+// response and the reviewer-chosen response are equivalent, without
+// touching the existing review row (the verdict already points to
+// `chosenResponseId` and remains valid). The page recomputes errors and
+// suppresses entries whose LLM↔chosen pair is in `response_equivalences`.
+export async function markLlmEquivalent(
+  projectId: string,
+  documentId: string,
+  fieldName: string,
+  llmResponseId: string,
+  chosenResponseId: string,
+) {
+  if (llmResponseId === chosenResponseId) {
+    throw new Error("Respostas já são as mesmas.");
+  }
+
+  const user = await getAuthUser();
+  if (!user) throw new Error("Não autenticado");
+
+  const supabase = await createSupabaseServer();
+  const [a, b] = canonicalPair(llmResponseId, chosenResponseId);
+
+  const { error } = await supabase.from("response_equivalences").upsert(
+    {
+      project_id: projectId,
+      document_id: documentId,
+      field_name: fieldName,
+      response_a_id: a,
+      response_b_id: b,
+      reviewer_id: user.id,
+    },
+    {
+      onConflict:
+        "project_id,document_id,field_name,response_a_id,response_b_id",
+      ignoreDuplicates: true,
+    },
+  );
+  if (error) throw new Error(error.message);
+
+  revalidatePath(`/projects/${projectId}/reviews/llm-insights`);
+  revalidatePath(`/projects/${projectId}/analyze/compare`);
+}
+
 // Removes a single equivalence pair. Also clears the current reviewer's
 // verdict for the affected (doc, field), since the previously chosen
 // gabarito no longer represents a fused group — forcing a fresh vote.

--- a/frontend/src/actions/equivalences.ts
+++ b/frontend/src/actions/equivalences.ts
@@ -132,6 +132,7 @@ export async function markLlmEquivalent(
 
   revalidatePath(`/projects/${projectId}/reviews/llm-insights`);
   revalidatePath(`/projects/${projectId}/analyze/compare`);
+  revalidatePath(`/projects/${projectId}/analyze/assignments`);
 }
 
 // Removes a single equivalence pair. Also clears the current reviewer's

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -3,6 +3,7 @@ import { getAuthUser } from "@/lib/auth";
 import { normalizeForComparison } from "@/lib/utils";
 import { LlmInsightsView } from "@/components/stats/LlmInsightsView";
 import { formatAnswer } from "@/lib/reviews/queries";
+import { canonicalPair } from "@/lib/equivalence";
 import type { PydanticField } from "@/lib/types";
 
 export interface LlmError {
@@ -15,6 +16,10 @@ export interface LlmError {
   chosenVerdict: string;
   reviewerComment: string | null;
   resolvedAt: string | null;
+  reviewedAt: string;
+  schemaVersion: string | null;
+  llmResponseId: string;
+  chosenResponseId: string | null;
 }
 
 export default async function LlmInsightsPage({
@@ -32,6 +37,7 @@ export default async function LlmInsightsPage({
     { data: reviews },
     { data: documents },
     { data: errorResolutions },
+    { data: equivalencePairs },
     { data: membership },
   ] = await Promise.all([
     supabase
@@ -41,14 +47,16 @@ export default async function LlmInsightsPage({
       .single(),
     supabase
       .from("responses")
-      .select("id, document_id, answers, justifications, respondent_name")
+      .select(
+        "id, document_id, answers, justifications, respondent_name, schema_version_major, schema_version_minor, schema_version_patch",
+      )
       .eq("project_id", id)
       .eq("respondent_type", "llm")
       .eq("is_current", true),
     supabase
       .from("reviews")
       .select(
-        "document_id, field_name, verdict, chosen_response_id, comment",
+        "document_id, field_name, verdict, chosen_response_id, comment, created_at",
       )
       .eq("project_id", id)
       .not("chosen_response_id", "is", null),
@@ -59,6 +67,10 @@ export default async function LlmInsightsPage({
     supabase
       .from("error_resolutions")
       .select("document_id, field_name, resolved_at")
+      .eq("project_id", id),
+    supabase
+      .from("response_equivalences")
+      .select("document_id, field_name, response_a_id, response_b_id")
       .eq("project_id", id),
     user
       ? supabase
@@ -75,13 +87,8 @@ export default async function LlmInsightsPage({
 
   const allFields = (project?.pydantic_fields || []) as PydanticField[];
 
-  const fields = (project?.pydantic_fields || []) as {
-    name: string;
-    description: string;
-    target?: string;
-  }[];
-
-  const fieldDescMap = new Map(fields.map((f) => [f.name, f.description]));
+  const fieldMap = new Map(allFields.map((f) => [f.name, f]));
+  const fieldDescMap = new Map(allFields.map((f) => [f.name, f.description]));
   const docMap = new Map(
     documents?.map((d) => [d.id, d.title || d.external_id || d.id]) || [],
   );
@@ -94,14 +101,20 @@ export default async function LlmInsightsPage({
       answers: Record<string, unknown>;
       justifications: Record<string, string> | null;
       respondent_name: string | null;
+      schemaVersion: string | null;
     }
   >();
   llmResponses?.forEach((r) => {
+    const v =
+      r.schema_version_major != null && r.schema_version_minor != null && r.schema_version_patch != null
+        ? `${r.schema_version_major}.${r.schema_version_minor}.${r.schema_version_patch}`
+        : null;
     llmByDoc.set(r.document_id, {
       id: r.id,
       answers: r.answers as Record<string, unknown>,
       justifications: r.justifications as Record<string, string> | null,
       respondent_name: r.respondent_name,
+      schemaVersion: v,
     });
   });
 
@@ -113,6 +126,13 @@ export default async function LlmInsightsPage({
     ]) || [],
   );
 
+  // Build equivalence pair set: "docId:fieldName:a|b" (canonical) for direct lookup
+  const equivPairSet = new Set<string>();
+  equivalencePairs?.forEach((p) => {
+    const [a, b] = canonicalPair(p.response_a_id, p.response_b_id);
+    equivPairSet.add(`${p.document_id}:${p.field_name}:${a}|${b}`);
+  });
+
   // Compute LLM errors
   const errors: LlmError[] = [];
   let llmFieldsReviewed = 0;
@@ -120,6 +140,13 @@ export default async function LlmInsightsPage({
   reviews?.forEach((review) => {
     const llmResp = llmByDoc.get(review.document_id);
     if (!llmResp) return;
+
+    const field = fieldMap.get(review.field_name);
+    // Skip fields that are hidden from humans (target=none) or LLM-only.
+    // These shouldn't show up as "errors" since coordenador chose to remove
+    // them from the review surface — past reviews would otherwise leak.
+    if (!field || field.target === "none" || field.target === "llm_only") return;
+
     llmFieldsReviewed++;
     if (review.chosen_response_id !== llmResp.id) {
       const llmAnswer = llmResp.answers?.[review.field_name];
@@ -129,6 +156,14 @@ export default async function LlmInsightsPage({
         normalizeForComparison(review.verdict)
       )
         return;
+
+      // Suppress if LLM response and chosen response were already marked equivalent.
+      if (review.chosen_response_id) {
+        const [a, b] = canonicalPair(llmResp.id, review.chosen_response_id);
+        if (equivPairSet.has(`${review.document_id}:${review.field_name}:${a}|${b}`))
+          return;
+      }
+
       errors.push({
         documentId: review.document_id,
         documentTitle: docMap.get(review.document_id) || review.document_id,
@@ -144,6 +179,10 @@ export default async function LlmInsightsPage({
           errorResolvedMap.get(
             `${review.document_id}:${review.field_name}`,
           ) || null,
+        reviewedAt: review.created_at,
+        schemaVersion: llmResp.schemaVersion,
+        llmResponseId: llmResp.id,
+        chosenResponseId: review.chosen_response_id,
       });
     }
   });
@@ -158,14 +197,17 @@ export default async function LlmInsightsPage({
   const reviewedDocIds = new Set(reviews?.map((r) => r.document_id) || []);
   const unreviewedLlmDocs = [...llmByDoc.keys()].filter((id) => !reviewedDocIds.has(id)).length;
 
+  // Visible fields for the dropdown filter (same criteria as the error suppression).
+  const visibleFields = allFields.filter(
+    (f) => f.target !== "llm_only" && f.target !== "none",
+  );
+
   return (
     <div className="mx-auto max-w-4xl p-6">
       <LlmInsightsView
         projectId={id}
         errors={errors}
-        fields={fields.filter(
-          (f) => f.target !== "llm_only" && f.target !== "none",
-        )}
+        fields={visibleFields}
         allFields={allFields}
         isCoordinator={isCoordinator}
         summary={{ totalLlmDocs, totalErrors, errorRate, unreviewedLlmDocs }}

--- a/frontend/src/components/stats/LlmErrorCard.tsx
+++ b/frontend/src/components/stats/LlmErrorCard.tsx
@@ -12,22 +12,7 @@ import {
   Equal,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-
-interface LlmError {
-  documentId: string;
-  documentTitle: string;
-  fieldName: string;
-  fieldDescription: string;
-  llmAnswer: string;
-  llmJustification: string | null;
-  chosenVerdict: string;
-  reviewerComment: string | null;
-  resolvedAt: string | null;
-  reviewedAt: string;
-  schemaVersion: string | null;
-  llmResponseId: string;
-  chosenResponseId: string | null;
-}
+import type { LlmError } from "@/app/(app)/projects/[id]/reviews/llm-insights/page";
 
 interface LlmErrorCardProps {
   error: LlmError;

--- a/frontend/src/components/stats/LlmErrorCard.tsx
+++ b/frontend/src/components/stats/LlmErrorCard.tsx
@@ -1,17 +1,15 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
-  ChevronDown,
-  ChevronRight,
   CheckCircle2,
   RotateCcw,
   Pencil,
   FileText,
+  Equal,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -25,6 +23,10 @@ interface LlmError {
   chosenVerdict: string;
   reviewerComment: string | null;
   resolvedAt: string | null;
+  reviewedAt: string;
+  schemaVersion: string | null;
+  llmResponseId: string;
+  chosenResponseId: string | null;
 }
 
 interface LlmErrorCardProps {
@@ -35,6 +37,7 @@ interface LlmErrorCardProps {
   onResolve: () => void;
   onReopen: () => void;
   onEditField?: () => void;
+  onMarkEquivalent?: () => void;
 }
 
 function formatVerdictDisplay(verdict: string): string {
@@ -52,6 +55,19 @@ function formatVerdictDisplay(verdict: string): string {
   return verdict;
 }
 
+function formatReviewedAt(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString("pt-BR", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
 export function LlmErrorCard({
   error,
   projectId,
@@ -60,9 +76,8 @@ export function LlmErrorCard({
   onResolve,
   onReopen,
   onEditField,
+  onMarkEquivalent,
 }: LlmErrorCardProps) {
-  const [showJustification, setShowJustification] = useState(false);
-
   return (
     <Card className={cn(error.resolvedAt && "opacity-60")}>
       <CardContent className="space-y-2 pt-4">
@@ -90,6 +105,12 @@ export function LlmErrorCard({
                 {error.fieldDescription}
               </p>
             )}
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground/70">
+              <span>Revisado em {formatReviewedAt(error.reviewedAt)}</span>
+              {error.schemaVersion && (
+                <span>· schema v{error.schemaVersion}</span>
+              )}
+            </div>
           </div>
           {error.resolvedAt && (
             <Badge variant="secondary">Resolvido</Badge>
@@ -110,23 +131,13 @@ export function LlmErrorCard({
         </div>
 
         {error.llmJustification && (
-          <div>
-            <button
-              onClick={() => setShowJustification(!showJustification)}
-              className="text-xs text-muted-foreground hover:text-foreground"
-            >
-              {showJustification ? (
-                <ChevronDown className="inline h-3 w-3" />
-              ) : (
-                <ChevronRight className="inline h-3 w-3" />
-              )}{" "}
-              Justificativa do LLM
-            </button>
-            {showJustification && (
-              <p className="mt-1 text-xs text-muted-foreground whitespace-pre-wrap">
-                {error.llmJustification}
-              </p>
-            )}
+          <div className="rounded-md bg-muted/40 px-3 py-2">
+            <p className="text-xs font-medium text-muted-foreground">
+              Justificativa do LLM:
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground whitespace-pre-wrap">
+              {error.llmJustification}
+            </p>
           </div>
         )}
 
@@ -143,6 +154,17 @@ export function LlmErrorCard({
               <FileText className="h-3.5 w-3.5" />
             </Link>
           </Button>
+          {!error.resolvedAt && onMarkEquivalent && error.chosenResponseId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={isPending}
+              onClick={onMarkEquivalent}
+              title="Marcar respostas como equivalentes"
+            >
+              <Equal className="h-3.5 w-3.5" />
+            </Button>
+          )}
           {error.resolvedAt ? (
             <Button
               variant="ghost"

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -22,6 +22,7 @@ import {
   resolveError,
   reopenError,
 } from "@/actions/stats";
+import { markLlmEquivalent } from "@/actions/equivalences";
 import { toast } from "sonner";
 import type { PydanticField } from "@/lib/types";
 
@@ -35,6 +36,10 @@ interface LlmError {
   chosenVerdict: string;
   reviewerComment: string | null;
   resolvedAt: string | null;
+  reviewedAt: string;
+  schemaVersion: string | null;
+  llmResponseId: string;
+  chosenResponseId: string | null;
 }
 
 interface LlmInsightsViewProps {
@@ -49,6 +54,27 @@ interface LlmInsightsViewProps {
     errorRate: number;
     unreviewedLlmDocs?: number;
   };
+}
+
+type DatePreset = "all" | "24h" | "7d" | "30d";
+type SortBy = "default" | "field" | "document" | "recent";
+
+function presetCutoffMs(preset: DatePreset): number | null {
+  if (preset === "24h") return Date.now() - 24 * 3600_000;
+  if (preset === "7d") return Date.now() - 7 * 24 * 3600_000;
+  if (preset === "30d") return Date.now() - 30 * 24 * 3600_000;
+  return null;
+}
+
+function compareSemverDesc(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return db - da;
+  }
+  return 0;
 }
 
 export function LlmInsightsView({
@@ -67,8 +93,21 @@ export function LlmInsightsView({
   const [errorFieldFilter, setErrorFieldFilter] = useState("all");
   const [errorSearchQuery, setErrorSearchQuery] = useState("");
   const [errorStatusFilter, setErrorStatusFilter] = useState("open");
+  const [errorDateFilter, setErrorDateFilter] = useState<DatePreset>("all");
+  const [errorSinceDate, setErrorSinceDate] = useState("");
+  const [errorVersionFilter, setErrorVersionFilter] = useState("all");
+  const [sortBy, setSortBy] = useState<SortBy>("default");
+
+  const availableVersions = useMemo(() => {
+    const set = new Set<string>();
+    for (const e of errors) if (e.schemaVersion) set.add(e.schemaVersion);
+    return [...set].sort(compareSemverDesc);
+  }, [errors]);
 
   const filteredErrors = useMemo(() => {
+    const sinceMs = errorSinceDate
+      ? new Date(errorSinceDate).getTime()
+      : presetCutoffMs(errorDateFilter);
     return errors.filter((e) => {
       if (errorStatusFilter === "open" && e.resolvedAt) return false;
       if (errorStatusFilter === "resolved" && !e.resolvedAt) return false;
@@ -81,9 +120,42 @@ export function LlmInsightsView({
           .includes(errorSearchQuery.toLowerCase())
       )
         return false;
+      if (sinceMs && new Date(e.reviewedAt).getTime() < sinceMs) return false;
+      if (
+        errorVersionFilter !== "all" &&
+        e.schemaVersion !== errorVersionFilter
+      )
+        return false;
       return true;
     });
-  }, [errors, errorFieldFilter, errorSearchQuery, errorStatusFilter]);
+  }, [
+    errors,
+    errorFieldFilter,
+    errorSearchQuery,
+    errorStatusFilter,
+    errorDateFilter,
+    errorSinceDate,
+    errorVersionFilter,
+  ]);
+
+  const sortedErrors = useMemo(() => {
+    if (sortBy === "default") return filteredErrors;
+    const arr = [...filteredErrors];
+    if (sortBy === "field") {
+      arr.sort((a, b) => {
+        const fa = a.fieldDescription.localeCompare(b.fieldDescription, "pt-BR");
+        if (fa !== 0) return fa;
+        return a.documentTitle.localeCompare(b.documentTitle, "pt-BR");
+      });
+    } else if (sortBy === "document") {
+      arr.sort((a, b) =>
+        a.documentTitle.localeCompare(b.documentTitle, "pt-BR"),
+      );
+    } else if (sortBy === "recent") {
+      arr.sort((a, b) => b.reviewedAt.localeCompare(a.reviewedAt));
+    }
+    return arr;
+  }, [filteredErrors, sortBy]);
 
   const openErrorCount = errors.filter((e) => !e.resolvedAt).length;
 
@@ -108,6 +180,25 @@ export function LlmInsightsView({
       } else {
         toast.success("Erro reaberto");
         router.refresh();
+      }
+    });
+  };
+
+  const handleMarkEquivalent = (e: LlmError) => {
+    if (!e.chosenResponseId) return;
+    startTransition(async () => {
+      try {
+        await markLlmEquivalent(
+          projectId,
+          e.documentId,
+          e.fieldName,
+          e.llmResponseId,
+          e.chosenResponseId!,
+        );
+        toast.success("Respostas marcadas como equivalentes");
+        router.refresh();
+      } catch (err) {
+        toast.error((err as Error).message);
       }
     });
   };
@@ -189,8 +280,64 @@ export function LlmInsightsView({
             <SelectItem value="all">Todos</SelectItem>
           </SelectContent>
         </Select>
+        <Select
+          value={errorDateFilter}
+          onValueChange={(v) => {
+            setErrorDateFilter(v as DatePreset);
+            setErrorSinceDate("");
+          }}
+        >
+          <SelectTrigger className="w-36" title="Data da revisão">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Qualquer data</SelectItem>
+            <SelectItem value="24h">Últimas 24h</SelectItem>
+            <SelectItem value="7d">Últimos 7 dias</SelectItem>
+            <SelectItem value="30d">Últimos 30 dias</SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          type="date"
+          value={errorSinceDate}
+          onChange={(e) => {
+            setErrorSinceDate(e.target.value);
+            if (e.target.value) setErrorDateFilter("all");
+          }}
+          className="w-40"
+          title="Apenas revisões a partir desta data"
+        />
+        {availableVersions.length > 0 && (
+          <Select
+            value={errorVersionFilter}
+            onValueChange={setErrorVersionFilter}
+          >
+            <SelectTrigger className="w-36" title="Versão do schema">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">Todas as versões</SelectItem>
+              {availableVersions.map((v) => (
+                <SelectItem key={v} value={v}>
+                  v{v}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        <Select value={sortBy} onValueChange={(v) => setSortBy(v as SortBy)}>
+          <SelectTrigger className="w-44" title="Ordenar por">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="default">Ordem padrão</SelectItem>
+            <SelectItem value="field">Por pergunta (A→Z)</SelectItem>
+            <SelectItem value="document">Por documento (A→Z)</SelectItem>
+            <SelectItem value="recent">Mais recentes primeiro</SelectItem>
+          </SelectContent>
+        </Select>
         <span className="ml-auto text-sm text-muted-foreground">
-          {filteredErrors.length} erro{filteredErrors.length !== 1 ? "s" : ""}
+          {sortedErrors.length} erro{sortedErrors.length !== 1 ? "s" : ""}
           {openErrorCount > 0 && (
             <Badge variant="destructive" className="ml-1.5">
               {openErrorCount} aberto{openErrorCount !== 1 ? "s" : ""}
@@ -199,7 +346,7 @@ export function LlmInsightsView({
         </span>
       </div>
 
-      {filteredErrors.length === 0 ? (
+      {sortedErrors.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">
           {errors.length === 0
             ? "Nenhum erro do LLM encontrado."
@@ -207,7 +354,7 @@ export function LlmInsightsView({
         </p>
       ) : (
         <div className="space-y-3">
-          {filteredErrors.map((e, i) => (
+          {sortedErrors.map((e, i) => (
             <LlmErrorCard
               key={`${e.documentId}-${e.fieldName}-${i}`}
               error={e}
@@ -217,6 +364,7 @@ export function LlmInsightsView({
               onResolve={() => handleResolveError(e.documentId, e.fieldName)}
               onReopen={() => handleReopenError(e.documentId, e.fieldName)}
               onEditField={() => setEditingField(e.fieldName)}
+              onMarkEquivalent={() => handleMarkEquivalent(e)}
             />
           ))}
         </div>

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useTransition } from "react";
+import { useState, useMemo, useTransition, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -25,22 +25,7 @@ import {
 import { markLlmEquivalent } from "@/actions/equivalences";
 import { toast } from "sonner";
 import type { PydanticField } from "@/lib/types";
-
-interface LlmError {
-  documentId: string;
-  documentTitle: string;
-  fieldName: string;
-  fieldDescription: string;
-  llmAnswer: string;
-  llmJustification: string | null;
-  chosenVerdict: string;
-  reviewerComment: string | null;
-  resolvedAt: string | null;
-  reviewedAt: string;
-  schemaVersion: string | null;
-  llmResponseId: string;
-  chosenResponseId: string | null;
-}
+import type { LlmError } from "@/app/(app)/projects/[id]/reviews/llm-insights/page";
 
 interface LlmInsightsViewProps {
   projectId: string;
@@ -59,10 +44,10 @@ interface LlmInsightsViewProps {
 type DatePreset = "all" | "24h" | "7d" | "30d";
 type SortBy = "default" | "field" | "document" | "recent";
 
-function presetCutoffMs(preset: DatePreset): number | null {
-  if (preset === "24h") return Date.now() - 24 * 3600_000;
-  if (preset === "7d") return Date.now() - 7 * 24 * 3600_000;
-  if (preset === "30d") return Date.now() - 30 * 24 * 3600_000;
+function presetCutoffMs(preset: DatePreset, now: number): number | null {
+  if (preset === "24h") return now - 24 * 3600_000;
+  if (preset === "7d") return now - 7 * 24 * 3600_000;
+  if (preset === "30d") return now - 30 * 24 * 3600_000;
   return null;
 }
 
@@ -98,47 +83,55 @@ export function LlmInsightsView({
   const [errorVersionFilter, setErrorVersionFilter] = useState("all");
   const [sortBy, setSortBy] = useState<SortBy>("default");
 
+  // Tick the "now" reference once a minute so the "Últimas 24h/7d/30d"
+  // cutoff doesn't freeze on long-open pages. State (rather than a raw
+  // Date.now() in render) keeps the component pure per React rules.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
   const availableVersions = useMemo(() => {
     const set = new Set<string>();
     for (const e of errors) if (e.schemaVersion) set.add(e.schemaVersion);
     return [...set].sort(compareSemverDesc);
   }, [errors]);
 
-  const filteredErrors = useMemo(() => {
-    const sinceMs = errorSinceDate
-      ? new Date(errorSinceDate).getTime()
-      : presetCutoffMs(errorDateFilter);
-    return errors.filter((e) => {
-      if (errorStatusFilter === "open" && e.resolvedAt) return false;
-      if (errorStatusFilter === "resolved" && !e.resolvedAt) return false;
-      if (errorFieldFilter !== "all" && e.fieldName !== errorFieldFilter)
-        return false;
-      if (
-        errorSearchQuery &&
-        !e.documentTitle
-          .toLowerCase()
-          .includes(errorSearchQuery.toLowerCase())
-      )
-        return false;
-      if (sinceMs && new Date(e.reviewedAt).getTime() < sinceMs) return false;
-      if (
-        errorVersionFilter !== "all" &&
-        e.schemaVersion !== errorVersionFilter
-      )
-        return false;
-      return true;
-    });
-  }, [
-    errors,
-    errorFieldFilter,
-    errorSearchQuery,
-    errorStatusFilter,
-    errorDateFilter,
-    errorSinceDate,
-    errorVersionFilter,
-  ]);
+  // Derive the effective version filter: if the selected version is no
+  // longer present (status filter toggled, all errors of that version
+  // resolved, etc.) treat it as "all" instead of letting the stale value
+  // zero out the list with no UI to fix it. Derivation in render avoids
+  // a setState-in-effect cascade.
+  const effectiveVersionFilter = availableVersions.includes(errorVersionFilter)
+    ? errorVersionFilter
+    : "all";
 
-  const sortedErrors = useMemo(() => {
+  const sinceMs = errorSinceDate
+    ? new Date(errorSinceDate + "T00:00:00").getTime()
+    : presetCutoffMs(errorDateFilter, now);
+  const filteredErrors = errors.filter((e) => {
+    if (errorStatusFilter === "open" && e.resolvedAt) return false;
+    if (errorStatusFilter === "resolved" && !e.resolvedAt) return false;
+    if (errorFieldFilter !== "all" && e.fieldName !== errorFieldFilter)
+      return false;
+    if (
+      errorSearchQuery &&
+      !e.documentTitle
+        .toLowerCase()
+        .includes(errorSearchQuery.toLowerCase())
+    )
+      return false;
+    if (sinceMs && new Date(e.reviewedAt).getTime() < sinceMs) return false;
+    if (
+      effectiveVersionFilter !== "all" &&
+      e.schemaVersion !== effectiveVersionFilter
+    )
+      return false;
+    return true;
+  });
+
+  const sortedErrors = (() => {
     if (sortBy === "default") return filteredErrors;
     const arr = [...filteredErrors];
     if (sortBy === "field") {
@@ -155,7 +148,7 @@ export function LlmInsightsView({
       arr.sort((a, b) => b.reviewedAt.localeCompare(a.reviewedAt));
     }
     return arr;
-  }, [filteredErrors, sortBy]);
+  })();
 
   const openErrorCount = errors.filter((e) => !e.resolvedAt).length;
 
@@ -287,7 +280,7 @@ export function LlmInsightsView({
             setErrorSinceDate("");
           }}
         >
-          <SelectTrigger className="w-36" title="Data da revisão">
+          <SelectTrigger className="w-36" title="Data de criação da revisão">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
@@ -305,11 +298,11 @@ export function LlmInsightsView({
             if (e.target.value) setErrorDateFilter("all");
           }}
           className="w-40"
-          title="Apenas revisões a partir desta data"
+          title="Apenas revisões criadas a partir desta data"
         />
         {availableVersions.length > 0 && (
           <Select
-            value={errorVersionFilter}
+            value={effectiveVersionFilter}
             onValueChange={setErrorVersionFilter}
           >
             <SelectTrigger className="w-36" title="Versão do schema">

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -95,7 +95,20 @@ export function isAnswerCorrect(
 export function formatAnswer(val: unknown): string {
   if (val == null) return "";
   if (typeof val === "string") return val;
-  if (Array.isArray(val)) return val.join(", ");
+  if (typeof val === "number" || typeof val === "boolean") return String(val);
+  if (Array.isArray(val)) {
+    return val
+      .map((v) => formatAnswer(v))
+      .filter((s) => s !== "")
+      .join(", ");
+  }
+  if (typeof val === "object") {
+    const obj = val as Record<string, unknown>;
+    const parts = Object.entries(obj)
+      .filter(([, v]) => v != null && v !== "")
+      .map(([k, v]) => `${k}: ${formatAnswer(v)}`);
+    return parts.join("; ");
+  }
   return String(val);
 }
 


### PR DESCRIPTION
## Summary

Melhorias na aba **Erros LLM** (`reviews/llm-insights`):

- **`[object Object]` corrigido**: `formatAnswer` agora serializa objetos aninhados (subfields/structured outputs) de forma legível (`tipo: monocratica; relator: nome: X; uf: SP`).
- **Justificativa do LLM visível por padrão**: removido o toggle, justificativa aparece direto em um bloco destacado.
- **Perguntas ocultas somem da lista**: campos com `target=none` ou `target=llm_only` deixam de gerar erros mesmo se há revisões históricas — antes eram filtradas só do dropdown, agora também do dataset.
- **Filtro por data da revisão**: dropdown com presets (24h, 7 dias, 30 dias) + input "desde" customizado.
- **Filtro por versão do schema**: dropdown lista as versões `MAJOR.MINOR.PATCH` presentes nas respostas LLM.
- **Ordenação**: por pergunta (A→Z), por documento (A→Z) ou mais recentes primeiro, além da ordem padrão.
- **Marcar equivalentes em 1-clique**: botão `Equal` no card cria um par em `response_equivalences` sem mexer no veredito existente. O erro some da lista (LLM ↔ chosen viram um grupo equivalente) e a equivalência também aparece na aba Compare.

## Test plan

- [ ] Build (`npm run build`) passa
- [ ] Card que antes mostrava `[object Object]` agora mostra os subfields formatados
- [ ] Justificativa aparece imediatamente em todo card que tem `llmJustification`
- [ ] Mudar `target` de uma pergunta para `none` ou `llm_only` faz seus erros sumirem da aba
- [ ] Filtro "Últimos 7 dias" e "Desde 2026-04-15" funcionam isoladamente
- [ ] Filtro de versão lista versões reais e filtra
- [ ] Cada opção de ordenação reordena visualmente os cards
- [ ] Clicar no botão `Equal` faz o erro sumir e cria a equivalência (verificar na aba Compare e em `response_equivalences`)
- [ ] Erros já com par equivalente em `response_equivalences` não aparecem mais na aba

🤖 Generated with [Claude Code](https://claude.com/claude-code)