### PR TITLE
feat(gabarito): criar comentário direto da aba Gabarito

### DIFF
--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -253,6 +253,7 @@ export function ComparisonPanel({
                 documentId={documentId}
                 documentTitle={documentTitle}
                 fieldName={fieldName}
+                fieldLabel={fieldDescription}
                 variant="outline"
                 size="sm"
                 label="Anotar"

--- a/frontend/src/components/reviews/GabaritoByDocument.tsx
+++ b/frontend/src/components/reviews/GabaritoByDocument.tsx
@@ -304,6 +304,7 @@ function FieldRow({
           documentId={documentId}
           documentTitle={documentTitle}
           fieldName={field.fieldName}
+          fieldLabel={field.fieldDescription}
         />
       </div>
 

--- a/frontend/src/components/reviews/GabaritoByDocument.tsx
+++ b/frontend/src/components/reviews/GabaritoByDocument.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
+import { AddNoteButton } from "@/components/shared/AddNoteButton";
 import type { PydanticField } from "@/lib/types";
 import type { ReviewedDocument } from "@/lib/reviews/types";
 
@@ -256,7 +257,13 @@ function DocumentCard({
 
         <div className="space-y-2">
           {doc.fields.map((field) => (
-            <FieldRow key={field.fieldName} field={field} />
+            <FieldRow
+              key={field.fieldName}
+              field={field}
+              projectId={projectId}
+              documentId={doc.documentId}
+              documentTitle={doc.documentTitle}
+            />
           ))}
         </div>
       </CardContent>
@@ -266,7 +273,17 @@ function DocumentCard({
 
 /* ── Field Row ── */
 
-function FieldRow({ field }: { field: ReviewedDocument["fields"][number] }) {
+function FieldRow({
+  field,
+  projectId,
+  documentId,
+  documentTitle,
+}: {
+  field: ReviewedDocument["fields"][number];
+  projectId: string;
+  documentId: string;
+  documentTitle: string;
+}) {
   const isSpecialVerdict =
     field.verdict === "ambiguo" || field.verdict === "pular";
 
@@ -278,9 +295,17 @@ function FieldRow({ field }: { field: ReviewedDocument["fields"][number] }) {
 
   return (
     <div className="rounded-md border p-3 space-y-1.5">
-      <p className="text-xs font-medium text-muted-foreground">
-        {field.fieldDescription}
-      </p>
+      <div className="flex items-start justify-between gap-2">
+        <p className="text-xs font-medium text-muted-foreground">
+          {field.fieldDescription}
+        </p>
+        <AddNoteButton
+          projectId={projectId}
+          documentId={documentId}
+          documentTitle={documentTitle}
+          fieldName={field.fieldName}
+        />
+      </div>
 
       <div
         className={cn(

--- a/frontend/src/components/shared/AddNoteButton.tsx
+++ b/frontend/src/components/shared/AddNoteButton.tsx
@@ -29,6 +29,7 @@ interface AddNoteButtonProps {
   documentId?: string | null;
   documentTitle?: string | null;
   fieldName?: string | null;
+  fieldLabel?: string | null;
   fields?: PydanticField[];
   variant?: "default" | "ghost" | "outline";
   size?: "default" | "sm" | "icon";
@@ -40,6 +41,7 @@ export function AddNoteButton({
   documentId,
   documentTitle,
   fieldName: fixedFieldName,
+  fieldLabel,
   fields,
   variant = "ghost",
   size = "sm",
@@ -56,7 +58,7 @@ export function AddNoteButton({
   // Build contextual subtitle
   const contextParts: string[] = [];
   if (documentTitle) contextParts.push(documentTitle);
-  if (fixedFieldName) contextParts.push(fixedFieldName);
+  if (fixedFieldName) contextParts.push(fieldLabel || fixedFieldName);
   const contextLabel = contextParts.length > 0 ? contextParts.join(" → ") : null;
 
   const handleSubmit = () => {

--- a/frontend/src/components/shared/__tests__/AddNoteButton.test.tsx
+++ b/frontend/src/components/shared/__tests__/AddNoteButton.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const createProjectComment = vi.fn();
+
+vi.mock("@/actions/project-comments", () => ({
+  createProjectComment: (...args: unknown[]) => createProjectComment(...args),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { AddNoteButton } from "@/components/shared/AddNoteButton";
+
+afterEach(cleanup);
+beforeEach(() => {
+  createProjectComment.mockReset();
+  createProjectComment.mockResolvedValue({ error: null });
+});
+
+describe("AddNoteButton — fixed field", () => {
+  it("shows the human-readable field label in the dialog context, not the machine name", async () => {
+    const user = userEvent.setup();
+    render(
+      <AddNoteButton
+        projectId="p1"
+        documentId="d1"
+        documentTitle="Documento X"
+        fieldName="tipo_decisao"
+        fieldLabel="Tipo de decisão"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /nota/i }));
+    const dialog = screen.getByRole("dialog");
+
+    expect(within(dialog).getByText("Documento X → Tipo de decisão")).toBeTruthy();
+    expect(within(dialog).queryByText("tipo_decisao")).toBeNull();
+  });
+
+  it("hides the field select and submits the comment bound to the fixed field", async () => {
+    const user = userEvent.setup();
+    render(
+      <AddNoteButton
+        projectId="p1"
+        documentId="d1"
+        documentTitle="Documento X"
+        fieldName="tipo_decisao"
+        fieldLabel="Tipo de decisão"
+        fields={[{ name: "tipo_decisao", type: "str", options: null, description: "Tipo de decisão" }]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /nota/i }));
+    const dialog = screen.getByRole("dialog");
+
+    // fieldName fixo => sem select de campo
+    expect(within(dialog).queryByRole("combobox")).toBeNull();
+
+    await user.type(within(dialog).getByRole("textbox"), "minha nota");
+    await user.click(within(dialog).getByRole("button", { name: /salvar nota/i }));
+
+    await vi.waitFor(() =>
+      expect(createProjectComment).toHaveBeenCalledWith(
+        "p1",
+        "minha nota",
+        "d1",
+        "tipo_decisao",
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Resumo

- Adiciona `AddNoteButton` em cada `FieldRow` da aba Gabarito (`GabaritoByDocument.tsx`), com campo e documento **pré-preenchidos** pelo contexto da linha.
- O comentário criado passa pelo mesmo `createProjectComment` / `project_comments` usado pela aba Comentários, então aparece lá normalmente.
- A criação na aba Comentários não foi tocada — continua funcionando como antes.

## Detalhes

`AddNoteButton` já suportava `documentId`, `documentTitle` e `fieldName` fixos: quando `fieldName` é passado, o select de campo some e a nota fica vinculada àquele campo. Só foi preciso passar `projectId` / `documentId` / `documentTitle` do `DocumentCard` para o `FieldRow` e renderizar o botão no cabeçalho da linha.

## Critério de aceite

- [x] Coordenador cria comentário direto da aba Gabarito, vinculado a campo + documento da linha.
- [x] Comentário criado aparece na aba Comentários.
- [x] Criação na aba Comentários continua funcionando como hoje.

## Test plan

- [ ] Abrir aba Gabarito de um projeto com documentos revisados; clicar em "Nota" numa linha de campo.
- [ ] Confirmar que o diálogo mostra o contexto (documento → campo) e não exibe o select de campo.
- [ ] Salvar a nota e verificar que ela aparece na aba Comentários vinculada ao campo + documento corretos.
- [ ] Confirmar que "Nova nota" na aba Comentários ainda funciona.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)