### PR TITLE
fix(fly): manter 1 maquina rodando para evitar PU02 e morte de jobs LLM

### DIFF
--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -1,8 +1,19 @@
 app = "gui-analise-sistematica-api"
 primary_region = "gru"
 
+# Dar tempo (5min, maximo permitido pelo Fly) para BackgroundTasks LLM em
+# andamento terminarem antes do SIGKILL durante deploys ou restarts.
+# Default do Fly e 5s, o que matava jobs no meio.
+kill_timeout = "5m"
+
 [build]
   dockerfile = "Dockerfile"
+
+[deploy]
+  # Bluegreen: sobe uma VM nova, espera passar no health check, transfere
+  # trafego e so depois derruba a antiga. Elimina a janela de 502 durante
+  # o deploy automatico (fly-deploy.yml).
+  strategy = "bluegreen"
 
 [http_service]
   internal_port = 8000
@@ -14,7 +25,6 @@ primary_region = "gru"
   # pandas + langchain) estourava o timeout do proxy do Fly e gerava 502
   # [PU02] na primeira request apos a maquina dormir.
   auto_stop_machines = "off"
-  auto_start_machines = true
   min_machines_running = 1
 
   # Health check: se o processo travar/sair (OOM, deadlock), o Fly reinicia

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -7,9 +7,24 @@ primary_region = "gru"
 [http_service]
   internal_port = 8000
   force_https = true
-  auto_stop_machines = "stop"
+  # Manter ao menos 1 maquina rodando: o backend roda LLM em BackgroundTasks
+  # apos retornar o HTTP response. Com auto_stop + min=0 (config anterior), o
+  # Fly considerava a maquina ociosa entre requests e a adormecia no meio do
+  # processamento, matando o job. Alem disso, o cold start (imagem pesada com
+  # pandas + langchain) estourava o timeout do proxy do Fly e gerava 502
+  # [PU02] na primeira request apos a maquina dormir.
+  auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
+
+  # Health check: se o processo travar/sair (OOM, deadlock), o Fly reinicia
+  # automaticamente. O endpoint /health esta em main.py:23.
+  [[http_service.checks]]
+    grace_period = "15s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/health"
 
 [env]
   PORT = "8000"


### PR DESCRIPTION
## Sintoma reportado

```
502 -- [PU02] could not complete HTTP request to instance: hyper error:
connection error, caused by: Operation timed out (os error 110)

Requisicao cross-origin bloqueada: ... https://gui-analise-sistematica-api.fly.dev/api/llm/run
(motivo: falta cabecalho 'Access-Control-Allow-Origin' no CORS).
```

O erro de CORS e falso sintoma: como o Fly retorna 502 sem chegar na app, nao ha resposta HTTP -> nao ha headers CORS -> browser bloqueia.

## Causa raiz

Config anterior em `backend/fly.toml`:

```toml
auto_stop_machines = "stop"
min_machines_running = 0
```

Duas patologias se manifestam:

1. **Cold start estourando o proxy do Fly**. A imagem Docker e pesada (pandas + langchain-{google,openai,anthropic} + dataframeit), e quando a maquina dorme o primeiro request tem que esperar o boot completo. Quando o tempo passa do limite do proxy, da `[PU02] Operation timed out`.

2. **Morte de job no meio do processamento**. `/api/llm/run` retorna `job_id` em milissegundos, e o trabalho real (chamadas ao LLM, save em Supabase) acontece via `BackgroundTasks`. Sem HTTP ativo, o Fly considera a maquina ociosa e adormece no meio da execucao, matando o processo Python silenciosamente. As runs ficavam zumbis ate o `mark_stale_runs_as_error` (10min depois) reconhecer pela ausencia de heartbeat.

## Mudancas

- `min_machines_running = 1` + `auto_stop_machines = "off"`: 1 maquina sempre acordada, sem cold start, sem morte de background work.
- Health check em `/health` (endpoint ja existe em `backend/main.py:23`): se o processo crashar (OOM, deadlock), o Fly reinicia automaticamente em vez de servir 502 indefinidamente.

## Custo

1 `shared-cpu-1x` rodando 24/7 = ~$2-3/mes no Fly. Cabe nos $5/mes gratuitos do plano pay-as-you-go.

## Test plan

- [ ] Apos merge, esperar deploy automatico via `.github/workflows/fly-deploy.yml`.
- [ ] Verificar em `flyctl status -a gui-analise-sistematica-api` que ha 1 maquina em `started` continuamente.
- [ ] Clicar "Executar" no projeto e confirmar que o request retorna 200 com `job_id` imediato (sem 502).
- [ ] Acompanhar uma run completa de ponta a ponta e verificar que ela completa sem mark_stale.
- [ ] Confirmar no Fly dashboard que o health check em `/health` esta passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)