### PR TITLE
feat(auto-revisao): justificativa obrigatoria ao contestar o LLM

### DIFF
--- a/frontend/src/actions/__tests__/field-reviews.test.ts
+++ b/frontend/src/actions/__tests__/field-reviews.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock minimo do supabase: captura os payloads de .update() para validar o
+// que submitAutoReview enviaria ao DB sem subir Postgres. Builder chainable e
+// thenable — `await builder` (ou apos .select()) resolve { data, error }.
+type UpdateCall = { table: string; payload: Record<string, unknown> };
+let updateCalls: UpdateCall[];
+let tableData: Record<string, unknown>;
+
+function makeClient() {
+  return {
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      for (const m of ["select", "eq", "is", "in", "neq"]) {
+        builder[m] = () => builder;
+      }
+      builder.update = (payload: Record<string, unknown>) => {
+        updateCalls.push({ table, payload });
+        return builder;
+      };
+      builder.upsert = () => builder;
+      builder.then = (resolve: (v: unknown) => unknown) =>
+        resolve({ data: tableData[table] ?? null, error: null });
+      return builder;
+    },
+  };
+}
+
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "user1" }),
+  isProjectCoordinator: async () => false,
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () => makeClient(),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createSupabaseAdmin: () => makeClient(),
+}));
+
+beforeEach(() => {
+  updateCalls = [];
+  tableData = {
+    // UPDATE de field_reviews retorna a linha tocada (via .select)
+    field_reviews: [{ field_name: "q1" }],
+    // pool de arbitragem vazio → assignArbitrator curto-circuita sem erro
+    project_members: [],
+  };
+});
+
+async function loadSubmit() {
+  return (await import("@/actions/field-reviews")).submitAutoReview;
+}
+
+describe("submitAutoReview — justificativa obrigatoria ao contestar o LLM", () => {
+  it("contesta_llm sem justificativa → erro e nenhum UPDATE", async () => {
+    const submitAutoReview = await loadSubmit();
+    const r = await submitAutoReview("p1", "doc1", [
+      { fieldName: "q1", verdict: "contesta_llm" },
+    ]);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("justificativa obrigatória");
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it("contesta_llm com justificativa só de espaços → erro e nenhum UPDATE", async () => {
+    const submitAutoReview = await loadSubmit();
+    const r = await submitAutoReview("p1", "doc1", [
+      { fieldName: "q1", verdict: "contesta_llm", justification: "   \n\t" },
+    ]);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("justificativa obrigatória");
+    expect(updateCalls).toHaveLength(0);
+  });
+
+  it("admite_erro → passa na validacao e grava self_justification: null", async () => {
+    const submitAutoReview = await loadSubmit();
+    const r = await submitAutoReview("p1", "doc1", [
+      { fieldName: "q1", verdict: "admite_erro" },
+    ]);
+    expect(r.success).toBe(true);
+    const frUpdate = updateCalls.find((u) => u.table === "field_reviews");
+    expect(frUpdate?.payload).toMatchObject({
+      self_verdict: "admite_erro",
+      self_justification: null,
+    });
+  });
+
+  it("contesta_llm com justificativa → grava o texto trimado", async () => {
+    const submitAutoReview = await loadSubmit();
+    const r = await submitAutoReview("p1", "doc1", [
+      { fieldName: "q1", verdict: "contesta_llm", justification: "  confere  " },
+    ]);
+    expect(r.success).toBe(true);
+    const frUpdate = updateCalls.find((u) => u.table === "field_reviews");
+    expect(frUpdate?.payload).toMatchObject({
+      self_verdict: "contesta_llm",
+      self_justification: "confere",
+    });
+  });
+});

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -16,6 +16,9 @@ import type {
 export interface SelfVerdictInput {
   fieldName: string;
   verdict: SelfVerdict;
+  // Obrigatoria quando verdict='contesta_llm': o pesquisador registra por que
+  // acha que sua resposta esta correta. Exibida ao arbitro na fase de revelacao.
+  justification?: string;
 }
 
 // Humano original conclui sua fase de auto-revisao. Para cada campo:
@@ -39,6 +42,17 @@ export async function submitAutoReview(
     const user = await getAuthUser();
     if (!user) return { success: false, error: "Não autenticado" };
 
+    // Contestar o LLM exige justificativa — o arbitro precisa do contraponto
+    // humano na fase de revelacao.
+    for (const v of verdicts) {
+      if (v.verdict === "contesta_llm" && !v.justification?.trim()) {
+        return {
+          success: false,
+          error: `Campo "${v.fieldName}": justificativa obrigatória quando você contesta o LLM.`,
+        };
+      }
+    }
+
     const admin = createSupabaseAdmin();
     const now = new Date().toISOString();
 
@@ -49,7 +63,14 @@ export async function submitAutoReview(
       verdicts.map((v) =>
         admin
           .from("field_reviews")
-          .update({ self_verdict: v.verdict, self_reviewed_at: now })
+          .update({
+            self_verdict: v.verdict,
+            self_reviewed_at: now,
+            self_justification:
+              v.verdict === "contesta_llm"
+                ? (v.justification?.trim() ?? null)
+                : null,
+          })
           .eq("project_id", projectId)
           .eq("document_id", documentId)
           .eq("field_name", v.fieldName)

--- a/frontend/src/app/(app)/projects/[id]/analyze/arbitragem/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/arbitragem/page.tsx
@@ -58,7 +58,7 @@ export default async function ArbitrationRoute({
     supabase
       .from("field_reviews")
       .select(
-        "id, document_id, field_name, human_response_id, llm_response_id, blind_verdict, final_verdict",
+        "id, document_id, field_name, human_response_id, llm_response_id, blind_verdict, final_verdict, self_justification",
       )
       .in("document_id", docIds)
       .eq("arbitrator_id", user.id)
@@ -98,6 +98,7 @@ export default async function ArbitrationRoute({
       humanName: string | null;
       llmName: string | null;
       llmJustification: string | null;
+      selfJustification: string | null;
     } | null;
   };
 
@@ -155,6 +156,7 @@ export default async function ArbitrationRoute({
                 (llm?.justifications as Record<string, string> | null)?.[
                   fr.field_name
                 ] ?? null,
+              selfJustification: fr.self_justification ?? null,
             }
           : null,
     });

--- a/frontend/src/app/(app)/projects/[id]/analyze/auto-revisao/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/auto-revisao/page.tsx
@@ -93,7 +93,7 @@ export default async function AutoReviewRoute({
     supabase
       .from("field_reviews")
       .select(
-        "id, document_id, field_name, human_response_id, llm_response_id, self_verdict",
+        "id, document_id, field_name, human_response_id, llm_response_id, self_verdict, self_justification",
       )
       .in("document_id", docIds)
       .eq("self_reviewer_id", targetUserId),
@@ -148,6 +148,7 @@ export default async function AutoReviewRoute({
           fr.field_name
         ] ?? null,
       alreadyAnswered: fr.self_verdict !== null,
+      selfJustification: fr.self_justification ?? null,
     });
   }
 

--- a/frontend/src/components/arbitration/ArbitrationPage.tsx
+++ b/frontend/src/components/arbitration/ArbitrationPage.tsx
@@ -38,6 +38,7 @@ export interface ArbitrationField {
     humanName: string | null;
     llmName: string | null;
     llmJustification: string | null;
+    selfJustification: string | null;
   } | null;
 }
 

--- a/frontend/src/components/arbitration/RevealPhase.tsx
+++ b/frontend/src/components/arbitration/RevealPhase.tsx
@@ -49,6 +49,7 @@ export function RevealPhase({
         const humanName = r?.humanName ?? null;
         const llmName = r?.llmName ?? null;
         const llmJustification = r?.llmJustification ?? null;
+        const selfJustification = r?.selfJustification ?? null;
 
         // Identifica qual lado (A/B) o arbitro escolheu na fase cega
         const blindSideLetter: "A" | "B" | null = r
@@ -97,6 +98,15 @@ export function RevealPhase({
                       r?.aSide === "humano" ? f.aAnswer : f.bAnswer,
                     )}
                   </div>
+                  {selfJustification ? (
+                    <div className="mt-2 text-xs text-muted-foreground border-l-2 border-muted pl-2 whitespace-pre-wrap">
+                      {selfJustification}
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-xs text-muted-foreground italic">
+                      Pesquisador não forneceu justificativa para este campo.
+                    </p>
+                  )}
                 </div>
                 <div
                   className={`border rounded-md p-3 ${

--- a/frontend/src/components/arbitration/RevealPhase.tsx
+++ b/frontend/src/components/arbitration/RevealPhase.tsx
@@ -104,7 +104,7 @@ export function RevealPhase({
                     </div>
                   ) : (
                     <p className="mt-2 text-xs text-muted-foreground italic">
-                      Pesquisador não forneceu justificativa para este campo.
+                      Sem justificativa registrada para este campo.
                     </p>
                   )}
                 </div>

--- a/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
+++ b/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
@@ -79,6 +79,15 @@ export function AutoReviewFieldPanel({
     setShowJustification(true);
   }, [field.fieldName]);
 
+  // Foca o textarea ao escolher contesta_llm — sem isto, teclar "1" abre o
+  // campo mas deixa o foco para tras. Keyed so em `choice`: navegar entre dois
+  // campos ambos contesta_llm nao rerroda o effect (mesmo valor), entao o foco
+  // so vai para o textarea no ato de escolher.
+  const justificationRef = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    if (choice === "contesta_llm") justificationRef.current?.focus();
+  }, [choice]);
+
   // Auto-advance pós-decisão: armazena handle do timeout num ref para poder
   // cancelar se o usuário trocar de doc/campo antes do disparo (evita pular
   // índice em contexto desatualizado).
@@ -250,6 +259,7 @@ export function AutoReviewFieldPanel({
             </Label>
             <Textarea
               id="self-justification"
+              ref={justificationRef}
               rows={3}
               value={justification}
               onChange={(e) => onJustificationChange(e.target.value)}

--- a/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
+++ b/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { ProgressDots } from "../coding/ProgressDots";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
 import { Keyboard, ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatAnswerDisplay } from "@/lib/format-answer";
@@ -15,6 +17,7 @@ export interface AutoReviewField {
   llmAnswer: unknown;
   llmJustification: string | null;
   alreadyAnswered: boolean;
+  selfJustification: string | null;
 }
 
 interface AutoReviewFieldPanelProps {
@@ -23,8 +26,10 @@ interface AutoReviewFieldPanelProps {
   totalFields: number;
   answered: boolean[];
   choice: SelfVerdict | null;
+  justification: string;
   readOnly: boolean;
   onChoose: (verdict: SelfVerdict) => void;
+  onJustificationChange: (value: string) => void;
   onFieldNavigate: (index: number) => void;
 }
 
@@ -36,8 +41,10 @@ export function AutoReviewFieldPanel({
   totalFields,
   answered,
   choice,
+  justification,
   readOnly,
   onChoose,
+  onJustificationChange,
   onFieldNavigate,
 }: AutoReviewFieldPanelProps) {
   // Aberta por padrão: pesquisador precisa ler a justificativa para decidir
@@ -113,6 +120,9 @@ export function AutoReviewFieldPanel({
 
   function handleChoose(v: SelfVerdict) {
     onChoose(v);
+    // contesta_llm exige justificativa: não auto-avança, senão o pesquisador
+    // perderia o campo de texto que acabou de abrir.
+    if (v === "contesta_llm") return;
     // Pula campos já respondidos no auto-advance pós-clique (P/N manuais
     // continuam navegando livremente para permitir re-conferência).
     const nextUnanswered = answered.findIndex((a, i) => i > fieldIndex && !a);
@@ -232,6 +242,32 @@ export function AutoReviewFieldPanel({
             </Button>
           </div>
         )}
+
+        {!readOnly && !field.alreadyAnswered && choice === "contesta_llm" ? (
+          <div className="space-y-1.5">
+            <Label htmlFor="self-justification" className="text-sm">
+              Justificativa <span className="text-destructive">*</span>
+            </Label>
+            <Textarea
+              id="self-justification"
+              rows={3}
+              value={justification}
+              onChange={(e) => onJustificationChange(e.target.value)}
+              placeholder="Por que você acha que sua resposta está correta? O árbitro verá isto."
+            />
+          </div>
+        ) : null}
+
+        {(readOnly || field.alreadyAnswered) && field.selfJustification ? (
+          <div className="space-y-1">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">
+              Sua justificativa
+            </div>
+            <p className="whitespace-pre-wrap border-l-2 border-muted pl-2 text-xs text-muted-foreground">
+              {field.selfJustification}
+            </p>
+          </div>
+        ) : null}
       </div>
 
       <div className="border-t px-4 py-2">

--- a/frontend/src/components/auto-review/AutoReviewPage.tsx
+++ b/frontend/src/components/auto-review/AutoReviewPage.tsx
@@ -29,6 +29,7 @@ import {
   type AutoReviewField,
 } from "./AutoReviewFieldPanel";
 import type { PydanticField, SelfVerdict } from "@/lib/types";
+import { isAutoReviewFieldDecided } from "@/lib/auto-review-decided";
 
 export interface AutoReviewDoc {
   docId: string;
@@ -206,12 +207,12 @@ export function AutoReviewPage({
   // Campo "decidido" = já respondido OU com escolha local; se a escolha for
   // contesta_llm, a justificativa também precisa estar preenchida.
   const isFieldDecided = (f: AutoReviewField) => {
-    if (f.alreadyAnswered) return true;
     const key = choiceKey(doc.docId, f.fieldName);
-    const choice = choices[key];
-    if (choice == null) return false;
-    if (choice === "contesta_llm") return !!justifications[key]?.trim();
-    return true;
+    return isAutoReviewFieldDecided(
+      f.alreadyAnswered,
+      choices[key],
+      justifications[key],
+    );
   };
   const allChosen = doc.fields.every(isFieldDecided);
   const answeredFlags = doc.fields.map(isFieldDecided);

--- a/frontend/src/components/auto-review/AutoReviewPage.tsx
+++ b/frontend/src/components/auto-review/AutoReviewPage.tsx
@@ -99,6 +99,10 @@ export function AutoReviewPage({
   // Sem o prefixo do docId, escolher "q1" no doc A pre-selecionaria "q1" do
   // doc B na navegação. O composto garante isolamento por (doc, campo).
   const [choices, setChoices] = useState<Record<string, SelfVerdict>>({});
+  // Justificativa por (doc, campo) — só usada quando a escolha é contesta_llm.
+  const [justifications, setJustifications] = useState<Record<string, string>>(
+    {},
+  );
 
   const choiceKey = (docId: string, fieldName: string) =>
     `${docId}::${fieldName}`;
@@ -199,22 +203,32 @@ export function AutoReviewPage({
 
   const doc = docs[docIndex];
   const currentField = doc.fields[fieldIndex];
-  const allChosen = doc.fields.every(
-    (f) => f.alreadyAnswered || choices[choiceKey(doc.docId, f.fieldName)] != null,
-  );
-  const answeredFlags = doc.fields.map(
-    (f) => f.alreadyAnswered || choices[choiceKey(doc.docId, f.fieldName)] != null,
-  );
+  // Campo "decidido" = já respondido OU com escolha local; se a escolha for
+  // contesta_llm, a justificativa também precisa estar preenchida.
+  const isFieldDecided = (f: AutoReviewField) => {
+    if (f.alreadyAnswered) return true;
+    const key = choiceKey(doc.docId, f.fieldName);
+    const choice = choices[key];
+    if (choice == null) return false;
+    if (choice === "contesta_llm") return !!justifications[key]?.trim();
+    return true;
+  };
+  const allChosen = doc.fields.every(isFieldDecided);
+  const answeredFlags = doc.fields.map(isFieldDecided);
 
   async function handleSubmit() {
     if (readOnly) return;
     setSubmitting(true);
     const payload = doc.fields
       .filter((f) => !f.alreadyAnswered)
-      .map((f) => ({
-        fieldName: f.fieldName,
-        verdict: choices[choiceKey(doc.docId, f.fieldName)],
-      }));
+      .map((f) => {
+        const key = choiceKey(doc.docId, f.fieldName);
+        return {
+          fieldName: f.fieldName,
+          verdict: choices[key],
+          justification: justifications[key],
+        };
+      });
     const result = await submitAutoReview(projectId, doc.docId, payload);
     setSubmitting(false);
     if (!result.success) {
@@ -232,6 +246,12 @@ export function AutoReviewPage({
     }
     setChoices((c) => {
       const next = { ...c };
+      for (const f of doc.fields)
+        delete next[choiceKey(doc.docId, f.fieldName)];
+      return next;
+    });
+    setJustifications((j) => {
+      const next = { ...j };
       for (const f of doc.fields)
         delete next[choiceKey(doc.docId, f.fieldName)];
       return next;
@@ -347,11 +367,22 @@ export function AutoReviewPage({
               choice={
                 choices[choiceKey(doc.docId, currentField.fieldName)] ?? null
               }
+              justification={
+                justifications[
+                  choiceKey(doc.docId, currentField.fieldName)
+                ] ?? ""
+              }
               readOnly={readOnly}
               onChoose={(v) =>
                 setChoices((c) => ({
                   ...c,
                   [choiceKey(doc.docId, currentField.fieldName)]: v,
+                }))
+              }
+              onJustificationChange={(value) =>
+                setJustifications((j) => ({
+                  ...j,
+                  [choiceKey(doc.docId, currentField.fieldName)]: value,
                 }))
               }
               onFieldNavigate={setFieldIndex}

--- a/frontend/src/lib/__tests__/auto-review-decided.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-decided.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { isAutoReviewFieldDecided } from "@/lib/auto-review-decided";
+
+describe("isAutoReviewFieldDecided", () => {
+  it("alreadyAnswered → decidido independente de choice/justificativa", () => {
+    expect(isAutoReviewFieldDecided(true, null, undefined)).toBe(true);
+    expect(isAutoReviewFieldDecided(true, "contesta_llm", undefined)).toBe(true);
+  });
+
+  it("sem escolha → não decidido", () => {
+    expect(isAutoReviewFieldDecided(false, null, undefined)).toBe(false);
+    expect(isAutoReviewFieldDecided(false, undefined, undefined)).toBe(false);
+  });
+
+  it("admite_erro → decidido sem precisar de justificativa", () => {
+    expect(isAutoReviewFieldDecided(false, "admite_erro", undefined)).toBe(true);
+  });
+
+  it("contesta_llm sem justificativa → não decidido", () => {
+    expect(isAutoReviewFieldDecided(false, "contesta_llm", undefined)).toBe(
+      false,
+    );
+    expect(isAutoReviewFieldDecided(false, "contesta_llm", "")).toBe(false);
+  });
+
+  it("contesta_llm com justificativa só de espaços → não decidido", () => {
+    expect(isAutoReviewFieldDecided(false, "contesta_llm", "   ")).toBe(false);
+    expect(isAutoReviewFieldDecided(false, "contesta_llm", "\n\t ")).toBe(false);
+  });
+
+  it("contesta_llm com justificativa preenchida → decidido", () => {
+    expect(
+      isAutoReviewFieldDecided(false, "contesta_llm", "minha resposta confere"),
+    ).toBe(true);
+    expect(isAutoReviewFieldDecided(false, "contesta_llm", "  ok  ")).toBe(true);
+  });
+});

--- a/frontend/src/lib/auto-review-decided.ts
+++ b/frontend/src/lib/auto-review-decided.ts
@@ -1,0 +1,20 @@
+import type { SelfVerdict } from "@/lib/types";
+
+// Um campo da auto-revisao esta "decidido" quando ja foi respondido em sessao
+// anterior, ou quando o pesquisador escolheu um verdict local. Excecao:
+// contesta_llm so conta como decidido se a justificativa obrigatoria estiver
+// preenchida (espelha a validacao server-side de submitAutoReview).
+//
+// Modulo separado de lib/auto-review.ts de proposito: aquele importa o
+// supabase admin client (server-only) e nao pode ser puxado para um client
+// component. Esta funcao e pura e client-safe.
+export function isAutoReviewFieldDecided(
+  alreadyAnswered: boolean,
+  choice: SelfVerdict | null | undefined,
+  justification: string | undefined,
+): boolean {
+  if (alreadyAnswered) return true;
+  if (choice == null) return false;
+  if (choice === "contesta_llm") return !!justification?.trim();
+  return true;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -170,6 +170,7 @@ export interface FieldReview {
   llm_response_id: string;
   self_reviewer_id: string;
   self_verdict: SelfVerdict | null;
+  self_justification: string | null;
   self_reviewed_at: string | null;
   arbitrator_id: string | null;
   blind_verdict: ArbitrationVerdict | null;

--- a/frontend/supabase/migrations/20260514000000_field_reviews_self_justification.sql
+++ b/frontend/supabase/migrations/20260514000000_field_reviews_self_justification.sql
@@ -1,0 +1,11 @@
+-- Justificativa do pesquisador ao contestar o LLM na auto-revisao.
+--
+-- Quando o humano original define self_verdict='contesta_llm', ele agora
+-- registra por que acha que sua resposta esta correta. Essa justificativa e
+-- exibida ao arbitro na fase de revelacao da arbitragem (segunda etapa), ao
+-- lado da resposta humana — espelhando a justificativa do LLM.
+--
+-- Nullable: field_reviews anteriores a esta migration ficam com NULL; a UI
+-- trata ausencia como "sem justificativa".
+
+ALTER TABLE field_reviews ADD COLUMN self_justification TEXT;

--- a/frontend/supabase/migrations/20260514000000_field_reviews_self_justification.sql
+++ b/frontend/supabase/migrations/20260514000000_field_reviews_self_justification.sql
@@ -8,4 +8,4 @@
 -- Nullable: field_reviews anteriores a esta migration ficam com NULL; a UI
 -- trata ausencia como "sem justificativa".
 
-ALTER TABLE field_reviews ADD COLUMN self_justification TEXT;
+ALTER TABLE field_reviews ADD COLUMN IF NOT EXISTS self_justification TEXT;


### PR DESCRIPTION
## Resumo

Na aba de **auto-revisão**, ao escolher "Eu acertei (LLM errou)" (`contesta_llm`), o pesquisador agora **precisa registrar uma justificativa** explicando por que considera sua resposta correta. Essa justificativa é exibida ao árbitro na **fase de revelação** da arbitragem, no painel do humano — espelhando como a justificativa do LLM já aparece hoje.

Antes, o pesquisador contestava o LLM sem registrar o porquê, e o árbitro chegava à fase 2 vendo só o contraponto do LLM.

## Mudanças

- **Migration** `20260514000000_field_reviews_self_justification.sql`: nova coluna `field_reviews.self_justification TEXT` (nullable, `IF NOT EXISTS`; linhas antigas ficam `NULL`).
- **`submitAutoReview`**: valida que todo `contesta_llm` tem justificativa não vazia e grava em `self_justification` (só para `contesta_llm`; `admite_erro` grava `NULL`).
- **`AutoReviewFieldPanel`**: textarea obrigatório quando a escolha é `contesta_llm`; clicar "Eu acertei" **não** dispara auto-advance (o pesquisador precisa parar para escrever); `admite_erro` continua avançando. O textarea **recebe foco** ao escolher `contesta_llm`. Justificativa também é exibida em modo leitura para campos já respondidos / visão do coordenador.
- **`AutoReviewPage`**: estado `justifications`; o botão "Enviar" fica desabilitado enquanto algum campo `contesta_llm` estiver sem justificativa. Lógica de "campo decidido" extraída para `lib/auto-review-decided.ts` (módulo puro, client-safe).
- **`RevealPhase`**: justificativa do pesquisador renderizada no painel do humano (só na fase de revelação, nunca na cega); mensagem neutra quando ausente (linhas anteriores à migration).

## Melhorias da review incorporadas

Segundo round de commits aplica os pontos da review: foco automático no textarea, mensagem neutra de justificativa ausente, migration idempotente (`IF NOT EXISTS`), extração de `isAutoReviewFieldDecided` para módulo puro testável, e testes Vitest (helper puro + validação server-side de `submitAutoReview`).

## Migration

A migration **já foi aplicada** ao banco remoto (`nryebmwlmxuwvynfuzsv`) via `supabase db push`.

## Test plan

- [x] Migration aplicada no banco
- [x] `npm test` — 186 testes passam (inclui os novos: `auto-review-decided.test.ts`, `field-reviews.test.ts`)
- [x] `tsc --noEmit` sem erros
- [ ] Como pesquisador, na aba Auto-revisão: clicar "Eu acertei (LLM errou)" → textarea aparece **e recebe foco**; "Enviar" desabilitado enquanto vazio, habilita ao digitar
- [ ] Confirmar que "Eu acertei" não faz auto-advance e "LLM acertou" ainda avança
- [ ] Como árbitro: concluir fase cega, avançar para Revelação → justificativa do pesquisador aparece no painel do humano
- [ ] Regressão: `admite_erro` sem textarea e com auto-advance; `field_reviews` antigos (sem `self_justification`) mostram "Sem justificativa registrada para este campo."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
