### PR TITLE
feat(coding): reordenar perguntas com drag-and-drop (pesquisador + coordenador)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@clerk/localizations": "^4.2.4",
         "@clerk/nextjs": "^7.0.7",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@monaco-editor/react": "^4.7.0",
         "@supabase/supabase-js": "^2.98.0",
         "@tailwindcss/typography": "^0.5.19",
@@ -995,6 +998,59 @@
       "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
       "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
       "license": "MIT"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.52.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "@clerk/localizations": "^4.2.4",
     "@clerk/nextjs": "^7.0.7",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@monaco-editor/react": "^4.7.0",
     "@supabase/supabase-js": "^2.98.0",
     "@tailwindcss/typography": "^0.5.19",

--- a/frontend/src/actions/field-order.ts
+++ b/frontend/src/actions/field-order.ts
@@ -1,0 +1,59 @@
+"use server";
+
+import { createSupabaseServer } from "@/lib/supabase/server";
+import { getAuthUser } from "@/lib/auth";
+
+export async function getResearcherFieldOrder(
+  projectId: string,
+): Promise<{ order: string[] | null; error?: string }> {
+  const user = await getAuthUser();
+  if (!user) return { order: null, error: "Não autenticado" };
+
+  const supabase = await createSupabaseServer();
+  const { data, error } = await supabase
+    .from("researcher_field_orders")
+    .select("field_order")
+    .eq("project_id", projectId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (error) {
+    console.error("[getResearcherFieldOrder]", error);
+    return { order: null, error: error.message };
+  }
+  if (!data) return { order: null };
+
+  const raw = data.field_order;
+  if (!Array.isArray(raw)) return { order: null };
+  const order = raw.filter((x): x is string => typeof x === "string");
+  return { order };
+}
+
+export async function saveResearcherFieldOrder(
+  projectId: string,
+  fieldOrder: string[],
+): Promise<{ success: boolean; error?: string }> {
+  const user = await getAuthUser();
+  if (!user) return { success: false, error: "Não autenticado" };
+
+  if (!Array.isArray(fieldOrder) || !fieldOrder.every((x) => typeof x === "string")) {
+    return { success: false, error: "Ordem inválida" };
+  }
+
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase.from("researcher_field_orders").upsert(
+    {
+      project_id: projectId,
+      user_id: user.id,
+      field_order: fieldOrder,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: "project_id,user_id" },
+  );
+
+  if (error) {
+    console.error("[saveResearcherFieldOrder]", error);
+    return { success: false, error: error.message };
+  }
+  return { success: true };
+}

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -109,12 +109,28 @@ export function CodingPage({
   useEffect(() => {
     let cancelled = false;
     getResearcherFieldOrder(projectId).then(({ order }) => {
-      if (!cancelled) setFieldOrder(order);
+      // Se o pesquisador ja arrastou antes da load resolver, o drag tem
+      // prioridade — descartamos o valor vindo do banco para nao sobrescrever
+      // a intencao recente do usuario.
+      if (cancelled || pendingOrderRef.current) return;
+      setFieldOrder(order);
     });
     return () => {
       cancelled = true;
     };
   }, [projectId]);
+
+  const doSave = useCallback(
+    (order: string[]) => {
+      saveResearcherFieldOrder(projectId, order).then((r) => {
+        if (!r.success) {
+          console.error("[field-order save]", r.error);
+          toast.error("Não foi possível salvar a ordem das perguntas");
+        }
+      });
+    },
+    [projectId],
+  );
 
   const flushOrderSave = useCallback(() => {
     if (reorderSaveTimer.current) {
@@ -124,10 +140,8 @@ export function CodingPage({
     const pending = pendingOrderRef.current;
     if (!pending) return;
     pendingOrderRef.current = null;
-    saveResearcherFieldOrder(projectId, pending).then((r) => {
-      if (!r.success) console.error("[field-order save]", r.error);
-    });
-  }, [projectId]);
+    doSave(pending);
+  }, [doSave]);
 
   const handleReorder = useCallback(
     (newOrder: string[]) => {
@@ -139,15 +153,10 @@ export function CodingPage({
         const pending = pendingOrderRef.current;
         if (!pending) return;
         pendingOrderRef.current = null;
-        saveResearcherFieldOrder(projectId, pending).then((r) => {
-          if (!r.success) {
-            console.error("[field-order save]", r.error);
-            toast.error("Não foi possível salvar a ordem das perguntas");
-          }
-        });
+        doSave(pending);
       }, 500);
     },
-    [projectId],
+    [doSave],
   );
 
   useEffect(() => {

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import { DocumentReader } from "./DocumentReader";
 import { QuestionsPanel } from "./QuestionsPanel";
@@ -13,6 +13,8 @@ import { DocumentPicker } from "./DocumentPicker";
 import { FullscreenNav } from "./FullscreenNav";
 import { saveResponse } from "@/actions/responses";
 import { getDocumentsForBrowse, getDocumentForCoding } from "@/actions/documents";
+import { getResearcherFieldOrder, saveResearcherFieldOrder } from "@/actions/field-order";
+import { applyFieldOrder } from "@/lib/field-order";
 import type { BrowseDocument } from "@/actions/documents";
 import type { PydanticField, Document, Assignment, Round, RoundStrategy } from "@/lib/types";
 import { ProgressBanner, type ProgressBannerData } from "./ProgressBanner";
@@ -98,6 +100,66 @@ export function CodingPage({
   // Fullscreen state
   const [isFullscreen, setIsFullscreen] = useState(false);
   const toggleFullscreen = useCallback(() => setIsFullscreen((prev) => !prev), []);
+
+  // Ordem custom de perguntas do pesquisador (carregada uma vez por projeto)
+  const [fieldOrder, setFieldOrder] = useState<string[] | null>(null);
+  const reorderSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingOrderRef = useRef<string[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getResearcherFieldOrder(projectId).then(({ order }) => {
+      if (!cancelled) setFieldOrder(order);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const flushOrderSave = useCallback(() => {
+    if (reorderSaveTimer.current) {
+      clearTimeout(reorderSaveTimer.current);
+      reorderSaveTimer.current = null;
+    }
+    const pending = pendingOrderRef.current;
+    if (!pending) return;
+    pendingOrderRef.current = null;
+    saveResearcherFieldOrder(projectId, pending).then((r) => {
+      if (!r.success) console.error("[field-order save]", r.error);
+    });
+  }, [projectId]);
+
+  const handleReorder = useCallback(
+    (newOrder: string[]) => {
+      setFieldOrder(newOrder);
+      pendingOrderRef.current = newOrder;
+      if (reorderSaveTimer.current) clearTimeout(reorderSaveTimer.current);
+      reorderSaveTimer.current = setTimeout(() => {
+        reorderSaveTimer.current = null;
+        const pending = pendingOrderRef.current;
+        if (!pending) return;
+        pendingOrderRef.current = null;
+        saveResearcherFieldOrder(projectId, pending).then((r) => {
+          if (!r.success) {
+            console.error("[field-order save]", r.error);
+            toast.error("Não foi possível salvar a ordem das perguntas");
+          }
+        });
+      }, 500);
+    },
+    [projectId],
+  );
+
+  useEffect(() => {
+    return () => {
+      flushOrderSave();
+    };
+  }, [flushOrderSave]);
+
+  const orderedFields = useMemo(
+    () => applyFieldOrder(fields, fieldOrder),
+    [fields, fieldOrder],
+  );
 
   // Dirty tracking — marks docs that the user has actually edited
   const [dirtyDocs, setDirtyDocs] = useState<Set<string>>(new Set());
@@ -534,7 +596,7 @@ export function CodingPage({
                 <ResizablePanel defaultSize={45} minSize={25}>
                   <QuestionsPanel
                     key={currentDoc?.id}
-                    fields={fields}
+                    fields={orderedFields}
                     answers={docAnswers}
                     onAnswer={handleAnswer}
                     onSubmit={handleSubmit}
@@ -542,6 +604,7 @@ export function CodingPage({
                     notes={docNotes}
                     onNotesChange={handleNotesChange}
                     readOnly={readOnly}
+                    onReorder={handleReorder}
                   />
                 </ResizablePanel>
               </ResizablePanelGroup>
@@ -580,7 +643,7 @@ export function CodingPage({
                 <ResizablePanel defaultSize={45} minSize={25}>
                   <QuestionsPanel
                     key={selectedBrowseDoc?.id}
-                    fields={fields}
+                    fields={orderedFields}
                     answers={browseAnswers}
                     onAnswer={handleBrowseAnswer}
                     onSubmit={handleBrowseSubmit}
@@ -588,6 +651,7 @@ export function CodingPage({
                     notes={browseNotes}
                     onNotesChange={setBrowseNotes}
                     readOnly={readOnly}
+                    onReorder={handleReorder}
                   />
                 </ResizablePanel>
               </ResizablePanelGroup>

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -5,11 +5,28 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FieldRenderer } from "./FieldRenderer";
-import { Check, Loader2, MessageSquare } from "lucide-react";
+import { Check, GripVertical, Loader2, MessageSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { isFieldVisible } from "@/lib/conditional";
+import { reorderFullList } from "@/lib/field-order";
 import type { PydanticField } from "@/lib/types";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 
 const OTHER_PREFIX = "Outro: ";
 const isIncompleteOther = (v: unknown) =>
@@ -33,9 +50,95 @@ interface QuestionsPanelProps {
   notes?: string;
   onNotesChange?: (notes: string) => void;
   readOnly?: boolean;
+  onReorder?: (newOrder: string[]) => void;
 }
 
-export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false }: QuestionsPanelProps) {
+interface SortableQuestionProps {
+  field: PydanticField;
+  index: number;
+  isHighlighted: boolean;
+  isAnswered: boolean;
+  answerValue: unknown;
+  onAnswerChange: (val: unknown) => void;
+  setRef: (el: HTMLDivElement | null) => void;
+  draggable: boolean;
+}
+
+function SortableQuestion({
+  field,
+  index,
+  isHighlighted,
+  isAnswered,
+  answerValue,
+  onAnswerChange,
+  setRef,
+  draggable,
+}: SortableQuestionProps) {
+  const sortable = useSortable({ id: field.name, disabled: !draggable });
+  const style = draggable
+    ? {
+        transform: CSS.Transform.toString(sortable.transform),
+        transition: sortable.transition,
+        opacity: sortable.isDragging ? 0.5 : 1,
+      }
+    : undefined;
+
+  return (
+    <div
+      ref={(el) => {
+        setRef(el);
+        if (draggable) sortable.setNodeRef(el);
+      }}
+      style={style}
+      className={cn(
+        "border-l-2 pl-4 py-2 rounded-r-md transition-colors",
+        isHighlighted
+          ? "border-l-destructive bg-destructive/10"
+          : isAnswered
+            ? "border-brand"
+            : "border-muted",
+      )}
+    >
+      <div className="flex items-start gap-1.5">
+        {draggable && (
+          <button
+            type="button"
+            className={cn(
+              "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground touch-none",
+              sortable.isDragging ? "cursor-grabbing" : "cursor-grab",
+            )}
+            aria-label="Arrastar para reordenar pergunta"
+            {...sortable.attributes}
+            {...sortable.listeners}
+          >
+            <GripVertical className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium mb-2 flex items-center gap-1.5">
+            <span className="text-muted-foreground">{index + 1}.</span> {field.description}
+            {field.required === false && (
+              <span className="text-xs text-muted-foreground font-normal">(opcional)</span>
+            )}
+            {isAnswered && <Check className="h-3.5 w-3.5 text-brand shrink-0" />}
+          </p>
+          {field.help_text && (
+            <p className="text-xs text-muted-foreground mb-2 whitespace-pre-line">
+              {field.help_text}
+            </p>
+          )}
+          <FieldRenderer
+            field={field}
+            value={answerValue ?? null}
+            onChange={onAnswerChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false, onReorder }: QuestionsPanelProps) {
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
 
@@ -55,8 +158,6 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     [visibleFields],
   );
 
-  // When a trigger answer changes, fields that became invisible should not
-  // keep stale values; clear them so they don't end up in the saved payload.
   useEffect(() => {
     if (readOnly) return;
     for (const f of fields) {
@@ -67,8 +168,6 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         onAnswer(f.name, null);
       }
     }
-    // Only react when the set of visible fields changes — answers churn
-    // is handled by the visibility recomputation.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visibleNames]);
 
@@ -113,48 +212,79 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     onSubmit();
   }, [visibleFields, isAnswered, onSubmit, submitting]);
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const dragEnabled = !!onReorder && !readOnly;
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      if (!onReorder) return;
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const visibleNamesArr = visibleFields.map((f) => f.name);
+      const from = visibleNamesArr.indexOf(String(active.id));
+      const to = visibleNamesArr.indexOf(String(over.id));
+      if (from < 0 || to < 0) return;
+      const newOrder = reorderFullList(
+        fields.map((f) => f.name),
+        visibleNamesArr,
+        from,
+        to,
+      );
+      onReorder(newOrder);
+    },
+    [fields, visibleFields, onReorder],
+  );
+
+  const questionItems = (
+    <>
+      {visibleFields.map((field, i) => (
+        <SortableQuestion
+          key={field.name}
+          field={field}
+          index={i}
+          isHighlighted={highlightedFields.has(field.name)}
+          isAnswered={isAnswered(field)}
+          answerValue={answers[field.name]}
+          onAnswerChange={(val) => handleAnswerWithClear(field.name, val)}
+          setRef={(el) => {
+            questionRefs.current[i] = el;
+          }}
+          draggable={dragEnabled}
+        />
+      ))}
+    </>
+  );
+
   return (
     <div className="flex h-full flex-col bg-card">
-      {/* Header */}
       <div className="border-b px-4 py-2.5 shrink-0">
         <p className="text-xs font-medium text-muted-foreground">
           Perguntas ({answeredRequiredCount}/{requiredFields.length} obrigatórias respondidas)
         </p>
       </div>
 
-      {/* Lista de perguntas scrollável */}
       <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6">
-        {visibleFields.map((field, i) => (
-          <div
-            key={field.name}
-            ref={(el) => { questionRefs.current[i] = el; }}
-            className={cn(
-              "border-l-2 pl-4 py-2 rounded-r-md transition-colors",
-              highlightedFields.has(field.name)
-                ? "border-l-destructive bg-destructive/10"
-                : isAnswered(field) ? "border-brand" : "border-muted"
-            )}
+        {dragEnabled ? (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
           >
-            <p className="text-sm font-medium mb-2 flex items-center gap-1.5">
-              <span className="text-muted-foreground">{i + 1}.</span>{" "}
-              {field.description}
-              {field.required === false && (
-                <span className="text-xs text-muted-foreground font-normal">(opcional)</span>
-              )}
-              {isAnswered(field) && <Check className="h-3.5 w-3.5 text-brand shrink-0" />}
-            </p>
-            {field.help_text && (
-              <p className="text-xs text-muted-foreground mb-2 whitespace-pre-line">{field.help_text}</p>
-            )}
-            <FieldRenderer
-              field={field}
-              value={answers[field.name] ?? null}
-              onChange={(val) => handleAnswerWithClear(field.name, val)}
-            />
-          </div>
-        ))}
+            <SortableContext
+              items={visibleFields.map((f) => f.name)}
+              strategy={verticalListSortingStrategy}
+            >
+              {questionItems}
+            </SortableContext>
+          </DndContext>
+        ) : (
+          questionItems
+        )}
 
-        {/* Notas e sugestões */}
         {onNotesChange && (
           <Collapsible defaultOpen={!!notes}>
             <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors">
@@ -174,7 +304,6 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         )}
       </div>
 
-      {/* Footer fixo com botão de enviar */}
       <div className="border-t px-4 py-3 shrink-0">
         <Button
           onClick={handleSubmitWithValidation}

--- a/frontend/src/components/schema/FieldCard.tsx
+++ b/frontend/src/components/schema/FieldCard.tsx
@@ -12,7 +12,9 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Switch } from "@/components/ui/switch";
-import { ChevronDown, ChevronUp, Trash2 } from "lucide-react";
+import { GripVertical, Trash2 } from "lucide-react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@/lib/utils";
 import { OptionsEditor } from "./OptionsEditor";
 import { ConditionEditor, candidateTriggersFor } from "./ConditionEditor";
@@ -25,16 +27,13 @@ import {
 import type { PydanticField } from "@/lib/types";
 
 interface FieldCardProps {
+  id: string;
   field: PydanticField;
-  index: number;
-  total: number;
   allFields: PydanticField[];
   isExpanded: boolean;
   onToggle: () => void;
   onChange: (field: PydanticField) => void;
   onRemove: () => void;
-  onMoveUp: () => void;
-  onMoveDown: () => void;
   // Opcional: callback para substituir TODA a lista de campos. Usado quando
   // remover uma opção exige também atualizar `condition` de outros campos.
   onAllFieldsChange?: (fields: PydanticField[]) => void;
@@ -61,20 +60,25 @@ const TARGET_LABELS: Record<string, string> = {
 };
 
 export function FieldCard({
+  id,
   field,
-  index,
-  total,
   allFields,
   isExpanded,
   onToggle,
   onChange,
   onRemove,
-  onMoveUp,
-  onMoveDown,
   onAllFieldsChange,
 }: FieldCardProps) {
   const updateField = (patch: Partial<PydanticField>) => {
     onChange({ ...field, ...patch });
+  };
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id });
+  const sortableStyle = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
   };
 
   const [pendingRemoval, setPendingRemoval] = useState<{
@@ -122,7 +126,8 @@ export function FieldCard({
   const nameIsValid = /^[a-z_][a-z0-9_]*$/.test(field.name);
 
   return (
-    <Collapsible open={isExpanded} onOpenChange={onToggle}>
+    <div ref={setNodeRef} style={sortableStyle}>
+      <Collapsible open={isExpanded} onOpenChange={onToggle}>
       <div
         className={cn(
           "rounded-lg border transition-colors",
@@ -131,27 +136,19 @@ export function FieldCard({
       >
         {/* Header */}
         <div className="flex items-center gap-2 px-3 py-2">
-          {/* Setas de reordenação */}
-          <div className="flex flex-col -space-y-1">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6 disabled:opacity-50"
-              disabled={index === 0}
-              onClick={onMoveUp}
-            >
-              <ChevronUp className="h-3.5 w-3.5" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-6 w-6 disabled:opacity-50"
-              disabled={index === total - 1}
-              onClick={onMoveDown}
-            >
-              <ChevronDown className="h-3.5 w-3.5" />
-            </Button>
-          </div>
+          {/* Drag handle */}
+          <button
+            type="button"
+            className={cn(
+              "flex h-7 w-7 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground touch-none",
+              isDragging ? "cursor-grabbing" : "cursor-grab"
+            )}
+            aria-label="Arrastar para reordenar"
+            {...attributes}
+            {...listeners}
+          >
+            <GripVertical className="h-4 w-4" />
+          </button>
 
           {/* Nome + badges */}
           <CollapsibleTrigger asChild>
@@ -506,6 +503,7 @@ export function FieldCard({
           }}
         />
       )}
-    </Collapsible>
+      </Collapsible>
+    </div>
   );
 }

--- a/frontend/src/components/schema/SchemaBuilderGUI.tsx
+++ b/frontend/src/components/schema/SchemaBuilderGUI.tsx
@@ -5,6 +5,20 @@ import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { FieldCard } from "./FieldCard";
 import type { PydanticField } from "@/lib/types";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 
 interface SchemaBuilderGUIProps {
   fields: PydanticField[];
@@ -13,6 +27,11 @@ interface SchemaBuilderGUIProps {
 
 export function SchemaBuilderGUI({ fields, onChange }: SchemaBuilderGUIProps) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
 
   const addField = () => {
     const newIndex = fields.length;
@@ -44,13 +63,29 @@ export function SchemaBuilderGUI({ fields, onChange }: SchemaBuilderGUIProps) {
   };
 
   const moveField = (from: number, to: number) => {
-    if (to < 0 || to >= fields.length) return;
+    if (from === to || to < 0 || to >= fields.length) return;
     const next = [...fields];
     const [moved] = next.splice(from, 1);
     next.splice(to, 0, moved);
     onChange(next);
     if (expandedIndex === from) setExpandedIndex(to);
-    else if (expandedIndex === to) setExpandedIndex(from);
+    else if (expandedIndex !== null) {
+      // Ajusta indice expandido para acompanhar o item que se moveu por cima dele
+      if (from < expandedIndex && to >= expandedIndex) {
+        setExpandedIndex(expandedIndex - 1);
+      } else if (from > expandedIndex && to <= expandedIndex) {
+        setExpandedIndex(expandedIndex + 1);
+      }
+    }
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const from = fields.findIndex((f) => f.name === active.id);
+    const to = fields.findIndex((f) => f.name === over.id);
+    if (from < 0 || to < 0) return;
+    moveField(from, to);
   };
 
   return (
@@ -72,24 +107,32 @@ export function SchemaBuilderGUI({ fields, onChange }: SchemaBuilderGUIProps) {
           </div>
         )}
 
-        {fields.map((field, i) => (
-          <FieldCard
-            key={i}
-            field={field}
-            index={i}
-            total={fields.length}
-            allFields={fields}
-            isExpanded={expandedIndex === i}
-            onToggle={() =>
-              setExpandedIndex(expandedIndex === i ? null : i)
-            }
-            onChange={(f) => updateField(i, f)}
-            onRemove={() => removeField(i)}
-            onMoveUp={() => moveField(i, i - 1)}
-            onMoveDown={() => moveField(i, i + 1)}
-            onAllFieldsChange={onChange}
-          />
-        ))}
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={fields.map((f) => f.name)}
+            strategy={verticalListSortingStrategy}
+          >
+            {fields.map((field, i) => (
+              <FieldCard
+                key={field.name}
+                id={field.name}
+                field={field}
+                allFields={fields}
+                isExpanded={expandedIndex === i}
+                onToggle={() =>
+                  setExpandedIndex(expandedIndex === i ? null : i)
+                }
+                onChange={(f) => updateField(i, f)}
+                onRemove={() => removeField(i)}
+                onAllFieldsChange={onChange}
+              />
+            ))}
+          </SortableContext>
+        </DndContext>
       </div>
 
       <div className="border-t px-4 py-2">

--- a/frontend/src/lib/__tests__/field-order.test.ts
+++ b/frontend/src/lib/__tests__/field-order.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { applyFieldOrder, reorderFullList } from "@/lib/field-order";
+import type { PydanticField } from "@/lib/types";
+
+function f(name: string): PydanticField {
+  return {
+    name,
+    type: "text",
+    options: null,
+    description: name,
+  };
+}
+
+describe("applyFieldOrder", () => {
+  it("retorna identidade quando order e null", () => {
+    const fields = [f("a"), f("b"), f("c")];
+    expect(applyFieldOrder(fields, null).map((x) => x.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("retorna identidade quando order e vazio", () => {
+    const fields = [f("a"), f("b"), f("c")];
+    expect(applyFieldOrder(fields, []).map((x) => x.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("aplica ordem custom completa", () => {
+    const fields = [f("a"), f("b"), f("c")];
+    expect(applyFieldOrder(fields, ["c", "a", "b"]).map((x) => x.name)).toEqual([
+      "c",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("manda campos novos para o fim", () => {
+    const fields = [f("a"), f("b"), f("c")];
+    expect(applyFieldOrder(fields, ["a"]).map((x) => x.name)).toEqual(["a", "b", "c"]);
+  });
+
+  it("descarta nomes em order que sumiram de fields", () => {
+    const fields = [f("a"), f("b")];
+    expect(applyFieldOrder(fields, ["x", "a"]).map((x) => x.name)).toEqual(["a", "b"]);
+  });
+
+  it("descarta nomes duplicados em order", () => {
+    const fields = [f("a"), f("b")];
+    expect(applyFieldOrder(fields, ["a", "a", "b"]).map((x) => x.name)).toEqual(["a", "b"]);
+  });
+
+  it("e idempotente", () => {
+    const fields = [f("a"), f("b"), f("c")];
+    const first = applyFieldOrder(fields, ["c", "a"]);
+    const second = applyFieldOrder(first, first.map((x) => x.name));
+    expect(second.map((x) => x.name)).toEqual(first.map((x) => x.name));
+  });
+
+  it("nao muta o array original", () => {
+    const fields = [f("a"), f("b"), f("c")];
+    const original = fields.map((x) => x.name);
+    applyFieldOrder(fields, ["c", "b", "a"]);
+    expect(fields.map((x) => x.name)).toEqual(original);
+  });
+});
+
+describe("reorderFullList", () => {
+  it("e equivalente a arrayMove quando todos sao visiveis", () => {
+    const full = ["a", "b", "c", "d"];
+    const visible = ["a", "b", "c", "d"];
+    expect(reorderFullList(full, visible, 0, 2)).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("preserva posicao de campo invisivel no meio", () => {
+    const full = ["a", "b", "c", "d"];
+    const visible = ["a", "b", "d"];
+    // mover 'a' (idx 0 visivel) para idx 2 visivel -> visivel passa a ser ["b","d","a"]
+    // full reconstituido: posicoes visiveis (0,1,3) recebem em ordem; (2) "c" intacto.
+    expect(reorderFullList(full, visible, 0, 2)).toEqual(["b", "d", "c", "a"]);
+  });
+
+  it("retorna copia quando from === to", () => {
+    const full = ["a", "b", "c"];
+    expect(reorderFullList(full, ["a", "b", "c"], 1, 1)).toEqual(full);
+  });
+
+  it("retorna copia em indices invalidos", () => {
+    const full = ["a", "b", "c"];
+    expect(reorderFullList(full, ["a", "b", "c"], -1, 0)).toEqual(full);
+    expect(reorderFullList(full, ["a", "b", "c"], 0, 99)).toEqual(full);
+  });
+
+  it("varios invisiveis intercalados", () => {
+    const full = ["i1", "a", "i2", "b", "c", "i3"];
+    const visible = ["a", "b", "c"];
+    // mover c para o inicio dos visiveis: nova ordem visivel ["c","a","b"]
+    // posicoes visiveis em full sao 1,3,4 -> ficam c,a,b; invisiveis ficam.
+    expect(reorderFullList(full, visible, 2, 0)).toEqual(["i1", "c", "i2", "a", "b", "i3"]);
+  });
+});

--- a/frontend/src/lib/field-order.ts
+++ b/frontend/src/lib/field-order.ts
@@ -1,0 +1,82 @@
+import type { PydanticField } from "@/lib/types";
+
+/**
+ * Aplica a ordem custom de um pesquisador sobre a ordem canonica de fields.
+ *
+ * Regras:
+ * - order=null/[]: retorna fields como veio (fallback para a ordem do coordenador).
+ * - Campos presentes em order e em fields aparecem na ordem de order.
+ * - Nomes em order que NAO existem mais em fields sao descartados silenciosamente.
+ * - Campos em fields que NAO estao em order vao para o FIM, preservando ordem original.
+ *
+ * Nunca muda visibilidade — so ordena.
+ */
+export function applyFieldOrder(
+  fields: PydanticField[],
+  order: string[] | null,
+): PydanticField[] {
+  if (!order || order.length === 0) {
+    return [...fields];
+  }
+  const map = new Map<string, PydanticField>();
+  for (const f of fields) map.set(f.name, f);
+
+  const ordered: PydanticField[] = [];
+  const seen = new Set<string>();
+  for (const name of order) {
+    const f = map.get(name);
+    if (f && !seen.has(name)) {
+      ordered.push(f);
+      seen.add(name);
+    }
+  }
+  const appended = fields.filter((f) => !seen.has(f.name));
+  return [...ordered, ...appended];
+}
+
+/**
+ * Reconcilia drag-and-drop sobre um subconjunto VISIVEL de fields com a lista COMPLETA.
+ *
+ * O pesquisador so arrasta o que ve. Mas a ordem persistida precisa cobrir todos os
+ * campos (inclusive os ocultos por target="none" ou condition false), senao um campo
+ * escondido perde a posicao relativa quando voltar a ficar visivel.
+ *
+ * Algoritmo:
+ * - Aplicar arrayMove sobre visibleNames para obter newVisibleOrder.
+ * - Percorrer fullNames; nas posicoes ocupadas por nomes visiveis, substituir em ordem
+ *   pelos newVisibleOrder. Nomes invisiveis (nao presentes em visibleNames) ficam no
+ *   mesmo lugar.
+ */
+export function reorderFullList(
+  fullNames: string[],
+  visibleNames: string[],
+  fromVisibleIdx: number,
+  toVisibleIdx: number,
+): string[] {
+  if (fromVisibleIdx === toVisibleIdx) return [...fullNames];
+  if (
+    fromVisibleIdx < 0 ||
+    toVisibleIdx < 0 ||
+    fromVisibleIdx >= visibleNames.length ||
+    toVisibleIdx >= visibleNames.length
+  ) {
+    return [...fullNames];
+  }
+
+  const newVisible = [...visibleNames];
+  const [moved] = newVisible.splice(fromVisibleIdx, 1);
+  newVisible.splice(toVisibleIdx, 0, moved);
+
+  const visibleSet = new Set(visibleNames);
+  const result: string[] = [];
+  let visibleCursor = 0;
+  for (const name of fullNames) {
+    if (visibleSet.has(name)) {
+      result.push(newVisible[visibleCursor]);
+      visibleCursor++;
+    } else {
+      result.push(name);
+    }
+  }
+  return result;
+}

--- a/frontend/src/lib/supabase/database.types.ts
+++ b/frontend/src/lib/supabase/database.types.ts
@@ -219,6 +219,9 @@ export type Database = {
       documents: {
         Row: {
           created_at: string | null
+          excluded_at: string | null
+          excluded_by: string | null
+          excluded_reason: string | null
           external_id: string | null
           id: string
           metadata: Json | null
@@ -229,6 +232,9 @@ export type Database = {
         }
         Insert: {
           created_at?: string | null
+          excluded_at?: string | null
+          excluded_by?: string | null
+          excluded_reason?: string | null
           external_id?: string | null
           id?: string
           metadata?: Json | null
@@ -239,6 +245,9 @@ export type Database = {
         }
         Update: {
           created_at?: string | null
+          excluded_at?: string | null
+          excluded_by?: string | null
+          excluded_reason?: string | null
           external_id?: string | null
           id?: string
           metadata?: Json | null
@@ -248,6 +257,13 @@ export type Database = {
           title?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "documents_excluded_by_fkey"
+            columns: ["excluded_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "documents_project_id_fkey"
             columns: ["project_id"]
@@ -309,6 +325,92 @@ export type Database = {
           },
         ]
       }
+      llm_runs: {
+        Row: {
+          completed_at: string | null
+          document_count: number | null
+          error_column: number | null
+          error_line: number | null
+          error_message: string | null
+          error_traceback: string | null
+          error_type: string | null
+          filter_mode: string | null
+          heartbeat_at: string | null
+          id: string
+          job_id: string
+          llm_model: string | null
+          llm_provider: string | null
+          phase: string | null
+          processed_complete: number
+          processed_empty: number
+          processed_partial: number
+          progress: number | null
+          project_id: string
+          pydantic_code: string | null
+          started_at: string
+          status: string
+          total: number | null
+        }
+        Insert: {
+          completed_at?: string | null
+          document_count?: number | null
+          error_column?: number | null
+          error_line?: number | null
+          error_message?: string | null
+          error_traceback?: string | null
+          error_type?: string | null
+          filter_mode?: string | null
+          heartbeat_at?: string | null
+          id?: string
+          job_id: string
+          llm_model?: string | null
+          llm_provider?: string | null
+          phase?: string | null
+          processed_complete?: number
+          processed_empty?: number
+          processed_partial?: number
+          progress?: number | null
+          project_id: string
+          pydantic_code?: string | null
+          started_at?: string
+          status: string
+          total?: number | null
+        }
+        Update: {
+          completed_at?: string | null
+          document_count?: number | null
+          error_column?: number | null
+          error_line?: number | null
+          error_message?: string | null
+          error_traceback?: string | null
+          error_type?: string | null
+          filter_mode?: string | null
+          heartbeat_at?: string | null
+          id?: string
+          job_id?: string
+          llm_model?: string | null
+          llm_provider?: string | null
+          phase?: string | null
+          processed_complete?: number
+          processed_empty?: number
+          processed_partial?: number
+          progress?: number | null
+          project_id?: string
+          pydantic_code?: string | null
+          started_at?: string
+          status?: string
+          total?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "llm_runs_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       master_users: {
         Row: {
           user_id: string
@@ -325,6 +427,55 @@ export type Database = {
             columns: ["user_id"]
             isOneToOne: true
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      note_resolutions: {
+        Row: {
+          id: string
+          note: string | null
+          project_id: string
+          resolved_at: string
+          resolved_by: string
+          response_id: string
+        }
+        Insert: {
+          id?: string
+          note?: string | null
+          project_id: string
+          resolved_at?: string
+          resolved_by: string
+          response_id: string
+        }
+        Update: {
+          id?: string
+          note?: string | null
+          project_id?: string
+          resolved_at?: string
+          resolved_by?: string
+          response_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "note_resolutions_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_resolutions_resolved_by_fkey"
+            columns: ["resolved_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "note_resolutions_response_id_fkey"
+            columns: ["response_id"]
+            isOneToOne: false
+            referencedRelation: "responses"
             referencedColumns: ["id"]
           },
         ]
@@ -361,8 +512,11 @@ export type Database = {
           document_id: string | null
           field_name: string | null
           id: string
+          kind: string
           parent_id: string | null
           project_id: string
+          rejected_at: string | null
+          rejected_reason: string | null
           resolved_at: string | null
           resolved_by: string | null
         }
@@ -373,8 +527,11 @@ export type Database = {
           document_id?: string | null
           field_name?: string | null
           id?: string
+          kind?: string
           parent_id?: string | null
           project_id: string
+          rejected_at?: string | null
+          rejected_reason?: string | null
           resolved_at?: string | null
           resolved_by?: string | null
         }
@@ -385,8 +542,11 @@ export type Database = {
           document_id?: string | null
           field_name?: string | null
           id?: string
+          kind?: string
           parent_id?: string | null
           project_id?: string
+          rejected_at?: string | null
+          rejected_reason?: string | null
           resolved_at?: string | null
           resolved_by?: string | null
         }
@@ -469,6 +629,7 @@ export type Database = {
           allow_researcher_review: boolean | null
           created_at: string | null
           created_by: string | null
+          current_round_id: string | null
           description: string | null
           id: string
           llm_kwargs: Json | null
@@ -481,6 +642,7 @@ export type Database = {
           pydantic_fields: Json | null
           pydantic_hash: string | null
           resolution_rule: string | null
+          round_strategy: string
           schema_version_major: number
           schema_version_minor: number
           schema_version_patch: number
@@ -489,6 +651,7 @@ export type Database = {
           allow_researcher_review?: boolean | null
           created_at?: string | null
           created_by?: string | null
+          current_round_id?: string | null
           description?: string | null
           id?: string
           llm_kwargs?: Json | null
@@ -501,6 +664,7 @@ export type Database = {
           pydantic_fields?: Json | null
           pydantic_hash?: string | null
           resolution_rule?: string | null
+          round_strategy?: string
           schema_version_major?: number
           schema_version_minor?: number
           schema_version_patch?: number
@@ -509,6 +673,7 @@ export type Database = {
           allow_researcher_review?: boolean | null
           created_at?: string | null
           created_by?: string | null
+          current_round_id?: string | null
           description?: string | null
           id?: string
           llm_kwargs?: Json | null
@@ -521,6 +686,7 @@ export type Database = {
           pydantic_fields?: Json | null
           pydantic_hash?: string | null
           resolution_rule?: string | null
+          round_strategy?: string
           schema_version_major?: number
           schema_version_minor?: number
           schema_version_patch?: number
@@ -531,6 +697,13 @@ export type Database = {
             columns: ["created_by"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "projects_current_round_fk"
+            columns: ["current_round_id"]
+            isOneToOne: false
+            referencedRelation: "rounds"
             referencedColumns: ["id"]
           },
         ]
@@ -564,6 +737,111 @@ export type Database = {
           },
         ]
       }
+      researcher_field_orders: {
+        Row: {
+          field_order: Json
+          project_id: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          field_order?: Json
+          project_id: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          field_order?: Json
+          project_id?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "researcher_field_orders_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "researcher_field_orders_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      response_equivalences: {
+        Row: {
+          created_at: string
+          document_id: string
+          field_name: string
+          id: string
+          project_id: string
+          response_a_id: string
+          response_b_id: string
+          reviewer_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          document_id: string
+          field_name: string
+          id?: string
+          project_id: string
+          response_a_id: string
+          response_b_id: string
+          reviewer_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          document_id?: string
+          field_name?: string
+          id?: string
+          project_id?: string
+          response_a_id?: string
+          response_b_id?: string
+          reviewer_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "response_equivalences_document_id_fkey"
+            columns: ["document_id"]
+            isOneToOne: false
+            referencedRelation: "documents"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "response_equivalences_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "response_equivalences_response_a_id_fkey"
+            columns: ["response_a_id"]
+            isOneToOne: false
+            referencedRelation: "responses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "response_equivalences_response_b_id_fkey"
+            columns: ["response_b_id"]
+            isOneToOne: false
+            referencedRelation: "responses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "response_equivalences_reviewer_id_fkey"
+            columns: ["reviewer_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       responses: {
         Row: {
           answer_field_hashes: Json | null
@@ -574,12 +852,14 @@ export type Database = {
           is_current: boolean | null
           is_partial: boolean
           justifications: Json | null
+          llm_error: string | null
           llm_job_id: string | null
           project_id: string | null
           pydantic_hash: string | null
           respondent_id: string | null
           respondent_name: string | null
           respondent_type: string
+          round_id: string | null
           schema_version_major: number | null
           schema_version_minor: number | null
           schema_version_patch: number | null
@@ -594,12 +874,14 @@ export type Database = {
           is_current?: boolean | null
           is_partial?: boolean
           justifications?: Json | null
+          llm_error?: string | null
           llm_job_id?: string | null
           project_id?: string | null
           pydantic_hash?: string | null
           respondent_id?: string | null
           respondent_name?: string | null
           respondent_type: string
+          round_id?: string | null
           schema_version_major?: number | null
           schema_version_minor?: number | null
           schema_version_patch?: number | null
@@ -614,12 +896,14 @@ export type Database = {
           is_current?: boolean | null
           is_partial?: boolean
           justifications?: Json | null
+          llm_error?: string | null
           llm_job_id?: string | null
           project_id?: string | null
           pydantic_hash?: string | null
           respondent_id?: string | null
           respondent_name?: string | null
           respondent_type?: string
+          round_id?: string | null
           schema_version_major?: number | null
           schema_version_minor?: number | null
           schema_version_patch?: number | null
@@ -645,6 +929,13 @@ export type Database = {
             columns: ["respondent_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "responses_round_id_fkey"
+            columns: ["round_id"]
+            isOneToOne: false
+            referencedRelation: "rounds"
             referencedColumns: ["id"]
           },
         ]
@@ -726,6 +1017,45 @@ export type Database = {
             columns: ["reviewer_id"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      rounds: {
+        Row: {
+          created_at: string
+          id: string
+          label: string
+          project_id: string
+          source_batch_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          label: string
+          project_id: string
+          source_batch_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          label?: string
+          project_id?: string
+          source_batch_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "rounds_project_id_fkey"
+            columns: ["project_id"]
+            isOneToOne: false
+            referencedRelation: "projects"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rounds_source_batch_id_fkey"
+            columns: ["source_batch_id"]
+            isOneToOne: false
+            referencedRelation: "assignment_batches"
             referencedColumns: ["id"]
           },
         ]
@@ -859,6 +1189,8 @@ export type Database = {
           comment: string | null
           created_at: string | null
           id: string
+          resolved_at: string | null
+          resolved_by: string | null
           respondent_id: string
           review_id: string
           status: string
@@ -867,6 +1199,8 @@ export type Database = {
           comment?: string | null
           created_at?: string | null
           id?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
           respondent_id: string
           review_id: string
           status?: string
@@ -875,11 +1209,20 @@ export type Database = {
           comment?: string | null
           created_at?: string | null
           id?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
           respondent_id?: string
           review_id?: string
           status?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "verdict_acknowledgments_resolved_by_fkey"
+            columns: ["resolved_by"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "verdict_acknowledgments_respondent_id_fkey"
             columns: ["respondent_id"]
@@ -901,6 +1244,11 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      auth_user_accessible_project_ids: { Args: never; Returns: string[] }
+      auth_user_coordinator_or_creator_project_ids: {
+        Args: never
+        Returns: string[]
+      }
       auth_user_coordinator_project_ids: { Args: never; Returns: string[] }
       auth_user_project_ids: { Args: never; Returns: string[] }
       clerk_uid: { Args: never; Returns: string }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -158,6 +158,13 @@ export interface QuestionMeta {
   priority: "ALTA" | "MEDIA" | "BAIXA";
 }
 
+export interface ResearcherFieldOrder {
+  project_id: string;
+  user_id: string;
+  field_order: string[];
+  updated_at: string;
+}
+
 export type SchemaChangeType = "major" | "minor" | "patch" | "initial";
 
 export interface SchemaChangeEntry {

--- a/frontend/supabase/migrations/20260513000000_researcher_field_orders.sql
+++ b/frontend/supabase/migrations/20260513000000_researcher_field_orders.sql
@@ -1,0 +1,39 @@
+-- Ordem custom de perguntas por pesquisador, por projeto.
+-- Quando ausente, o app cai na ordem canonica de projects.pydantic_fields (fallback).
+-- field_order e array de PydanticField.name; campos nao-listados (renomeados/removidos)
+-- sao tratados no client via lib/field-order.ts (applyFieldOrder): nomes desconhecidos
+-- sao descartados, nomes novos vao para o fim.
+
+CREATE TABLE researcher_field_orders (
+  project_id   UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  user_id      UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  field_order  JSONB NOT NULL DEFAULT '[]'::jsonb,
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (project_id, user_id)
+);
+
+-- PK (project_id, user_id) ja cobre o unico padrao de acesso ("para este projeto, qual a
+-- minha ordem"). Sem indice adicional.
+
+ALTER TABLE researcher_field_orders ENABLE ROW LEVEL SECURITY;
+
+-- SELECT: usuario so le sua propria linha e desde que tenha acesso ao projeto.
+CREATE POLICY "Users view own field order" ON researcher_field_orders
+  FOR SELECT USING (
+    user_id = clerk_uid()
+    AND project_id IN (SELECT auth_user_accessible_project_ids())
+  );
+
+-- INSERT/UPSERT: idem.
+CREATE POLICY "Users insert own field order" ON researcher_field_orders
+  FOR INSERT WITH CHECK (
+    user_id = clerk_uid()
+    AND project_id IN (SELECT auth_user_accessible_project_ids())
+  );
+
+CREATE POLICY "Users update own field order" ON researcher_field_orders
+  FOR UPDATE USING (user_id = clerk_uid())
+  WITH CHECK (user_id = clerk_uid());
+
+CREATE POLICY "Users delete own field order" ON researcher_field_orders
+  FOR DELETE USING (user_id = clerk_uid());


### PR DESCRIPTION
## Resumo

- **Pesquisadores** agora arrastam perguntas no painel de coding para definir a própria ordem — persistida por `(project_id, user_id)` no Supabase, sincroniza entre dispositivos.
- **Coordenadores** passam a reordenar o schema com drag-and-drop também (substitui os botões up/down).
- Quando o pesquisador não definiu ordem, cai na ordem do coordenador (fallback). Campos novos pelo coordenador aparecem no fim; renomeados/removidos se acomodam sem quebrar.

## Implementação

- **Migration** `20260513000000_researcher_field_orders.sql`: nova tabela com RLS por `clerk_uid()` + `auth_user_accessible_project_ids()`.
- **`lib/field-order.ts`**: `applyFieldOrder` (merge ordem custom + canônica) e `reorderFullList` (reconciliação DnD sobre subconjunto visível com a lista completa, preservando posição de campos invisíveis por `target: "none"` ou `condition`). 13 testes unitários.
- **Actions** `getResearcherFieldOrder` / `saveResearcherFieldOrder` em `actions/field-order.ts` (upsert por `(project_id, user_id)`, sem revalidate para não recarregar a página de coding).
- **DnD**: `@dnd-kit/core` + `@dnd-kit/sortable`. `PointerSensor` com `activationConstraint: { distance: 5 }` para não disparar drag em clique, `KeyboardSensor` para a11y.
- **`CodingPage.tsx`**: carrega ordem no mount, debounce de 500ms no save, flush no unmount.
- **`QuestionsPanel.tsx`**: extrai `SortableQuestion` com handle `GripVertical` (listeners só no handle, não no card — preserva seleção/clique nos inputs).
- **Coordenador**: `FieldCard.tsx` e `SchemaBuilderGUI.tsx` migrados para DnD; `moveField` reaproveitado em `onDragEnd`.

## Test plan

- [ ] Coordenador: arrastar campo no editor de schema, salvar, recarregar — ordem persiste em `projects.pydantic_fields`
- [ ] Coordenador: reordenar via teclado (Tab no handle, Space pega, setas movem, Space solta)
- [ ] Pesquisador: arrastar pergunta no painel de coding, esperar ~500ms, conferir linha em `researcher_field_orders`
- [ ] Abrir mesmo projeto em incognito como mesmo pesquisador → ordem aparece (sincronização)
- [ ] Pesquisador B vê ordem canônica do coordenador (fallback), não a do pesquisador A (isolamento RLS)
- [ ] Coordenador adiciona campo novo → pesquisador A vê o novo campo no fim
- [ ] Coordenador remove campo → some da ordem do pesquisador A sem quebrar
- [ ] Coordenador renomeia campo → renomeado aparece no fim para o pesquisador A
- [ ] Campos com `condition` mantêm a posição custom quando voltam a ficar visíveis
- [ ] Campos com `target: "none"` continuam ocultos para o pesquisador

🤖 Generated with [Claude Code](https://claude.com/claude-code)