### PR TITLE
feat(comments): pesquisador sugere exclusão de documento fora de escopo

### DIFF
--- a/frontend/src/actions/project-comments.ts
+++ b/frontend/src/actions/project-comments.ts
@@ -23,9 +23,149 @@ export async function createProjectComment(
     author_id: user.id,
     body: body.trim(),
     parent_id: parentId || null,
+    kind: "note",
   });
 
   if (error) return { error: error.message };
+
+  revalidatePath(`/projects/${projectId}/reviews/comments`);
+  return { success: true };
+}
+
+// Pesquisador sinaliza documento como fora de escopo. Coordenador resolve em
+// /reviews/comments aprovando (soft delete) ou rejeitando.
+export async function requestDocumentExclusion(
+  projectId: string,
+  documentId: string,
+  reason: string,
+) {
+  const user = await getAuthUser();
+  if (!user) return { error: "Não autenticado" };
+  if (!reason?.trim())
+    return { error: "Informe o motivo da sugestão de exclusão" };
+
+  const supabase = await createSupabaseServer();
+
+  // Evita duplicata: ja existe pedido pendente do mesmo autor para o mesmo doc?
+  const { data: existing } = await supabase
+    .from("project_comments")
+    .select("id")
+    .eq("project_id", projectId)
+    .eq("document_id", documentId)
+    .eq("author_id", user.id)
+    .eq("kind", "exclusion_request")
+    .is("resolved_at", null)
+    .is("rejected_at", null)
+    .maybeSingle();
+
+  if (existing) {
+    return {
+      error: "Você já tem uma sugestão pendente para este documento",
+    };
+  }
+
+  const { error } = await supabase.from("project_comments").insert({
+    project_id: projectId,
+    document_id: documentId,
+    field_name: null,
+    author_id: user.id,
+    body: reason.trim(),
+    parent_id: null,
+    kind: "exclusion_request",
+  });
+
+  if (error) return { error: error.message };
+
+  revalidatePath(`/projects/${projectId}/reviews/comments`);
+  return { success: true };
+}
+
+// Coordenador aprova: faz soft delete no documento e marca o pedido como
+// resolvido (resolved_at).
+export async function approveExclusionRequest(
+  commentId: string,
+  projectId: string,
+) {
+  const user = await getAuthUser();
+  if (!user) return { error: "Não autenticado" };
+
+  const supabase = await createSupabaseServer();
+
+  const { data: comment } = await supabase
+    .from("project_comments")
+    .select("id, document_id, body, kind")
+    .eq("id", commentId)
+    .eq("project_id", projectId)
+    .single();
+
+  if (!comment) return { error: "Sugestão não encontrada" };
+  if (comment.kind !== "exclusion_request")
+    return { error: "Comentário não é uma sugestão de exclusão" };
+  if (!comment.document_id)
+    return { error: "Sugestão sem documento associado" };
+
+  const reason = `Aprovada sugestão do pesquisador: ${comment.body}`.slice(
+    0,
+    1000,
+  );
+
+  // 1. soft delete documento
+  const { error: docError } = await supabase
+    .from("documents")
+    .update({
+      excluded_at: new Date().toISOString(),
+      excluded_reason: reason,
+      excluded_by: user.id,
+    })
+    .eq("id", comment.document_id)
+    .eq("project_id", projectId);
+
+  if (docError) return { error: docError.message };
+
+  // 2. resolver comment
+  const { error: commentError } = await supabase
+    .from("project_comments")
+    .update({
+      resolved_at: new Date().toISOString(),
+      resolved_by: user.id,
+    })
+    .eq("id", commentId)
+    .eq("project_id", projectId);
+
+  if (commentError) return { error: commentError.message };
+
+  revalidatePath(`/projects/${projectId}/reviews/comments`);
+  revalidatePath(`/projects/${projectId}/config/documents`);
+  return { success: true };
+}
+
+export async function rejectExclusionRequest(
+  commentId: string,
+  projectId: string,
+  rejectionReason: string,
+) {
+  const user = await getAuthUser();
+  if (!user) return { error: "Não autenticado" };
+  if (!rejectionReason?.trim())
+    return { error: "Informe o motivo da rejeição" };
+
+  const supabase = await createSupabaseServer();
+
+  const { data, error } = await supabase
+    .from("project_comments")
+    .update({
+      rejected_at: new Date().toISOString(),
+      rejected_reason: rejectionReason.trim(),
+      resolved_by: user.id,
+    })
+    .eq("id", commentId)
+    .eq("project_id", projectId)
+    .eq("kind", "exclusion_request")
+    .select("id");
+
+  if (error) return { error: error.message };
+  if (!data || data.length === 0)
+    return { error: "Sem permissão para rejeitar esta sugestão" };
 
   revalidatePath(`/projects/${projectId}/reviews/comments`);
   return { success: true };

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -74,7 +74,7 @@ export default async function CommentsPage({
       .eq("project_id", id),
     supabase
       .from("project_comments")
-      .select("id, document_id, field_name, author_id, body, parent_id, resolved_at, resolved_by, created_at, profiles!author_id(email)")
+      .select("id, document_id, field_name, author_id, body, parent_id, resolved_at, resolved_by, created_at, kind, rejected_at, rejected_reason, profiles!author_id(email)")
       .eq("project_id", id)
       .is("parent_id", null)
       .order("created_at", { ascending: false }),
@@ -287,13 +287,54 @@ export default async function CommentsPage({
     };
   });
 
-  // Map project_comments (anotações soltas) as ReviewComment
-  const annotationComments: ReviewComment[] = (projectComments || []).map((c) => {
-    const p = c.profiles as unknown as { email: string | null } | null;
+  // Map project_comments — separa entre anotacoes livres e sugestoes de exclusao.
+  // Para sugestoes aprovadas, o doc esta excluido — busca titulo separadamente.
+  type ProjectCommentRow = {
+    id: string;
+    document_id: string | null;
+    field_name: string | null;
+    body: string;
+    resolved_at: string | null;
+    created_at: string;
+    kind: "note" | "exclusion_request";
+    rejected_at: string | null;
+    rejected_reason: string | null;
+    profiles: { email: string | null } | null;
+  };
+  const typedProjectComments = (projectComments ||
+    []) as unknown as ProjectCommentRow[];
+
+  const exclusionRows = typedProjectComments.filter(
+    (c) => c.kind === "exclusion_request",
+  );
+  const noteRows = typedProjectComments.filter((c) => c.kind !== "exclusion_request");
+
+  // Buscar titulos de docs excluidos referenciados por exclusion_requests resolvidas
+  const excludedDocIds = exclusionRows
+    .filter((c) => !!c.document_id && !docMap.has(c.document_id!))
+    .map((c) => c.document_id!) as string[];
+  const excludedDocTitles = new Map<string, string>();
+  if (excludedDocIds.length > 0) {
+    const { data: excludedDocs } = await supabase
+      .from("documents")
+      .select("id, title, external_id")
+      .in("id", excludedDocIds);
+    for (const d of excludedDocs || []) {
+      excludedDocTitles.set(d.id, d.title || d.external_id || d.id);
+    }
+  }
+
+  function titleForDocId(docId: string | null): string {
+    if (!docId) return "";
+    return docMap.get(docId) || excludedDocTitles.get(docId) || docId;
+  }
+
+  const annotationComments: ReviewComment[] = noteRows.map((c) => {
+    const p = c.profiles;
     return {
       id: `anotacao-${c.id}`,
       documentId: c.document_id || "",
-      documentTitle: c.document_id ? docMap.get(c.document_id) || c.document_id : "",
+      documentTitle: titleForDocId(c.document_id),
       fieldName: c.field_name || "(geral)",
       fieldDescription: c.field_name
         ? fieldMap.get(c.field_name)?.description || c.field_name
@@ -309,9 +350,40 @@ export default async function CommentsPage({
     };
   });
 
-  // Pending suggestions first, then all others by date
+  const exclusionComments: ReviewComment[] = exclusionRows.map((c) => {
+    const p = c.profiles;
+    const status: "pending" | "approved" | "rejected" = c.rejected_at
+      ? "rejected"
+      : c.resolved_at
+        ? "approved"
+        : "pending";
+    return {
+      id: `exclusao-${c.id}`,
+      documentId: c.document_id || "",
+      documentTitle: titleForDocId(c.document_id),
+      fieldName: "(geral)",
+      fieldDescription: "Sugestão de exclusão",
+      verdict: "exclusao",
+      comment: c.body,
+      reviewerName: p?.email?.split("@")[0] || "Anônimo",
+      resolvedAt: c.resolved_at,
+      createdAt: c.created_at,
+      chosenResponseId: null,
+      source: "exclusao" as const,
+      responseSnapshot: null,
+      exclusionCommentId: c.id,
+      exclusionDocumentId: c.document_id || undefined,
+      exclusionStatus: status,
+      exclusionRejectedReason: c.rejected_reason,
+    };
+  });
+
+  // Pending suggestions e exclusoes primeiro, demais por data
   const pendingSuggestions = suggestionComments.filter(
     (s) => s.suggestionStatus === "pending",
+  );
+  const pendingExclusions = exclusionComments.filter(
+    (e) => e.exclusionStatus === "pending",
   );
   const restComments = [
     ...reviewComments,
@@ -320,10 +392,11 @@ export default async function CommentsPage({
     ...duvidaComments,
     ...annotationComments,
     ...suggestionComments.filter((s) => s.suggestionStatus !== "pending"),
+    ...exclusionComments.filter((e) => e.exclusionStatus !== "pending"),
   ].sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
-  const comments = [...pendingSuggestions, ...restComments];
+  const comments = [...pendingExclusions, ...pendingSuggestions, ...restComments];
 
   const totalLlmDocs = llmResponses?.length ?? 0;
   const llmDocsWithoutAmbiguities = (llmResponses ?? []).filter((r) => {

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 import { RunLlmButton } from "@/components/shared/RunLlmButton";
+import { SuggestExclusionDialog } from "./SuggestExclusionDialog";
 import { CURRENT_FILTER_VALUE, isCurrentFilter } from "@/lib/rounds";
 import type { RoundFilterData } from "./CodingPage";
 
@@ -33,6 +34,8 @@ type DocSection =
       total: number;
       onNavigate: (index: number) => void;
       parecerUrl?: string;
+      projectId: string;
+      documentId: string;
     }
   | {
       variant: "browse";
@@ -200,6 +203,12 @@ function AssignedDocSection({
         >
           <ChevronRight className="h-4 w-4" />
         </Button>
+        <SuggestExclusionDialog
+          projectId={doc.projectId}
+          documentId={doc.documentId}
+          documentTitle={doc.title}
+          iconOnly
+        />
         <Button
           variant="ghost"
           size="icon"
@@ -251,6 +260,12 @@ function BrowseDocSection({
         >
           <Shuffle className="h-4 w-4" />
         </Button>
+        <SuggestExclusionDialog
+          projectId={doc.projectId}
+          documentId={doc.documentId}
+          documentTitle={doc.title}
+          iconOnly
+        />
         <Button
           variant="ghost"
           size="icon"

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -420,6 +420,8 @@ export function CodingPage({
                     total: documents.length,
                     onNavigate: handleDocNavigate,
                     parecerUrl: assignedParecerUrl,
+                    projectId,
+                    documentId: currentDoc.id,
                   }
                 : mode === "browse" && selectedBrowseDoc
                 ? {

--- a/frontend/src/components/coding/SuggestExclusionDialog.tsx
+++ b/frontend/src/components/coding/SuggestExclusionDialog.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Flag, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { requestDocumentExclusion } from "@/actions/project-comments";
+import { toast } from "sonner";
+
+interface SuggestExclusionDialogProps {
+  projectId: string;
+  documentId: string;
+  documentTitle?: string;
+  /** botao no header e icon-only com tooltip */
+  iconOnly?: boolean;
+}
+
+export function SuggestExclusionDialog({
+  projectId,
+  documentId,
+  documentTitle,
+  iconOnly = false,
+}: SuggestExclusionDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  function handleSubmit() {
+    if (!reason.trim()) {
+      toast.error("Informe o motivo da sugestão");
+      return;
+    }
+    startTransition(async () => {
+      const result = await requestDocumentExclusion(
+        projectId,
+        documentId,
+        reason,
+      );
+      if (result?.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          "Sugestão enviada — coordenador será notificado em Comentários",
+        );
+        setOpen(false);
+        setReason("");
+      }
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        {iconOnly ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            title="Sinalizar fora de escopo"
+          >
+            <Flag className="h-3.5 w-3.5" />
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm">
+            <Flag className="mr-1.5 h-3.5 w-3.5" />
+            Sinalizar fora de escopo
+          </Button>
+        )}
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Sinalizar documento fora de escopo</DialogTitle>
+          <DialogDescription>
+            Sua sugestão será enviada ao coordenador. Se aprovada, o documento
+            é removido das suas atribuições e da listagem do projeto.
+            {documentTitle && (
+              <span className="mt-1 block text-foreground">
+                <strong>{documentTitle}</strong>
+              </span>
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="exclusion-reason">
+            Por que parece fora de escopo?{" "}
+            <span className="text-destructive">*</span>
+          </Label>
+          <Textarea
+            id="exclusion-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Ex: parecer trata de medicamento diferente do estudado"
+            rows={4}
+            autoFocus
+          />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={isPending}
+          >
+            Cancelar
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isPending || !reason.trim()}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                Enviando…
+              </>
+            ) : (
+              "Enviar sugestão"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -24,6 +24,10 @@ import {
   type GabaritoRespondentAnswer,
 } from "@/actions/stats";
 import { resolveSchemaSuggestion } from "@/actions/suggestions";
+import {
+  approveExclusionRequest,
+  rejectExclusionRequest,
+} from "@/actions/project-comments";
 import { SuggestionDiff } from "./SuggestionDiff";
 import { toast } from "sonner";
 
@@ -64,7 +68,14 @@ export interface ReviewComment {
   resolvedAt: string | null;
   createdAt: string;
   chosenResponseId: string | null;
-  source: "review" | "nota" | "sugestao" | "dificuldade" | "anotacao" | "duvida";
+  source:
+    | "review"
+    | "nota"
+    | "sugestao"
+    | "dificuldade"
+    | "anotacao"
+    | "duvida"
+    | "exclusao";
   responseSnapshot: ResponseSnapshotEntry[] | null;
   suggestionId?: string;
   suggestionStatus?: "pending" | "approved" | "rejected";
@@ -82,6 +93,11 @@ export interface ReviewComment {
   difficultyDocumentId?: string;
   duvidaReviewId?: string;
   duvidaRespondentId?: string;
+  /** Para exclusao_request — id do project_comment, status e document_id alvo. */
+  exclusionCommentId?: string;
+  exclusionDocumentId?: string;
+  exclusionStatus?: "pending" | "approved" | "rejected";
+  exclusionRejectedReason?: string | null;
 }
 
 interface CommentCardProps {
@@ -101,6 +117,7 @@ function formatVerdictLabel(verdict: string): string {
   if (verdict === "anotacao") return "Anotação";
   if (verdict === "dificuldade") return "Dificuldade do LLM";
   if (verdict === "sugestao") return "Sugestão";
+  if (verdict === "exclusao") return "Sugestão de exclusão";
   if (verdict === "duvida") return "Dúvida do gabarito";
   if (verdict === "ambiguo") return "Ambíguo";
   if (verdict === "pular") return "Pular";
@@ -125,6 +142,7 @@ function verdictVariant(
   if (verdict === "anotacao") return "secondary";
   if (verdict === "dificuldade") return "secondary";
   if (verdict === "sugestao") return "outline";
+  if (verdict === "exclusao") return "destructive";
   if (verdict === "duvida") return "secondary";
   if (verdict === "ambiguo") return "secondary";
   if (verdict === "pular") return "outline";
@@ -205,7 +223,7 @@ export function CommentCard({
               <code className="text-xs font-mono text-muted-foreground/70">
                 {comment.fieldName}
               </code>
-              {isCoordinator && onEditField && comment.source !== "nota" && comment.source !== "dificuldade" && (
+              {isCoordinator && onEditField && comment.source !== "nota" && comment.source !== "dificuldade" && comment.source !== "exclusao" && (
                 <Button
                   variant="ghost"
                   size="sm"
@@ -216,7 +234,7 @@ export function CommentCard({
                   <Pencil className="h-3 w-3" />
                 </Button>
               )}
-              {!isCoordinator && onSuggestField && comment.source !== "nota" && comment.source !== "dificuldade" && (
+              {!isCoordinator && onSuggestField && comment.source !== "nota" && comment.source !== "dificuldade" && comment.source !== "exclusao" && (
                 <Button
                   variant="ghost"
                   size="sm"
@@ -324,8 +342,19 @@ export function CommentCard({
           </div>
         )}
 
+        {/* Acoes de sugestao de exclusao */}
+        {comment.source === "exclusao" && comment.exclusionCommentId && (
+          <ExclusionActions
+            commentId={comment.exclusionCommentId}
+            projectId={projectId}
+            status={comment.exclusionStatus ?? "pending"}
+            rejectedReason={comment.exclusionRejectedReason}
+            isCoordinator={!!isCoordinator}
+          />
+        )}
+
         {/* Gabarito expansível (só para reviews, não para notas) */}
-        {comment.source !== "nota" && comment.source !== "dificuldade" && comment.source !== "anotacao" && <Collapsible open={gabaritoOpen} onOpenChange={handleGabaritoToggle}>
+        {comment.source !== "nota" && comment.source !== "dificuldade" && comment.source !== "anotacao" && comment.source !== "exclusao" && <Collapsible open={gabaritoOpen} onOpenChange={handleGabaritoToggle}>
           <CollapsibleTrigger asChild>
             <Button
               variant="ghost"
@@ -410,7 +439,9 @@ export function CommentCard({
             )}
           </p>
           <div className="flex gap-1">
-            {comment.source === "sugestao" ? null : isResolved ? (
+            {comment.source === "sugestao" || comment.source === "exclusao"
+              ? null
+              : isResolved ? (
               <Button
                 variant="ghost"
                 size="sm"
@@ -435,5 +466,136 @@ export function CommentCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function ExclusionActions({
+  commentId,
+  projectId,
+  status,
+  rejectedReason,
+  isCoordinator,
+}: {
+  commentId: string;
+  projectId: string;
+  status: "pending" | "approved" | "rejected";
+  rejectedReason?: string | null;
+  isCoordinator: boolean;
+}) {
+  const router = useRouter();
+  const [isPending, startAction] = useTransition();
+  const [showRejectInput, setShowRejectInput] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+
+  if (status === "approved") {
+    return (
+      <Badge className="text-xs bg-red-500/10 text-red-700 w-fit">
+        Documento excluído
+      </Badge>
+    );
+  }
+  if (status === "rejected") {
+    return (
+      <div className="flex flex-col gap-1">
+        <Badge className="text-xs bg-muted text-muted-foreground w-fit">
+          Sugestão rejeitada
+        </Badge>
+        {rejectedReason && (
+          <p className="text-xs text-muted-foreground italic">
+            Motivo: {rejectedReason}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (!isCoordinator) {
+    return (
+      <Badge className="text-xs bg-amber-500/10 text-amber-700 w-fit">
+        Aguardando coordenador
+      </Badge>
+    );
+  }
+
+  if (showRejectInput) {
+    return (
+      <div className="flex flex-col gap-2">
+        <input
+          className="rounded-md border bg-background px-2 py-1 text-xs"
+          placeholder="Motivo da rejeição"
+          value={rejectReason}
+          onChange={(e) => setRejectReason(e.target.value)}
+          autoFocus
+        />
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 text-xs"
+            disabled={isPending}
+            onClick={() => {
+              setShowRejectInput(false);
+              setRejectReason("");
+            }}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            className="h-6 text-xs"
+            disabled={isPending || !rejectReason.trim()}
+            onClick={() => {
+              startAction(async () => {
+                const result = await rejectExclusionRequest(
+                  commentId,
+                  projectId,
+                  rejectReason,
+                );
+                if (result.error) toast.error(result.error);
+                else {
+                  toast.success("Sugestão rejeitada");
+                  router.refresh();
+                }
+              });
+            }}
+          >
+            Confirmar rejeição
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="destructive"
+        size="sm"
+        className="h-6 text-xs"
+        disabled={isPending}
+        onClick={() => {
+          startAction(async () => {
+            const result = await approveExclusionRequest(commentId, projectId);
+            if (result.error) toast.error(result.error);
+            else {
+              toast.success("Documento excluído");
+              router.refresh();
+            }
+          });
+        }}
+      >
+        Aprovar e excluir
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-6 text-xs"
+        disabled={isPending}
+        onClick={() => setShowRejectInput(true)}
+      >
+        Rejeitar
+      </Button>
+    </div>
   );
 }

--- a/frontend/src/components/stats/ReviewCommentsView.tsx
+++ b/frontend/src/components/stats/ReviewCommentsView.tsx
@@ -43,11 +43,23 @@ interface ReviewCommentsViewProps {
   llmDocsWithoutAmbiguities?: number;
 }
 
-function verdictType(verdict: string): "answer" | "ambiguo" | "pular" | "nota" | "sugestao" | "dificuldade" | "anotacao" | "duvida" {
+function verdictType(
+  verdict: string,
+):
+  | "answer"
+  | "ambiguo"
+  | "pular"
+  | "nota"
+  | "sugestao"
+  | "dificuldade"
+  | "anotacao"
+  | "duvida"
+  | "exclusao" {
   if (verdict === "nota") return "nota";
   if (verdict === "anotacao") return "anotacao";
   if (verdict === "dificuldade") return "dificuldade";
   if (verdict === "sugestao") return "sugestao";
+  if (verdict === "exclusao") return "exclusao";
   if (verdict === "duvida") return "duvida";
   if (verdict === "ambiguo") return "ambiguo";
   if (verdict === "pular") return "pular";
@@ -242,6 +254,7 @@ export function ReviewCommentsView({
             <SelectItem value="dificuldade">Dificuldade LLM</SelectItem>
             <SelectItem value="duvida">Dúvidas do gabarito</SelectItem>
             <SelectItem value="anotacao">Anotações</SelectItem>
+            <SelectItem value="exclusao">Sugestões de exclusão</SelectItem>
           </SelectContent>
         </Select>
         <span className="ml-auto text-sm text-muted-foreground">

--- a/frontend/supabase/migrations/20260508031637_project_comments_exclusion_request.sql
+++ b/frontend/supabase/migrations/20260508031637_project_comments_exclusion_request.sql
@@ -1,0 +1,18 @@
+-- Sugestao de exclusao de documentos pelo pesquisador.
+--
+-- Reusa project_comments adicionando kind='exclusion_request'. Pesquisador
+-- cria comentario nesse tipo a partir da view de codificacao quando suspeita
+-- que o documento e fora de escopo. Coordenador, em /reviews/comments, ve a
+-- sugestao e pode aprovar (faz soft delete em documents) ou rejeitar.
+
+ALTER TABLE project_comments
+  ADD COLUMN kind TEXT NOT NULL DEFAULT 'note'
+    CHECK (kind IN ('note', 'exclusion_request')),
+  ADD COLUMN rejected_at TIMESTAMPTZ NULL,
+  ADD COLUMN rejected_reason TEXT NULL;
+
+CREATE INDEX idx_pc_pending_exclusions
+  ON project_comments(project_id)
+  WHERE kind = 'exclusion_request'
+    AND resolved_at IS NULL
+    AND rejected_at IS NULL;


### PR DESCRIPTION
## Summary

Pesquisadores agora têm um caminho formal para sinalizar documentos fora de escopo.

- **Pesquisador**: ícone Flag no header da codificação → dialog com motivo → cria `project_comment` com `kind='exclusion_request'`
- **Coordenador** (em `/reviews/comments`, filtro "Sugestões de exclusão"): vê pendentes priorizadas no topo, com botões **Aprovar e excluir** (soft delete) ou **Rejeitar** (com motivo).
- Reusa o sistema existente de `project_comments` ao invés de criar tabela nova.

Depende de **#95** (soft delete columns) para o approve funcionar.

## Por quê

O caso da última rodada do Zolgensma com pareceres de Nusinersena mostrou que o coordenador nem sempre detecta documentos fora de escopo na hora do upload — o pesquisador, ao codificar, é quem percebe primeiro. Antes não tinha caminho claro; agora a sugestão vai direto para a fila do coordenador.

## Test plan

- [ ] `npx supabase db push` aplica `20260508031637_project_comments_exclusion_request.sql`
- [ ] Como pesquisador (atribuído a um doc), abrir `/projects/<id>/analyze/code`:
  - [ ] Clicar no Flag → dialog abre
  - [ ] Submeter sem motivo → toast erro
  - [ ] Submeter com motivo → toast sucesso
  - [ ] Tentar de novo no mesmo doc → erro "já tem sugestão pendente"
- [ ] Como coordenador, em `/projects/<id>/reviews/comments`:
  - [ ] Filtro "Sugestões de exclusão" mostra a pendente no topo
  - [ ] **Aprovar e excluir** → doc some da listagem; comment vira `resolved`
  - [ ] Outra sugestão: **Rejeitar** com motivo → comment vira `rejected` com motivo

🤖 Generated with [Claude Code](https://claude.com/claude-code)