### PR TITLE
fix(schema): respostas LLM sobrevivem ao schema bump (#85)

### DIFF
--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -30,13 +30,6 @@ export async function saveSchema(
   const supabase = await createSupabaseServer();
   const hash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
 
-  // Fetch previous schema (hash + fields with per-field hashes)
-  const { data: project } = await supabase
-    .from("projects")
-    .select("pydantic_hash, pydantic_fields")
-    .eq("id", projectId)
-    .single();
-
   const updatePayload: Record<string, unknown> = {
     pydantic_code: code,
     pydantic_hash: hash,
@@ -55,18 +48,10 @@ export async function saveSchema(
 
   if (error) throw new Error(error.message);
 
-  // Invalidate old LLM responses if hash changed
-  if (project?.pydantic_hash && project.pydantic_hash !== hash) {
-    await supabase
-      .from("responses")
-      .update({ is_current: false })
-      .eq("project_id", projectId)
-      .eq("respondent_type", "llm")
-      .neq("pydantic_hash", hash);
-  }
-
-  // Human answers are no longer deleted when fields change.
-  // Staleness is detected at display time via answer_field_hashes.
+  // is_current não é flipado para false aqui — staleness é detectada no
+  // display via answer_field_hashes (lib/reviews/queries.ts:isFieldStale).
+  // Caso contrário, ajustar schema durante uma revisão de erros LLM apaga as
+  // respostas antigas e perde o contexto da investigação. Ver #85.
 
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/analyze/compare`);

--- a/frontend/supabase/migrations/20260505000001_revive_orphan_llm_responses.sql
+++ b/frontend/supabase/migrations/20260505000001_revive_orphan_llm_responses.sql
@@ -1,0 +1,30 @@
+-- Backfill: revive respostas LLM zeradas por schema bumps anteriores.
+--
+-- Contexto: até o commit que removeu o flip em saveSchema (PR #87), editar o
+-- schema Pydantic disparava UPDATE responses SET is_current=false sempre que
+-- o pydantic_hash do projeto mudava. Como LLM Insights, Compare e várias
+-- outras telas filtram por is_current=true, todas as respostas LLM somem da
+-- UI até uma nova run rodar — destruindo o contexto da revisão de erros que
+-- motivou a edição do schema (caso real: projeto Zolgensma, 67 respostas).
+--
+-- Esta migration ressuscita apenas as respostas onde a "mais recente
+-- não-parcial" por (project_id, document_id) está com is_current=false.
+-- Quando há uma resposta is_current=true mais nova ela vence o DISTINCT ON e
+-- o filtro nada faz — supersede legítimo (llm_runner.py:766) é preservado.
+-- Respostas com is_partial=true não são tocadas: is_current=false é o estado
+-- intencional para parciais (llm_runner.py:932-936).
+--
+-- Idempotente: rodar novamente é no-op.
+
+UPDATE responses
+SET is_current = true
+WHERE id IN (
+  SELECT DISTINCT ON (project_id, document_id) id
+  FROM responses
+  WHERE respondent_type = 'llm'
+    AND is_partial = false
+  ORDER BY project_id, document_id, created_at DESC
+)
+AND is_current = false
+AND is_partial = false
+AND respondent_type = 'llm';


### PR DESCRIPTION
## Summary

- Remove o \`UPDATE responses SET is_current=false\` em \`saveSchema\` que disparava sempre que o \`pydantic_hash\` mudava.
- Respostas LLM agora seguem a mesma política das humanas: \`is_current\` permanece \`true\` mesmo quando o schema é editado; staleness é detectada no display via \`answer_field_hashes\` (ver \`isFieldStale\` em \`lib/reviews/queries.ts:54-67\`).
- O sinal \"superseded\" continua íntegro: \`backend/services/llm_runner.py:766\` ainda flipa \`is_current=false\` quando uma nova run LLM roda nos mesmos documentos.

## Por quê

Hoje (2026-05-04 → 05-05), revisando erros LLM no projeto Zolgensma: schema foi de \`0.14.1\` → \`0.14.2\` no meio da revisão (provavelmente para reformular alguma pergunta), e isso virou todas as 67 respostas LLM \`is_current=false\`. \`/reviews/llm-insights\` ficou vazio. Voltar ao estado anterior exigia rodar nova run LLM — que pode produzir respostas diferentes, perdendo a investigação.

Detalhe completo + mapeamento dos usos de \`is_current\` em #85.

## Test plan

- [x] \`tsc --noEmit\` passa
- [ ] Editar um field do schema em um projeto com respostas LLM existentes; conferir que \`/reviews/llm-insights\` continua mostrando os erros após o save
- [ ] Rodar nova run LLM no mesmo projeto; conferir que as respostas anteriores viram \`is_current=false\` (comportamento de superseded preservado)
- [ ] Conferir que \`Compare\` segue mostrando staleness por field via \`answer_field_hashes\` (já era o caso para humanos; agora vale também para LLM)

## Follow-up

- #86 — rename \`responses.is_current\` → \`is_latest\` para deixar a semântica explícita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)