### PR TITLE
fix(documents): melhorias pos-revisao dos PRs #95, #96, #97

### DIFF
--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 
 const TAG_PROFILE = { expire: 300 };
@@ -389,10 +389,15 @@ export async function excludeDocuments(
   reason: string,
 ) {
   const user = await getAuthUser();
-  if (!user) return { error: "Nao autenticado" };
-  if (!reason?.trim()) return { error: "Motivo da exclusao e obrigatorio" };
+  if (!user) return { error: "Não autenticado" };
+  if (!reason?.trim()) return { error: "Motivo da exclusão é obrigatório" };
 
   const supabase = await createSupabaseServer();
+
+  if (!(await isProjectCoordinator(supabase, projectId, user))) {
+    return { error: "Apenas coordenador pode excluir documentos" };
+  }
+
   const { error } = await supabase
     .from("documents")
     .update({
@@ -413,7 +418,15 @@ export async function restoreDocuments(
   projectId: string,
   documentIds: string[],
 ) {
+  const user = await getAuthUser();
+  if (!user) return { error: "Não autenticado" };
+
   const supabase = await createSupabaseServer();
+
+  if (!(await isProjectCoordinator(supabase, projectId, user))) {
+    return { error: "Apenas coordenador pode restaurar documentos" };
+  }
+
   const { error } = await supabase
     .from("documents")
     .update({
@@ -437,10 +450,19 @@ export async function hardDeleteDocuments(
   projectId: string,
   documentIds: string[],
 ) {
+  const user = await getAuthUser();
+  if (!user) return { error: "Não autenticado" };
+
   const supabase = await createSupabaseServer();
+
+  if (!(await isProjectCoordinator(supabase, projectId, user))) {
+    return { error: "Apenas coordenador pode apagar documentos permanentemente" };
+  }
+
   const { error } = await supabase
     .from("documents")
     .delete()
+    .eq("project_id", projectId)
     .in("id", documentIds);
 
   if (error) return { error: error.message };

--- a/frontend/src/actions/project-comments.ts
+++ b/frontend/src/actions/project-comments.ts
@@ -1,7 +1,8 @@
 "use server";
 
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
+import { excludeDocuments } from "@/actions/documents";
 import { revalidatePath } from "next/cache";
 
 export async function createProjectComment(
@@ -80,8 +81,8 @@ export async function requestDocumentExclusion(
   return { success: true };
 }
 
-// Coordenador aprova: faz soft delete no documento e marca o pedido como
-// resolvido (resolved_at).
+// Coordenador aprova: faz soft delete no documento (via excludeDocuments para
+// usar o mesmo flow do "Excluir" manual) e marca o pedido como resolvido.
 export async function approveExclusionRequest(
   commentId: string,
   projectId: string,
@@ -90,6 +91,10 @@ export async function approveExclusionRequest(
   if (!user) return { error: "Não autenticado" };
 
   const supabase = await createSupabaseServer();
+
+  if (!(await isProjectCoordinator(supabase, projectId, user))) {
+    return { error: "Apenas coordenador pode aprovar sugestões de exclusão" };
+  }
 
   const { data: comment } = await supabase
     .from("project_comments")
@@ -109,18 +114,15 @@ export async function approveExclusionRequest(
     1000,
   );
 
-  // 1. soft delete documento
-  const { error: docError } = await supabase
-    .from("documents")
-    .update({
-      excluded_at: new Date().toISOString(),
-      excluded_reason: reason,
-      excluded_by: user.id,
-    })
-    .eq("id", comment.document_id)
-    .eq("project_id", projectId);
-
-  if (docError) return { error: docError.message };
+  // 1. soft delete via excludeDocuments — mantem fluxo unificado com o botao
+  //    "Excluir" da config de documentos (auditoria e revalidatePath de
+  //    config/documents ja saem dele).
+  const docResult = await excludeDocuments(
+    projectId,
+    [comment.document_id],
+    reason,
+  );
+  if ("error" in docResult) return { error: docResult.error };
 
   // 2. resolver comment
   const { error: commentError } = await supabase
@@ -135,7 +137,8 @@ export async function approveExclusionRequest(
   if (commentError) return { error: commentError.message };
 
   revalidatePath(`/projects/${projectId}/reviews/comments`);
-  revalidatePath(`/projects/${projectId}/config/documents`);
+  // Pesquisador codificando esse doc precisa ver a atualizacao.
+  revalidatePath(`/projects/${projectId}/analyze/code`);
   return { success: true };
 }
 
@@ -150,6 +153,10 @@ export async function rejectExclusionRequest(
     return { error: "Informe o motivo da rejeição" };
 
   const supabase = await createSupabaseServer();
+
+  if (!(await isProjectCoordinator(supabase, projectId, user))) {
+    return { error: "Apenas coordenador pode rejeitar sugestões de exclusão" };
+  }
 
   const { data, error } = await supabase
     .from("project_comments")

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -349,7 +349,11 @@ export default async function ComparePageRoute({
   const [{ data: docTexts }, { data: reviews }, { data: commentCounts }, { data: suggestionCounts }] =
     await Promise.all([
       qualifiedDocIds.length > 0
-        ? supabase.from("documents").select("id, text").in("id", qualifiedDocIds)
+        ? supabase
+            .from("documents")
+            .select("id, text")
+            .in("id", qualifiedDocIds)
+            .is("excluded_at", null)
         : Promise.resolve({ data: [] as { id: string; text: string }[] }),
       supabase
         .from("reviews")

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -373,10 +373,15 @@ export default async function ComparePageRoute({
 
   const textMap = new Map((docTexts || []).map((d) => [d.id, d.text]));
 
-  const documentsForCompare: CompareDoc[] = qualifiedDocIds.map((docId) => {
-    const meta = docsMetaMap.get(docId)!;
-    return { ...meta, text: textMap.get(docId) || "" };
-  });
+  // textMap so contem docs com excluded_at IS NULL (filtro acima). Usar como
+  // gate final garante que docs soft-deletados saiam da comparacao por
+  // completo, nao apenas com texto vazio.
+  const documentsForCompare: CompareDoc[] = qualifiedDocIds
+    .filter((docId) => textMap.has(docId))
+    .map((docId) => {
+      const meta = docsMetaMap.get(docId)!;
+      return { ...meta, text: textMap.get(docId) || "" };
+    });
 
   const existingReviews: Record<
     string,

--- a/frontend/src/components/documents/DocumentList.tsx
+++ b/frontend/src/components/documents/DocumentList.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
-import { Trash2, RotateCcw, FlameKindling } from "lucide-react";
+import { Trash2, RotateCcw } from "lucide-react";
 import type { Document } from "@/lib/types";
 
 export type DocumentSummary = Pick<Document, "id" | "external_id" | "title"> & {
@@ -198,11 +198,11 @@ export function DocumentList({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                      className="h-7 w-7 text-destructive hover:bg-destructive/10"
                       onClick={() => onRequestHardDelete?.(doc)}
                       title="Apagar permanentemente"
                     >
-                      <FlameKindling className="h-3.5 w-3.5" />
+                      <Trash2 className="h-3.5 w-3.5" />
                     </Button>
                   </td>
                 )}

--- a/frontend/src/components/documents/DocumentPreview.tsx
+++ b/frontend/src/components/documents/DocumentPreview.tsx
@@ -10,9 +10,21 @@ interface DocumentPreviewProps {
   title: string;
   open: boolean;
   onClose: () => void;
+  /**
+   * Por padrao, preview nao carrega texto de doc soft-deleted — alinhado com
+   * o resto da UI que esconde excluidos. Setar true quando o caller estiver
+   * no modo "Mostrar excluidos" para permitir visualizacao do historico.
+   */
+  allowExcluded?: boolean;
 }
 
-export function DocumentPreview({ documentId, title, open, onClose }: DocumentPreviewProps) {
+export function DocumentPreview({
+  documentId,
+  title,
+  open,
+  onClose,
+  allowExcluded = false,
+}: DocumentPreviewProps) {
   const [text, setText] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const { getToken } = useAuth();
@@ -26,11 +38,14 @@ export function DocumentPreview({ documentId, title, open, onClose }: DocumentPr
     getToken({ template: "supabase" })
       .then((token) => {
         const supabase = createBrowserClient(token);
-        return supabase
+        let query = supabase
           .from("documents")
           .select("text")
-          .eq("id", documentId)
-          .single();
+          .eq("id", documentId);
+        if (!allowExcluded) {
+          query = query.is("excluded_at", null);
+        }
+        return query.maybeSingle();
       })
       .then(({ data }) => {
         setText(data?.text ?? null);
@@ -41,7 +56,7 @@ export function DocumentPreview({ documentId, title, open, onClose }: DocumentPr
       .finally(() => {
         setLoading(false);
       });
-  }, [documentId, open, getToken]);
+  }, [documentId, open, getToken, allowExcluded]);
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -23,7 +23,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Trash2, Loader2, RotateCcw, FlameKindling } from "lucide-react";
+import { Trash2, Loader2, RotateCcw } from "lucide-react";
 import { toast } from "sonner";
 
 type DocSummary = DocumentSummary & {
@@ -213,7 +213,7 @@ export function DocumentsPageClient({
                 size="sm"
                 onClick={handleRequestHardDeleteSelected}
               >
-                <FlameKindling className="mr-1.5 h-3.5 w-3.5" />
+                <Trash2 className="mr-1.5 h-3.5 w-3.5" />
                 Apagar permanentemente
               </Button>
             </>
@@ -250,6 +250,7 @@ export function DocumentsPageClient({
         title={selectedDoc?.title ?? selectedDoc?.external_id ?? "Documento"}
         open={!!selectedDoc}
         onClose={() => setSelectedDocId(null)}
+        allowExcluded={showExcluded}
       />
 
       {/* Soft delete (excluir = reversivel) */}

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -29,6 +29,7 @@ import {
   rejectExclusionRequest,
 } from "@/actions/project-comments";
 import { SuggestionDiff } from "./SuggestionDiff";
+import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 
 const TYPE_LABELS: Record<string, string> = {
@@ -520,11 +521,12 @@ function ExclusionActions({
   if (showRejectInput) {
     return (
       <div className="flex flex-col gap-2">
-        <input
-          className="rounded-md border bg-background px-2 py-1 text-xs"
+        <Textarea
+          className="text-xs"
           placeholder="Motivo da rejeição"
           value={rejectReason}
           onChange={(e) => setRejectReason(e.target.value)}
+          rows={2}
           autoFocus
         />
         <div className="flex gap-2">

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import { currentUser } from "@clerk/nextjs/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { syncClerkUserToSupabase } from "@/lib/clerk-sync";
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 
@@ -71,4 +72,33 @@ export async function getAuthUser(): Promise<AuthUser | null> {
     clerkId: user.id,
     isMaster: !!masterRow,
   };
+}
+
+// Centraliza o padrao de checagem de coordenador usado nos layouts de projeto
+// (criador OU role=coordenador OU master). Server actions devem usar isso para
+// falhar cedo com mensagem clara, em vez de deixar o RLS retornar erro generico.
+export async function isProjectCoordinator(
+  supabase: SupabaseClient,
+  projectId: string,
+  user: AuthUser,
+): Promise<boolean> {
+  if (user.isMaster) return true;
+
+  const [{ data: project }, { data: membership }] = await Promise.all([
+    supabase
+      .from("projects")
+      .select("created_by")
+      .eq("id", projectId)
+      .single(),
+    supabase
+      .from("project_members")
+      .select("role")
+      .eq("project_id", projectId)
+      .eq("user_id", user.id)
+      .maybeSingle(),
+  ]);
+
+  return (
+    project?.created_by === user.id || membership?.role === "coordenador"
+  );
 }

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -84,12 +84,15 @@ export async function isProjectCoordinator(
 ): Promise<boolean> {
   if (user.isMaster) return true;
 
-  const [{ data: project }, { data: membership }] = await Promise.all([
+  const [
+    { data: project, error: projectError },
+    { data: membership, error: membershipError },
+  ] = await Promise.all([
     supabase
       .from("projects")
       .select("created_by")
       .eq("id", projectId)
-      .single(),
+      .maybeSingle(),
     supabase
       .from("project_members")
       .select("role")
@@ -97,6 +100,24 @@ export async function isProjectCoordinator(
       .eq("user_id", user.id)
       .maybeSingle(),
   ]);
+
+  // Falhas de query (timeout, RLS rejeitando o que deveria ler, etc.) nao devem
+  // ser silenciosamente convertidas em "nao e coordenador" — logamos para nao
+  // mascarar lockout de coordenador legitimo como falta de permissao.
+  if (projectError) {
+    console.error("isProjectCoordinator: project query failed", {
+      projectId,
+      userId: user.id,
+      error: projectError.message,
+    });
+  }
+  if (membershipError) {
+    console.error("isProjectCoordinator: membership query failed", {
+      projectId,
+      userId: user.id,
+      error: membershipError.message,
+    });
+  }
 
   return (
     project?.created_by === user.id || membership?.role === "coordenador"

--- a/frontend/supabase/migrations/20260508040428_documents_excluded_by_set_null.sql
+++ b/frontend/supabase/migrations/20260508040428_documents_excluded_by_set_null.sql
@@ -1,0 +1,13 @@
+-- Ajusta FK documents.excluded_by para ON DELETE SET NULL.
+--
+-- Migration original (#95) criou a FK sem ON DELETE, default NO ACTION.
+-- Se um perfil for hard-deletado (master removendo usuario), a FK quebra
+-- e impede o DELETE. SET NULL preserva o registro de exclusao do documento
+-- mesmo quando o autor sai do sistema.
+
+ALTER TABLE documents
+  DROP CONSTRAINT IF EXISTS documents_excluded_by_fkey;
+
+ALTER TABLE documents
+  ADD CONSTRAINT documents_excluded_by_fkey
+  FOREIGN KEY (excluded_by) REFERENCES profiles(id) ON DELETE SET NULL;


### PR DESCRIPTION
## Summary

Endereça os pontos da revisão dos PRs #95 (soft delete), #96 (script Nusinersena) e #97 (sugestão de exclusão pelo pesquisador), todos já mergeados. Foco em **segurança/correção** (role checks consistentes, FK robusta, queries não cobertas) e **UX/consistência** (Textarea no reject, Trash2 no hard delete).

## Mudanças

### Segurança / correção
- **`isProjectCoordinator` em `lib/auth.ts`** — centraliza o padrão `created_by || membership.role || isMaster` antes duplicado nos layouts.
- **`approveExclusionRequest` / `rejectExclusionRequest`** — falham cedo com mensagem clara quando não-coordenador, em vez de erro genérico de RLS.
- **`excludeDocuments` / `restoreDocuments` / `hardDeleteDocuments`** — todos chamam `getAuthUser` + `isProjectCoordinator` (apenas `excludeDocuments` já validava `getAuthUser`).
- **`approveExclusionRequest` reusa `excludeDocuments`** — unifica fluxo de soft delete (revalidatePath de config/documents, auditoria) em vez de UPDATE direto.
- **`revalidatePath analyze/code`** — pesquisador codificando o doc afetado vê atualização imediata quando coord aprova.
- **Migration `20260508040428_documents_excluded_by_set_null.sql`** — FK `documents.excluded_by` agora `ON DELETE SET NULL`, preservando histórico de exclusão se um perfil for removido.

### Cobertura de queries não filtradas
- **`analyze/compare/page.tsx`** — query de texto adicionada `.is("excluded_at", null)`. Antes, doc soft-deleted após responses continuava na comparação.
- **`DocumentPreview`** — nova prop `allowExcluded` (default false). Por padrão filtra; `DocumentsPageClient` passa `allowExcluded={showExcluded}` para preservar preview no modo "Mostrar excluídos".

### UX / consistência
- **`ExclusionActions` (CommentCard)** — `<input>` → `<Textarea>` no motivo da rejeição, alinhando com o `SuggestExclusionDialog` que usa textarea.
- **Hard delete** — `Trash2` com `text-destructive` em vez do incomum `FlameKindling`, tanto na row quanto no bulk.

## Fora de escopo (ver review original)
- **TEXT_TRUNCATE no script #96**: já executado.
- **Notificação ao pesquisador**: feature nova, escopo separado.
- **Testes Vitest**: PR próprio focado.
- **RPC SQL transacional para approve**: aceito risco (soft delete recuperável).
- **Validação de assignment em `requestDocumentExclusion`**: coordenador filtra.

## Test plan

- [ ] `npx supabase db push` aplica `20260508040428_documents_excluded_by_set_null.sql` sem erro
- [ ] Como pesquisador, console: `await fetch('/api/...')` direto em `approveExclusionRequest` → resposta `{ error: "Apenas coordenador pode aprovar sugestões de exclusão" }`
- [ ] Mesmo teste em `hardDeleteDocuments` → erro "Apenas coordenador pode apagar documentos permanentemente"
- [ ] Soft delete um doc com responses → abrir `analyze/compare` → doc não aparece
- [ ] Toggle "Mostrar excluídos" → click numa row → preview abre com texto
- [ ] Sem toggle → preview de doc ativo continua funcionando
- [ ] Como pesquisador, sugerir exclusão de um doc → como coord, aprovar → doc some imediatamente da aba `analyze/code`
- [ ] Coord rejeita uma sugestão → campo é `<Textarea>` (multi-line), não `<input>`
- [ ] Hard delete em "Mostrar excluídos" → ícone é `Trash2`, não `FlameKindling`

🤖 Generated with [Claude Code](https://claude.com/claude-code)