### PR TITLE
feat(documents): soft delete com motivo e restauração

### DIFF
--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -141,11 +141,12 @@ async function computeLottery(
     .eq("project_id", params.projectId)
     .eq("role", "pesquisador");
 
-  // 2. Fetch documents
+  // 2. Fetch documents (excluidos sao ignorados na alocacao)
   const { data: docs } = await supabase
     .from("documents")
     .select("id")
-    .eq("project_id", params.projectId);
+    .eq("project_id", params.projectId)
+    .is("excluded_at", null);
 
   if (!docs?.length) {
     throw new Error("Necessário ter documentos.");

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -46,12 +46,14 @@ export async function checkDuplicates(
   const duplicates: DuplicateMatch[] = [];
   const matchedCsvIndices = new Set<number>();
 
-  // 1. Match by external_id
+  // 1. Match by external_id (excluidos sao ignorados — re-upload de doc
+  //    excluido por engano cria um novo registro normal)
   if (externalIds.length > 0) {
     const { data: byExtId } = await supabase
       .from("documents")
       .select("id, external_id")
       .eq("project_id", projectId)
+      .is("excluded_at", null)
       .in(
         "external_id",
         externalIds.map((e) => e.id!)
@@ -84,6 +86,7 @@ export async function checkDuplicates(
       .from("documents")
       .select("id, text_hash")
       .eq("project_id", projectId)
+      .is("excluded_at", null)
       .in("text_hash", uniqueHashes);
 
     if (byHash) {
@@ -272,6 +275,7 @@ export async function getDocumentsForBrowse(projectId: string): Promise<BrowseDo
     .from("documents")
     .select("id, external_id, title, created_at")
     .eq("project_id", projectId)
+    .is("excluded_at", null)
     .order("created_at", { ascending: true });
 
   if (!docs || docs.length === 0) return [];
@@ -317,6 +321,7 @@ export async function getDocumentForCoding(
       .select("id, external_id, title, text")
       .eq("id", documentId)
       .eq("project_id", projectId)
+      .is("excluded_at", null)
       .single(),
     supabase
       .from("projects")
@@ -376,19 +381,62 @@ export async function getDocumentText(
   return { text: data.text, title: data.title || documentId };
 }
 
-export async function deleteDocument(projectId: string, documentId: string) {
+// Soft delete: marca documents.excluded_at. Reads default filtram excluidos.
+// Coordenador pode visualizar/restaurar via toggle "Mostrar excluidos".
+export async function excludeDocuments(
+  projectId: string,
+  documentIds: string[],
+  reason: string,
+) {
+  const user = await getAuthUser();
+  if (!user) return { error: "Nao autenticado" };
+  if (!reason?.trim()) return { error: "Motivo da exclusao e obrigatorio" };
+
   const supabase = await createSupabaseServer();
   const { error } = await supabase
     .from("documents")
-    .delete()
-    .eq("id", documentId);
+    .update({
+      excluded_at: new Date().toISOString(),
+      excluded_reason: reason.trim(),
+      excluded_by: user.id,
+    })
+    .eq("project_id", projectId)
+    .in("id", documentIds);
 
   if (error) return { error: error.message };
   revalidatePath(`/projects/${projectId}/config/documents`);
   revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+  return { count: documentIds.length };
 }
 
-export async function deleteDocuments(projectId: string, documentIds: string[]) {
+export async function restoreDocuments(
+  projectId: string,
+  documentIds: string[],
+) {
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase
+    .from("documents")
+    .update({
+      excluded_at: null,
+      excluded_reason: null,
+      excluded_by: null,
+    })
+    .eq("project_id", projectId)
+    .in("id", documentIds);
+
+  if (error) return { error: error.message };
+  revalidatePath(`/projects/${projectId}/config/documents`);
+  revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+  return { count: documentIds.length };
+}
+
+// Hard delete: remove DB permanente (CASCADE em responses/reviews/assignments).
+// So usar quando coordenador confirma que o doc nao deve voltar nem manter
+// historico — tipicamente apos soft delete + revisao.
+export async function hardDeleteDocuments(
+  projectId: string,
+  documentIds: string[],
+) {
   const supabase = await createSupabaseServer();
   const { error } = await supabase
     .from("documents")
@@ -398,4 +446,5 @@ export async function deleteDocuments(projectId: string, documentIds: string[]) 
   if (error) return { error: error.message };
   revalidatePath(`/projects/${projectId}/config/documents`);
   revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+  return { count: documentIds.length };
 }

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -14,7 +14,8 @@ export async function getEligibleDocCount(
     supabase
       .from("documents")
       .select("id", { count: "exact", head: true })
-      .eq("project_id", projectId),
+      .eq("project_id", projectId)
+      .is("excluded_at", null),
     supabase
       .from("responses")
       .select("document_id")
@@ -280,6 +281,7 @@ export async function getDocumentsForSelection(
       .from("documents")
       .select("id, title, external_id")
       .eq("project_id", projectId)
+      .is("excluded_at", null)
       .order("external_id"),
     supabase
       .from("responses")

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
@@ -14,6 +14,7 @@ function getCachedDocuments(projectId: string) {
         .from("documents")
         .select("id, external_id, title")
         .eq("project_id", projectId)
+        .is("excluded_at", null)
         .order("created_at", { ascending: true });
       return data || [];
     },

--- a/frontend/src/app/(app)/projects/[id]/config/documents/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/documents/page.tsx
@@ -4,23 +4,62 @@ import { DocumentsPageClient } from "@/components/documents/DocumentsPageClient"
 
 export default async function ConfigDocumentsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ show?: string }>;
 }) {
   const { id } = await params;
+  const { show } = await searchParams;
+  const showExcluded = show === "excluded";
   const supabase = await createSupabaseServer();
 
-  const { data: documents } = await supabase
+  let query = supabase
     .from("documents")
-    .select("id, external_id, title, created_at, responses(count)")
-    .eq("project_id", id)
-    .order("created_at", { ascending: true });
+    .select(
+      "id, external_id, title, created_at, excluded_at, excluded_reason, excluded_by, responses(count)",
+    )
+    .eq("project_id", id);
+
+  query = showExcluded
+    ? query.not("excluded_at", "is", null)
+    : query.is("excluded_at", null);
+
+  const { data: documents } = await query.order("created_at", {
+    ascending: true,
+  });
+
+  // Resolve excluded_by ids para nomes (so quando mostrando excluidos)
+  const excludedByIds = showExcluded
+    ? Array.from(
+        new Set(
+          (documents || [])
+            .map((d) => d.excluded_by)
+            .filter((v): v is string => !!v),
+        ),
+      )
+    : [];
+
+  const profileById = new Map<string, string>();
+  if (excludedByIds.length > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, first_name, email")
+      .in("id", excludedByIds);
+    for (const p of profiles || []) {
+      profileById.set(p.id, p.first_name || p.email || p.id);
+    }
+  }
 
   const docsWithCounts = (documents || []).map((d) => ({
     id: d.id,
     external_id: d.external_id,
     title: d.title,
     created_at: d.created_at,
+    excluded_at: d.excluded_at,
+    excluded_reason: d.excluded_reason,
+    excluded_by: d.excluded_by,
+    excluded_by_name: d.excluded_by ? profileById.get(d.excluded_by) || null : null,
     responseCount:
       (d.responses as unknown as { count: number }[])?.[0]?.count || 0,
   }));
@@ -28,7 +67,11 @@ export default async function ConfigDocumentsPage({
   return (
     <div className="mx-auto max-w-4xl space-y-6 p-6">
       <DocumentUpload projectId={id} />
-      <DocumentsPageClient documents={docsWithCounts} projectId={id} />
+      <DocumentsPageClient
+        documents={docsWithCounts}
+        projectId={id}
+        showExcluded={showExcluded}
+      />
     </div>
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
@@ -22,7 +22,8 @@ export default async function LlmConfigurePage({
       supabase
         .from("documents")
         .select("id", { count: "exact", head: true })
-        .eq("project_id", id),
+        .eq("project_id", id)
+        .is("excluded_at", null),
       supabase
         .from("responses")
         .select("document_id")

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -42,7 +42,8 @@ export default async function CommentsPage({
     supabase
       .from("documents")
       .select("id, title, external_id")
-      .eq("project_id", id),
+      .eq("project_id", id)
+      .is("excluded_at", null),
     user
       ? supabase
           .from("project_members")

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -75,7 +75,8 @@ export default async function LlmInsightsPage({
     supabase
       .from("documents")
       .select("id, title, external_id")
-      .eq("project_id", id),
+      .eq("project_id", id)
+      .is("excluded_at", null),
     supabase
       .from("error_resolutions")
       .select("document_id, field_name, resolved_at")

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -101,7 +101,8 @@ export default async function MyVerdictsPage({
     supabase
       .from("documents")
       .select("id, title, external_id")
-      .in("id", myDocIds),
+      .in("id", myDocIds)
+      .is("excluded_at", null),
     supabase
       .from("verdict_acknowledgments")
       .select("review_id, status, comment")

--- a/frontend/src/components/documents/DocumentList.tsx
+++ b/frontend/src/components/documents/DocumentList.tsx
@@ -6,11 +6,14 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
-import { Trash2 } from "lucide-react";
+import { Trash2, RotateCcw, FlameKindling } from "lucide-react";
 import type { Document } from "@/lib/types";
 
 export type DocumentSummary = Pick<Document, "id" | "external_id" | "title"> & {
   responseCount?: number;
+  excluded_at?: string | null;
+  excluded_reason?: string | null;
+  excluded_by_name?: string | null;
 };
 
 interface DocumentListProps {
@@ -21,6 +24,19 @@ interface DocumentListProps {
   onToggleSelect?: (docId: string) => void;
   onToggleAll?: (checked: boolean) => void;
   onRequestDelete?: (doc: DocumentSummary) => void;
+  onRequestRestore?: (doc: DocumentSummary) => void;
+  onRequestHardDelete?: (doc: DocumentSummary) => void;
+  /** quando true, lista mostra apenas excluidos e troca acoes (restaurar / apagar permanente) */
+  showExcluded?: boolean;
+}
+
+function formatDate(iso: string | null | undefined) {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
 }
 
 export function DocumentList({
@@ -31,20 +47,26 @@ export function DocumentList({
   onToggleSelect,
   onToggleAll,
   onRequestDelete,
+  onRequestRestore,
+  onRequestHardDelete,
+  showExcluded = false,
 }: DocumentListProps) {
   const [search, setSearch] = useState("");
   const deferredSearch = useDeferredValue(search);
 
   const filtered = documents.filter(
     (d) =>
-      (d.title?.toLowerCase().includes(deferredSearch.toLowerCase()) ||
-        d.external_id?.toLowerCase().includes(deferredSearch.toLowerCase()))
+      d.title?.toLowerCase().includes(deferredSearch.toLowerCase()) ||
+      d.external_id?.toLowerCase().includes(deferredSearch.toLowerCase()),
   );
 
   const canSelect = !!onToggleSelect;
-  const canDelete = !!onRequestDelete;
+  const canDelete = !!onRequestDelete && !showExcluded;
+  const canRestore = !!onRequestRestore && showExcluded;
+  const canHardDelete = !!onRequestHardDelete && showExcluded;
 
-  const allFilteredSelected = filtered.length > 0 && filtered.every((d) => selectedIds?.has(d.id));
+  const allFilteredSelected =
+    filtered.length > 0 && filtered.every((d) => selectedIds?.has(d.id));
   const someFilteredSelected = filtered.some((d) => selectedIds?.has(d.id));
 
   return (
@@ -56,7 +78,9 @@ export function DocumentList({
           onChange={(e) => setSearch(e.target.value)}
           className="max-w-sm"
         />
-        <span className="text-sm text-muted-foreground">{filtered.length} docs</span>
+        <span className="text-sm text-muted-foreground">
+          {filtered.length} {showExcluded ? "excluídos" : "docs"}
+        </span>
       </div>
       <div className="rounded-lg border">
         <table className="w-full text-sm">
@@ -65,16 +89,36 @@ export function DocumentList({
               {canSelect && (
                 <th className="w-10 px-4 py-2">
                   <Checkbox
-                    checked={allFilteredSelected ? true : someFilteredSelected ? "indeterminate" : false}
+                    checked={
+                      allFilteredSelected
+                        ? true
+                        : someFilteredSelected
+                          ? "indeterminate"
+                          : false
+                    }
                     onCheckedChange={(checked) => onToggleAll?.(!!checked)}
                   />
                 </th>
               )}
               <th className="px-4 py-2 text-left font-medium">ID</th>
               <th className="px-4 py-2 text-left font-medium">Título</th>
-              <th className="px-4 py-2 text-left font-medium">Respostas</th>
-              {projectId && <th className="px-4 py-2 text-left font-medium w-10"></th>}
+              {showExcluded ? (
+                <>
+                  <th className="px-4 py-2 text-left font-medium">
+                    Excluído em
+                  </th>
+                  <th className="px-4 py-2 text-left font-medium">Por</th>
+                  <th className="px-4 py-2 text-left font-medium">Motivo</th>
+                </>
+              ) : (
+                <th className="px-4 py-2 text-left font-medium">Respostas</th>
+              )}
+              {projectId && !showExcluded && (
+                <th className="w-10 px-4 py-2"></th>
+              )}
               {canDelete && <th className="w-10 px-4 py-2"></th>}
+              {canRestore && <th className="w-10 px-4 py-2"></th>}
+              {canHardDelete && <th className="w-10 px-4 py-2"></th>}
             </tr>
           </thead>
           <tbody>
@@ -92,14 +136,35 @@ export function DocumentList({
                     />
                   </td>
                 )}
-                <td className="px-4 py-2 font-mono text-xs">{doc.external_id || doc.id.slice(0, 8)}</td>
-                <td className="px-4 py-2">{doc.title || "Sem título"}</td>
-                <td className="px-4 py-2">
-                  <Badge variant="secondary">{doc.responseCount || 0}</Badge>
+                <td className="px-4 py-2 font-mono text-xs">
+                  {doc.external_id || doc.id.slice(0, 8)}
                 </td>
-                {projectId && (
+                <td className="px-4 py-2">{doc.title || "Sem título"}</td>
+                {showExcluded ? (
+                  <>
+                    <td className="px-4 py-2 whitespace-nowrap text-muted-foreground">
+                      {formatDate(doc.excluded_at)}
+                    </td>
+                    <td className="px-4 py-2 text-muted-foreground">
+                      {doc.excluded_by_name || "—"}
+                    </td>
+                    <td
+                      className="max-w-xs truncate px-4 py-2 text-muted-foreground"
+                      title={doc.excluded_reason || ""}
+                    >
+                      {doc.excluded_reason || "—"}
+                    </td>
+                  </>
+                ) : (
                   <td className="px-4 py-2">
-                    <CopyLinkButton url={`${typeof window !== "undefined" ? window.location.origin : ""}/projects/${projectId}/analyze/code?doc=${doc.id}`} />
+                    <Badge variant="secondary">{doc.responseCount || 0}</Badge>
+                  </td>
+                )}
+                {projectId && !showExcluded && (
+                  <td className="px-4 py-2">
+                    <CopyLinkButton
+                      url={`${typeof window !== "undefined" ? window.location.origin : ""}/projects/${projectId}/analyze/code?doc=${doc.id}`}
+                    />
                   </td>
                 )}
                 {canDelete && (
@@ -109,8 +174,35 @@ export function DocumentList({
                       size="icon"
                       className="h-7 w-7 text-muted-foreground hover:text-destructive"
                       onClick={() => onRequestDelete?.(doc)}
+                      title="Excluir"
                     >
                       <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </td>
+                )}
+                {canRestore && (
+                  <td className="px-4 py-2" onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground hover:text-foreground"
+                      onClick={() => onRequestRestore?.(doc)}
+                      title="Restaurar"
+                    >
+                      <RotateCcw className="h-3.5 w-3.5" />
+                    </Button>
+                  </td>
+                )}
+                {canHardDelete && (
+                  <td className="px-4 py-2" onClick={(e) => e.stopPropagation()}>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                      onClick={() => onRequestHardDelete?.(doc)}
+                      title="Apagar permanentemente"
+                    >
+                      <FlameKindling className="h-3.5 w-3.5" />
                     </Button>
                   </td>
                 )}

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -1,10 +1,18 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter, usePathname } from "next/navigation";
 import { DocumentList, type DocumentSummary } from "@/components/documents/DocumentList";
 import { DocumentPreview } from "@/components/documents/DocumentPreview";
-import { deleteDocuments } from "@/actions/documents";
+import {
+  excludeDocuments,
+  restoreDocuments,
+  hardDeleteDocuments,
+} from "@/actions/documents";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,29 +23,48 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Trash2, Loader2 } from "lucide-react";
+import { Trash2, Loader2, RotateCcw, FlameKindling } from "lucide-react";
 import { toast } from "sonner";
-import type { Document } from "@/lib/types";
 
-type DocSummary = Pick<Document, "id" | "external_id" | "title" | "created_at"> & {
-  responseCount?: number;
+type DocSummary = DocumentSummary & {
+  created_at?: string;
 };
 
 interface DocumentsPageClientProps {
   documents: DocSummary[];
   projectId?: string;
+  showExcluded?: boolean;
 }
 
-export function DocumentsPageClient({ documents, projectId }: DocumentsPageClientProps) {
+type ExcludeTarget = { ids: string[]; totalResponses: number };
+type RestoreTarget = { ids: string[] };
+type HardDeleteTarget = { ids: string[] };
+
+export function DocumentsPageClient({
+  documents,
+  projectId,
+  showExcluded = false,
+}: DocumentsPageClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+
   const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [deleteTarget, setDeleteTarget] = useState<{
-    ids: string[];
-    totalResponses: number;
-  } | null>(null);
+  const [excludeTarget, setExcludeTarget] = useState<ExcludeTarget | null>(null);
+  const [excludeReason, setExcludeReason] = useState("");
+  const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
+  const [hardDeleteTarget, setHardDeleteTarget] =
+    useState<HardDeleteTarget | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const selectedDoc = documents.find((d) => d.id === selectedDocId) ?? null;
+
+  function handleToggleShowExcluded(checked: boolean) {
+    if (!pathname) return;
+    const url = checked ? `${pathname}?show=excluded` : pathname;
+    setSelectedIds(new Set());
+    router.push(url);
+  }
 
   function handleToggleSelect(docId: string) {
     setSelectedIds((prev) => {
@@ -49,67 +76,157 @@ export function DocumentsPageClient({ documents, projectId }: DocumentsPageClien
   }
 
   function handleToggleAll(checked: boolean) {
-    if (checked) {
-      setSelectedIds(new Set(documents.map((d) => d.id)));
-    } else {
-      setSelectedIds(new Set());
-    }
+    setSelectedIds(checked ? new Set(documents.map((d) => d.id)) : new Set());
   }
 
-  function handleRequestDeleteSingle(doc: DocumentSummary) {
+  function handleRequestExcludeSingle(doc: DocumentSummary) {
     const full = documents.find((d) => d.id === doc.id);
-    setDeleteTarget({
+    setExcludeTarget({
       ids: [doc.id],
       totalResponses: full?.responseCount ?? 0,
     });
+    setExcludeReason("");
   }
 
-  function handleRequestDeleteSelected() {
+  function handleRequestExcludeSelected() {
     const totalResponses = documents
       .filter((d) => selectedIds.has(d.id))
       .reduce((sum, d) => sum + (d.responseCount ?? 0), 0);
-    setDeleteTarget({ ids: Array.from(selectedIds), totalResponses });
+    setExcludeTarget({ ids: Array.from(selectedIds), totalResponses });
+    setExcludeReason("");
   }
 
-  function handleConfirmDelete() {
-    if (!deleteTarget || !projectId) return;
-    const { ids } = deleteTarget;
+  function handleConfirmExclude() {
+    if (!excludeTarget || !projectId) return;
+    if (!excludeReason.trim()) {
+      toast.error("Informe o motivo da exclusão");
+      return;
+    }
+    const { ids } = excludeTarget;
     const count = ids.length;
     startTransition(async () => {
-      const result = await deleteDocuments(projectId, ids);
+      const result = await excludeDocuments(projectId, ids, excludeReason);
       if (result?.error) {
         toast.error(result.error);
       } else {
         toast.success(
           count === 1
-            ? "Documento excluído com sucesso"
-            : `${count} documentos excluídos com sucesso`
+            ? "Documento excluído (reversível)"
+            : `${count} documentos excluídos (reversíveis)`,
         );
-        setSelectedIds((prev) => {
-          const next = new Set(prev);
-          ids.forEach((id) => next.delete(id));
-          return next;
-        });
-        setDeleteTarget(null);
+        setSelectedIds(new Set());
+        setExcludeTarget(null);
+        setExcludeReason("");
+      }
+    });
+  }
+
+  function handleRequestRestoreSingle(doc: DocumentSummary) {
+    setRestoreTarget({ ids: [doc.id] });
+  }
+
+  function handleRequestRestoreSelected() {
+    setRestoreTarget({ ids: Array.from(selectedIds) });
+  }
+
+  function handleConfirmRestore() {
+    if (!restoreTarget || !projectId) return;
+    const { ids } = restoreTarget;
+    const count = ids.length;
+    startTransition(async () => {
+      const result = await restoreDocuments(projectId, ids);
+      if (result?.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          count === 1 ? "Documento restaurado" : `${count} documentos restaurados`,
+        );
+        setSelectedIds(new Set());
+        setRestoreTarget(null);
+      }
+    });
+  }
+
+  function handleRequestHardDeleteSingle(doc: DocumentSummary) {
+    setHardDeleteTarget({ ids: [doc.id] });
+  }
+
+  function handleRequestHardDeleteSelected() {
+    setHardDeleteTarget({ ids: Array.from(selectedIds) });
+  }
+
+  function handleConfirmHardDelete() {
+    if (!hardDeleteTarget || !projectId) return;
+    const { ids } = hardDeleteTarget;
+    const count = ids.length;
+    startTransition(async () => {
+      const result = await hardDeleteDocuments(projectId, ids);
+      if (result?.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          count === 1
+            ? "Documento apagado permanentemente"
+            : `${count} documentos apagados permanentemente`,
+        );
+        setSelectedIds(new Set());
+        setHardDeleteTarget(null);
       }
     });
   }
 
   return (
     <>
+      {projectId && (
+        <div className="flex items-center justify-end gap-3">
+          <Label
+            htmlFor="show-excluded"
+            className="text-sm text-muted-foreground"
+          >
+            Mostrar excluídos
+          </Label>
+          <Switch
+            id="show-excluded"
+            checked={showExcluded}
+            onCheckedChange={handleToggleShowExcluded}
+          />
+        </div>
+      )}
+
       {projectId && selectedIds.size > 0 && (
         <div className="flex items-center gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-2">
           <span className="text-sm font-medium">
             {selectedIds.size} selecionado(s)
           </span>
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={handleRequestDeleteSelected}
-          >
-            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-            Excluir selecionados
-          </Button>
+          {showExcluded ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRequestRestoreSelected}
+              >
+                <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+                Restaurar selecionados
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleRequestHardDeleteSelected}
+              >
+                <FlameKindling className="mr-1.5 h-3.5 w-3.5" />
+                Apagar permanentemente
+              </Button>
+            </>
+          ) : (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={handleRequestExcludeSelected}
+            >
+              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+              Excluir selecionados
+            </Button>
+          )}
         </div>
       )}
 
@@ -120,7 +237,12 @@ export function DocumentsPageClient({ documents, projectId }: DocumentsPageClien
         selectedIds={projectId ? selectedIds : undefined}
         onToggleSelect={projectId ? handleToggleSelect : undefined}
         onToggleAll={projectId ? handleToggleAll : undefined}
-        onRequestDelete={projectId ? handleRequestDeleteSingle : undefined}
+        onRequestDelete={projectId ? handleRequestExcludeSingle : undefined}
+        onRequestRestore={projectId ? handleRequestRestoreSingle : undefined}
+        onRequestHardDelete={
+          projectId ? handleRequestHardDeleteSingle : undefined
+        }
+        showExcluded={showExcluded}
       />
 
       <DocumentPreview
@@ -130,44 +252,65 @@ export function DocumentsPageClient({ documents, projectId }: DocumentsPageClien
         onClose={() => setSelectedDocId(null)}
       />
 
+      {/* Soft delete (excluir = reversivel) */}
       <AlertDialog
-        open={!!deleteTarget}
-        onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+        open={!!excludeTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            setExcludeTarget(null);
+            setExcludeReason("");
+          }
+        }}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {deleteTarget?.ids.length === 1
+              {excludeTarget?.ids.length === 1
                 ? "Excluir documento?"
-                : `Excluir ${deleteTarget?.ids.length} documentos?`}
+                : `Excluir ${excludeTarget?.ids.length} documentos?`}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {deleteTarget && deleteTarget.totalResponses > 0 ? (
+              {excludeTarget && excludeTarget.totalResponses > 0 ? (
                 <>
-                  {deleteTarget.ids.length === 1
+                  {excludeTarget.ids.length === 1
                     ? "Este documento"
-                    : `Estes ${deleteTarget.ids.length} documentos`}{" "}
+                    : `Estes ${excludeTarget.ids.length} documentos`}{" "}
                   e suas{" "}
-                  <strong>
-                    {deleteTarget.totalResponses} resposta(s)
-                  </strong>{" "}
-                  serão excluídos permanentemente, incluindo revisões e atribuições associadas.
+                  <strong>{excludeTarget.totalResponses} resposta(s)</strong>{" "}
+                  serão ocultados das listas. A exclusão é reversível —
+                  você pode restaurar ou apagar permanentemente depois em
+                  &quot;Mostrar excluídos&quot;.
                 </>
               ) : (
                 <>
-                  {deleteTarget?.ids.length === 1
-                    ? "Este documento não possui respostas e"
-                    : `Estes ${deleteTarget?.ids.length} documentos não possuem respostas e`}{" "}
-                  será(ão) excluído(s) permanentemente.
+                  {excludeTarget?.ids.length === 1
+                    ? "O documento"
+                    : `Os ${excludeTarget?.ids.length} documentos`}{" "}
+                  serão ocultados das listas. A exclusão é reversível.
                 </>
               )}
             </AlertDialogDescription>
           </AlertDialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="exclude-reason">
+              Motivo da exclusão <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="exclude-reason"
+              value={excludeReason}
+              onChange={(e) => setExcludeReason(e.target.value)}
+              placeholder="Ex: parecer fora do escopo do projeto"
+              rows={3}
+              autoFocus
+            />
+          </div>
+
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleConfirmDelete}
-              disabled={isPending}
+              onClick={handleConfirmExclude}
+              disabled={isPending || !excludeReason.trim()}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {isPending ? (
@@ -177,6 +320,85 @@ export function DocumentsPageClient({ documents, projectId }: DocumentsPageClien
                 </>
               ) : (
                 "Excluir"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Restaurar */}
+      <AlertDialog
+        open={!!restoreTarget}
+        onOpenChange={(open) => {
+          if (!open) setRestoreTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {restoreTarget?.ids.length === 1
+                ? "Restaurar documento?"
+                : `Restaurar ${restoreTarget?.ids.length} documentos?`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {restoreTarget?.ids.length === 1
+                ? "O documento voltará à lista ativa do projeto."
+                : `Os ${restoreTarget?.ids.length} documentos voltarão à lista ativa do projeto.`}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmRestore}
+              disabled={isPending}
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  Restaurando…
+                </>
+              ) : (
+                "Restaurar"
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Hard delete (apagar permanentemente) */}
+      <AlertDialog
+        open={!!hardDeleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setHardDeleteTarget(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {hardDeleteTarget?.ids.length === 1
+                ? "Apagar permanentemente?"
+                : `Apagar ${hardDeleteTarget?.ids.length} documentos permanentemente?`}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              <strong>Esta ação não pode ser desfeita.</strong> O documento e
+              todas as respostas, revisões e atribuições associadas serão
+              removidos do banco de dados.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmHardDelete}
+              disabled={isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  Apagando…
+                </>
+              ) : (
+                "Apagar definitivamente"
               )}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -178,7 +178,8 @@ export async function fetchReviewBaseData(
     supabase
       .from("documents")
       .select("id, title, external_id")
-      .eq("project_id", projectId),
+      .eq("project_id", projectId)
+      .is("excluded_at", null),
   ]);
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -81,6 +81,9 @@ export interface Document {
   text: string;
   metadata: Record<string, unknown> | null;
   created_at: string;
+  excluded_at: string | null;
+  excluded_reason: string | null;
+  excluded_by: string | null;
 }
 
 export interface Assignment {

--- a/frontend/supabase/migrations/20260508030508_documents_soft_delete.sql
+++ b/frontend/supabase/migrations/20260508030508_documents_soft_delete.sql
@@ -1,0 +1,19 @@
+-- Soft delete de documentos.
+--
+-- Antes: deleteDocuments fazia DELETE FROM documents (CASCADE removia
+-- responses/reviews/assignments). Sem reversibilidade nem auditoria.
+--
+-- Agora: documents.excluded_at marca exclusao logica. Reads filtram
+-- excluded_at IS NULL por padrao. Coordenador pode visualizar excluidos via
+-- toggle e restaurar, ou apagar permanentemente quando confirmado.
+
+ALTER TABLE documents
+  ADD COLUMN excluded_at TIMESTAMPTZ NULL,
+  ADD COLUMN excluded_reason TEXT NULL,
+  ADD COLUMN excluded_by UUID NULL REFERENCES profiles(id);
+
+-- Index parcial: queries default (excluded_at IS NULL) sao maioria;
+-- excluidos sao raros e so coordenador acessa.
+CREATE INDEX idx_documents_active
+  ON documents(project_id)
+  WHERE excluded_at IS NULL;


### PR DESCRIPTION
## Summary

- Documentos ganham `excluded_at` / `excluded_reason` / `excluded_by`. O botão "Excluir" agora é soft delete (reversível).
- Toggle "Mostrar excluídos" expõe o histórico para o coordenador, com ações de **Restaurar** e **Apagar permanentemente** (hard delete CASCADE — só nesse modo).
- Todas as queries de listagem de documents passam a filtrar `excluded_at IS NULL` por padrão (assignments, LLM, reviews, comments, etc).

## Por quê

Última rodada de inclusão no projeto Zolgensma misturou pareceres de Nusinersena. Hard delete sem reversão é arriscado — soft delete deixa rastro e permite undo. Triagem assistida por LLM virá em PR separado e depende deste para o `--apply`.

## Test plan

- [ ] `npx supabase db push` aplica a migration sem warnings
- [ ] Como coordenador, em `/projects/<id>/config/documents`:
  - [ ] Excluir 1 doc com motivo → some da lista
  - [ ] Toggle "Mostrar excluídos" → reaparece com motivo / quem / quando
  - [ ] Restaurar → volta para a lista ativa
  - [ ] Apagar permanentemente → some de vez (CASCADE limpa responses/reviews)
- [ ] LLM, assignments e reviews ignoram excluídos por padrão (verificar contagens)
- [ ] Re-upload de doc excluído por engano cria novo registro (checkDuplicates ignora excluídos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)