### PR TITLE
fix(schema): corrige inconsistência no Zolgensma e melhora UX dos erros de validação

### DIFF
--- a/frontend/scripts/fix-zolgensma-schema-2026-05-12.mjs
+++ b/frontend/scripts/fix-zolgensma-schema-2026-05-12.mjs
@@ -1,0 +1,370 @@
+// Corrige duas inconsistencias no schema do projeto Zolgensma:
+//
+// 1. q26_ressalva_evidencias.condition.in contem "NatJus aponta incerteza",
+//    valor que nao existe em q25_conclusao_evidencias.options. Esse valor
+//    existe em q20_metodologia_evidencia (provavel erro de configuracao).
+//    Solucao: remover "NatJus aponta incerteza" da condicao do q26.
+//
+// 2. q7_idade_paciente nao tem options. Adicionar "Nao informada" como
+//    sentinel value (mesmo padrao de q2/q3/q6).
+//
+// Uso:
+//   node frontend/scripts/fix-zolgensma-schema-2026-05-12.mjs           # dry-run
+//   node frontend/scripts/fix-zolgensma-schema-2026-05-12.mjs --apply   # persiste
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import crypto from "node:crypto";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const APPLY = process.argv.includes("--apply");
+
+const envPath = resolve(__dirname, "..", ".env.local");
+const env = Object.fromEntries(
+  readFileSync(envPath, "utf8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith("#") && l.includes("="))
+    .map((l) => {
+      const i = l.indexOf("=");
+      return [l.slice(0, i), l.slice(i + 1).replace(/^"|"$/g, "")];
+    }),
+);
+const URL = env.NEXT_PUBLIC_SUPABASE_URL;
+const KEY = env.SUPABASE_SERVICE_ROLE_KEY;
+if (!URL || !KEY) throw new Error("URL/KEY nao encontrados em .env.local");
+
+const PROJECT_ID = "0c6394da-dd2e-4ac0-af83-a107fae37ad4";
+const CHANGED_BY = "234c08f3-b4eb-41fc-8b99-5b1419f4f7b0"; // bruno
+
+const headers = {
+  apikey: KEY,
+  Authorization: `Bearer ${KEY}`,
+  "Content-Type": "application/json",
+  Prefer: "return=representation",
+};
+
+async function rest(method, path, body) {
+  const res = await fetch(`${URL}/rest/v1${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`${method} ${path} -> ${res.status}: ${await res.text()}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+// ---- Port de generatePydanticCode (frontend/src/lib/schema-utils.ts) -------
+
+function escapeString(s) {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+
+function subfieldClassName(name) {
+  return `_${name}_fields`;
+}
+
+function baseAnnotation(field) {
+  if (field.type === "single" && field.options) {
+    return `Literal[${field.options.map((o) => `"${escapeString(o)}"`).join(", ")}]`;
+  }
+  if (field.type === "multi" && field.options) {
+    return `list[Literal[${field.options.map((o) => `"${escapeString(o)}"`).join(", ")}]]`;
+  }
+  if (field.subfields && field.subfields.length > 0) {
+    return subfieldClassName(field.name);
+  }
+  return "str";
+}
+
+function fieldAnnotation(field) {
+  const base = baseAnnotation(field);
+  if (field.condition) return `Optional[${base}]`;
+  return base;
+}
+
+function pythonScalar(v) {
+  if (typeof v === "boolean") return v ? "True" : "False";
+  if (typeof v === "number") return Number.isFinite(v) ? String(v) : "None";
+  return `"${escapeString(v)}"`;
+}
+
+function pythonScalarList(values) {
+  return `[${values.map(pythonScalar).join(", ")}]`;
+}
+
+function conditionToPython(c) {
+  const parts = [`"field": "${escapeString(c.field)}"`];
+  if ("equals" in c) parts.push(`"equals": ${pythonScalar(c.equals)}`);
+  else if ("not_equals" in c) parts.push(`"not_equals": ${pythonScalar(c.not_equals)}`);
+  else if ("in" in c) parts.push(`"in": ${pythonScalarList(c.in)}`);
+  else if ("not_in" in c) parts.push(`"not_in": ${pythonScalarList(c.not_in)}`);
+  else if ("exists" in c) parts.push(`"exists": ${c.exists ? "True" : "False"}`);
+  return `{${parts.join(", ")}}`;
+}
+
+function fieldExtra(field) {
+  const extras = [];
+  if (field.target && field.target !== "all") {
+    extras.push(`"target": "${field.target}"`);
+  }
+  if (field.type === "date") {
+    extras.push(`"field_type": "date"`);
+    if (field.options && field.options.length > 0) {
+      const opts = field.options.map((o) => `"${escapeString(o)}"`).join(", ");
+      extras.push(`"options": [${opts}]`);
+    }
+  }
+  if ((field.type === "single" || field.type === "multi") && field.allow_other) {
+    extras.push(`"allowOther": True`);
+  }
+  if (
+    field.subfields &&
+    field.subfields.length > 0 &&
+    field.subfield_rule &&
+    field.subfield_rule !== "all"
+  ) {
+    extras.push(`"subfield_rule": "${field.subfield_rule}"`);
+  }
+  if (field.help_text && field.help_text.trim()) {
+    extras.push(`"help_text": "${escapeString(field.help_text.trim())}"`);
+  }
+  if (field.condition) {
+    extras.push(`"condition": ${conditionToPython(field.condition)}`);
+  }
+  if (extras.length === 0) return "";
+  return `, json_schema_extra={${extras.join(", ")}}`;
+}
+
+function generatePydanticCode(fields, modelName = "Analysis") {
+  const lines = [
+    "from pydantic import BaseModel, Field",
+    "from typing import Literal, Optional",
+    "",
+  ];
+
+  for (const field of fields) {
+    if (field.subfields && field.subfields.length > 0) {
+      lines.push("");
+      lines.push(`class ${subfieldClassName(field.name)}(BaseModel):`);
+      for (const sf of field.subfields) {
+        const ann =
+          sf.required && field.subfield_rule !== "at_least_one"
+            ? "str"
+            : "Optional[str]";
+        lines.push(
+          `    ${sf.key}: ${ann} = Field(${
+            ann === "Optional[str]" ? "default=None, " : ""
+          }description="${escapeString(sf.label)}")`,
+        );
+      }
+    }
+  }
+
+  lines.push("");
+  lines.push(`class ${modelName}(BaseModel):`);
+  if (fields.length === 0) lines.push("    pass");
+
+  for (const field of fields) {
+    const ann = fieldAnnotation(field);
+    let desc = escapeString(field.description);
+    if (field.type === "date") {
+      desc += ". Formato: DD/MM/AAAA (use XX para partes desconhecidas)";
+    }
+    if (field.type === "date" && field.options && field.options.length > 0) {
+      const sentinelList = field.options
+        .map((o) => `\\"${escapeString(o)}\\"`)
+        .join(", ");
+      desc += `. Caso não seja possível informar a data, usar um dos seguintes valores: ${sentinelList}`;
+    }
+    if (field.help_text && field.help_text.trim()) {
+      desc += `. Instrucoes: ${escapeString(field.help_text.trim())}`;
+    }
+    const extra = fieldExtra(field);
+    const defaultPart = field.condition ? "default=None, " : "";
+    lines.push(
+      `    ${field.name}: ${ann} = Field(${defaultPart}description="${desc}"${extra})`,
+    );
+  }
+
+  return lines.join("\n") + "\n";
+}
+
+// ---- Helpers de hash ------------------------------------------------------
+
+function pythonListRepr(items) {
+  return `[${items.map((s) => `"${s.replace(/"/g, '\\"')}"`).join(", ")}]`;
+}
+
+function computeFieldHash(name, type, options, description) {
+  const optionsPart = options ? pythonListRepr([...options].sort()) : "";
+  const content = `${name}|${type}|${optionsPart}|${description}`;
+  return crypto.createHash("sha256").update(content).digest("hex").slice(0, 12);
+}
+
+// ---- Main -----------------------------------------------------------------
+
+function snapshotOf(field) {
+  return {
+    name: field.name,
+    type: field.type,
+    description: field.description,
+    help_text: field.help_text ?? null,
+    options: field.options ?? null,
+    target: field.target ?? null,
+    required: field.required ?? null,
+    subfields: field.subfields ?? null,
+    subfield_rule: field.subfield_rule ?? null,
+    allow_other: field.allow_other ?? null,
+    condition: field.condition ?? null,
+  };
+}
+
+const [project] = await rest(
+  "GET",
+  `/projects?id=eq.${PROJECT_ID}&select=name,pydantic_fields,pydantic_code,schema_version_major,schema_version_minor,schema_version_patch`,
+);
+if (!project) throw new Error("projeto nao encontrado");
+
+console.log(`Projeto: ${project.name}`);
+console.log(
+  `Versao atual: ${project.schema_version_major}.${project.schema_version_minor}.${project.schema_version_patch}`,
+);
+
+const oldFields = structuredClone(project.pydantic_fields);
+const newFields = structuredClone(project.pydantic_fields);
+
+const q7 = newFields.find((f) => f.name === "q7_idade_paciente");
+const q26 = newFields.find((f) => f.name === "q26_ressalva_evidencias");
+if (!q7) throw new Error("q7_idade_paciente nao encontrado");
+if (!q26) throw new Error("q26_ressalva_evidencias nao encontrado");
+
+const oldQ7 = oldFields.find((f) => f.name === "q7_idade_paciente");
+const oldQ26 = oldFields.find((f) => f.name === "q26_ressalva_evidencias");
+
+// Fix 1: remover "NatJus aponta incerteza" da condition do q26
+const SENTINEL = "NatJus aponta incerteza";
+if (
+  q26.condition &&
+  Array.isArray(q26.condition.in) &&
+  q26.condition.in.includes(SENTINEL)
+) {
+  q26.condition = {
+    ...q26.condition,
+    in: q26.condition.in.filter((v) => v !== SENTINEL),
+  };
+  console.log(
+    `\n[q26] condition.in: ${JSON.stringify(oldQ26.condition.in)} -> ${JSON.stringify(q26.condition.in)}`,
+  );
+} else {
+  console.log(`\n[q26] sem mudanca (condition.in nao contem "${SENTINEL}")`);
+}
+
+// Fix 2: adicionar "Nao informada" em options de q7
+const NAO_INFORMADA = "Não informada";
+const currentOpts = Array.isArray(q7.options) ? q7.options : [];
+if (!currentOpts.includes(NAO_INFORMADA)) {
+  q7.options = [...currentOpts, NAO_INFORMADA];
+  console.log(
+    `[q7]  options: ${JSON.stringify(oldQ7.options ?? null)} -> ${JSON.stringify(q7.options)}`,
+  );
+} else {
+  console.log(`[q7]  sem mudanca (options ja contem "${NAO_INFORMADA}")`);
+}
+
+// Regerar pydantic_code
+const newCode = generatePydanticCode(newFields);
+const codeChanged = newCode !== project.pydantic_code;
+
+// Calcular log entries (formato schema_change_log: before_value/after_value)
+const logEntries = [];
+function maybeLog(oldF, newF) {
+  const before = snapshotOf(oldF);
+  const after = snapshotOf(newF);
+  const diffs = [];
+  const fieldsToCompare = ["options", "condition"];
+  for (const k of fieldsToCompare) {
+    if (JSON.stringify(oldF[k] ?? null) !== JSON.stringify(newF[k] ?? null)) {
+      diffs.push(k === "options" ? "opções" : "condição");
+    }
+  }
+  if (diffs.length > 0) {
+    logEntries.push({
+      field_name: newF.name,
+      change_summary: diffs.join(", "),
+      before_value: before,
+      after_value: after,
+    });
+  }
+}
+maybeLog(oldQ7, q7);
+maybeLog(oldQ26, q26);
+
+if (logEntries.length === 0) {
+  console.log("\nNada a fazer.");
+  process.exit(0);
+}
+
+// Versionamento: opcoes/condicao sao mudancas estruturais -> MINOR bump
+const bumped = {
+  major: project.schema_version_major,
+  minor: project.schema_version_minor + 1,
+  patch: 0,
+};
+console.log(
+  `\nNova versao: ${bumped.major}.${bumped.minor}.${bumped.patch} (bump MINOR)`,
+);
+console.log(`pydantic_code mudou: ${codeChanged ? "sim" : "nao"}`);
+console.log(`\nLog entries (${logEntries.length}):`);
+for (const e of logEntries) {
+  console.log(`  - ${e.field_name}: ${e.change_summary}`);
+}
+
+if (!APPLY) {
+  console.log("\nDRY-RUN. Rode com --apply para persistir.");
+  process.exit(0);
+}
+
+// Apply: PATCH project + INSERT schema_change_log
+const fieldsWithHash = newFields.map((f) => ({
+  ...f,
+  hash: computeFieldHash(
+    f.name,
+    f.type,
+    f.options ?? null,
+    f.description ?? "",
+  ),
+}));
+
+await rest("PATCH", `/projects?id=eq.${PROJECT_ID}`, {
+  pydantic_fields: fieldsWithHash,
+  pydantic_code: newCode,
+  schema_version_major: bumped.major,
+  schema_version_minor: bumped.minor,
+  schema_version_patch: bumped.patch,
+});
+console.log("\nProjeto atualizado.");
+
+await rest(
+  "POST",
+  `/schema_change_log`,
+  logEntries.map((e) => ({
+    project_id: PROJECT_ID,
+    changed_by: CHANGED_BY,
+    change_type: "minor",
+    version_major: bumped.major,
+    version_minor: bumped.minor,
+    version_patch: bumped.patch,
+    ...e,
+  })),
+);
+console.log(`schema_change_log: ${logEntries.length} entrada(s) inseridas.`);
+console.log("\nOK.");

--- a/frontend/src/components/schema/FieldCard.tsx
+++ b/frontend/src/components/schema/FieldCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,12 @@ import { ChevronDown, ChevronUp, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { OptionsEditor } from "./OptionsEditor";
 import { ConditionEditor, candidateTriggersFor } from "./ConditionEditor";
+import { RemoveOptionDialog } from "./RemoveOptionDialog";
+import {
+  findConditionConflicts,
+  stripOptionFromConditions,
+  type ConditionConflict,
+} from "@/lib/schema-utils";
 import type { PydanticField } from "@/lib/types";
 
 interface FieldCardProps {
@@ -28,6 +35,9 @@ interface FieldCardProps {
   onRemove: () => void;
   onMoveUp: () => void;
   onMoveDown: () => void;
+  // Opcional: callback para substituir TODA a lista de campos. Usado quando
+  // remover uma opção exige também atualizar `condition` de outros campos.
+  onAllFieldsChange?: (fields: PydanticField[]) => void;
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -61,9 +71,38 @@ export function FieldCard({
   onRemove,
   onMoveUp,
   onMoveDown,
+  onAllFieldsChange,
 }: FieldCardProps) {
   const updateField = (patch: Partial<PydanticField>) => {
     onChange({ ...field, ...patch });
+  };
+
+  const [pendingRemoval, setPendingRemoval] = useState<{
+    option: string;
+    conflicts: ConditionConflict[];
+    resolve: (confirmed: boolean) => void;
+  } | null>(null);
+
+  const handleBeforeRemoveOption = async (opt: string): Promise<boolean> => {
+    if (!onAllFieldsChange) return true;
+    const conflicts = findConditionConflicts(allFields, field.name, opt);
+    if (conflicts.length === 0) return true;
+
+    const confirmed = await new Promise<boolean>((resolve) => {
+      setPendingRemoval({ option: opt, conflicts, resolve });
+    });
+
+    if (!confirmed) return false;
+
+    const stripped = stripOptionFromConditions(allFields, field.name, opt);
+    const filteredOpts = (field.options || []).filter((o) => o !== opt);
+    const final = stripped.map((f) =>
+      f.name === field.name
+        ? { ...f, options: filteredOpts.length > 0 ? filteredOpts : null }
+        : f,
+    );
+    onAllFieldsChange(final);
+    return false; // já aplicado pelo onAllFieldsChange
   };
 
   const handleTypeChange = (type: PydanticField["type"]) => {
@@ -273,6 +312,7 @@ export function FieldCard({
                 <OptionsEditor
                   options={field.options || []}
                   onChange={(opts) => updateField({ options: opts })}
+                  onBeforeRemove={handleBeforeRemoveOption}
                 />
               </div>
             )}
@@ -287,6 +327,7 @@ export function FieldCard({
                   onChange={(opts) =>
                     updateField({ options: opts.length > 0 ? opts : null })
                   }
+                  onBeforeRemove={handleBeforeRemoveOption}
                 />
               </div>
             )}
@@ -431,6 +472,7 @@ export function FieldCard({
                     <OptionsEditor
                       options={field.options || []}
                       onChange={(opts) => updateField({ options: opts.length > 0 ? opts : null })}
+                      onBeforeRemove={handleBeforeRemoveOption}
                     />
                   </div>
                 )}
@@ -446,6 +488,24 @@ export function FieldCard({
           </div>
         </CollapsibleContent>
       </div>
+
+      {pendingRemoval && (
+        <RemoveOptionDialog
+          open
+          onOpenChange={(open) => {
+            if (!open && pendingRemoval) {
+              pendingRemoval.resolve(false);
+              setPendingRemoval(null);
+            }
+          }}
+          option={pendingRemoval.option}
+          conflicts={pendingRemoval.conflicts}
+          onConfirm={() => {
+            pendingRemoval.resolve(true);
+            setPendingRemoval(null);
+          }}
+        />
+      )}
     </Collapsible>
   );
 }

--- a/frontend/src/components/schema/OptionsEditor.tsx
+++ b/frontend/src/components/schema/OptionsEditor.tsx
@@ -8,9 +8,16 @@ import { Plus, X } from "lucide-react";
 interface OptionsEditorProps {
   options: string[];
   onChange: (options: string[]) => void;
+  // Chamado antes de remover uma opção não-vazia. Retornar `false` cancela.
+  // Útil para verificar se a opção está em uso por `condition` de outro campo.
+  onBeforeRemove?: (option: string) => Promise<boolean> | boolean;
 }
 
-export function OptionsEditor({ options, onChange }: OptionsEditorProps) {
+export function OptionsEditor({
+  options,
+  onChange,
+  onBeforeRemove,
+}: OptionsEditorProps) {
   const lastInputRef = useRef<HTMLInputElement>(null);
   const shouldFocusLast = useRef(false);
 
@@ -27,7 +34,12 @@ export function OptionsEditor({ options, onChange }: OptionsEditorProps) {
     onChange(next);
   };
 
-  const removeOption = (index: number) => {
+  const removeOption = async (index: number) => {
+    const opt = options[index];
+    if (onBeforeRemove && opt.trim() !== "") {
+      const ok = await onBeforeRemove(opt);
+      if (!ok) return;
+    }
     onChange(options.filter((_, i) => i !== index));
   };
 

--- a/frontend/src/components/schema/RemoveOptionDialog.tsx
+++ b/frontend/src/components/schema/RemoveOptionDialog.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import type { ConditionConflict } from "@/lib/schema-utils";
+
+interface RemoveOptionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  option: string;
+  conflicts: ConditionConflict[];
+  onConfirm: () => void;
+}
+
+export function RemoveOptionDialog({
+  open,
+  onOpenChange,
+  option,
+  conflicts,
+  onConfirm,
+}: RemoveOptionDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remover opção em uso?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                A opção <strong>&quot;{option}&quot;</strong> é usada na
+                condição de{" "}
+                {conflicts.length === 1
+                  ? "1 campo"
+                  : `${conflicts.length} campos`}
+                :
+              </p>
+              <ul className="list-disc space-y-0.5 pl-5 text-sm">
+                {conflicts.map((c) => (
+                  <li key={c.fieldName}>
+                    <span className="font-mono">{c.fieldName}</span>{" "}
+                    <span className="text-muted-foreground">
+                      ({c.fieldLabel}, {c.conditionKey})
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <p>
+                Se você remover, as condições afetadas também serão atualizadas
+                (o valor sai da lista <code>in/not_in</code> ou a condition
+                inteira é removida se for <code>equals/not_equals</code>).
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            Remover e atualizar condições
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/schema/SchemaBuilderGUI.tsx
+++ b/frontend/src/components/schema/SchemaBuilderGUI.tsx
@@ -87,6 +87,7 @@ export function SchemaBuilderGUI({ fields, onChange }: SchemaBuilderGUIProps) {
             onRemove={() => removeField(i)}
             onMoveUp={() => moveField(i, i - 1)}
             onMoveDown={() => moveField(i, i + 1)}
+            onAllFieldsChange={onChange}
           />
         ))}
       </div>

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 import { LayoutGrid, Code, Rocket, Info, X, History } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SchemaBuilderGUI } from "./SchemaBuilderGUI";
+import { ValidationErrorPanel } from "./ValidationErrorPanel";
 import type { PydanticField } from "@/lib/types";
 
 const MonacoEditor = dynamic(
@@ -63,6 +64,7 @@ export function SchemaEditor({
     "idle" | "valid" | "error"
   >("idle");
   const [errors, setErrors] = useState<string[]>([]);
+  const [guiErrors, setGuiErrors] = useState<string[]>([]);
   const [isPending, startTransition] = useTransition();
   const [majorDialogOpen, setMajorDialogOpen] = useState(false);
   const [backfillDialogOpen, setBackfillDialogOpen] = useState(false);
@@ -118,12 +120,14 @@ export function SchemaEditor({
     setCode(generated);
     setCodeFields(fields);
     setValidationStatus("idle");
+    setGuiErrors([]);
     setMode("code");
   };
 
   const switchToGUI = async () => {
     if (!code.trim()) {
       setFields([]);
+      setGuiErrors([]);
       setMode("gui");
       return;
     }
@@ -133,6 +137,7 @@ export function SchemaEditor({
         setFields(result.fields);
         setCodeFields(result.fields);
         setValidationStatus("valid");
+        setGuiErrors([]);
         setMode("gui");
       } else {
         toast.error(
@@ -173,11 +178,12 @@ export function SchemaEditor({
     startTransition(async () => {
       try {
         if (mode === "gui") {
-          const guiErrors = validateGUIFields(fields);
-          if (guiErrors.length > 0) {
-            toast.error(guiErrors[0]);
+          const errs = validateGUIFields(fields);
+          if (errs.length > 0) {
+            setGuiErrors(errs);
             return;
           }
+          setGuiErrors([]);
           await saveSchemaFromGUI(projectId, fields);
           toast.success("Schema salvo!");
         } else {
@@ -325,6 +331,15 @@ export function SchemaEditor({
           />
         )}
       </div>
+
+      {mode === "gui" && guiErrors.length > 0 && (
+        <div className="border-t px-4 py-3">
+          <ValidationErrorPanel
+            errors={guiErrors}
+            onDismiss={() => setGuiErrors([])}
+          />
+        </div>
+      )}
 
       {/* Footer */}
       <div className="flex items-center gap-2 border-t px-4 py-2">

--- a/frontend/src/components/schema/ValidationErrorPanel.tsx
+++ b/frontend/src/components/schema/ValidationErrorPanel.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { OctagonX, Copy, Check, X } from "lucide-react";
+import { toast } from "sonner";
+
+interface ValidationErrorPanelProps {
+  errors: string[];
+  onDismiss: () => void;
+}
+
+export function ValidationErrorPanel({
+  errors,
+  onDismiss,
+}: ValidationErrorPanelProps) {
+  const [copied, setCopied] = useState(false);
+
+  if (errors.length === 0) return null;
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(errors.join("\n"));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("Não foi possível copiar para a área de transferência.");
+    }
+  };
+
+  return (
+    <Card className="border-destructive/40 bg-destructive/5">
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0 pb-3">
+        <div className="flex items-center gap-2">
+          <OctagonX className="h-5 w-5 shrink-0 text-destructive" />
+          <p className="text-sm font-medium leading-snug">
+            {errors.length === 1
+              ? "1 erro impede o save"
+              : `${errors.length} erros impedem o save`}
+          </p>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1.5"
+            onClick={handleCopy}
+          >
+            {copied ? (
+              <>
+                <Check className="h-3.5 w-3.5" />
+                Copiado
+              </>
+            ) : (
+              <>
+                <Copy className="h-3.5 w-3.5" />
+                Copiar
+              </>
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={onDismiss}
+            aria-label="Fechar"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <ul className="list-disc space-y-1 pl-5 text-sm text-foreground select-text">
+          {errors.map((err, i) => (
+            <li key={i} className="leading-snug">
+              {err}
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -20,6 +20,12 @@ import {
   ConditionEditor,
   candidateTriggersFor,
 } from "@/components/schema/ConditionEditor";
+import { RemoveOptionDialog } from "@/components/schema/RemoveOptionDialog";
+import {
+  findConditionConflicts,
+  stripOptionFromConditions,
+  type ConditionConflict,
+} from "@/lib/schema-utils";
 import { saveSchemaFromGUI } from "@/actions/schema";
 import { approveSchemaSuggestionWithEdits } from "@/actions/suggestions";
 import { toast } from "sonner";
@@ -91,6 +97,19 @@ export function EditFieldDialog({
   const [subfieldRule, setSubfieldRule] = useState<"all" | "at_least_one">(field?.subfield_rule ?? "all");
   const [condition, setCondition] = useState<FieldCondition | undefined>(field?.condition);
   const [isSaving, startSave] = useTransition();
+  const [pendingRemoval, setPendingRemoval] = useState<{
+    option: string;
+    conflicts: ConditionConflict[];
+    resolve: (confirmed: boolean) => void;
+  } | null>(null);
+
+  const handleBeforeRemoveOption = async (opt: string): Promise<boolean> => {
+    const conflicts = findConditionConflicts(allFields, fieldName, opt);
+    if (conflicts.length === 0) return true;
+    return await new Promise<boolean>((resolve) => {
+      setPendingRemoval({ option: opt, conflicts, resolve });
+    });
+  };
 
   // Reset state when dialog opens with a different field or suggestion
   const resetKey = `${fieldName}::${pendingSuggestion?.id ?? ""}`;
@@ -115,7 +134,9 @@ export function EditFieldDialog({
 
   const handleSave = () => {
     startSave(async () => {
-      const updatedFields = allFields.map((f) =>
+      const originalOpts = field.options ?? [];
+      const removedOpts = originalOpts.filter((o) => !options.includes(o));
+      let updatedFields = allFields.map((f) =>
         f.name === fieldName
           ? {
               ...f,
@@ -132,6 +153,9 @@ export function EditFieldDialog({
             }
           : f,
       );
+      for (const removed of removedOpts) {
+        updatedFields = stripOptionFromConditions(updatedFields, fieldName, removed);
+      }
       try {
         if (pendingSuggestion) {
           const result = await approveSchemaSuggestionWithEdits(
@@ -156,6 +180,7 @@ export function EditFieldDialog({
   };
 
   return (
+    <>
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
@@ -219,7 +244,11 @@ export function EditFieldDialog({
             <div className="space-y-3">
               <div className="space-y-1.5">
                 <Label className="text-xs">Opções</Label>
-                <OptionsEditor options={options} onChange={setOptions} />
+                <OptionsEditor
+                  options={options}
+                  onChange={setOptions}
+                  onBeforeRemove={handleBeforeRemoveOption}
+                />
               </div>
               <div className="flex items-center justify-between">
                 <div>
@@ -239,7 +268,11 @@ export function EditFieldDialog({
               <p className="text-xs text-muted-foreground">
                 Aparecem como botões ao lado do campo de data (ex: &quot;Não identificável&quot;).
               </p>
-              <OptionsEditor options={options} onChange={setOptions} />
+              <OptionsEditor
+                options={options}
+                onChange={setOptions}
+                onBeforeRemove={handleBeforeRemoveOption}
+              />
             </div>
           )}
 
@@ -362,7 +395,11 @@ export function EditFieldDialog({
                   <p className="text-xs text-muted-foreground">
                     Botões de atalho para consistência na comparação
                   </p>
-                  <OptionsEditor options={options} onChange={setOptions} />
+                  <OptionsEditor
+                    options={options}
+                    onChange={setOptions}
+                    onBeforeRemove={handleBeforeRemoveOption}
+                  />
                 </div>
               )}
             </div>
@@ -391,5 +428,24 @@ export function EditFieldDialog({
         </DialogFooter>
       </DialogContent>
     </Dialog>
+
+    {pendingRemoval && (
+      <RemoveOptionDialog
+        open
+        onOpenChange={(open) => {
+          if (!open && pendingRemoval) {
+            pendingRemoval.resolve(false);
+            setPendingRemoval(null);
+          }
+        }}
+        option={pendingRemoval.option}
+        conflicts={pendingRemoval.conflicts}
+        onConfirm={() => {
+          pendingRemoval.resolve(true);
+          setPendingRemoval(null);
+        }}
+      />
+    )}
+    </>
   );
 }

--- a/frontend/src/lib/__tests__/schema-utils-conditions.test.ts
+++ b/frontend/src/lib/__tests__/schema-utils-conditions.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  findConditionConflicts,
+  stripOptionFromConditions,
+  validateGUIFields,
+} from "@/lib/schema-utils";
+import type { PydanticField } from "@/lib/types";
+
+const baseField = (over: Partial<PydanticField>): PydanticField => ({
+  name: "x",
+  type: "single",
+  description: "x",
+  options: null,
+  ...over,
+});
+
+describe("findConditionConflicts", () => {
+  it("returns empty when no field references the option", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A", "B"] }),
+      baseField({ name: "q2", type: "text" }),
+    ];
+    expect(findConditionConflicts(fields, "q1", "A")).toEqual([]);
+  });
+
+  it("flags equals match", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A", "B"] }),
+      baseField({
+        name: "q2",
+        type: "text",
+        condition: { field: "q1", equals: "A" },
+      }),
+    ];
+    const c = findConditionConflicts(fields, "q1", "A");
+    expect(c).toEqual([
+      { fieldName: "q2", fieldLabel: "Campo 2", conditionKey: "equals" },
+    ]);
+  });
+
+  it("flags in match and skips unrelated", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A", "B", "C"] }),
+      baseField({
+        name: "q2",
+        type: "text",
+        condition: { field: "q1", in: ["A", "B"] },
+      }),
+      baseField({
+        name: "q3",
+        type: "text",
+        condition: { field: "q1", in: ["C"] },
+      }),
+    ];
+    expect(findConditionConflicts(fields, "q1", "A")).toEqual([
+      { fieldName: "q2", fieldLabel: "Campo 2", conditionKey: "in" },
+    ]);
+  });
+
+  it("ignores conditions that target a different trigger field", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A"] }),
+      baseField({ name: "q2", options: ["A"] }),
+      baseField({
+        name: "q3",
+        type: "text",
+        condition: { field: "q2", equals: "A" },
+      }),
+    ];
+    expect(findConditionConflicts(fields, "q1", "A")).toEqual([]);
+  });
+});
+
+describe("stripOptionFromConditions", () => {
+  it("filters value from in list", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A", "B"] }),
+      baseField({
+        name: "q2",
+        type: "text",
+        condition: { field: "q1", in: ["A", "B"] },
+      }),
+    ];
+    const next = stripOptionFromConditions(fields, "q1", "A");
+    expect(next[1].condition).toEqual({ field: "q1", in: ["B"] });
+  });
+
+  it("removes the entire condition when in becomes empty", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A"] }),
+      baseField({
+        name: "q2",
+        type: "text",
+        condition: { field: "q1", in: ["A"] },
+      }),
+    ];
+    const next = stripOptionFromConditions(fields, "q1", "A");
+    expect(next[1].condition).toBeUndefined();
+  });
+
+  it("removes the entire condition on equals match", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A"] }),
+      baseField({
+        name: "q2",
+        type: "text",
+        condition: { field: "q1", equals: "A" },
+      }),
+    ];
+    const next = stripOptionFromConditions(fields, "q1", "A");
+    expect(next[1].condition).toBeUndefined();
+  });
+
+  it("does not touch unrelated conditions", () => {
+    const fields: PydanticField[] = [
+      baseField({ name: "q1", options: ["A"] }),
+      baseField({
+        name: "q2",
+        type: "text",
+        condition: { field: "other", equals: "A" },
+      }),
+    ];
+    const next = stripOptionFromConditions(fields, "q1", "A");
+    expect(next[1].condition).toEqual({ field: "other", equals: "A" });
+  });
+});
+
+describe("after strip, validateGUIFields should pass", () => {
+  it("reproduces the Zolgensma scenario then fixes it", () => {
+    // q25 sem "NatJus aponta incerteza", q26 com condition que referencia.
+    const fields: PydanticField[] = [
+      baseField({
+        name: "q25",
+        options: ["Sim", "Sim, com ressalvas"],
+        description: "q25",
+      }),
+      baseField({
+        name: "q26",
+        type: "text",
+        description: "q26",
+        condition: {
+          field: "q25",
+          in: ["Sim, com ressalvas", "NatJus aponta incerteza"],
+        },
+      }),
+    ];
+    expect(validateGUIFields(fields)).toContain(
+      'Campo 2: valor "NatJus aponta incerteza" não está nas opções de "q25"',
+    );
+
+    const fixed = stripOptionFromConditions(fields, "q25", "NatJus aponta incerteza");
+    expect(validateGUIFields(fixed)).toEqual([]);
+  });
+});

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -286,3 +286,98 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
 
   return errors;
 }
+
+// ---------- Detecção de conflito de condition ao remover opção ----------
+
+export type ConditionConflict = {
+  fieldName: string;
+  fieldLabel: string;
+  conditionKey: "equals" | "not_equals" | "in" | "not_in";
+};
+
+// Retorna os campos que referenciam `removedOption` em suas condições, quando
+// a condition tem `field === triggerFieldName`. Usado para avisar o usuário
+// (e oferecer auto-correção) antes de remover uma opção em uso.
+export function findConditionConflicts(
+  fields: PydanticField[],
+  triggerFieldName: string,
+  removedOption: string,
+): ConditionConflict[] {
+  const conflicts: ConditionConflict[] = [];
+  for (let i = 0; i < fields.length; i++) {
+    const f = fields[i];
+    const c = f.condition;
+    if (!c || c.field !== triggerFieldName) continue;
+
+    let conditionKey: ConditionConflict["conditionKey"] | null = null;
+    if ("equals" in c && c.equals === removedOption) conditionKey = "equals";
+    else if ("not_equals" in c && c.not_equals === removedOption)
+      conditionKey = "not_equals";
+    else if ("in" in c && Array.isArray(c.in) && c.in.includes(removedOption))
+      conditionKey = "in";
+    else if (
+      "not_in" in c &&
+      Array.isArray(c.not_in) &&
+      c.not_in.includes(removedOption)
+    )
+      conditionKey = "not_in";
+
+    if (conditionKey) {
+      conflicts.push({
+        fieldName: f.name,
+        fieldLabel: `Campo ${i + 1}`,
+        conditionKey,
+      });
+    }
+  }
+  return conflicts;
+}
+
+// Remove `removedOption` das conditions afetadas. Se a condition usa equals/
+// not_equals com o valor removido, apaga a condition inteira (não há valor
+// alternativo); se usa in/not_in, filtra o array (e remove a condition se
+// ficar vazio).
+export function stripOptionFromConditions(
+  fields: PydanticField[],
+  triggerFieldName: string,
+  removedOption: string,
+): PydanticField[] {
+  return fields.map((f) => {
+    const c = f.condition;
+    if (!c || c.field !== triggerFieldName) return f;
+
+    if ("equals" in c && c.equals === removedOption) {
+      const next = { ...f };
+      delete next.condition;
+      return next;
+    }
+    if ("not_equals" in c && c.not_equals === removedOption) {
+      const next = { ...f };
+      delete next.condition;
+      return next;
+    }
+    if ("in" in c && Array.isArray(c.in) && c.in.includes(removedOption)) {
+      const filtered = c.in.filter((v) => v !== removedOption);
+      if (filtered.length === 0) {
+        const next = { ...f };
+        delete next.condition;
+        return next;
+      }
+      return { ...f, condition: { ...c, in: filtered } };
+    }
+    if (
+      "not_in" in c &&
+      Array.isArray(c.not_in) &&
+      c.not_in.includes(removedOption)
+    ) {
+      const filtered = c.not_in.filter((v) => v !== removedOption);
+      if (filtered.length === 0) {
+        const next = { ...f };
+        delete next.condition;
+        return next;
+      }
+      return { ...f, condition: { ...c, not_in: filtered } };
+    }
+    return f;
+  });
+}


### PR DESCRIPTION
## Contexto

O usuário tentou adicionar a opção padronizada `\"Não informada\"` ao campo `q7_idade_paciente` do projeto Zolgensma e recebeu o erro:

> Campo 21: valor \"NatJus aponta incerteza\" não está nas opções de \"q25_conclusao_evidencias\"

### Causa raiz

`validateGUIFields()` (em `frontend/src/lib/schema-utils.ts`) valida **todas** as condições do schema a cada save. O Campo 21 do Zolgensma é `q26_ressalva_evidencias`, com `condition: { field: \"q25_conclusao_evidencias\", in: [\"Sim, com ressalvas\", \"NatJus aponta incerteza\"] }`. As opções atuais de `q25_conclusao_evidencias` **não contêm** \"NatJus aponta incerteza\" — esse valor existe em `q20_metodologia_evidencia`. Provavelmente foi um erro de configuração ou alguém removeu a opção de q25 no passado sem ajustar a condição que a referenciava.

Como a validação roda em todo o schema, qualquer save (mesmo edições não-relacionadas como adicionar opção a q7) era bloqueado por essa inconsistência pré-existente. Além disso, o toast `toast.error(guiErrors[0])` só mostrava o primeiro erro e não permitia copiar — o usuário precisou tirar print pra reportar.

## Summary

- **Commit 1** — Script `frontend/scripts/fix-zolgensma-schema-2026-05-12.mjs` corrige o schema do projeto Zolgensma em produção: remove \"NatJus aponta incerteza\" da `condition.in` de q26 e adiciona \"Não informada\" como sentinel value em q7. Já aplicado (versão 0.16.4 → 0.17.0; 2 entradas em `schema_change_log`).
- **Commit 2** — Substitui `toast.error(guiErrors[0])` em `SchemaEditor` por `ValidationErrorPanel`: card persistente abaixo do conteúdo que lista TODOS os erros, com botão Copiar e texto selecionável. Some quando não há erro.
- **Commit 3** — Prevenção: ao remover uma opção em uso por `condition` de outro campo, abre `RemoveOptionDialog` que lista os campos afetados. Ao confirmar, o sistema também atualiza/remove as conditions afetadas (filtra in/not_in, remove condition inteira em equals/not_equals). Aplicado em `FieldCard` (aba Schema) e `EditFieldDialog` (Comentários, LLM Insights). Helpers `findConditionConflicts` e `stripOptionFromConditions` em `schema-utils.ts` cobertos por 9 testes (incluindo o cenário Zolgensma como regression test).

## Test plan

- [x] `npx vitest run` (frontend) — 140/140 testes passam (9 novos)
- [x] `npx tsc --noEmit` limpo
- [x] `npx eslint` limpo nos arquivos tocados
- [ ] Smoke: abrir Zolgensma → Schema, verificar q26 sem \"NatJus aponta incerteza\" e q7 com \"Não informada\"; salvar com sucesso
- [ ] Smoke: criar erro artificial (renomear campo para nome inválido) e ver painel persistente com botão Copiar funcionando
- [ ] Smoke: remover opção \"Sim, com ressalvas\" de q25_conclusao_evidencias; ver dialog avisando que afeta q26 e confirmando auto-correção da condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)