### PR TITLE
fix(coding): permite substituir valor já preenchido em campos de data

### DIFF
--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -186,6 +186,7 @@ function DateFieldRenderer({
               value={day}
               onChange={(e) => handlePart("day", e.target.value)}
               onBlur={() => handleBlur("day")}
+              onFocus={(e) => e.currentTarget.select()}
               maxLength={2}
               inputMode="numeric"
               aria-label="Dia"
@@ -199,6 +200,7 @@ function DateFieldRenderer({
               value={month}
               onChange={(e) => handlePart("month", e.target.value)}
               onBlur={() => handleBlur("month")}
+              onFocus={(e) => e.currentTarget.select()}
               onKeyDown={(e) => handleBackspaceJump(e, dayRef)}
               maxLength={2}
               inputMode="numeric"
@@ -212,6 +214,7 @@ function DateFieldRenderer({
               placeholder="AAAA"
               value={year}
               onChange={(e) => handlePart("year", e.target.value)}
+              onFocus={(e) => e.currentTarget.select()}
               onKeyDown={(e) => handleBackspaceJump(e, monthRef)}
               maxLength={4}
               inputMode="numeric"


### PR DESCRIPTION
## Summary

- Após #90, ao tentar editar uma data já preenchida no `DateFieldRenderer` (ex: trocar dia `05` por `12`), o dígito digitado era descartado e o valor parecia "travado".
- Causa: `handlePart` faz `raw.replace(/\D/g, "").slice(0, maxLen)` — corta sempre os 2 primeiros chars, ignorando a posição do cursor. Clicar entre `0` e `5` em `05` e digitar `1` gerava `015` → slice → `"01"`. Repetir com `2` mantinha `01`.
- Fix: `onFocus={(e) => e.currentTarget.select()}` nos três `<Input>` (dia/mês/ano). Padrão clássico de date input de largura fixa: ao focar, o valor é selecionado e a próxima tecla substitui.

## Test plan

- [ ] Caso reportado: dia preenchido com `05`, clicar no campo, digitar `1` depois `2` → vira `12` e foco autopula para mês.
- [ ] Substituir mês e ano já preenchidos pelo mesmo fluxo (click → digitar).
- [ ] Não regredir #90: limpar tudo, digitar só `2024` no ano → persiste como `XX/XX/2024`.
- [ ] Auto-pad continua: digitar só `5` no dia e dar Tab → vira `05`.
- [ ] Backspace em campo vazio devolve foco ao anterior (regressão #90).
- [ ] `npx vitest run src/lib/__tests__/date-parts.test.ts` (22/22 passando).

🤖 Generated with [Claude Code](https://claude.com/claude-code)