### PR TITLE
feat(coding): filtro de rodada na aba Codificar

### DIFF
--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -36,7 +36,7 @@ export async function saveResponse(
       supabase
         .from("projects")
         .select(
-          "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch",
+          "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, round_strategy, current_round_id",
         )
         .eq("id", projectId)
         .single(),
@@ -67,6 +67,11 @@ export async function saveResponse(
       }
     }
 
+    const roundIdToPersist =
+      project?.round_strategy === "manual"
+        ? (project?.current_round_id ?? null)
+        : null;
+
     const responsePayload = {
       answers: sanitizedAnswers,
       justifications,
@@ -76,6 +81,7 @@ export async function saveResponse(
       schema_version_minor: project?.schema_version_minor ?? 1,
       schema_version_patch: project?.schema_version_patch ?? 0,
       version_inferred_from: "live_save",
+      round_id: roundIdToPersist,
     };
 
     if (existing) {

--- a/frontend/src/actions/rounds.ts
+++ b/frontend/src/actions/rounds.ts
@@ -5,6 +5,17 @@ import { getAuthUser } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import type { RoundStrategy } from "@/lib/types";
 
+// Postgres unique_violation. Tabela `rounds` tem UNIQUE(project_id, label) —
+// sem mapeamento, o usuario veria o erro cru "duplicate key value violates...".
+const PG_UNIQUE_VIOLATION = "23505";
+
+function mapRoundsError(err: { code?: string; message: string }): string {
+  if (err.code === PG_UNIQUE_VIOLATION) {
+    return "Já existe uma rodada com esse nome neste projeto.";
+  }
+  return err.message;
+}
+
 async function assertCoordinator(
   projectId: string,
 ): Promise<{ error?: string; userId?: string }> {
@@ -51,7 +62,7 @@ export async function createRound(
     .insert({ project_id: projectId, label: trimmed })
     .select("id")
     .single();
-  if (error) return { error: error.message };
+  if (error) return { error: mapRoundsError(error) };
 
   if (setAsCurrent && data?.id) {
     // Nao-transacional: se este update falhar, a rodada ja foi criada e o
@@ -86,7 +97,7 @@ export async function renameRound(
     .update({ label: trimmed })
     .eq("id", roundId)
     .eq("project_id", projectId);
-  if (error) return { error: error.message };
+  if (error) return { error: mapRoundsError(error) };
 
   revalidatePath(`/projects/${projectId}/config/rounds`);
   revalidatePath(`/projects/${projectId}/analyze/code`);
@@ -155,6 +166,11 @@ export async function setRoundStrategy(
   if (strategy !== "schema_version" && strategy !== "manual") {
     return { error: "Estratégia inválida." };
   }
+
+  // Nota: nao limpamos current_round_id ao mudar para schema_version. Isso
+  // preserva a config caso o coordenador volte para manual depois. Leituras
+  // (page.tsx, saveResponse) ignoram current_round_id quando strategy nao e
+  // 'manual', entao manter o valor stale e seguro.
 
   const auth = await assertCoordinator(projectId);
   if (auth.error) return { error: auth.error };

--- a/frontend/src/actions/rounds.ts
+++ b/frontend/src/actions/rounds.ts
@@ -11,6 +11,9 @@ async function assertCoordinator(
   const user = await getAuthUser();
   if (!user) return { error: "Não autenticado." };
 
+  // Master users tem acesso global (consistente com impersonacao em /analyze/code).
+  if (user.isMaster) return { userId: user.id };
+
   const supabase = await createSupabaseServer();
   const { data: project } = await supabase
     .from("projects")
@@ -51,6 +54,9 @@ export async function createRound(
   if (error) return { error: error.message };
 
   if (setAsCurrent && data?.id) {
+    // Nao-transacional: se este update falhar, a rodada ja foi criada e o
+    // coordenador precisa marca-la como atual manualmente em /config/rounds.
+    // Uma RPC com transacao seria overkill para a baixa frequencia da operacao.
     const { error: updErr } = await supabase
       .from("projects")
       .update({ current_round_id: data.id })
@@ -95,6 +101,20 @@ export async function setCurrentRound(
   if (auth.error) return { error: auth.error };
 
   const supabase = await createSupabaseServer();
+
+  // Validar cross-project: a FK garante que round_id existe em rounds, mas
+  // nao que pertence ao project_id correto. Sem essa checagem, um coordenador
+  // de dois projetos poderia apontar A.current_round_id para uma rodada de B.
+  if (roundId) {
+    const { data: round } = await supabase
+      .from("rounds")
+      .select("id")
+      .eq("id", roundId)
+      .eq("project_id", projectId)
+      .maybeSingle();
+    if (!round) return { error: "Rodada inválida para este projeto." };
+  }
+
   const { error } = await supabase
     .from("projects")
     .update({ current_round_id: roundId })
@@ -130,6 +150,12 @@ export async function setRoundStrategy(
   projectId: string,
   strategy: RoundStrategy,
 ): Promise<{ error?: string }> {
+  // Server actions recebem dados arbitrarios do cliente; o tipo TS protege so
+  // em compile-time. CHECK constraint do DB barra, mas mensagem fica feia.
+  if (strategy !== "schema_version" && strategy !== "manual") {
+    return { error: "Estratégia inválida." };
+  }
+
   const auth = await assertCoordinator(projectId);
   if (auth.error) return { error: auth.error };
 

--- a/frontend/src/actions/rounds.ts
+++ b/frontend/src/actions/rounds.ts
@@ -1,0 +1,146 @@
+"use server";
+
+import { createSupabaseServer } from "@/lib/supabase/server";
+import { getAuthUser } from "@/lib/auth";
+import { revalidatePath } from "next/cache";
+import type { RoundStrategy } from "@/lib/types";
+
+async function assertCoordinator(
+  projectId: string,
+): Promise<{ error?: string; userId?: string }> {
+  const user = await getAuthUser();
+  if (!user) return { error: "Não autenticado." };
+
+  const supabase = await createSupabaseServer();
+  const { data: project } = await supabase
+    .from("projects")
+    .select("created_by")
+    .eq("id", projectId)
+    .single();
+  if (project?.created_by === user.id) return { userId: user.id };
+
+  const { data: member } = await supabase
+    .from("project_members")
+    .select("role")
+    .eq("project_id", projectId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (member?.role !== "coordenador") {
+    return { error: "Apenas coordenadores podem alterar rodadas." };
+  }
+  return { userId: user.id };
+}
+
+export async function createRound(
+  projectId: string,
+  label: string,
+  setAsCurrent: boolean = false,
+): Promise<{ error?: string; id?: string }> {
+  const trimmed = label.trim();
+  if (!trimmed) return { error: "Nome da rodada é obrigatório." };
+
+  const auth = await assertCoordinator(projectId);
+  if (auth.error) return { error: auth.error };
+
+  const supabase = await createSupabaseServer();
+  const { data, error } = await supabase
+    .from("rounds")
+    .insert({ project_id: projectId, label: trimmed })
+    .select("id")
+    .single();
+  if (error) return { error: error.message };
+
+  if (setAsCurrent && data?.id) {
+    const { error: updErr } = await supabase
+      .from("projects")
+      .update({ current_round_id: data.id })
+      .eq("id", projectId);
+    if (updErr) return { error: updErr.message };
+  }
+
+  revalidatePath(`/projects/${projectId}/config/rounds`);
+  revalidatePath(`/projects/${projectId}/analyze/code`);
+  return { id: data?.id };
+}
+
+export async function renameRound(
+  projectId: string,
+  roundId: string,
+  label: string,
+): Promise<{ error?: string }> {
+  const trimmed = label.trim();
+  if (!trimmed) return { error: "Nome da rodada é obrigatório." };
+
+  const auth = await assertCoordinator(projectId);
+  if (auth.error) return { error: auth.error };
+
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase
+    .from("rounds")
+    .update({ label: trimmed })
+    .eq("id", roundId)
+    .eq("project_id", projectId);
+  if (error) return { error: error.message };
+
+  revalidatePath(`/projects/${projectId}/config/rounds`);
+  revalidatePath(`/projects/${projectId}/analyze/code`);
+  return {};
+}
+
+export async function setCurrentRound(
+  projectId: string,
+  roundId: string | null,
+): Promise<{ error?: string }> {
+  const auth = await assertCoordinator(projectId);
+  if (auth.error) return { error: auth.error };
+
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase
+    .from("projects")
+    .update({ current_round_id: roundId })
+    .eq("id", projectId);
+  if (error) return { error: error.message };
+
+  revalidatePath(`/projects/${projectId}/config/rounds`);
+  revalidatePath(`/projects/${projectId}/analyze/code`);
+  return {};
+}
+
+export async function deleteRound(
+  projectId: string,
+  roundId: string,
+): Promise<{ error?: string }> {
+  const auth = await assertCoordinator(projectId);
+  if (auth.error) return { error: auth.error };
+
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase
+    .from("rounds")
+    .delete()
+    .eq("id", roundId)
+    .eq("project_id", projectId);
+  if (error) return { error: error.message };
+
+  revalidatePath(`/projects/${projectId}/config/rounds`);
+  revalidatePath(`/projects/${projectId}/analyze/code`);
+  return {};
+}
+
+export async function setRoundStrategy(
+  projectId: string,
+  strategy: RoundStrategy,
+): Promise<{ error?: string }> {
+  const auth = await assertCoordinator(projectId);
+  if (auth.error) return { error: auth.error };
+
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase
+    .from("projects")
+    .update({ round_strategy: strategy })
+    .eq("id", projectId);
+  if (error) return { error: error.message };
+
+  revalidatePath(`/projects/${projectId}/config/rounds`);
+  revalidatePath(`/projects/${projectId}/analyze/code`);
+  return {};
+}

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -3,14 +3,28 @@ import { getAuthUser } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { CodingPage } from "@/components/coding/CodingPage";
 import { getResearcherProgress } from "@/actions/progress";
-import type { Document, Assignment, PydanticField } from "@/lib/types";
+import type {
+  Document,
+  Assignment,
+  PydanticField,
+  Round,
+  RoundStrategy,
+} from "@/lib/types";
+import {
+  classifyDocStatus,
+  versionLabel,
+  isCurrentFilter,
+  type RoundContext,
+  type ResponseRoundFields,
+  type SchemaVersion,
+} from "@/lib/rounds";
 
 export default async function CodePage({
   params,
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ viewAsUser?: string }>;
+  searchParams: Promise<{ viewAsUser?: string; round?: string }>;
 }) {
   const { id } = await params;
   const sp = await searchParams;
@@ -18,79 +32,152 @@ export default async function CodePage({
   if (!user) redirect("/auth/login");
 
   const isImpersonating = !!(user.isMaster && sp.viewAsUser);
-  const effectiveUserId =
-    isImpersonating ? sp.viewAsUser! : user.id;
+  const effectiveUserId = isImpersonating ? sp.viewAsUser! : user.id;
+  const roundParam = sp.round ?? "current";
 
   const supabase = await createSupabaseServer();
 
-  // Round 1: project + assignments + progress in parallel
-  const [{ data: project }, { data: assignments }, progressResult] = await Promise.all([
-    supabase
-      .from("projects")
-      .select("pydantic_fields")
-      .eq("id", id)
-      .single(),
-    supabase
-      .from("assignments")
-      .select("id, status, document_id, documents(id, external_id, title, text)")
-      .eq("project_id", id)
-      .eq("user_id", effectiveUserId)
-      .eq("type", "codificacao")
-      .order("status", { ascending: true }),
-    getResearcherProgress(id, effectiveUserId).catch(() => null),
-  ]);
+  const [{ data: project }, { data: assignments }, { data: rounds }, progressResult] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select(
+          "pydantic_fields, round_strategy, current_round_id, schema_version_major, schema_version_minor, schema_version_patch",
+        )
+        .eq("id", id)
+        .single(),
+      supabase
+        .from("assignments")
+        .select("id, status, document_id, documents(id, external_id, title, text)")
+        .eq("project_id", id)
+        .eq("user_id", effectiveUserId)
+        .eq("type", "codificacao")
+        .order("status", { ascending: true }),
+      supabase
+        .from("rounds")
+        .select("id, project_id, label, created_at")
+        .eq("project_id", id)
+        .order("created_at", { ascending: true }),
+      getResearcherProgress(id, effectiveUserId).catch(() => null),
+    ]);
 
-  const documents = (assignments || []).map((a) => ({
+  const allDocuments = (assignments || []).map((a) => ({
     ...(a.documents as unknown as Document),
     assignment: { id: a.id, status: a.status } as Pick<Assignment, "id" | "status">,
   }));
 
-  // Get existing responses for these documents
-  const docIds = documents.map((d) => d.id);
+  // Responses incluem agora round_id e schema_version para classificacao por rodada
+  const docIds = allDocuments.map((d) => d.id);
   const { data: responses } = await supabase
     .from("responses")
-    .select("document_id, answers, justifications")
+    .select(
+      "document_id, answers, justifications, round_id, schema_version_major, schema_version_minor, schema_version_patch",
+    )
     .eq("project_id", id)
     .eq("respondent_id", effectiveUserId)
     .in("document_id", docIds.length > 0 ? docIds : ["__none__"]);
 
-  const rawAnswers: Record<string, Record<string, unknown>> = {};
-  responses?.forEach((r) => {
-    rawAnswers[r.document_id] = r.answers as Record<string, unknown>;
-  });
-
-  const existingJustifications: Record<string, Record<string, unknown>> = {};
-  responses?.forEach((r) => {
-    if (r.justifications) {
-      existingJustifications[r.document_id] = r.justifications as Record<string, unknown>;
+  const responseByDoc = new Map<
+    string,
+    ResponseRoundFields & {
+      answers: Record<string, unknown>;
+      justifications: Record<string, unknown> | null;
     }
+  >();
+  responses?.forEach((r) => {
+    responseByDoc.set(r.document_id, {
+      answers: (r.answers as Record<string, unknown>) ?? {},
+      justifications: (r.justifications as Record<string, unknown> | null) ?? null,
+      round_id: r.round_id,
+      schema_version_major: r.schema_version_major,
+      schema_version_minor: r.schema_version_minor,
+      schema_version_patch: r.schema_version_patch,
+    });
   });
 
-  // Sanitize: remove answers whose values don't match current schema options
+  const currentVersion: SchemaVersion = {
+    major: project?.schema_version_major ?? 0,
+    minor: project?.schema_version_minor ?? 1,
+    patch: project?.schema_version_patch ?? 0,
+  };
+  const strategy: RoundStrategy =
+    (project?.round_strategy as RoundStrategy) ?? "schema_version";
+  const ctx: RoundContext = {
+    strategy,
+    currentRoundId: project?.current_round_id ?? null,
+    currentVersion,
+    rounds: (rounds ?? []) as Round[],
+  };
+  const roundsById = new Map(ctx.rounds.map((r) => [r.id, r]));
+
+  // Versoes anteriores presentes em responses (apenas estrategia schema_version)
+  const previousVersions = Array.from(
+    new Set(
+      (responses ?? [])
+        .map((r) => {
+          const m = r.schema_version_major;
+          const n = r.schema_version_minor;
+          const p = r.schema_version_patch;
+          if (m == null || n == null || p == null) return null;
+          const v = versionLabel({ major: m, minor: n, patch: p });
+          if (v === versionLabel(currentVersion)) return null;
+          return v;
+        })
+        .filter((v): v is string => v != null),
+    ),
+  ).sort();
+
+  // Filtro server-side conforme roundParam
+  const filteredDocuments = allDocuments.filter((d) => {
+    const resp = responseByDoc.get(d.id);
+    const status = classifyDocStatus(ctx, resp ?? null, roundsById);
+
+    if (roundParam === "all") return true;
+    if (isCurrentFilter(roundParam)) {
+      // Padrao: mostra docs que ainda precisam ser respondidos na rodada atual
+      // (sem resposta OU resposta de rodada anterior). Concluidos da atual saem.
+      return status.kind !== "current_done";
+    }
+    // Rodada especifica: id (manual) ou label (schema_version)
+    if (strategy === "manual") {
+      return resp?.round_id === roundParam;
+    }
+    return (
+      status.kind === "previous" && status.label === roundParam
+    );
+  });
+
   const fields = ((project?.pydantic_fields || []) as PydanticField[]).filter(
-    (f) => f.target !== "llm_only" && f.target !== "none"
+    (f) => f.target !== "llm_only" && f.target !== "none",
   );
   const existingAnswers: Record<string, Record<string, unknown>> = {};
-  for (const [docId, answers] of Object.entries(rawAnswers)) {
+  const existingJustifications: Record<string, Record<string, unknown>> = {};
+  for (const d of filteredDocuments) {
+    const r = responseByDoc.get(d.id);
+    if (!r) continue;
     const clean: Record<string, unknown> = {};
     for (const field of fields) {
-      const val = answers[field.name];
+      const val = r.answers[field.name];
       if (val === undefined || val === null) continue;
       if (field.type === "single" && field.options) {
         if (field.options.includes(val as string)) clean[field.name] = val;
       } else if (field.type === "multi" && field.options) {
-        const arr = Array.isArray(val) ? val.filter((v: string) => field.options!.includes(v)) : [];
+        const arr = Array.isArray(val)
+          ? val.filter((v: string) => field.options!.includes(v))
+          : [];
         if (arr.length > 0) clean[field.name] = arr;
       } else {
-        clean[field.name] = val; // text fields: always keep
+        clean[field.name] = val;
       }
     }
-    existingAnswers[docId] = clean;
+    existingAnswers[d.id] = clean;
+    if (r.justifications) {
+      existingJustifications[d.id] = r.justifications;
+    }
   }
 
-  // Progress was fetched in parallel above
   let progress = null;
-  if (documents.length > 0 && progressResult) {
+  if (allDocuments.length > 0 && progressResult) {
     progress = {
       completed: progressResult.completed,
       total: progressResult.total,
@@ -101,16 +188,42 @@ export default async function CodePage({
     };
   }
 
+  // Quando filtra por rodada anterior, painel fica readOnly para evitar
+  // que pesquisador edite achando que ainda esta na rodada antiga.
+  // (Salvar promove para a rodada atual de qualquer jeito.)
+  const isViewingPreviousRound =
+    !isCurrentFilter(roundParam) && roundParam !== "all";
+
+  const currentRoundLabel =
+    strategy === "manual"
+      ? ctx.currentRoundId
+        ? roundsById.get(ctx.currentRoundId)?.label ?? "Sem rodada atual"
+        : "Sem rodada atual"
+      : versionLabel(currentVersion);
+
+  const currentRoundKey =
+    strategy === "manual"
+      ? ctx.currentRoundId ?? ""
+      : versionLabel(currentVersion);
+
   return (
     <CodingPage
       projectId={id}
-      documents={documents}
+      documents={filteredDocuments}
       fields={fields}
       existingAnswers={existingAnswers}
       existingJustifications={existingJustifications}
-      hasAssignments={documents.length > 0}
+      hasAssignments={allDocuments.length > 0}
       progress={progress}
-      readOnly={isImpersonating}
+      readOnly={isImpersonating || isViewingPreviousRound}
+      roundFilter={{
+        strategy,
+        currentRoundKey,
+        currentRoundLabel,
+        rounds: ctx.rounds,
+        previousVersions,
+        selected: roundParam,
+      }}
     />
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -13,8 +13,9 @@ import type {
 import {
   classifyDocStatus,
   versionLabel,
-  isCurrentFilter,
   getCurrentRoundDescriptor,
+  compareVersionLabels,
+  resolveRoundFilter,
   type RoundContext,
   type ResponseRoundFields,
   type SchemaVersion,
@@ -67,7 +68,9 @@ export default async function CodePage({
     assignment: { id: a.id, status: a.status } as Pick<Assignment, "id" | "status">,
   }));
 
-  // Responses incluem agora round_id e schema_version para classificacao por rodada
+  // Responses incluem agora round_id e schema_version para classificacao por rodada.
+  // Filtra respondent_type=humano: respostas LLM têm respondent_id distinto, mas o
+  // filtro explícito alinha com saveResponse e protege contra colisões futuras.
   const docIds = allDocuments.map((d) => d.id);
   const { data: responses } = await supabase
     .from("responses")
@@ -76,6 +79,7 @@ export default async function CodePage({
     )
     .eq("project_id", id)
     .eq("respondent_id", effectiveUserId)
+    .eq("respondent_type", "humano")
     .in("document_id", docIds.length > 0 ? docIds : ["__none__"]);
 
   const responseByDoc = new Map<
@@ -114,6 +118,7 @@ export default async function CodePage({
 
   // Versoes anteriores presentes em responses — so faz sentido em schema_version.
   // Em manual, o select de rodadas anteriores vem da tabela `rounds`.
+  // Sort numerico (compareVersionLabels) para ordenar 0.9.0 < 0.10.0 corretamente.
   const previousVersions =
     strategy === "schema_version"
       ? Array.from(
@@ -130,26 +135,38 @@ export default async function CodePage({
               })
               .filter((v): v is string => v != null),
           ),
-        ).sort()
+        ).sort(compareVersionLabels)
       : [];
 
-  // Filtro server-side conforme roundParam
+  const { key: currentRoundKey, label: currentRoundLabel } =
+    getCurrentRoundDescriptor(ctx, roundsById);
+
+  // Normaliza ?round= para evitar lista vazia silenciosa (URL manipulada,
+  // troca de estrategia com filtro stale, ou ?round=<currentRoundKey>).
+  const effectiveRound = resolveRoundFilter(
+    roundParam,
+    ctx,
+    currentRoundKey,
+    previousVersions,
+  );
+
+  // Filtro server-side conforme effectiveRound
   const filteredDocuments = allDocuments.filter((d) => {
     const resp = responseByDoc.get(d.id);
     const status = classifyDocStatus(ctx, resp ?? null, roundsById);
 
-    if (roundParam === "all") return true;
-    if (isCurrentFilter(roundParam)) {
+    if (effectiveRound === "all") return true;
+    if (effectiveRound === "current") {
       // Padrao: mostra docs que ainda precisam ser respondidos na rodada atual
       // (sem resposta OU resposta de rodada anterior). Concluidos da atual saem.
       return status.kind !== "current_done";
     }
     // Rodada especifica: id (manual) ou label (schema_version)
     if (strategy === "manual") {
-      return resp?.round_id === roundParam;
+      return resp?.round_id === effectiveRound;
     }
     return (
-      status.kind === "previous" && status.label === roundParam
+      status.kind === "previous" && status.label === effectiveRound
     );
   });
 
@@ -198,10 +215,7 @@ export default async function CodePage({
   // que pesquisador edite achando que ainda esta na rodada antiga.
   // (Salvar promove para a rodada atual de qualquer jeito.)
   const isViewingPreviousRound =
-    !isCurrentFilter(roundParam) && roundParam !== "all";
-
-  const { key: currentRoundKey, label: currentRoundLabel } =
-    getCurrentRoundDescriptor(ctx, roundsById);
+    effectiveRound !== "current" && effectiveRound !== "all";
 
   return (
     <CodingPage
@@ -219,7 +233,7 @@ export default async function CodePage({
         currentRoundLabel,
         rounds: ctx.rounds,
         previousVersions,
-        selected: roundParam,
+        selected: effectiveRound,
       }}
     />
   );

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -14,6 +14,7 @@ import {
   classifyDocStatus,
   versionLabel,
   isCurrentFilter,
+  getCurrentRoundDescriptor,
   type RoundContext,
   type ResponseRoundFields,
   type SchemaVersion,
@@ -71,7 +72,7 @@ export default async function CodePage({
   const { data: responses } = await supabase
     .from("responses")
     .select(
-      "document_id, answers, justifications, round_id, schema_version_major, schema_version_minor, schema_version_patch",
+      "document_id, answers, justifications, round_id, schema_version_major, schema_version_minor, schema_version_patch, is_partial",
     )
     .eq("project_id", id)
     .eq("respondent_id", effectiveUserId)
@@ -92,6 +93,7 @@ export default async function CodePage({
       schema_version_major: r.schema_version_major,
       schema_version_minor: r.schema_version_minor,
       schema_version_patch: r.schema_version_patch,
+      is_partial: r.is_partial,
     });
   });
 
@@ -110,22 +112,26 @@ export default async function CodePage({
   };
   const roundsById = new Map(ctx.rounds.map((r) => [r.id, r]));
 
-  // Versoes anteriores presentes em responses (apenas estrategia schema_version)
-  const previousVersions = Array.from(
-    new Set(
-      (responses ?? [])
-        .map((r) => {
-          const m = r.schema_version_major;
-          const n = r.schema_version_minor;
-          const p = r.schema_version_patch;
-          if (m == null || n == null || p == null) return null;
-          const v = versionLabel({ major: m, minor: n, patch: p });
-          if (v === versionLabel(currentVersion)) return null;
-          return v;
-        })
-        .filter((v): v is string => v != null),
-    ),
-  ).sort();
+  // Versoes anteriores presentes em responses — so faz sentido em schema_version.
+  // Em manual, o select de rodadas anteriores vem da tabela `rounds`.
+  const previousVersions =
+    strategy === "schema_version"
+      ? Array.from(
+          new Set(
+            (responses ?? [])
+              .map((r) => {
+                const m = r.schema_version_major;
+                const n = r.schema_version_minor;
+                const p = r.schema_version_patch;
+                if (m == null || n == null || p == null) return null;
+                const v = versionLabel({ major: m, minor: n, patch: p });
+                if (v === versionLabel(currentVersion)) return null;
+                return v;
+              })
+              .filter((v): v is string => v != null),
+          ),
+        ).sort()
+      : [];
 
   // Filtro server-side conforme roundParam
   const filteredDocuments = allDocuments.filter((d) => {
@@ -194,17 +200,8 @@ export default async function CodePage({
   const isViewingPreviousRound =
     !isCurrentFilter(roundParam) && roundParam !== "all";
 
-  const currentRoundLabel =
-    strategy === "manual"
-      ? ctx.currentRoundId
-        ? roundsById.get(ctx.currentRoundId)?.label ?? "Sem rodada atual"
-        : "Sem rodada atual"
-      : versionLabel(currentVersion);
-
-  const currentRoundKey =
-    strategy === "manual"
-      ? ctx.currentRoundId ?? ""
-      : versionLabel(currentVersion);
+  const { key: currentRoundKey, label: currentRoundLabel } =
+    getCurrentRoundDescriptor(ctx, roundsById);
 
   return (
     <CodingPage

--- a/frontend/src/app/(app)/projects/[id]/config/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/layout.tsx
@@ -8,6 +8,7 @@ const configTabs = [
   { label: "Geral", href: "general" },
   { label: "Documentos", href: "documents" },
   { label: "Schema", href: "schema" },
+  { label: "Rodadas", href: "rounds" },
   { label: "Histórico", href: "history" },
   { label: "Membros", href: "members" },
   { label: "Regras", href: "rules" },

--- a/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
@@ -39,6 +39,7 @@ export default async function RoundsConfigPage({
     ]);
 
   const isCoordinator =
+    user.isMaster ||
     project?.created_by === user.id ||
     membership?.role === "coordenador";
 

--- a/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
@@ -1,0 +1,63 @@
+import { createSupabaseServer } from "@/lib/supabase/server";
+import { getAuthUser } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { RoundsConfig } from "@/components/config/RoundsConfig";
+import type { Round, RoundStrategy } from "@/lib/types";
+import { versionLabel } from "@/lib/rounds";
+
+export default async function RoundsConfigPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const user = await getAuthUser();
+  if (!user) redirect("/auth/login");
+
+  const supabase = await createSupabaseServer();
+
+  const [{ data: project }, { data: rounds }, { data: membership }] =
+    await Promise.all([
+      supabase
+        .from("projects")
+        .select(
+          "round_strategy, current_round_id, schema_version_major, schema_version_minor, schema_version_patch, created_by",
+        )
+        .eq("id", id)
+        .single(),
+      supabase
+        .from("rounds")
+        .select("id, project_id, label, created_at")
+        .eq("project_id", id)
+        .order("created_at", { ascending: true }),
+      supabase
+        .from("project_members")
+        .select("role")
+        .eq("project_id", id)
+        .eq("user_id", user.id)
+        .maybeSingle(),
+    ]);
+
+  const isCoordinator =
+    project?.created_by === user.id ||
+    membership?.role === "coordenador";
+
+  const currentVersion = versionLabel({
+    major: project?.schema_version_major ?? 0,
+    minor: project?.schema_version_minor ?? 1,
+    patch: project?.schema_version_patch ?? 0,
+  });
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <RoundsConfig
+        projectId={id}
+        strategy={(project?.round_strategy as RoundStrategy) ?? "schema_version"}
+        currentRoundId={project?.current_round_id ?? null}
+        currentVersion={currentVersion}
+        rounds={(rounds ?? []) as Round[]}
+        isCoordinator={isCoordinator}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -17,11 +17,21 @@ import { FullscreenNav } from "./FullscreenNav";
 import { saveResponse } from "@/actions/responses";
 import { getDocumentsForBrowse, getDocumentForCoding } from "@/actions/documents";
 import type { BrowseDocument } from "@/actions/documents";
-import type { PydanticField, Document, Assignment } from "@/lib/types";
+import type { PydanticField, Document, Assignment, Round, RoundStrategy } from "@/lib/types";
 import { ProgressBanner, type ProgressBannerData } from "./ProgressBanner";
+import { RoundFilter } from "./RoundFilter";
 import { toast } from "sonner";
 import { CheckCircle2, FileQuestion, ClipboardList } from "lucide-react";
 import { Button } from "@/components/ui/button";
+
+export interface RoundFilterData {
+  strategy: RoundStrategy;
+  currentRoundKey: string;
+  currentRoundLabel: string;
+  rounds: Round[];
+  previousVersions: string[];
+  selected: string;
+}
 
 interface CodingPageProps {
   projectId: string;
@@ -32,6 +42,7 @@ interface CodingPageProps {
   hasAssignments?: boolean;
   progress?: ProgressBannerData | null;
   readOnly?: boolean;
+  roundFilter?: RoundFilterData;
 }
 
 export function CodingPage({
@@ -43,6 +54,7 @@ export function CodingPage({
   hasAssignments = false,
   progress = null,
   readOnly = false,
+  roundFilter,
 }: CodingPageProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -412,6 +424,16 @@ export function CodingPage({
               </TabsList>
             </div>
           </Tabs>
+          {mode === "assigned" && roundFilter && (
+            <RoundFilter
+              strategy={roundFilter.strategy}
+              currentRoundKey={roundFilter.currentRoundKey}
+              currentRoundLabel={roundFilter.currentRoundLabel}
+              rounds={roundFilter.rounds}
+              previousVersions={roundFilter.previousVersions}
+              selected={roundFilter.selected}
+            />
+          )}
           {progress && mode === "assigned" && <ProgressBanner data={progress} />}
         </>
       )}
@@ -440,9 +462,25 @@ export function CodingPage({
           ) : !currentDoc ? (
             <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
               <ClipboardList className="h-10 w-10 text-muted-foreground/50" />
-              <p className="text-sm text-muted-foreground">
-                Nenhum documento atribuído. Use a aba Explorar.
-              </p>
+              {hasAssignments && roundFilter ? (
+                roundFilter.selected === "all" ? (
+                  <p className="text-sm text-muted-foreground">
+                    Nenhum documento corresponde ao filtro.
+                  </p>
+                ) : roundFilter.selected === "" || roundFilter.selected === "current" ? (
+                  <p className="text-sm text-muted-foreground">
+                    Tudo em dia na rodada atual ({roundFilter.currentRoundLabel}).
+                  </p>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Nenhuma resposta sua nessa rodada.
+                  </p>
+                )
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Nenhum documento atribuído. Use a aba Explorar.
+                </p>
+              )}
             </div>
           ) : (
             <>

--- a/frontend/src/components/coding/RoundFilter.tsx
+++ b/frontend/src/components/coding/RoundFilter.tsx
@@ -9,6 +9,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { isCurrentFilter } from "@/lib/rounds";
 import type { Round, RoundStrategy } from "@/lib/types";
 
 interface RoundFilterProps {
@@ -36,9 +37,12 @@ export function RoundFilter({
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
+  // Default e "current" sao a mesma coisa: ausencia do param na URL.
+  const normalizedSelected = isCurrentFilter(selected) ? "current" : selected;
+
   const handleChange = (value: string) => {
     const params = new URLSearchParams(searchParams.toString());
-    if (value === "current") {
+    if (isCurrentFilter(value)) {
       params.delete("round");
     } else {
       params.set("round", value);
@@ -52,7 +56,7 @@ export function RoundFilter({
   return (
     <div className="flex items-center gap-2 px-4 py-1.5 border-b text-xs">
       <span className="text-muted-foreground">Rodada:</span>
-      <Select value={selected || "current"} onValueChange={handleChange} disabled={isPending}>
+      <Select value={normalizedSelected} onValueChange={handleChange} disabled={isPending}>
         <SelectTrigger size="sm" className="h-7 w-auto min-w-[180px] text-xs">
           <SelectValue />
         </SelectTrigger>

--- a/frontend/src/components/coding/RoundFilter.tsx
+++ b/frontend/src/components/coding/RoundFilter.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Round, RoundStrategy } from "@/lib/types";
+
+interface RoundFilterProps {
+  strategy: RoundStrategy;
+  /** Identificador da rodada atual (UUID se manual, "X.Y.Z" se schema_version). */
+  currentRoundKey: string;
+  currentRoundLabel: string;
+  rounds: Round[];
+  /** Conjunto de versões (X.Y.Z) anteriores presentes em responses do user. */
+  previousVersions: string[];
+  /** Valor atualmente selecionado em ?round= ("current" | "all" | id | versão). */
+  selected: string;
+}
+
+export function RoundFilter({
+  strategy,
+  currentRoundKey,
+  currentRoundLabel,
+  rounds,
+  previousVersions,
+  selected,
+}: RoundFilterProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  const handleChange = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (value === "current") {
+      params.delete("round");
+    } else {
+      params.set("round", value);
+    }
+    const qs = params.toString();
+    startTransition(() => {
+      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+    });
+  };
+
+  return (
+    <div className="flex items-center gap-2 px-4 py-1.5 border-b text-xs">
+      <span className="text-muted-foreground">Rodada:</span>
+      <Select value={selected || "current"} onValueChange={handleChange} disabled={isPending}>
+        <SelectTrigger size="sm" className="h-7 w-auto min-w-[180px] text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="current">
+            Atual ({currentRoundLabel}) — pendentes
+          </SelectItem>
+          <SelectItem value="all">Todas as rodadas</SelectItem>
+          {strategy === "manual"
+            ? rounds
+                .filter((r) => r.id !== currentRoundKey)
+                .map((r) => (
+                  <SelectItem key={r.id} value={r.id}>
+                    {r.label}
+                  </SelectItem>
+                ))
+            : previousVersions.map((v) => (
+                <SelectItem key={v} value={v}>
+                  Versão {v}
+                </SelectItem>
+              ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/frontend/src/components/config/RoundsConfig.tsx
+++ b/frontend/src/components/config/RoundsConfig.tsx
@@ -7,6 +7,16 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Trash2, Plus, Check } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -37,6 +47,7 @@ export function RoundsConfig({
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [newLabel, setNewLabel] = useState("");
+  const [pendingDelete, setPendingDelete] = useState<Round | null>(null);
 
   const handleStrategyChange = (next: string) => {
     if (next !== "schema_version" && next !== "manual") return;
@@ -75,10 +86,12 @@ export function RoundsConfig({
     });
   };
 
-  const handleDelete = (roundId: string) => {
-    if (!confirm("Excluir esta rodada? Respostas associadas ficarão sem rodada.")) return;
+  const handleConfirmDelete = () => {
+    const round = pendingDelete;
+    if (!round) return;
+    setPendingDelete(null);
     startTransition(async () => {
-      const r = await deleteRound(projectId, roundId);
+      const r = await deleteRound(projectId, round.id);
       if (r.error) toast.error(r.error);
       else {
         toast.success("Rodada excluída");
@@ -212,7 +225,7 @@ export function RoundsConfig({
                       <Button
                         size="icon"
                         variant="ghost"
-                        onClick={() => handleDelete(r.id)}
+                        onClick={() => setPendingDelete(r)}
                         disabled={disabled}
                         className="h-7 w-7"
                         aria-label="Excluir rodada"
@@ -233,6 +246,34 @@ export function RoundsConfig({
           Apenas coordenadores podem alterar essas configurações.
         </p>
       )}
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Excluir rodada?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingDelete && (
+                <>
+                  Excluir a rodada <strong>{pendingDelete.label}</strong>? As respostas
+                  associadas continuam preservadas, mas ficam sem rodada (aparecem como
+                  &quot;Sem rodada&quot; no filtro).
+                </>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirmDelete} disabled={isPending}>
+              {isPending ? "Excluindo…" : "Excluir"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/components/config/RoundsConfig.tsx
+++ b/frontend/src/components/config/RoundsConfig.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Badge } from "@/components/ui/badge";
+import { Trash2, Plus, Check } from "lucide-react";
+import { toast } from "sonner";
+import {
+  createRound,
+  deleteRound,
+  setCurrentRound,
+  setRoundStrategy,
+} from "@/actions/rounds";
+import type { Round, RoundStrategy } from "@/lib/types";
+
+interface Props {
+  projectId: string;
+  strategy: RoundStrategy;
+  currentRoundId: string | null;
+  currentVersion: string;
+  rounds: Round[];
+  isCoordinator: boolean;
+}
+
+export function RoundsConfig({
+  projectId,
+  strategy,
+  currentRoundId,
+  currentVersion,
+  rounds,
+  isCoordinator,
+}: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [newLabel, setNewLabel] = useState("");
+
+  const handleStrategyChange = (next: string) => {
+    if (next !== "schema_version" && next !== "manual") return;
+    startTransition(async () => {
+      const r = await setRoundStrategy(projectId, next as RoundStrategy);
+      if (r.error) toast.error(r.error);
+      else {
+        toast.success("Estratégia atualizada");
+        router.refresh();
+      }
+    });
+  };
+
+  const handleCreate = () => {
+    const label = newLabel.trim();
+    if (!label) return;
+    startTransition(async () => {
+      const r = await createRound(projectId, label, rounds.length === 0);
+      if (r.error) toast.error(r.error);
+      else {
+        toast.success("Rodada criada");
+        setNewLabel("");
+        router.refresh();
+      }
+    });
+  };
+
+  const handleSetCurrent = (roundId: string) => {
+    startTransition(async () => {
+      const r = await setCurrentRound(projectId, roundId);
+      if (r.error) toast.error(r.error);
+      else {
+        toast.success("Rodada atual atualizada");
+        router.refresh();
+      }
+    });
+  };
+
+  const handleDelete = (roundId: string) => {
+    if (!confirm("Excluir esta rodada? Respostas associadas ficarão sem rodada.")) return;
+    startTransition(async () => {
+      const r = await deleteRound(projectId, roundId);
+      if (r.error) toast.error(r.error);
+      else {
+        toast.success("Rodada excluída");
+        router.refresh();
+      }
+    });
+  };
+
+  const disabled = !isCoordinator || isPending;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Rodadas</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Define como as rodadas de codificação são identificadas. O filtro na aba
+          Codificar usa essa configuração para separar o que ainda precisa ser
+          respondido na rodada vigente das respostas de rodadas anteriores.
+        </p>
+      </div>
+
+      <div className="rounded-lg border p-4 space-y-4">
+        <div>
+          <Label className="text-sm font-medium">Estratégia</Label>
+          <p className="text-xs text-muted-foreground mt-1">
+            Como definir a rodada atual.
+          </p>
+        </div>
+        <RadioGroup
+          value={strategy}
+          onValueChange={handleStrategyChange}
+          disabled={disabled}
+          className="gap-3"
+        >
+          <div className="flex items-start gap-3 rounded-md border p-3">
+            <RadioGroupItem value="schema_version" id="strategy-schema" className="mt-0.5" />
+            <div className="flex-1">
+              <Label htmlFor="strategy-schema" className="text-sm font-medium">
+                Versão do schema (automático)
+              </Label>
+              <p className="text-xs text-muted-foreground mt-1">
+                A rodada atual é a versão atual do formulário (
+                <span className="font-mono">{currentVersion}</span>). Cada bump de
+                versão inicia uma nova rodada implicitamente.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3 rounded-md border p-3">
+            <RadioGroupItem value="manual" id="strategy-manual" className="mt-0.5" />
+            <div className="flex-1">
+              <Label htmlFor="strategy-manual" className="text-sm font-medium">
+                Rodadas manuais
+              </Label>
+              <p className="text-xs text-muted-foreground mt-1">
+                Você cria e nomeia rodadas explicitamente. Marque uma como atual
+                para que novas respostas sejam atribuídas a ela.
+              </p>
+            </div>
+          </div>
+        </RadioGroup>
+      </div>
+
+      {strategy === "manual" && (
+        <div className="rounded-lg border p-4 space-y-4">
+          <div>
+            <Label className="text-sm font-medium">Rodadas do projeto</Label>
+            <p className="text-xs text-muted-foreground mt-1">
+              Marque qual é a rodada atual. Respostas novas em /analyze/code serão
+              associadas a ela.
+            </p>
+          </div>
+
+          <div className="flex gap-2">
+            <Input
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              placeholder="Ex.: Piloto, Rodada 2…"
+              disabled={disabled}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleCreate();
+                }
+              }}
+            />
+            <Button
+              onClick={handleCreate}
+              disabled={disabled || !newLabel.trim()}
+              size="sm"
+              className="shrink-0"
+            >
+              <Plus className="h-4 w-4" />
+              Criar
+            </Button>
+          </div>
+
+          {rounds.length === 0 ? (
+            <p className="text-xs text-muted-foreground italic">
+              Nenhuma rodada criada ainda.
+            </p>
+          ) : (
+            <ul className="space-y-1.5">
+              {rounds.map((r) => {
+                const isCurrent = r.id === currentRoundId;
+                return (
+                  <li
+                    key={r.id}
+                    className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+                  >
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-sm truncate">{r.label}</span>
+                      {isCurrent && (
+                        <Badge variant="default" className="text-xs">
+                          Atual
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 shrink-0">
+                      {!isCurrent && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleSetCurrent(r.id)}
+                          disabled={disabled}
+                          className="h-7 text-xs"
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                          Tornar atual
+                        </Button>
+                      )}
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => handleDelete(r.id)}
+                        disabled={disabled}
+                        className="h-7 w-7"
+                        aria-label="Excluir rodada"
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {!isCoordinator && (
+        <p className="text-xs text-muted-foreground">
+          Apenas coordenadores podem alterar essas configurações.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/__tests__/rounds.test.ts
+++ b/frontend/src/lib/__tests__/rounds.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyDocStatus,
+  versionLabel,
+  versionEquals,
+  responseRoundLabel,
+  isCurrentFilter,
+  getCurrentRoundDescriptor,
+  type RoundContext,
+  type ResponseRoundFields,
+  type SchemaVersion,
+} from "@/lib/rounds";
+import type { Round } from "@/lib/types";
+
+const v = (major: number, minor: number, patch: number): SchemaVersion => ({
+  major,
+  minor,
+  patch,
+});
+
+const round = (id: string, label: string, projectId = "p1"): Round => ({
+  id,
+  project_id: projectId,
+  label,
+  created_at: new Date().toISOString(),
+});
+
+const mapRounds = (rs: Round[]) => new Map(rs.map((r) => [r.id, r]));
+
+describe("versionLabel / versionEquals", () => {
+  it("formata X.Y.Z", () => {
+    expect(versionLabel(v(1, 2, 3))).toBe("1.2.3");
+    expect(versionLabel(v(0, 1, 0))).toBe("0.1.0");
+  });
+
+  it("compara versoes por igualdade estrutural", () => {
+    expect(versionEquals(v(1, 0, 0), v(1, 0, 0))).toBe(true);
+    expect(versionEquals(v(1, 0, 0), v(1, 0, 1))).toBe(false);
+    expect(versionEquals(v(0, 1, 0), v(1, 0, 0))).toBe(false);
+  });
+});
+
+describe("isCurrentFilter", () => {
+  it("considera vazio/null/undefined/'current' como atual", () => {
+    expect(isCurrentFilter(undefined)).toBe(true);
+    expect(isCurrentFilter(null)).toBe(true);
+    expect(isCurrentFilter("")).toBe(true);
+    expect(isCurrentFilter("current")).toBe(true);
+  });
+
+  it("nao considera valores especificos como atual", () => {
+    expect(isCurrentFilter("all")).toBe(false);
+    expect(isCurrentFilter("1.2.3")).toBe(false);
+    expect(isCurrentFilter("uuid-xyz")).toBe(false);
+  });
+});
+
+describe("getCurrentRoundDescriptor", () => {
+  it("schema_version usa versionLabel", () => {
+    const ctx: RoundContext = {
+      strategy: "schema_version",
+      currentRoundId: null,
+      currentVersion: v(1, 2, 0),
+      rounds: [],
+    };
+    expect(getCurrentRoundDescriptor(ctx, mapRounds([]))).toEqual({
+      key: "1.2.0",
+      label: "1.2.0",
+    });
+  });
+
+  it("manual sem rodada atual retorna chave vazia", () => {
+    const ctx: RoundContext = {
+      strategy: "manual",
+      currentRoundId: null,
+      currentVersion: v(0, 1, 0),
+      rounds: [],
+    };
+    expect(getCurrentRoundDescriptor(ctx, mapRounds([]))).toEqual({
+      key: "",
+      label: "Sem rodada atual",
+    });
+  });
+
+  it("manual com rodada atual mas removida cai no fallback", () => {
+    const ctx: RoundContext = {
+      strategy: "manual",
+      currentRoundId: "missing",
+      currentVersion: v(0, 1, 0),
+      rounds: [],
+    };
+    expect(getCurrentRoundDescriptor(ctx, mapRounds([]))).toEqual({
+      key: "missing",
+      label: "Sem rodada atual",
+    });
+  });
+
+  it("manual com rodada atual conhecida usa o label", () => {
+    const r = round("r1", "Piloto");
+    const ctx: RoundContext = {
+      strategy: "manual",
+      currentRoundId: "r1",
+      currentVersion: v(0, 1, 0),
+      rounds: [r],
+    };
+    expect(getCurrentRoundDescriptor(ctx, mapRounds([r]))).toEqual({
+      key: "r1",
+      label: "Piloto",
+    });
+  });
+});
+
+describe("classifyDocStatus — schema_version", () => {
+  const ctx: RoundContext = {
+    strategy: "schema_version",
+    currentRoundId: null,
+    currentVersion: v(1, 0, 0),
+    rounds: [],
+  };
+
+  it("sem resposta -> no_response", () => {
+    expect(classifyDocStatus(ctx, null, mapRounds([]))).toEqual({
+      kind: "no_response",
+    });
+  });
+
+  it("resposta na versao atual -> current_done", () => {
+    const r: ResponseRoundFields = {
+      schema_version_major: 1,
+      schema_version_minor: 0,
+      schema_version_patch: 0,
+    };
+    expect(classifyDocStatus(ctx, r, mapRounds([]))).toEqual({
+      kind: "current_done",
+    });
+  });
+
+  it("resposta em versao anterior -> previous com label", () => {
+    const r: ResponseRoundFields = {
+      schema_version_major: 0,
+      schema_version_minor: 1,
+      schema_version_patch: 0,
+    };
+    expect(classifyDocStatus(ctx, r, mapRounds([]))).toEqual({
+      kind: "previous",
+      label: "0.1.0",
+    });
+  });
+
+  it("resposta sem versao -> current_pending (legado)", () => {
+    const r: ResponseRoundFields = {
+      schema_version_major: null,
+      schema_version_minor: null,
+      schema_version_patch: null,
+    };
+    expect(classifyDocStatus(ctx, r, mapRounds([]))).toEqual({
+      kind: "current_pending",
+    });
+  });
+
+  it("resposta parcial em versao atual -> current_pending", () => {
+    const r: ResponseRoundFields = {
+      schema_version_major: 1,
+      schema_version_minor: 0,
+      schema_version_patch: 0,
+      is_partial: true,
+    };
+    expect(classifyDocStatus(ctx, r, mapRounds([]))).toEqual({
+      kind: "current_pending",
+    });
+  });
+});
+
+describe("classifyDocStatus — manual", () => {
+  const piloto = round("rp", "Piloto");
+  const r2 = round("r2", "Rodada 2");
+  const ctx: RoundContext = {
+    strategy: "manual",
+    currentRoundId: "r2",
+    currentVersion: v(1, 0, 0),
+    rounds: [piloto, r2],
+  };
+
+  it("sem rodada atual definida tudo vira pendente", () => {
+    const noCurrent: RoundContext = { ...ctx, currentRoundId: null };
+    const r: ResponseRoundFields = { round_id: "rp" };
+    expect(classifyDocStatus(noCurrent, r, mapRounds([piloto, r2]))).toEqual({
+      kind: "current_pending",
+    });
+  });
+
+  it("resposta na rodada atual -> current_done", () => {
+    const r: ResponseRoundFields = { round_id: "r2" };
+    expect(classifyDocStatus(ctx, r, mapRounds([piloto, r2]))).toEqual({
+      kind: "current_done",
+    });
+  });
+
+  it("resposta em rodada anterior -> previous com label", () => {
+    const r: ResponseRoundFields = { round_id: "rp" };
+    expect(classifyDocStatus(ctx, r, mapRounds([piloto, r2]))).toEqual({
+      kind: "previous",
+      label: "Piloto",
+    });
+  });
+
+  it("resposta com round_id inexistente cai em 'Rodada removida'", () => {
+    // Caso de borda; com FK ON DELETE SET NULL deveria virar null antes de
+    // chegar aqui. Mantido como guardrail.
+    const r: ResponseRoundFields = { round_id: "fantasma" };
+    expect(classifyDocStatus(ctx, r, mapRounds([piloto, r2]))).toEqual({
+      kind: "previous",
+      label: "Rodada removida",
+    });
+  });
+
+  it("resposta sem round_id (FK setou null apos delete) -> 'Sem rodada'", () => {
+    const r: ResponseRoundFields = { round_id: null };
+    expect(classifyDocStatus(ctx, r, mapRounds([piloto, r2]))).toEqual({
+      kind: "previous",
+      label: "Sem rodada",
+    });
+  });
+
+  it("resposta parcial mesmo na rodada atual -> current_pending", () => {
+    const r: ResponseRoundFields = { round_id: "r2", is_partial: true };
+    expect(classifyDocStatus(ctx, r, mapRounds([piloto, r2]))).toEqual({
+      kind: "current_pending",
+    });
+  });
+});
+
+describe("responseRoundLabel", () => {
+  const piloto = round("rp", "Piloto");
+
+  it("manual usa label da tabela rounds", () => {
+    const ctx: RoundContext = {
+      strategy: "manual",
+      currentRoundId: "rp",
+      currentVersion: v(1, 0, 0),
+      rounds: [piloto],
+    };
+    expect(responseRoundLabel(ctx, { round_id: "rp" }, mapRounds([piloto]))).toBe(
+      "Piloto",
+    );
+  });
+
+  it("manual com round_id null retorna null", () => {
+    const ctx: RoundContext = {
+      strategy: "manual",
+      currentRoundId: "rp",
+      currentVersion: v(1, 0, 0),
+      rounds: [piloto],
+    };
+    expect(responseRoundLabel(ctx, { round_id: null }, mapRounds([piloto]))).toBeNull();
+  });
+
+  it("schema_version usa X.Y.Z da resposta", () => {
+    const ctx: RoundContext = {
+      strategy: "schema_version",
+      currentRoundId: null,
+      currentVersion: v(1, 0, 0),
+      rounds: [],
+    };
+    const r: ResponseRoundFields = {
+      schema_version_major: 0,
+      schema_version_minor: 9,
+      schema_version_patch: 1,
+    };
+    expect(responseRoundLabel(ctx, r, mapRounds([]))).toBe("0.9.1");
+  });
+
+  it("response null/undefined retorna null", () => {
+    const ctx: RoundContext = {
+      strategy: "schema_version",
+      currentRoundId: null,
+      currentVersion: v(1, 0, 0),
+      rounds: [],
+    };
+    expect(responseRoundLabel(ctx, null, mapRounds([]))).toBeNull();
+    expect(responseRoundLabel(ctx, undefined, mapRounds([]))).toBeNull();
+  });
+});

--- a/frontend/src/lib/__tests__/rounds.test.ts
+++ b/frontend/src/lib/__tests__/rounds.test.ts
@@ -6,6 +6,8 @@ import {
   responseRoundLabel,
   isCurrentFilter,
   getCurrentRoundDescriptor,
+  compareVersionLabels,
+  resolveRoundFilter,
   type RoundContext,
   type ResponseRoundFields,
   type SchemaVersion,
@@ -279,5 +281,90 @@ describe("responseRoundLabel", () => {
     };
     expect(responseRoundLabel(ctx, null, mapRounds([]))).toBeNull();
     expect(responseRoundLabel(ctx, undefined, mapRounds([]))).toBeNull();
+  });
+});
+
+describe("compareVersionLabels", () => {
+  it("ordena numericamente, nao lexicograficamente", () => {
+    const versions = ["0.10.0", "0.9.0", "1.0.0", "0.2.5"];
+    expect([...versions].sort(compareVersionLabels)).toEqual([
+      "0.2.5",
+      "0.9.0",
+      "0.10.0",
+      "1.0.0",
+    ]);
+  });
+
+  it("trata versoes iguais como 0", () => {
+    expect(compareVersionLabels("1.2.3", "1.2.3")).toBe(0);
+  });
+
+  it("compara major antes de minor antes de patch", () => {
+    expect(compareVersionLabels("2.0.0", "1.99.99")).toBeGreaterThan(0);
+    expect(compareVersionLabels("1.2.0", "1.1.99")).toBeGreaterThan(0);
+    expect(compareVersionLabels("1.1.2", "1.1.1")).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveRoundFilter", () => {
+  const piloto = round("rp", "Piloto");
+  const r2 = round("r2", "Rodada 2");
+
+  describe("schema_version", () => {
+    const ctx: RoundContext = {
+      strategy: "schema_version",
+      currentRoundId: null,
+      currentVersion: v(1, 0, 0),
+      rounds: [],
+    };
+
+    it("undefined/null/'current' viram 'current'", () => {
+      expect(resolveRoundFilter(undefined, ctx, "1.0.0", ["0.9.0"])).toBe("current");
+      expect(resolveRoundFilter(null, ctx, "1.0.0", ["0.9.0"])).toBe("current");
+      expect(resolveRoundFilter("current", ctx, "1.0.0", ["0.9.0"])).toBe("current");
+    });
+
+    it("'all' permanece 'all'", () => {
+      expect(resolveRoundFilter("all", ctx, "1.0.0", ["0.9.0"])).toBe("all");
+    });
+
+    it("versao igual a current vira 'current'", () => {
+      expect(resolveRoundFilter("1.0.0", ctx, "1.0.0", ["0.9.0"])).toBe("current");
+    });
+
+    it("versao em previousVersions e mantida", () => {
+      expect(resolveRoundFilter("0.9.0", ctx, "1.0.0", ["0.9.0", "0.8.0"])).toBe(
+        "0.9.0",
+      );
+    });
+
+    it("versao desconhecida vira 'current' (URL stale apos troca)", () => {
+      expect(resolveRoundFilter("99.0.0", ctx, "1.0.0", ["0.9.0"])).toBe("current");
+    });
+  });
+
+  describe("manual", () => {
+    const ctx: RoundContext = {
+      strategy: "manual",
+      currentRoundId: "r2",
+      currentVersion: v(1, 0, 0),
+      rounds: [piloto, r2],
+    };
+
+    it("id de rodada conhecida e mantido", () => {
+      expect(resolveRoundFilter("rp", ctx, "r2", [])).toBe("rp");
+    });
+
+    it("id == currentRoundKey vira 'current'", () => {
+      expect(resolveRoundFilter("r2", ctx, "r2", [])).toBe("current");
+    });
+
+    it("id desconhecido vira 'current'", () => {
+      expect(resolveRoundFilter("fantasma", ctx, "r2", [])).toBe("current");
+    });
+
+    it("'all' permanece 'all'", () => {
+      expect(resolveRoundFilter("all", ctx, "r2", [])).toBe("all");
+    });
   });
 });

--- a/frontend/src/lib/rounds.ts
+++ b/frontend/src/lib/rounds.ts
@@ -125,3 +125,36 @@ export function getCurrentRoundDescriptor(
   const v = versionLabel(ctx.currentVersion);
   return { key: v, label: v };
 }
+
+/**
+ * Compara duas versões "X.Y.Z" numericamente (não lexicograficamente).
+ * "0.10.0" deve vir DEPOIS de "0.9.0", mas o sort default trataria como antes.
+ */
+export function compareVersionLabels(a: string, b: string): number {
+  const [am = 0, an = 0, ap = 0] = a.split(".").map((n) => Number(n) || 0);
+  const [bm = 0, bn = 0, bp = 0] = b.split(".").map((n) => Number(n) || 0);
+  return am - bm || an - bn || ap - bp;
+}
+
+/**
+ * Normaliza o valor de `?round=` para um filtro válido.
+ *
+ * - Se não corresponde a nenhuma rodada/versão conhecida, faz fallback para "current"
+ *   (evita lista vazia silenciosa após troca de estratégia ou URL manipulada).
+ * - Se aponta para a rodada atual (mesma key), também vira "current" para que o
+ *   painel não fique read-only sobre o que ainda é a rodada vigente.
+ */
+export function resolveRoundFilter(
+  raw: string | null | undefined,
+  ctx: RoundContext,
+  currentRoundKey: string,
+  previousVersions: string[],
+): "current" | "all" | string {
+  if (isCurrentFilter(raw)) return "current";
+  if (raw === "all") return "all";
+  if (raw === currentRoundKey) return "current";
+  if (ctx.strategy === "manual") {
+    return ctx.rounds.some((r) => r.id === raw) ? (raw as string) : "current";
+  }
+  return previousVersions.includes(raw as string) ? (raw as string) : "current";
+}

--- a/frontend/src/lib/rounds.ts
+++ b/frontend/src/lib/rounds.ts
@@ -1,0 +1,97 @@
+import type { RoundStrategy, Round } from "./types";
+
+export interface SchemaVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+export interface RoundContext {
+  strategy: RoundStrategy;
+  currentRoundId: string | null;
+  currentVersion: SchemaVersion;
+  rounds: Round[];
+}
+
+export interface ResponseRoundFields {
+  round_id?: string | null;
+  schema_version_major?: number | null;
+  schema_version_minor?: number | null;
+  schema_version_patch?: number | null;
+}
+
+export function versionLabel(v: SchemaVersion): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+export function versionEquals(a: SchemaVersion, b: SchemaVersion): boolean {
+  return a.major === b.major && a.minor === b.minor && a.patch === b.patch;
+}
+
+export function responseRoundLabel(
+  ctx: RoundContext,
+  response: ResponseRoundFields | null | undefined,
+  roundsById: Map<string, Round>,
+): string | null {
+  if (!response) return null;
+  if (ctx.strategy === "manual") {
+    if (!response.round_id) return null;
+    return roundsById.get(response.round_id)?.label ?? null;
+  }
+  const m = response.schema_version_major;
+  const n = response.schema_version_minor;
+  const p = response.schema_version_patch;
+  if (m == null || n == null || p == null) return null;
+  return `${m}.${n}.${p}`;
+}
+
+export type DocRoundStatus =
+  | { kind: "current_pending" }
+  | { kind: "current_done" }
+  | { kind: "previous"; label: string }
+  | { kind: "no_response" };
+
+export function classifyDocStatus(
+  ctx: RoundContext,
+  response: ResponseRoundFields | null | undefined,
+  roundsById: Map<string, Round>,
+): DocRoundStatus {
+  if (!response) return { kind: "no_response" };
+
+  if (ctx.strategy === "manual") {
+    if (!ctx.currentRoundId) {
+      // Estrategia manual mas nao ha rodada atual definida.
+      // Tudo vira "sem rodada" / pendente.
+      return { kind: "current_pending" };
+    }
+    if (response.round_id === ctx.currentRoundId) {
+      return { kind: "current_done" };
+    }
+    const label = response.round_id
+      ? roundsById.get(response.round_id)?.label ?? "Rodada removida"
+      : "Sem rodada";
+    return { kind: "previous", label };
+  }
+
+  // schema_version
+  const m = response.schema_version_major;
+  const n = response.schema_version_minor;
+  const p = response.schema_version_patch;
+  if (m == null || n == null || p == null) return { kind: "current_pending" };
+  const v: SchemaVersion = { major: m, minor: n, patch: p };
+  if (versionEquals(v, ctx.currentVersion)) return { kind: "current_done" };
+  return { kind: "previous", label: versionLabel(v) };
+}
+
+/**
+ * Identificadores possiveis para o filtro de rodada na URL (`?round=`).
+ *  - "current": padrao, mostra docs pendentes da rodada atual
+ *  - "all": mostra tudo (comportamento legacy)
+ *  - rodada manual: id (UUID)
+ *  - rodada schema_version: label "X.Y.Z"
+ */
+export type RoundFilterValue = "current" | "all" | string;
+
+export function isCurrentFilter(value: string | null | undefined): boolean {
+  return !value || value === "current";
+}

--- a/frontend/src/lib/rounds.ts
+++ b/frontend/src/lib/rounds.ts
@@ -18,6 +18,7 @@ export interface ResponseRoundFields {
   schema_version_major?: number | null;
   schema_version_minor?: number | null;
   schema_version_patch?: number | null;
+  is_partial?: boolean | null;
 }
 
 export function versionLabel(v: SchemaVersion): string {
@@ -58,6 +59,10 @@ export function classifyDocStatus(
 ): DocRoundStatus {
   if (!response) return { kind: "no_response" };
 
+  // Resposta parcial (autosave em andamento) ainda precisa ser concluida —
+  // tratar como pendente da rodada atual independente de schema/round_id.
+  if (response.is_partial === true) return { kind: "current_pending" };
+
   if (ctx.strategy === "manual") {
     if (!ctx.currentRoundId) {
       // Estrategia manual mas nao ha rodada atual definida.
@@ -67,6 +72,9 @@ export function classifyDocStatus(
     if (response.round_id === ctx.currentRoundId) {
       return { kind: "current_done" };
     }
+    // Guardrail: com FK responses.round_id ON DELETE SET NULL, round_id de uma
+    // rodada removida vira null (cai no branch "Sem rodada") — o lookup falhar
+    // com label "Rodada removida" so deve ocorrer em estado intermediario.
     const label = response.round_id
       ? roundsById.get(response.round_id)?.label ?? "Rodada removida"
       : "Sem rodada";
@@ -94,4 +102,26 @@ export type RoundFilterValue = "current" | "all" | string;
 
 export function isCurrentFilter(value: string | null | undefined): boolean {
   return !value || value === "current";
+}
+
+export interface CurrentRoundDescriptor {
+  /** Identificador estavel da rodada atual usado em URLs/comparacoes. */
+  key: string;
+  /** Texto apresentado ao usuario. */
+  label: string;
+}
+
+export function getCurrentRoundDescriptor(
+  ctx: RoundContext,
+  roundsById: Map<string, Round>,
+): CurrentRoundDescriptor {
+  if (ctx.strategy === "manual") {
+    if (!ctx.currentRoundId) {
+      return { key: "", label: "Sem rodada atual" };
+    }
+    const label = roundsById.get(ctx.currentRoundId)?.label ?? "Sem rodada atual";
+    return { key: ctx.currentRoundId, label };
+  }
+  const v = versionLabel(ctx.currentVersion);
+  return { key: v, label: v };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,6 +6,15 @@ export interface Profile {
   created_at: string;
 }
 
+export type RoundStrategy = "schema_version" | "manual";
+
+export interface Round {
+  id: string;
+  project_id: string;
+  label: string;
+  created_at: string;
+}
+
 export interface Project {
   id: string;
   name: string;
@@ -22,6 +31,8 @@ export interface Project {
   resolution_rule: string;
   min_responses_for_comparison: number;
   allow_researcher_review: boolean;
+  round_strategy: RoundStrategy;
+  current_round_id: string | null;
 }
 
 export interface SubfieldDef {

--- a/frontend/supabase/migrations/20260507000000_rounds.sql
+++ b/frontend/supabase/migrations/20260507000000_rounds.sql
@@ -1,0 +1,52 @@
+-- Rodadas de codificacao.
+--
+-- Coordenadores podem optar entre duas estrategias:
+--   1) schema_version (default): rodada = versao atual do schema do projeto.
+--      Reaproveita schema_version_major/minor/patch ja gravado em responses.
+--   2) manual: rodada = entidade explicita (tabela rounds). Coordenador cria
+--      rodadas e marca uma como atual via projects.current_round_id.
+--
+-- Quando estrategia=manual, saveResponse grava round_id = current_round_id
+-- no momento do save. Re-codificar uma resposta antiga "promove" para a
+-- rodada atual (sobrescrevendo round_id), seguindo o mesmo modelo de update
+-- in-place que ja existe para schema_version.
+
+ALTER TABLE projects
+  ADD COLUMN round_strategy TEXT NOT NULL DEFAULT 'schema_version'
+    CHECK (round_strategy IN ('schema_version', 'manual')),
+  ADD COLUMN current_round_id UUID NULL;
+
+CREATE TABLE rounds (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id  UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  label       TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (project_id, label)
+);
+
+CREATE INDEX idx_rounds_project ON rounds(project_id, created_at DESC);
+
+ALTER TABLE projects
+  ADD CONSTRAINT projects_current_round_fk
+  FOREIGN KEY (current_round_id) REFERENCES rounds(id) ON DELETE SET NULL;
+
+ALTER TABLE responses
+  ADD COLUMN round_id UUID NULL REFERENCES rounds(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_responses_round ON responses(project_id, round_id);
+
+ALTER TABLE rounds ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Members view rounds" ON rounds FOR SELECT USING (
+  project_id IN (SELECT auth_user_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+);
+
+CREATE POLICY "Coordinators manage rounds" ON rounds FOR ALL USING (
+  project_id IN (SELECT auth_user_coordinator_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+)
+WITH CHECK (
+  project_id IN (SELECT auth_user_coordinator_project_ids())
+  OR project_id IN (SELECT id FROM projects WHERE created_by = clerk_uid())
+);


### PR DESCRIPTION
## Summary

- Aba **Analisar → Codificar** agora filtra a lista de documentos pela rodada vigente. Por padrão (`?round=current`) só aparecem docs pendentes da rodada atual (sem resposta ou com resposta de rodada anterior). Seletor permite ver "Todas as rodadas" ou inspecionar rodadas anteriores em read-only.
- Nova sub-aba **Configurações → Rodadas** com toggle de estratégia:
  - `schema_version` (default): rodada = versão atual do schema (`schema_version_*`). Funciona automaticamente sem o coordenador precisar fazer nada.
  - `manual`: coordenador cria/nomeia rodadas e marca uma como atual. `responses.round_id` é preenchido em `saveResponse`.
- Mensagem vazia específica quando o pesquisador zera a rodada atual ("Tudo em dia na rodada atual…").

### Migration

`frontend/supabase/migrations/20260507000000_rounds.sql` adiciona:
- `projects.round_strategy` + `projects.current_round_id`
- Tabela `rounds` (id, project_id, label, created_at) + RLS
- `responses.round_id` + index

Aplicar via `cd frontend && npx supabase db push`.

## Test plan

- [ ] Aplicar migration no Supabase remoto
- [ ] **Estratégia `schema_version`** (default): atribuir 3 docs, responder 2. Conferir que default mostra só 1. Bumpar schema (mudar opção de campo `single`). Voltar pra `/analyze/code` — devem aparecer 3 (2 antigas + 1 nunca respondida). Selecionar versão antiga: lista os 2 já respondidos, painel read-only.
- [ ] **Estratégia `manual`**: trocar em `/config/rounds`, criar "Piloto" + marcar atual, responder 2 docs, criar "Rodada 2" + marcar atual. Default mostra só pendentes da Rodada 2; selecionar "Piloto" mostra os respondidos read-only.
- [ ] Coordenador apaga rodada com responses → FK `ON DELETE SET NULL`, responses ficam órfãs (filtro classifica como "Sem rodada").
- [ ] Pesquisador (não-coordenador) abre `/config/rounds` — toggle e CRUD ficam desabilitados.

## Validação local

- `tsc --noEmit` ✓
- `npm run lint` ✓ (arquivos novos/modificados sem novos erros)
- `npm test` 91/91 ✓
- `npm run build` ✓ (rota `/config/rounds` aparece no output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)