### PR TITLE
fix(llm): propagar erros do Supabase em actions/llm.ts

### DIFF
--- a/frontend/src/actions/__tests__/llm.test.ts
+++ b/frontend/src/actions/__tests__/llm.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock do Supabase: builder encadeavel cujo resultado por tabela e
+// configurado por teste via `results`. Padrao alinhado a responses.test.ts.
+
+interface QueryResult {
+  data?: unknown;
+  count?: number | null;
+  error?: { message: string } | null;
+}
+
+let results: Record<string, QueryResult>;
+
+beforeEach(() => {
+  results = {};
+});
+
+function makeChain(result: QueryResult) {
+  const r: QueryResult = { data: null, count: null, error: null, ...result };
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "is", "gt", "order", "limit", "range"]) {
+    chain[m] = () => chain;
+  }
+  chain.maybeSingle = () => Promise.resolve(r);
+  chain.single = () => Promise.resolve(r);
+  // Thenable: `await query` (sem .single/.maybeSingle) resolve aqui.
+  chain.then = (resolve: (v: QueryResult) => unknown) => resolve(r);
+  return chain;
+}
+
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () => ({
+    from: (table: string) =>
+      makeChain(results[table] ?? { data: [], count: 0, error: null }),
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchFastAPI: vi.fn(),
+}));
+
+async function loadLlm() {
+  return import("@/actions/llm");
+}
+
+describe("getEligibleDocCount", () => {
+  it("propaga erro da query de documents", async () => {
+    results.documents = { error: { message: "rls documents" } };
+    results.responses = { data: [] };
+    const { getEligibleDocCount } = await loadLlm();
+    await expect(getEligibleDocCount("p1", "pending")).rejects.toThrow(
+      "rls documents"
+    );
+  });
+
+  it("propaga erro da query de responses", async () => {
+    results.documents = { count: 10 };
+    results.responses = { error: { message: "rls responses" } };
+    const { getEligibleDocCount } = await loadLlm();
+    await expect(getEligibleDocCount("p1", "pending")).rejects.toThrow(
+      "rls responses"
+    );
+  });
+
+  it("caminho feliz retorna a contagem", async () => {
+    results.documents = { count: 10 };
+    results.responses = { data: [{ document_id: "d1" }] };
+    const { getEligibleDocCount } = await loadLlm();
+    await expect(getEligibleDocCount("p1", "all")).resolves.toEqual({
+      total: 10,
+      eligible: 10,
+    });
+  });
+});
+
+describe("getLlmRuns", () => {
+  it("propaga erro", async () => {
+    results.llm_runs = { error: { message: "boom runs" } };
+    const { getLlmRuns } = await loadLlm();
+    await expect(getLlmRuns("p1")).rejects.toThrow("boom runs");
+  });
+
+  it("caminho feliz retorna os registros", async () => {
+    results.llm_runs = { data: [{ id: "r1" }, { id: "r2" }] };
+    const { getLlmRuns } = await loadLlm();
+    await expect(getLlmRuns("p1")).resolves.toHaveLength(2);
+  });
+});
+
+describe("getRunningLlmCount", () => {
+  it("propaga erro", async () => {
+    results.llm_runs = { error: { message: "boom count" } };
+    const { getRunningLlmCount } = await loadLlm();
+    await expect(getRunningLlmCount("p1")).rejects.toThrow("boom count");
+  });
+
+  it("caminho feliz retorna o count", async () => {
+    results.llm_runs = { count: 3 };
+    const { getRunningLlmCount } = await loadLlm();
+    await expect(getRunningLlmCount("p1")).resolves.toBe(3);
+  });
+});
+
+describe("getLlmRunStats", () => {
+  it("propaga erro das contagens", async () => {
+    results.responses = { error: { message: "boom stats" } };
+    const { getLlmRunStats } = await loadLlm();
+    await expect(getLlmRunStats("job-1")).rejects.toThrow("boom stats");
+  });
+
+  it("caminho feliz retorna current e partial", async () => {
+    results.responses = { count: 7 };
+    const { getLlmRunStats } = await loadLlm();
+    await expect(getLlmRunStats("job-1")).resolves.toEqual({
+      current: 7,
+      partial: 7,
+    });
+  });
+});
+
+describe("getLlmResponsesForProject", () => {
+  it("propaga erro", async () => {
+    results.responses = { error: { message: "boom resp" } };
+    const { getLlmResponsesForProject } = await loadLlm();
+    await expect(getLlmResponsesForProject("p1")).rejects.toThrow("boom resp");
+  });
+
+  it("caminho feliz mapeia os registros", async () => {
+    results.responses = {
+      data: [{ id: "x1", document_id: "d1", answers: null, documents: null }],
+    };
+    const { getLlmResponsesForProject } = await loadLlm();
+    const res = await getLlmResponsesForProject("p1");
+    expect(res).toHaveLength(1);
+    expect(res[0].answers).toEqual({});
+  });
+});
+
+describe("getRunningLlmJob", () => {
+  it("propaga erro", async () => {
+    results.llm_runs = { error: { message: "boom job" } };
+    const { getRunningLlmJob } = await loadLlm();
+    await expect(getRunningLlmJob("p1")).rejects.toThrow("boom job");
+  });
+
+  it("retorna null quando nao ha run ativa", async () => {
+    results.llm_runs = { data: null };
+    const { getRunningLlmJob } = await loadLlm();
+    await expect(getRunningLlmJob("p1")).resolves.toBeNull();
+  });
+
+  it("caminho feliz retorna o job", async () => {
+    results.llm_runs = {
+      data: {
+        job_id: "j1",
+        started_at: "2026-05-14T00:00:00Z",
+        heartbeat_at: "2026-05-14T00:01:00Z",
+      },
+    };
+    const { getRunningLlmJob } = await loadLlm();
+    await expect(getRunningLlmJob("p1")).resolves.toEqual({
+      job_id: "j1",
+      started_at: "2026-05-14T00:00:00Z",
+    });
+  });
+});
+
+describe("getDocumentsForSelection", () => {
+  it("propaga erro da query de documents", async () => {
+    results.documents = { error: { message: "boom docs" } };
+    results.responses = { data: [] };
+    const { getDocumentsForSelection } = await loadLlm();
+    await expect(getDocumentsForSelection("p1")).rejects.toThrow("boom docs");
+  });
+
+  it("propaga erro da query de responses", async () => {
+    results.documents = { data: [] };
+    results.responses = { error: { message: "boom docs resp" } };
+    const { getDocumentsForSelection } = await loadLlm();
+    await expect(getDocumentsForSelection("p1")).rejects.toThrow(
+      "boom docs resp"
+    );
+  });
+
+  it("caminho feliz monta os itens de selecao", async () => {
+    results.documents = {
+      data: [{ id: "d1", title: "T", external_id: "E" }],
+    };
+    results.responses = {
+      data: [{ document_id: "d1", respondent_type: "humano" }],
+    };
+    const { getDocumentsForSelection } = await loadLlm();
+    await expect(getDocumentsForSelection("p1")).resolves.toEqual([
+      {
+        id: "d1",
+        title: "T",
+        external_id: "E",
+        hasHumanResponse: true,
+        llmResponseCount: 0,
+      },
+    ]);
+  });
+});

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -10,7 +10,10 @@ export async function getEligibleDocCount(
 ): Promise<{ total: number; eligible: number }> {
   const supabase = await createSupabaseServer();
 
-  const [{ count: total }, { data: llmResponses }] = await Promise.all([
+  const [
+    { count: total, error: totalError },
+    { data: llmResponses, error: llmError },
+  ] = await Promise.all([
     supabase
       .from("documents")
       .select("id", { count: "exact", head: true })
@@ -23,6 +26,9 @@ export async function getEligibleDocCount(
       .eq("respondent_type", "llm")
       .eq("is_current", true),
   ]);
+
+  if (totalError) throw new Error(totalError.message);
+  if (llmError) throw new Error(llmError.message);
 
   const totalDocs = total ?? 0;
 
@@ -87,7 +93,7 @@ export async function getLlmRuns(
 ): Promise<LlmRunRecord[]> {
   const supabase = await createSupabaseServer();
 
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("llm_runs")
     .select(
       "id, job_id, status, phase, llm_provider, llm_model, filter_mode, " +
@@ -98,16 +104,19 @@ export async function getLlmRuns(
     .order("started_at", { ascending: false })
     .limit(limit);
 
+  if (error) throw new Error(error.message);
+
   return (data ?? []) as unknown as LlmRunRecord[];
 }
 
 export async function getRunningLlmCount(projectId: string): Promise<number> {
   const supabase = await createSupabaseServer();
-  const { count } = await supabase
+  const { count, error } = await supabase
     .from("llm_runs")
     .select("id", { count: "exact", head: true })
     .eq("project_id", projectId)
     .eq("status", "running");
+  if (error) throw new Error(error.message);
   return count ?? 0;
 }
 
@@ -118,7 +127,10 @@ export async function getLlmRunStats(
   // Usa is_partial (imutável) em vez de is_current para distinguir complete vs
   // partial. is_current muda quando uma run posterior roda nos mesmos docs, o
   // que inflaria artificialmente a contagem de parciais de runs antigas.
-  const [{ count: complete }, { count: partial }] = await Promise.all([
+  const [
+    { count: complete, error: completeError },
+    { count: partial, error: partialError },
+  ] = await Promise.all([
     supabase
       .from("responses")
       .select("id", { count: "exact", head: true })
@@ -130,6 +142,8 @@ export async function getLlmRunStats(
       .eq("llm_job_id", jobId)
       .eq("is_partial", true),
   ]);
+  if (completeError) throw new Error(completeError.message);
+  if (partialError) throw new Error(partialError.message);
   return { current: complete ?? 0, partial: partial ?? 0 };
 }
 
@@ -176,7 +190,9 @@ export async function getLlmResponsesForProject(
 
   if (options.jobId) query = query.eq("llm_job_id", options.jobId);
 
-  const { data } = await query;
+  const { data, error } = await query;
+
+  if (error) throw new Error(error.message);
 
   return ((data ?? []) as unknown as Array<{
     id: string;
@@ -258,7 +274,7 @@ export async function getRunningLlmJob(
 ): Promise<RunningLlmJob | null> {
   const supabase = await createSupabaseServer();
   const heartbeatCutoff = new Date(Date.now() - 10 * 60 * 1000).toISOString();
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("llm_runs")
     .select("job_id, started_at, heartbeat_at")
     .eq("project_id", projectId)
@@ -267,6 +283,7 @@ export async function getRunningLlmJob(
     .order("started_at", { ascending: false })
     .limit(1)
     .maybeSingle();
+  if (error) throw new Error(error.message);
   if (!data) return null;
   return { job_id: data.job_id, started_at: data.started_at };
 }
@@ -276,7 +293,10 @@ export async function getDocumentsForSelection(
 ): Promise<DocSelectionItem[]> {
   const supabase = await createSupabaseServer();
 
-  const [{ data: docs }, { data: responses }] = await Promise.all([
+  const [
+    { data: docs, error: docsError },
+    { data: responses, error: responsesError },
+  ] = await Promise.all([
     supabase
       .from("documents")
       .select("id, title, external_id")
@@ -289,6 +309,9 @@ export async function getDocumentsForSelection(
       .eq("project_id", projectId)
       .eq("is_current", true),
   ]);
+
+  if (docsError) throw new Error(docsError.message);
+  if (responsesError) throw new Error(responsesError.message);
 
   const humanDocs = new Set<string>();
   const llmCounts = new Map<string, number>();

--- a/frontend/src/app/(app)/projects/[id]/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/layout.tsx
@@ -29,7 +29,9 @@ export default async function ProjectLayout({
         .select("first_name")
         .eq("id", user.id)
         .single(),
-      getRunningLlmCount(id),
+      // Best-effort: o badge "LLM rodando" e cosmetico. Uma falha aqui (RLS,
+      // rede) nao deve derrubar o layout inteiro do projeto — degrada para 0.
+      getRunningLlmCount(id).catch(() => 0),
     ]);
 
   if (!project) notFound();

--- a/frontend/src/app/(app)/projects/[id]/llm/error.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function LlmError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Erro na aba LLM:", error);
+  }, [error]);
+
+  return (
+    <div className="mx-auto max-w-4xl p-6">
+      <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-6 space-y-3">
+        <h2 className="text-base font-medium">
+          Não foi possível carregar esta aba
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Ocorreu um erro ao buscar os dados de LLM. Pode ser uma falha
+          temporária de rede ou de permissão de acesso ao projeto.
+        </p>
+        {error.message && (
+          <p className="rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
+            {error.message}
+          </p>
+        )}
+        <Button size="sm" onClick={reset}>
+          Tentar de novo
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -310,20 +310,27 @@ export function LlmConfigurePane({
   useEffect(() => {
     let cancelled = false;
     async function check() {
-      await cleanupStaleLlmRuns(projectId);
-      if (cancelled) return;
-      const running = await getRunningLlmJob(projectId);
-      if (cancelled || !running) return;
-      // Reset counters antes de religar polling: sem isso, valores residuais
-      // de uma run anterior (encerrada nesta sessao) ficariam visiveis ate o
-      // primeiro tick do polling preencher os valores reais.
-      setProcessedComplete(0);
-      setProcessedPartial(0);
-      setProcessedEmpty(0);
-      setJobId(running.job_id);
-      setStatus("running");
-      setPhase("loading");
-      pollProgress(running.job_id);
+      // Best-effort: retomar o card de polling e cosmetico. Se getRunningLlmJob
+      // falhar (RLS, rede), apenas nao religa o polling — mesmo resultado de
+      // antes, sem unhandled rejection.
+      try {
+        await cleanupStaleLlmRuns(projectId);
+        if (cancelled) return;
+        const running = await getRunningLlmJob(projectId);
+        if (cancelled || !running) return;
+        // Reset counters antes de religar polling: sem isso, valores residuais
+        // de uma run anterior (encerrada nesta sessao) ficariam visiveis ate o
+        // primeiro tick do polling preencher os valores reais.
+        setProcessedComplete(0);
+        setProcessedPartial(0);
+        setProcessedEmpty(0);
+        setJobId(running.job_id);
+        setStatus("running");
+        setPhase("loading");
+        pollProgress(running.job_id);
+      } catch (e) {
+        console.error("Falha ao retomar run em andamento:", e);
+      }
     }
     check();
     return () => {
@@ -336,12 +343,18 @@ export function LlmConfigurePane({
     if (filterMode === "specific") return;
     let cancelled = false;
     async function fetch() {
-      const result = await getEligibleDocCount(
-        projectId,
-        filterMode as "all" | "pending" | "max_responses" | "random_sample",
-        filterMode === "max_responses" ? maxResponseCount : undefined
-      );
-      if (!cancelled) setEligibleCount(result.eligible);
+      // Best-effort: se a contagem falhar, mantem o valor anterior (o display
+      // cai no fallback totalDocs) em vez de gerar unhandled rejection.
+      try {
+        const result = await getEligibleDocCount(
+          projectId,
+          filterMode as "all" | "pending" | "max_responses" | "random_sample",
+          filterMode === "max_responses" ? maxResponseCount : undefined
+        );
+        if (!cancelled) setEligibleCount(result.eligible);
+      } catch (e) {
+        console.error("Falha ao calcular documentos elegiveis:", e);
+      }
     }
     fetch();
     return () => { cancelled = true; };

--- a/frontend/src/components/llm/__tests__/LlmConfigurePane.degradation.test.tsx
+++ b/frontend/src/components/llm/__tests__/LlmConfigurePane.degradation.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+
+// Quando getRunningLlmJob / getEligibleDocCount lancam (RLS, rede), o
+// LlmConfigurePane deve degradar sem quebrar a arvore nem gerar unhandled
+// rejection — os useEffect tratam o erro com try/catch + console.error.
+
+// vi.hoisted: os mocks precisam existir antes dos imports (hoisted) que
+// disparam o factory de vi.mock.
+const { getRunningLlmJob, getEligibleDocCount, cleanupStaleLlmRuns } =
+  vi.hoisted(() => ({
+    getRunningLlmJob: vi.fn(),
+    getEligibleDocCount: vi.fn(),
+    cleanupStaleLlmRuns: vi.fn(async () => ({ cleaned: 0 })),
+  }));
+
+vi.mock("@/actions/llm", () => ({
+  getRunningLlmJob,
+  getEligibleDocCount,
+  cleanupStaleLlmRuns,
+}));
+
+vi.mock("@/actions/schema", () => ({
+  saveLlmConfig: vi.fn(),
+  savePrompt: vi.fn(),
+  toggleLlmField: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchFastAPI: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { LlmConfigurePane } from "@/components/llm/LlmConfigurePane";
+
+const baseProps = {
+  projectId: "p1",
+  promptTemplate: "",
+  projectDescription: "",
+  config: {
+    llm_provider: "anthropic",
+    llm_model: "claude-test",
+    llm_kwargs: {},
+  },
+  pydanticFields: [],
+  pydanticCode: null,
+  totalDocs: 42,
+  docsWithLlm: 0,
+};
+
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  getRunningLlmJob.mockReset();
+  getEligibleDocCount.mockReset();
+  cleanupStaleLlmRuns.mockClear();
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  cleanup();
+  consoleErrorSpy.mockRestore();
+});
+
+describe("LlmConfigurePane — degradacao quando actions lancam", () => {
+  it("renderiza sem quebrar quando getRunningLlmJob e getEligibleDocCount lancam", async () => {
+    getRunningLlmJob.mockRejectedValue(new Error("rls failure"));
+    getEligibleDocCount.mockRejectedValue(new Error("rls failure"));
+
+    render(<LlmConfigurePane {...baseProps} />);
+
+    // A arvore montou apesar das actions lancarem.
+    expect(
+      screen.getByRole("button", { name: "Rodar LLM" })
+    ).toBeDefined();
+
+    // Os dois useEffect capturaram o erro (sem unhandled rejection).
+    await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+  });
+
+  it("nao mostra o card de polling quando getRunningLlmJob lanca", async () => {
+    getRunningLlmJob.mockRejectedValue(new Error("rls failure"));
+    getEligibleDocCount.mockResolvedValue({ total: 42, eligible: 42 });
+
+    render(<LlmConfigurePane {...baseProps} />);
+
+    await waitFor(() => {
+      expect(getRunningLlmJob).toHaveBeenCalled();
+    });
+    // O card "running" so aparece com status === "running"; a falha nao deve
+    // religar o polling.
+    expect(screen.queryByText("Carregando documentos...")).toBeNull();
+  });
+
+  it("cai no fallback totalDocs quando getEligibleDocCount lanca", async () => {
+    getRunningLlmJob.mockResolvedValue(null);
+    getEligibleDocCount.mockRejectedValue(new Error("rls failure"));
+
+    render(<LlmConfigurePane {...baseProps} />);
+
+    await waitFor(() => {
+      expect(getEligibleDocCount).toHaveBeenCalled();
+    });
+    // displayEligible = eligibleCount ?? totalDocs => 42 (eligibleCount fica null).
+    await waitFor(() => {
+      expect(
+        screen.getByText(/42 documentos ser/i)
+      ).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Resumo

`actions/llm.ts` ignorava o campo `error` do Supabase em 7 queries — falhas de RLS, rede ou query viravam resultado vazio silencioso (`[]` / `0`), escondendo a causa raiz. Agora todas as queries checam `error` e propagam via `throw new Error(error.message)`, seguindo o padrão de `actions/assignments.ts`.

A revisão apontou que o `throw` é **correto na maioria dos call sites** (páginas cujo propósito é exatamente aquele dado — falhar alto é o objetivo do #36), mas seria **regressão em 3 call sites cosméticos**. Esses ganharam tratamento; foi adicionado `error.tsx` para a rota `/llm`; e a mudança ficou coberta por testes.

## Mudanças

**Propagação de erro nas actions** (`actions/llm.ts`)
- `getEligibleDocCount`, `getLlmRuns`, `getRunningLlmCount`, `getLlmRunStats`, `getLlmResponsesForProject`, `getRunningLlmJob`, `getDocumentsForSelection` — checam e propagam `error`.

**Degradação nos call sites cosméticos**
- `projects/[id]/layout.tsx` — `getRunningLlmCount` roda no layout; um throw derrubava todas as abas do projeto por causa de um badge. Agora `.catch(() => 0)`.
- `LlmConfigurePane.tsx` — `getRunningLlmJob` e `getEligibleDocCount` rodavam em `useEffect` sem try/catch, gerando unhandled rejection. Agora `try/catch` + `console.error`, degradando como antes do #36.
- `DocumentSelector.tsx` — sem mudança; já tinha `.catch`, agora significativo.

**Error boundary**
- `app/(app)/projects/[id]/llm/error.tsx` (novo) — crashes das páginas de dados (`runs`/`responses`) mostram UI de erro com botão "Tentar de novo" em vez do boundary default do Next.

**Testes**
- `actions/__tests__/llm.test.ts` (novo) — cada uma das 7 funções lança quando o Supabase retorna `{error}` e funciona no caminho feliz.
- `components/llm/__tests__/LlmConfigurePane.degradation.test.tsx` (novo) — o componente não quebra quando as actions lançam, não religa polling e cai no fallback `totalDocs`.

## Test plan

- [x] `npm run test` — 206 testes passam (inclui os 20 novos)
- [x] `npx tsc --noEmit` — sem erros de tipo nos arquivos modificados
- [ ] Forçar falha de RLS: páginas `/llm/runs` e `/llm/responses` mostram o `error.tsx`; abas do projeto continuam navegáveis (badge some, layout não quebra); `LlmConfigurePane` não gera unhandled rejection
- [ ] Fluxo normal (aba Execuções, seleção de documentos, configure) continua funcionando

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)
