### PR TITLE
fix(upload): evita FUNCTION_PAYLOAD_TOO_LARGE no upload de documentos

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "react-resizable-panels": "^4.7.3",
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
+        "spark-md5": "^3.0.2",
         "svix": "^1.89.0",
         "tailwind-merge": "^3.5.0",
         "xlsx": "^0.18.5"
@@ -40,6 +41,7 @@
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/spark-md5": "^3.0.5",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
         "shadcn": "^3.8.5",
@@ -4637,6 +4639,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/spark-md5": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.5.tgz",
+      "integrity": "sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
@@ -12951,6 +12960,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/ssf": {
       "version": "0.11.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-resizable-panels": "^4.7.3",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
+    "spark-md5": "^3.0.2",
     "svix": "^1.89.0",
     "tailwind-merge": "^3.5.0",
     "xlsx": "^0.18.5"
@@ -46,6 +47,7 @@
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/spark-md5": "^3.0.5",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
     "shadcn": "^3.8.5",

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -26,15 +26,17 @@ export interface DuplicateMatch {
 
 export async function checkDuplicates(
   projectId: string,
-  documents: { external_id?: string; text: string }[]
+  documents: { external_id?: string; text_hash: string; csvIndex?: number }[]
 ): Promise<{
   duplicates: DuplicateMatch[];
   duplicatesWithResponses: number;
 }> {
   const supabase = await createSupabaseServer();
 
-  // Compute hashes for all incoming docs
-  const hashes = documents.map((d) => md5(d.text));
+  // Hash is computed client-side to keep payload small (Vercel ~4.5MB limit).
+  // csvIndex maps back to the full CSV array when caller chunks the check.
+  const hashes = documents.map((d) => d.text_hash);
+  const indexFor = (i: number) => documents[i].csvIndex ?? i;
 
   // Collect external_ids that are present
   const externalIds = documents
@@ -61,7 +63,7 @@ export async function checkDuplicates(
         const existingId = extIdMap.get(id!);
         if (existingId) {
           duplicates.push({
-            csvIndex: index,
+            csvIndex: indexFor(index),
             existingDocId: existingId,
             matchType: "external_id",
           });
@@ -90,7 +92,7 @@ export async function checkDuplicates(
         const existingId = hashMap.get(hash);
         if (existingId) {
           duplicates.push({
-            csvIndex: index,
+            csvIndex: indexFor(index),
             existingDocId: existingId,
             matchType: "text_hash",
           });

--- a/frontend/src/components/documents/DocumentUpload.tsx
+++ b/frontend/src/components/documents/DocumentUpload.tsx
@@ -12,6 +12,7 @@ import {
 import { DuplicateAnalysis } from "./DuplicateAnalysis";
 import { toast } from "sonner";
 import Papa from "papaparse";
+import { md5 } from "@/lib/hash";
 
 interface DocumentUploadProps {
   projectId: string;
@@ -24,6 +25,44 @@ interface AnalysisResult {
   duplicates: DuplicateMatch[];
   duplicatesWithResponses: number;
   matchType: string;
+}
+
+// Vercel Server Actions reject payloads above ~4.5 MB (FUNCTION_PAYLOAD_TOO_LARGE).
+// Pack docs by aggregate text size to stay safely under that, with a count cap to avoid latency spikes.
+const MAX_CHUNK_BYTES = 3_500_000;
+const MAX_DOCS_PER_CHUNK = 500;
+const MAX_HASH_DOCS_PER_CHUNK = 5_000;
+
+interface UploadDoc {
+  text: string;
+  title?: string;
+  external_id?: string;
+}
+
+function chunkByBytes(
+  docs: UploadDoc[]
+): { items: UploadDoc[]; startIndex: number }[] {
+  const chunks: { items: UploadDoc[]; startIndex: number }[] = [];
+  let current: UploadDoc[] = [];
+  let currentBytes = 0;
+  let startIndex = 0;
+  for (let i = 0; i < docs.length; i++) {
+    const itemBytes = docs[i].text.length;
+    if (
+      current.length > 0 &&
+      (currentBytes + itemBytes > MAX_CHUNK_BYTES ||
+        current.length >= MAX_DOCS_PER_CHUNK)
+    ) {
+      chunks.push({ items: current, startIndex });
+      current = [];
+      currentBytes = 0;
+      startIndex = i;
+    }
+    current.push(docs[i]);
+    currentBytes += itemBytes;
+  }
+  if (current.length > 0) chunks.push({ items: current, startIndex });
+  return chunks;
 }
 
 export function DocumentUpload({ projectId }: DocumentUploadProps) {
@@ -73,25 +112,42 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
       }));
   };
 
-  const doUpload = async (docs: { text: string; title?: string; external_id?: string }[], options?: UploadOptions) => {
+  const doUpload = async (docs: UploadDoc[], options?: UploadOptions) => {
     setStep("uploading");
     setLoading(true);
     setProgress({ current: 0, total: docs.length });
 
     try {
-      const chunkSize = 100;
-      for (let i = 0; i < docs.length; i += chunkSize) {
-        const chunk = docs.slice(i, i + chunkSize);
-        const isLast = i + chunkSize >= docs.length;
-        // Pass options only on first chunk (duplicateMap indices refer to full array)
+      const chunks = chunkByBytes(docs);
+      let processed = 0;
+      for (let ci = 0; ci < chunks.length; ci++) {
+        const { items, startIndex } = chunks[ci];
+        const endIndex = startIndex + items.length;
+        const isLast = ci === chunks.length - 1;
+
+        // Localize duplicateMap indices to the chunk so uploadDocuments can index
+        // into `items` directly (csvIndex must be relative to the array sent).
+        const localOptions: UploadOptions | undefined = options
+          ? {
+              mode: options.mode,
+              deleteResponses: options.deleteResponses,
+              duplicateMap: options.duplicateMap
+                ?.filter(
+                  (d) => d.csvIndex >= startIndex && d.csvIndex < endIndex
+                )
+                .map((d) => ({ ...d, csvIndex: d.csvIndex - startIndex })),
+            }
+          : undefined;
+
         const result = await uploadDocuments(
           projectId,
-          chunk,
+          items,
           isLast,
-          i === 0 ? options : { mode: options?.mode ?? "add_all" }
+          localOptions
         );
         if (result.error) throw new Error(result.error);
-        setProgress({ current: Math.min(i + chunkSize, docs.length), total: docs.length });
+        processed += items.length;
+        setProgress({ current: processed, total: docs.length });
       }
       toast.success(`${docs.length} documentos importados!`);
       setParsedData(null);
@@ -99,8 +155,14 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
       setAnalysis(null);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "";
-      if (msg.includes("Body exceeded") || msg.includes("413")) {
-        toast.error("Os documentos ultrapassam o limite de 10 MB por envio. Tente importar um arquivo com menos documentos ou documentos menores.");
+      if (
+        msg.includes("Body exceeded") ||
+        msg.includes("413") ||
+        msg.includes("FUNCTION_PAYLOAD_TOO_LARGE")
+      ) {
+        toast.error(
+          "O envio excedeu o limite do servidor. Tente importar menos documentos por vez ou divida o CSV em partes menores."
+        );
       } else {
         toast.error(msg || "Erro ao importar documentos");
       }
@@ -122,23 +184,38 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
     setLoading(true);
 
     try {
-      const result = await checkDuplicates(
-        projectId,
-        docs.map((d) => ({ external_id: d.external_id, text: d.text }))
-      );
+      // Hash client-side so the request payload stays small (Vercel ~4.5MB limit).
+      const docsWithHash = docs.map((d, i) => ({
+        external_id: d.external_id,
+        text_hash: md5(d.text),
+        csvIndex: i,
+      }));
 
-      if (result.duplicates.length === 0) {
+      const allDuplicates: DuplicateMatch[] = [];
+      let duplicatesWithResponses = 0;
+      for (
+        let i = 0;
+        i < docsWithHash.length;
+        i += MAX_HASH_DOCS_PER_CHUNK
+      ) {
+        const chunk = docsWithHash.slice(i, i + MAX_HASH_DOCS_PER_CHUNK);
+        const r = await checkDuplicates(projectId, chunk);
+        allDuplicates.push(...r.duplicates);
+        duplicatesWithResponses += r.duplicatesWithResponses;
+      }
+
+      if (allDuplicates.length === 0) {
         // No duplicates — upload directly
         await doUpload(docs);
       } else {
         // Has duplicates — show analysis panel
-        const hasExternalIdMatch = result.duplicates.some(
+        const hasExternalIdMatch = allDuplicates.some(
           (d) => d.matchType === "external_id"
         );
         setAnalysis({
           docs,
-          duplicates: result.duplicates,
-          duplicatesWithResponses: result.duplicatesWithResponses,
+          duplicates: allDuplicates,
+          duplicatesWithResponses,
           matchType: hasExternalIdMatch ? "ID externo" : "conteúdo (hash)",
         });
         setStep("analysis");
@@ -146,8 +223,14 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "";
-      if (msg.includes("Body exceeded") || msg.includes("413")) {
-        toast.error("Os documentos ultrapassam o limite de 10 MB por envio. Tente importar um arquivo com menos documentos ou documentos menores.");
+      if (
+        msg.includes("Body exceeded") ||
+        msg.includes("413") ||
+        msg.includes("FUNCTION_PAYLOAD_TOO_LARGE")
+      ) {
+        toast.error(
+          "O envio excedeu o limite do servidor. Tente importar menos documentos por vez ou divida o CSV em partes menores."
+        );
       } else {
         toast.error(msg || "Erro ao verificar duplicatas");
       }

--- a/frontend/src/components/documents/DocumentUpload.tsx
+++ b/frontend/src/components/documents/DocumentUpload.tsx
@@ -28,10 +28,22 @@ interface AnalysisResult {
 }
 
 // Vercel Server Actions reject payloads above ~4.5 MB (FUNCTION_PAYLOAD_TOO_LARGE).
-// Pack docs by aggregate text size to stay safely under that, with a count cap to avoid latency spikes.
+// Pack docs by aggregate UTF-8 byte size to stay safely under that, with a count cap to avoid latency spikes.
 const MAX_CHUNK_BYTES = 3_500_000;
 const MAX_DOCS_PER_CHUNK = 500;
+// checkDuplicates payload is small (~50B/doc), but we still chunk to bound request size on huge CSVs.
 const MAX_HASH_DOCS_PER_CHUNK = 5_000;
+
+const textEncoder = new TextEncoder();
+const utf8Bytes = (s: string) => textEncoder.encode(s).length;
+
+function isPayloadTooLarge(msg: string): boolean {
+  return (
+    msg.includes("Body exceeded") ||
+    msg.includes("413") ||
+    msg.includes("FUNCTION_PAYLOAD_TOO_LARGE")
+  );
+}
 
 interface UploadDoc {
   text: string;
@@ -47,7 +59,7 @@ function chunkByBytes(
   let currentBytes = 0;
   let startIndex = 0;
   for (let i = 0; i < docs.length; i++) {
-    const itemBytes = docs[i].text.length;
+    const itemBytes = utf8Bytes(docs[i].text);
     if (
       current.length > 0 &&
       (currentBytes + itemBytes > MAX_CHUNK_BYTES ||
@@ -155,11 +167,7 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
       setAnalysis(null);
     } catch (e) {
       const msg = e instanceof Error ? e.message : "";
-      if (
-        msg.includes("Body exceeded") ||
-        msg.includes("413") ||
-        msg.includes("FUNCTION_PAYLOAD_TOO_LARGE")
-      ) {
+      if (isPayloadTooLarge(msg)) {
         toast.error(
           "O envio excedeu o limite do servidor. Tente importar menos documentos por vez ou divida o CSV em partes menores."
         );
@@ -177,6 +185,17 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
     const docs = buildDocs();
     if (docs.length === 0) {
       toast.error("Nenhum documento válido encontrado");
+      return;
+    }
+
+    // Fail early if a single doc exceeds the per-chunk byte budget — chunking can't rescue it.
+    const oversizeIdx = docs.findIndex((d) => utf8Bytes(d.text) > MAX_CHUNK_BYTES);
+    if (oversizeIdx !== -1) {
+      const sizeMb = (utf8Bytes(docs[oversizeIdx].text) / 1_000_000).toFixed(2);
+      const limitMb = (MAX_CHUNK_BYTES / 1_000_000).toFixed(1);
+      toast.error(
+        `Documento na linha ${oversizeIdx + 1} tem ${sizeMb} MB, acima do limite de ${limitMb} MB por documento. Remova-o ou divida o texto antes de importar.`
+      );
       return;
     }
 
@@ -223,11 +242,7 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : "";
-      if (
-        msg.includes("Body exceeded") ||
-        msg.includes("413") ||
-        msg.includes("FUNCTION_PAYLOAD_TOO_LARGE")
-      ) {
+      if (isPayloadTooLarge(msg)) {
         toast.error(
           "O envio excedeu o limite do servidor. Tente importar menos documentos por vez ou divida o CSV em partes menores."
         );

--- a/frontend/src/lib/hash.ts
+++ b/frontend/src/lib/hash.ts
@@ -1,0 +1,5 @@
+import SparkMD5 from "spark-md5";
+
+export function md5(text: string): string {
+  return SparkMD5.hash(text);
+}


### PR DESCRIPTION
## Sumário

Resolve o erro `Request Entity Too Large / FUNCTION_PAYLOAD_TOO_LARGE` ao subir CSV de documentos.

A Vercel rejeita Server Actions com payload acima de ~4.5 MB (limite de plataforma, sobrepõe o `bodySizeLimit: "10mb"` do Next). Dois pontos do fluxo de upload estouravam esse teto:

1. `checkDuplicates` era chamado **uma única vez com TODOS os textos** parseados do CSV, só para calcular MD5 no servidor.
2. `uploadDocuments` chunkava por contagem fixa de 100 docs — se houver docs grandes (~50 KB+), o lote estoura.

## Mudanças

- **Hash no client**: `text_hash` calculado com `spark-md5` antes de enviar (MD5 idêntico ao Node `crypto`, mantém compatibilidade com a coluna `documents.text_hash`).
- **`checkDuplicates` enxuto**: assinatura nova `{external_id?, text_hash, csvIndex?}` — payload cai de "soma de todos os textos" para ~50 bytes/doc.
- **Chunking adaptativo por bytes**: `doUpload` empacota docs até atingir 3.5 MB ou 500 docs (o que vier primeiro).
- **`duplicateMap` localizado por chunk**: csvIndex remapeado para o range do chunk, corrigindo um caso latente onde `replace_and_add` em CSV grande tentava acessar `documents[csvIndex]` fora do array.
- **Mensagens de erro** atualizadas para refletir o limite de plataforma.

## Arquivos

- `frontend/src/lib/hash.ts` (novo)
- `frontend/src/actions/documents.ts` — refactor de `checkDuplicates`
- `frontend/src/components/documents/DocumentUpload.tsx` — hash no client + chunking adaptativo
- `frontend/package.json` — `spark-md5` + `@types/spark-md5`

## Plano de teste

- [ ] Subir CSV pequeno (~50 docs curtos) — fluxo normal de duplicatas
- [ ] Subir CSV grande em volume (~5 mil docs curtos) — vários chunks, sem 413
- [ ] Subir CSV pesado por doc (~30 docs com ~200 KB cada, total ~6 MB) — antes estourava na primeira chamada `checkDuplicates`; agora deve passar
- [ ] DevTools Network: confirmar que nenhum POST de Server Action passa de ~4 MB
- [ ] Subir o mesmo CSV duas vezes — segunda vez deve abrir o painel `DuplicateAnalysis`
- [ ] Confirmar `replace_and_add` com `deleteResponses` em CSV multi-chunk

🤖 Generated with [Claude Code](https://claude.com/claude-code)