### PR TITLE
fix(cors): garantir headers CORS em respostas 500 do backend

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     supabase_url: str = ""
     supabase_service_key: str = ""
     cors_origins: list[str] = ["http://localhost:3000"]
+    cors_origin_regex: str | None = None
 
     model_config = {"env_file": ".env"}
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,7 @@
 import logging
+import re
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
@@ -10,15 +11,50 @@ from routes.llm_routes import router as llm_router
 
 logger = logging.getLogger(__name__)
 
+
+def _normalize_origin(value: str) -> str:
+    return value.strip().rstrip("/").lower()
+
+
+_ALLOWED_ORIGINS = {_normalize_origin(o) for o in settings.cors_origins if o}
+_ORIGIN_REGEX = (
+    re.compile(settings.cors_origin_regex) if settings.cors_origin_regex else None
+)
+
+
+def _match_origin(origin: str | None) -> str | None:
+    # Returns the Origin string to echo back, or None if it isn't authorized.
+    # Mirrors CORSMiddleware's matching semantics so success and 500 responses
+    # agree on which origins are allowed.
+    if not origin:
+        return None
+    normalized = _normalize_origin(origin)
+    if normalized in _ALLOWED_ORIGINS:
+        return origin
+    if _ORIGIN_REGEX is not None and _ORIGIN_REGEX.fullmatch(origin):
+        return origin
+    return None
+
+
 app = FastAPI(title="dataframeit API")
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
+    allow_origin_regex=settings.cors_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def _cors_headers_for(request: Request) -> dict[str, str]:
+    headers: dict[str, str] = {"Vary": "Origin"}
+    allowed = _match_origin(request.headers.get("origin"))
+    if allowed is not None:
+        headers["Access-Control-Allow-Origin"] = allowed
+        headers["Access-Control-Allow-Credentials"] = "true"
+    return headers
 
 
 @app.exception_handler(Exception)
@@ -30,17 +66,30 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
     # we lose any chance to surface the real failure. Echo the headers manually
     # for authorized origins.
     logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
-
-    origin = request.headers.get("origin")
-    headers: dict[str, str] = {"Vary": "Origin"}
-    if origin and origin in settings.cors_origins:
-        headers["Access-Control-Allow-Origin"] = origin
-        headers["Access-Control-Allow-Credentials"] = "true"
-
     return JSONResponse(
         status_code=500,
         content={"detail": "Internal Server Error"},
-        headers=headers,
+        headers=_cors_headers_for(request),
+    )
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    # Unlike the generic Exception handler above, HTTPException responses still
+    # flow back through CORSMiddleware, so it adds Access-Control-Allow-Origin /
+    # Vary on its own. We only override `detail` to collapse 5xx bodies into an
+    # opaque payload (the original `detail` may carry internal messages); 4xx
+    # detail is preserved so clients can react to validation/auth errors.
+    if exc.status_code >= 500:
+        logger.exception(
+            "HTTPException %s on %s %s", exc.status_code, request.method, request.url.path
+        )
+        content = {"detail": "Internal Server Error"}
+    else:
+        content = {"detail": exc.detail}
+
+    return JSONResponse(
+        status_code=exc.status_code, content=content, headers=exc.headers or None
     )
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,14 @@
-from fastapi import FastAPI
+import logging
+
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from config import settings
 from routes.pydantic_routes import router as pydantic_router
 from routes.llm_routes import router as llm_router
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="dataframeit API")
 
@@ -14,6 +19,30 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    # CORSMiddleware sits below ServerErrorMiddleware in Starlette's stack, so
+    # 500s from unhandled exceptions never pass back through it. Without this
+    # handler the response goes out without Access-Control-Allow-Origin, the
+    # browser hides it from the frontend as a "CORS error" (status null), and
+    # we lose any chance to surface the real failure. Echo the headers manually
+    # for authorized origins.
+    logger.exception("Unhandled exception on %s %s", request.method, request.url.path)
+
+    origin = request.headers.get("origin")
+    headers: dict[str, str] = {"Vary": "Origin"}
+    if origin and origin in settings.cors_origins:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Access-Control-Allow-Credentials"] = "true"
+
+    return JSONResponse(
+        status_code=500,
+        content={"detail": "Internal Server Error"},
+        headers=headers,
+    )
+
 
 app.include_router(pydantic_router, prefix="/api/pydantic", tags=["pydantic"])
 app.include_router(llm_router, prefix="/api/llm", tags=["llm"])

--- a/backend/tests/test_main_cors.py
+++ b/backend/tests/test_main_cors.py
@@ -1,0 +1,95 @@
+"""Tests for CORS handling in 500 and HTTPException responses."""
+from __future__ import annotations
+
+import re
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+import main
+from main import app
+
+
+def _boom() -> None:
+    raise RuntimeError("kaboom")
+
+
+def _http_500() -> None:
+    raise HTTPException(status_code=500, detail="internal message that should be hidden")
+
+
+def _http_404() -> None:
+    raise HTTPException(status_code=404, detail="not found")
+
+
+app.add_api_route("/__test_boom__", _boom, methods=["GET"])
+app.add_api_route("/__test_http_500__", _http_500, methods=["GET"])
+app.add_api_route("/__test_http_404__", _http_404, methods=["GET"])
+
+
+@pytest.fixture
+def client() -> TestClient:
+    # raise_server_exceptions=False is critical — otherwise TestClient re-raises
+    # the RuntimeError instead of letting the exception handler run.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_match_origin_exact() -> None:
+    assert main._match_origin("http://localhost:3000") == "http://localhost:3000"
+
+
+def test_match_origin_normalizes_case_and_trailing_slash() -> None:
+    assert main._match_origin("HTTP://localhost:3000") == "HTTP://localhost:3000"
+    assert main._match_origin("http://localhost:3000/") == "http://localhost:3000/"
+
+
+def test_match_origin_rejects_unauthorized() -> None:
+    assert main._match_origin("https://evil.example.com") is None
+    assert main._match_origin(None) is None
+    assert main._match_origin("") is None
+
+
+def test_match_origin_regex(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        main, "_ORIGIN_REGEX", re.compile(r"https://[a-z0-9-]+\.preview\.example\.com")
+    )
+    assert (
+        main._match_origin("https://pr-42.preview.example.com")
+        == "https://pr-42.preview.example.com"
+    )
+    assert main._match_origin("https://evil.example.com") is None
+
+
+def test_500_carries_cors_for_authorized_origin(client: TestClient) -> None:
+    r = client.get("/__test_boom__", headers={"Origin": "http://localhost:3000"})
+    assert r.status_code == 500
+    assert r.headers["access-control-allow-origin"] == "http://localhost:3000"
+    assert r.headers["access-control-allow-credentials"] == "true"
+    assert r.headers["vary"] == "Origin"
+    assert r.json() == {"detail": "Internal Server Error"}
+
+
+def test_500_omits_cors_for_unauthorized_origin(client: TestClient) -> None:
+    r = client.get("/__test_boom__", headers={"Origin": "https://evil.example.com"})
+    assert r.status_code == 500
+    assert "access-control-allow-origin" not in r.headers
+    assert r.headers["vary"] == "Origin"
+    assert r.json() == {"detail": "Internal Server Error"}
+
+
+def test_http_exception_5xx_uses_opaque_body(client: TestClient) -> None:
+    r = client.get("/__test_http_500__", headers={"Origin": "http://localhost:3000"})
+    assert r.status_code == 500
+    assert r.json() == {"detail": "Internal Server Error"}
+    # CORSMiddleware adds these headers since HTTPException responses flow
+    # back through it (unlike generic Exception responses).
+    assert r.headers["access-control-allow-origin"] == "http://localhost:3000"
+    assert "Origin" in r.headers["vary"]
+
+
+def test_http_exception_4xx_preserves_detail(client: TestClient) -> None:
+    r = client.get("/__test_http_404__", headers={"Origin": "http://localhost:3000"})
+    assert r.status_code == 404
+    assert r.json() == {"detail": "not found"}
+    assert r.headers["access-control-allow-origin"] == "http://localhost:3000"


### PR DESCRIPTION
## Summary

- Adiciona `@app.exception_handler(Exception)` em `backend/main.py` para que respostas 500 carreguem `Access-Control-Allow-Origin` corretamente, evitando que erros internos sejam mascarados como "CORS error" no frontend.
- Loga o traceback completo com `logger.exception(...)` → vai aparecer em `fly logs -a gui-analise-sistematica-api` para diagnóstico da causa raiz.
- Retorna body JSON opaco `{"detail":"Internal Server Error"}` em vez de plaintext, sem vazar `str(exc)` (que pode conter payload/PII).

## Por que

O usuário viu no console:

```
Requisição cross-origin bloqueada: A diretiva Same Origin não permite a leitura do
recurso remoto em https://gui-analise-sistematica-api.fly.dev/api/llm/run
(motivo: falha na requisição CORS). Código de status: (null).
```

E reclamou que isso já tinha sido "consertado". O PR #111 anterior consertou só PU02 (cold start), não esse caso. Diagnóstico via `curl` em produção:

| Request | Status | Tem `access-control-allow-origin`? |
|---|---|---|
| `OPTIONS /api/llm/run` | 200 | ✅ sim |
| `POST /api/llm/run` JSON inválido | 422 | ✅ sim |
| `POST /api/llm/run` com `project_id` inexistente | **500** | ❌ **NÃO** |

Causa raiz: o `ServerErrorMiddleware` do Starlette fica ACIMA do `CORSMiddleware` na stack ASGI. Quando uma exceção sobe, o `ServerErrorMiddleware` responde 500 sem passar de volta pelo CORS — então sai sem header → browser vê como "CORS error" com `status: (null)` → frontend não consegue exibir o erro real → o BackgroundTask `run_llm` provavelmente já tinha consumido crédito do Gemini, mas o resultado não foi registrado/persistido por causa da exceção subjacente.

Esse PR é **fix preventivo de visibilidade**: a próxima exceção vai chegar ao frontend como 500 com body JSON, e o traceback completo cairá nos logs do Fly. Depois disso vamos abrir um segundo PR para corrigir a CAUSA do 500 (provavelmente em `init_job` → `_persist_run_insert` em `backend/services/llm_runner.py:554`, com base nos logs que vamos finalmente conseguir ler).

## Decisões de design

- **Handler global**, não try/except local: cobre todos os endpoints atuais e futuros.
- **Match de Origin** contra `settings.cors_origins`: ecoar cego quebraria dev local (origin `localhost:3000` receberia `ac.brunodcdo.com.br`).
- **Body opaco** em produção: traceback só nos logs, não no body.
- `Vary: Origin` para CDNs não servirem resposta com Origin trocado.

## Test plan

Verificação local com backend em `localhost:8765` (env vars `CORS_ORIGINS='["http://localhost:3000","https://ac.brunodcdo.com.br"]'`, `SUPABASE_URL=https://fake.supabase.co` para forçar exceção):

- [x] `OPTIONS /api/llm/run` continua 200 com `access-control-allow-origin` (regressão).
- [x] `POST /api/llm/run` com `Origin: http://localhost:3000` agora retorna 500 COM `access-control-allow-origin: http://localhost:3000`, `access-control-allow-credentials: true`, `vary: Origin` e body `{"detail":"Internal Server Error"}`.
- [x] `POST /api/llm/run` com `Origin: https://evil.example.com` retorna 500 SEM `access-control-allow-origin` (Vary: Origin presente).
- [x] Traceback completo aparece no log do uvicorn (`logger.exception` capturou httpx.ConnectError → postgrest → `_persist_run_insert` → `init_job` → `routes/llm_routes.py:69`).

Após merge e deploy automático no Fly (`.github/workflows/fly-deploy.yml`):

- [ ] `curl -i -X POST https://gui-analise-sistematica-api.fly.dev/api/llm/run -H "Origin: https://ac.brunodcdo.com.br" -H "Content-Type: application/json" -d '{"project_id":"00000000-0000-0000-0000-000000000000","filter_mode":"all"}'` retorna 500 COM headers CORS e body JSON.
- [ ] `fly logs -a gui-analise-sistematica-api | tail -200` mostra traceback completo da exceção real disparada pelo usuário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)