### PR TITLE
fix(progress): exclui docs soft-deletados da contagem do pesquisador

### DIFF
--- a/frontend/src/actions/__tests__/progress.test.ts
+++ b/frontend/src/actions/__tests__/progress.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocks precisam ser declarados antes do import dinamico do modulo sob teste.
+// unstable_cache: aplica a fn imediatamente, sem cache, para o teste rodar offline.
+vi.mock("next/cache", () => ({
+  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+type Assignment = {
+  id: string;
+  status: string;
+  deadline: string | null;
+  completed_at: string | null;
+  // Quando INNER JOIN com documents resolve, o Supabase devolve a relacao
+  // como objeto/array. Aqui simulamos a presenca (apos o filtro is(null)).
+  documents: { id: string };
+};
+
+let lastSelect = "";
+let isCalls: { col: string; val: unknown }[] = [];
+let resolvedAssignments: Assignment[] = [];
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createSupabaseAdmin: () => ({
+    from: (_table: string) => {
+      const builder = {
+        select: (cols: string) => {
+          lastSelect = cols;
+          return builder;
+        },
+        eq: () => builder,
+        is: (col: string, val: unknown) => {
+          isCalls.push({ col, val });
+          return builder;
+        },
+        // Chainable thenable: await builder retorna { data, error }.
+        then: (
+          resolve: (v: { data: Assignment[]; error: null }) => unknown,
+        ) => resolve({ data: resolvedAssignments, error: null }),
+      };
+      return builder;
+    },
+  }),
+}));
+
+beforeEach(() => {
+  lastSelect = "";
+  isCalls = [];
+  resolvedAssignments = [];
+});
+
+async function loadProgress() {
+  return (await import("@/actions/progress")).getResearcherProgress;
+}
+
+describe("getResearcherProgress — filtro de documentos soft-deletados", () => {
+  it("monta query com INNER JOIN documents + excluded_at IS NULL", async () => {
+    resolvedAssignments = [];
+    const getResearcherProgress = await loadProgress();
+    await getResearcherProgress("proj-1", "user-1");
+
+    // Regression guard: sem esses dois, contagem incluiria assignments
+    // orfaos cujo documento foi soft-deletado (PR #100).
+    expect(lastSelect).toContain("documents!inner(id)");
+    expect(isCalls).toContainEqual({ col: "documents.excluded_at", val: null });
+  });
+
+  it("total e completed refletem somente assignments retornados pela query (docs ativos)", async () => {
+    // Simula o estado pos-filtro: docs soft-deletados ja foram descartados
+    // pelo INNER JOIN, entao a query devolve apenas os 3 ativos.
+    resolvedAssignments = [
+      {
+        id: "a1",
+        status: "concluido",
+        deadline: null,
+        completed_at: "2026-05-10T12:00:00Z",
+        documents: { id: "d1" },
+      },
+      {
+        id: "a2",
+        status: "pendente",
+        deadline: null,
+        completed_at: null,
+        documents: { id: "d2" },
+      },
+      {
+        id: "a3",
+        status: "pendente",
+        deadline: null,
+        completed_at: null,
+        documents: { id: "d3" },
+      },
+    ];
+
+    const getResearcherProgress = await loadProgress();
+    const progress = await getResearcherProgress("proj-1", "user-1");
+
+    expect(progress.total).toBe(3);
+    expect(progress.completed).toBe(1);
+  });
+});

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -411,6 +411,7 @@ export async function excludeDocuments(
   if (error) return { error: error.message };
   revalidatePath(`/projects/${projectId}/config/documents`);
   revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+  revalidateTag(`project-${projectId}-progress`, { expire: 60 });
   return { count: documentIds.length };
 }
 
@@ -440,6 +441,7 @@ export async function restoreDocuments(
   if (error) return { error: error.message };
   revalidatePath(`/projects/${projectId}/config/documents`);
   revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+  revalidateTag(`project-${projectId}-progress`, { expire: 60 });
   return { count: documentIds.length };
 }
 
@@ -468,5 +470,6 @@ export async function hardDeleteDocuments(
   if (error) return { error: error.message };
   revalidatePath(`/projects/${projectId}/config/documents`);
   revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+  revalidateTag(`project-${projectId}-progress`, { expire: 60 });
   return { count: documentIds.length };
 }

--- a/frontend/src/actions/progress.ts
+++ b/frontend/src/actions/progress.ts
@@ -24,11 +24,15 @@ export async function getResearcherProgress(
     async () => {
       const supabase = createSupabaseAdmin();
 
+      // INNER JOIN com documents + filtro excluded_at IS NULL descarta
+      // assignments orfaos de docs soft-deletados. Sem isso, contagem inclui
+      // pendentes que o pesquisador nao consegue ver na lista (ver code/page).
       const { data: assignments } = await supabase
         .from("assignments")
-        .select("id, status, deadline, completed_at")
+        .select("id, status, deadline, completed_at, documents!inner(id)")
         .eq("project_id", projectId)
-        .eq("user_id", userId);
+        .eq("user_id", userId)
+        .is("documents.excluded_at", null);
 
       const all = assignments || [];
       const total = all.length;

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -51,10 +51,11 @@ export default async function CodePage({
         .single(),
       supabase
         .from("assignments")
-        .select("id, status, document_id, documents(id, external_id, title, text)")
+        .select("id, status, document_id, documents!inner(id, external_id, title, text)")
         .eq("project_id", id)
         .eq("user_id", effectiveUserId)
         .eq("type", "codificacao")
+        .is("documents.excluded_at", null)
         .order("status", { ascending: true }),
       supabase
         .from("rounds")


### PR DESCRIPTION
## Summary

- Pesquisadora (Mariana Puschel, projeto Zolgensma) via "faltam 2 notas" no banner de progresso, mas a lista de codificação vinha vazia.
- Causa: `actions/progress.ts` contava `assignments` sem filtrar `documents.excluded_at`, enquanto `analyze/code/page.tsx` escondia esses docs indiretamente via `classifyDocStatus` + filtro de rodada (respostas parciais salvas na versão atual do schema marcavam o doc como `current_done`).
- Os 2 documentos pendentes dela foram soft-deletados pelo script `triage-nusinersen-zolgensma-2026-05-07.mjs` em 2026-05-08 (pareceres de Risdiplam/Nusinersena, fora do escopo Zolgensma).
- Decisão: docs soft-deletados não devem aparecer em lugar algum para o pesquisador — nem contagem nem lista.

## Mudanças

- `frontend/src/actions/progress.ts`: query passa a usar `documents!inner(id)` + `.is("documents.excluded_at", null)`. Conserta o banner em `analyze/code` e a tela `my-progress`.
- `frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx`: mesmo filtro na query de assignments (defesa em profundidade — antes dependia só do filtro de rodada).

Soft delete continua reversível: se o coordenador restaurar o doc, o assignment volta a aparecer.

## Test plan

- [x] `npx tsc --noEmit` passa
- [x] `npx vitest run` — 129/129 testes ok
- [x] Validado no banco: query nova retorna 30/30 para a Mariana (era 34/36)
- [ ] Verificar na UI: ProgressBanner mostra `30/30` e a lista de codificação não traz os docs excluídos
- [ ] Smoke: restaurar um doc excluído via `/config/documents` → assignment volta a aparecer para o pesquisador

🤖 Generated with [Claude Code](https://claude.com/claude-code)