### PR TITLE
fix(llm-insights): contadores respeitam filtros aplicados

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -22,6 +22,18 @@ export interface LlmError {
   chosenResponseId: string | null;
 }
 
+// Every reviewed (doc, field) pair the LLM also answered, after applying the
+// same hidden/equivalent/same-content suppressions used to build `errors`.
+// Used client-side as the denominator so the error rate respects active filters.
+export interface ReviewedEntry {
+  documentId: string;
+  documentTitle: string;
+  fieldName: string;
+  schemaVersion: string | null;
+  reviewedAt: string;
+  isError: boolean;
+}
+
 export default async function LlmInsightsPage({
   params,
 }: {
@@ -133,9 +145,11 @@ export default async function LlmInsightsPage({
     equivPairSet.add(`${p.document_id}:${p.field_name}:${a}|${b}`);
   });
 
-  // Compute LLM errors
+  // Compute LLM errors and the parallel list of every reviewed (doc, field)
+  // entry that survived the same suppressions. The client uses
+  // `reviewedEntries` as the denominator so the rate matches the filtered card.
   const errors: LlmError[] = [];
-  let llmFieldsReviewed = 0;
+  const reviewedEntries: ReviewedEntry[] = [];
 
   reviews?.forEach((review) => {
     const llmResp = llmByDoc.get(review.document_id);
@@ -147,52 +161,57 @@ export default async function LlmInsightsPage({
     // them from the review surface — past reviews would otherwise leak.
     if (!field || field.target === "none" || field.target === "llm_only") return;
 
-    llmFieldsReviewed++;
+    let isError = false;
     if (review.chosen_response_id !== llmResp.id) {
       const llmAnswer = llmResp.answers?.[review.field_name];
-      // Skip if the LLM answer matches the chosen verdict (same content, different responder)
-      if (
+      const sameContent =
         normalizeForComparison(llmAnswer) ===
-        normalizeForComparison(review.verdict)
-      )
-        return;
+        normalizeForComparison(review.verdict);
 
-      // Suppress if LLM response and chosen response were already marked equivalent.
+      let markedEquivalent = false;
       if (review.chosen_response_id) {
         const [a, b] = canonicalPair(llmResp.id, review.chosen_response_id);
-        if (equivPairSet.has(`${review.document_id}:${review.field_name}:${a}|${b}`))
-          return;
+        markedEquivalent = equivPairSet.has(
+          `${review.document_id}:${review.field_name}:${a}|${b}`,
+        );
       }
 
-      errors.push({
-        documentId: review.document_id,
-        documentTitle: docMap.get(review.document_id) || review.document_id,
-        fieldName: review.field_name,
-        fieldDescription:
-          fieldDescMap.get(review.field_name) || review.field_name,
-        llmAnswer: formatAnswer(llmAnswer),
-        llmJustification:
-          llmResp.justifications?.[review.field_name] || null,
-        chosenVerdict: review.verdict,
-        reviewerComment: review.comment,
-        resolvedAt:
-          errorResolvedMap.get(
-            `${review.document_id}:${review.field_name}`,
-          ) || null,
-        reviewedAt: review.created_at,
-        schemaVersion: llmResp.schemaVersion,
-        llmResponseId: llmResp.id,
-        chosenResponseId: review.chosen_response_id,
-      });
+      if (!sameContent && !markedEquivalent) {
+        isError = true;
+        errors.push({
+          documentId: review.document_id,
+          documentTitle: docMap.get(review.document_id) || review.document_id,
+          fieldName: review.field_name,
+          fieldDescription:
+            fieldDescMap.get(review.field_name) || review.field_name,
+          llmAnswer: formatAnswer(llmAnswer),
+          llmJustification:
+            llmResp.justifications?.[review.field_name] || null,
+          chosenVerdict: review.verdict,
+          reviewerComment: review.comment,
+          resolvedAt:
+            errorResolvedMap.get(
+              `${review.document_id}:${review.field_name}`,
+            ) || null,
+          reviewedAt: review.created_at,
+          schemaVersion: llmResp.schemaVersion,
+          llmResponseId: llmResp.id,
+          chosenResponseId: review.chosen_response_id,
+        });
+      }
     }
+
+    reviewedEntries.push({
+      documentId: review.document_id,
+      documentTitle: docMap.get(review.document_id) || review.document_id,
+      fieldName: review.field_name,
+      schemaVersion: llmResp.schemaVersion,
+      reviewedAt: review.created_at,
+      isError,
+    });
   });
 
   const totalLlmDocs = llmByDoc.size;
-  const totalErrors = errors.length;
-  const errorRate =
-    llmFieldsReviewed > 0
-      ? Math.round((totalErrors / llmFieldsReviewed) * 100)
-      : 0;
 
   const reviewedDocIds = new Set(reviews?.map((r) => r.document_id) || []);
   const unreviewedLlmDocs = [...llmByDoc.keys()].filter((id) => !reviewedDocIds.has(id)).length;
@@ -207,10 +226,11 @@ export default async function LlmInsightsPage({
       <LlmInsightsView
         projectId={id}
         errors={errors}
+        reviewedEntries={reviewedEntries}
         fields={visibleFields}
         allFields={allFields}
         isCoordinator={isCoordinator}
-        summary={{ totalLlmDocs, totalErrors, errorRate, unreviewedLlmDocs }}
+        summary={{ totalLlmDocs, unreviewedLlmDocs }}
       />
     </div>
   );

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -25,18 +25,20 @@ import {
 import { markLlmEquivalent } from "@/actions/equivalences";
 import { toast } from "sonner";
 import type { PydanticField } from "@/lib/types";
-import type { LlmError } from "@/app/(app)/projects/[id]/reviews/llm-insights/page";
+import type {
+  LlmError,
+  ReviewedEntry,
+} from "@/app/(app)/projects/[id]/reviews/llm-insights/page";
 
 interface LlmInsightsViewProps {
   projectId: string;
   errors: LlmError[];
+  reviewedEntries: ReviewedEntry[];
   fields: { name: string; description: string }[];
   allFields?: PydanticField[];
   isCoordinator?: boolean;
   summary: {
     totalLlmDocs: number;
-    totalErrors: number;
-    errorRate: number;
     unreviewedLlmDocs?: number;
   };
 }
@@ -65,6 +67,7 @@ function compareSemverDesc(a: string, b: string): number {
 export function LlmInsightsView({
   projectId,
   errors,
+  reviewedEntries,
   fields,
   allFields,
   isCoordinator,
@@ -92,11 +95,13 @@ export function LlmInsightsView({
     return () => clearInterval(id);
   }, []);
 
+  // Derived from the full reviewed population so a version with 0 errors is
+  // still selectable — useful for "0% rate" sanity checks.
   const availableVersions = useMemo(() => {
     const set = new Set<string>();
-    for (const e of errors) if (e.schemaVersion) set.add(e.schemaVersion);
+    for (const r of reviewedEntries) if (r.schemaVersion) set.add(r.schemaVersion);
     return [...set].sort(compareSemverDesc);
-  }, [errors]);
+  }, [reviewedEntries]);
 
   // Derive the effective version filter: if the selected version is no
   // longer present (status filter toggled, all errors of that version
@@ -110,9 +115,16 @@ export function LlmInsightsView({
   const sinceMs = errorSinceDate
     ? new Date(errorSinceDate + "T00:00:00").getTime()
     : presetCutoffMs(errorDateFilter, now);
-  const filteredErrors = errors.filter((e) => {
-    if (errorStatusFilter === "open" && e.resolvedAt) return false;
-    if (errorStatusFilter === "resolved" && !e.resolvedAt) return false;
+
+  // Scope filters affect both numerator and denominator (so the rate matches
+  // the population the user is looking at). Status only affects which errors
+  // the user wants to see in the list and in the card.
+  const matchesScopeFilters = (e: {
+    fieldName: string;
+    documentTitle: string;
+    reviewedAt: string;
+    schemaVersion: string | null;
+  }): boolean => {
     if (errorFieldFilter !== "all" && e.fieldName !== errorFieldFilter)
       return false;
     if (
@@ -129,7 +141,22 @@ export function LlmInsightsView({
     )
       return false;
     return true;
+  };
+
+  const filteredReviewed = reviewedEntries.filter(matchesScopeFilters);
+
+  const filteredErrors = errors.filter((e) => {
+    if (errorStatusFilter === "open" && e.resolvedAt) return false;
+    if (errorStatusFilter === "resolved" && !e.resolvedAt) return false;
+    return matchesScopeFilters(e);
   });
+
+  // Rate uses the same numerator shown in the card (so the two are always
+  // consistent) over the scope-filtered reviewed population.
+  const filteredErrorRate =
+    filteredReviewed.length > 0
+      ? Math.round((filteredErrors.length / filteredReviewed.length) * 100)
+      : 0;
 
   const sortedErrors = (() => {
     if (sortBy === "default") return filteredErrors;
@@ -150,7 +177,10 @@ export function LlmInsightsView({
     return arr;
   })();
 
-  const openErrorCount = errors.filter((e) => !e.resolvedAt).length;
+  // Counted within the current scope so the badge matches the cards.
+  const openErrorCount = errors.filter(
+    (e) => !e.resolvedAt && matchesScopeFilters(e),
+  ).length;
 
   // Error handlers
   const handleResolveError = (documentId: string, fieldName: string) => {
@@ -218,7 +248,7 @@ export function LlmInsightsView({
             <AlertTriangle className="h-5 w-5 text-red-500" />
             <div>
               <p className="text-2xl font-bold tabular-nums">
-                {summary.totalErrors}
+                {filteredErrors.length}
               </p>
               <p className="text-xs text-muted-foreground">
                 Campos incorretos
@@ -229,7 +259,7 @@ export function LlmInsightsView({
         <Card>
           <CardContent className="pt-6 text-center">
             <p className="text-2xl font-bold tabular-nums">
-              {summary.errorRate}%
+              {filteredErrorRate}%
             </p>
             <p className="text-xs text-muted-foreground">Taxa de erro</p>
           </CardContent>


### PR DESCRIPTION
## Summary

- Card **Campos incorretos** e **Taxa de erro** agora reagem aos filtros (data, versão, status, campo, busca). Antes mostravam o total bruto enquanto a lista filtrava — números incoerentes.
- Servidor envia `reviewedEntries[]` (toda revisão válida do LLM, com `isError`) além de `errors[]`. Cliente filtra a mesma população com os mesmos critérios para calcular numerador e denominador da taxa.
- Filtros de **scope** (campo/data/versão/busca) reduzem numerador e denominador; **status** reduz apenas o numerador (caso contrário "ver só resolvidos" daria 100% sempre).
- Dropdown de versão agora lista todas as versões revisadas, não só as que tiveram erros — útil para sanidade de "0% de erro nessa versão".

### Nota operacional fora do diff

A migration `20260504000000_response_equivalences.sql` (PR #75) **não havia rodado em produção** por causa de um clash de timestamps com `20260504000000_schema_change_log_composite_index.sql` (PR #76) — o registro em `supabase_migrations.schema_migrations` ficou apontando para o SQL do composite_index. Por isso a página estava 500 (`Could not find table 'public.response_equivalences' in schema cache`). Já apliquei o `CREATE TABLE` direto no remoto e dei `NOTIFY pgrst, 'reload schema'`. A tabela existe agora com índices, RLS e policies conforme o arquivo da migration.

## Test plan

- [ ] Abrir `/projects/<id>/reviews/llm-insights` e verificar que carrega sem 500
- [ ] Filtrar por versão → card "Campos incorretos" e "Taxa de erro" mudam
- [ ] Filtrar por data (24h/7d/30d/desde) → card e taxa mudam
- [ ] Filtrar por campo → card, taxa e dropdown de versão refletem só esse campo
- [ ] Trocar status entre Abertos/Resolvidos/Todos → card muda; denominador da taxa permanece o mesmo
- [ ] Buscar documento → card e taxa filtram pelo título
- [ ] Abrir `/projects/<id>/analyze/compare` e marcar dois respostas como equivalentes — confirmar que insere em `response_equivalences` sem erro

🤖 Generated with [Claude Code](https://claude.com/claude-code)