### PR TITLE
feat: usar navigator.sendBeacon para autosave no visibilitychange

### DIFF
--- a/frontend/src/app/api/autosave/__tests__/route.test.ts
+++ b/frontend/src/app/api/autosave/__tests__/route.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { saveResponse } from "@/actions/responses";
+
+vi.mock("@/actions/responses", () => ({
+  saveResponse: vi.fn(async () => ({ success: true })),
+}));
+
+async function loadPOST() {
+  return (await import("@/app/api/autosave/route")).POST;
+}
+
+function makeRequest(
+  body: unknown,
+  {
+    origin = "https://app.test",
+    host = "app.test",
+    rawBody,
+  }: { origin?: string | null; host?: string | null; rawBody?: string } = {},
+) {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (origin !== null) headers.set("origin", origin);
+  if (host !== null) headers.set("host", host);
+  return new Request("https://app.test/api/autosave", {
+    method: "POST",
+    headers,
+    body: rawBody ?? JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  projectId: "proj-1",
+  documentId: "doc-1",
+  answers: { q1: "a" },
+  notes: "comentario",
+};
+
+beforeEach(() => {
+  vi.mocked(saveResponse).mockClear();
+  vi.mocked(saveResponse).mockResolvedValue({ success: true });
+});
+
+describe("POST /api/autosave — validacao de origem", () => {
+  it("rejeita request sem header Origin com 403", async () => {
+    const POST = await loadPOST();
+    const res = await POST(makeRequest(validBody, { origin: null }));
+    expect(res.status).toBe(403);
+    expect(saveResponse).not.toHaveBeenCalled();
+  });
+
+  it("rejeita Origin que nao bate com Host com 403", async () => {
+    const POST = await loadPOST();
+    const res = await POST(
+      makeRequest(validBody, { origin: "https://evil.test" }),
+    );
+    expect(res.status).toBe(403);
+    expect(saveResponse).not.toHaveBeenCalled();
+  });
+
+  it("aceita Origin same-origin", async () => {
+    const POST = await loadPOST();
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/autosave — validacao de body", () => {
+  it("rejeita JSON invalido com 400", async () => {
+    const POST = await loadPOST();
+    const res = await POST(makeRequest(null, { rawBody: "{nao-e-json" }));
+    expect(res.status).toBe(400);
+    expect(saveResponse).not.toHaveBeenCalled();
+  });
+
+  it("rejeita projectId/documentId ausentes com 400", async () => {
+    const POST = await loadPOST();
+    const res = await POST(
+      makeRequest({ answers: { q1: "a" } }),
+    );
+    expect(res.status).toBe(400);
+    expect(saveResponse).not.toHaveBeenCalled();
+  });
+
+  it("rejeita answers nao-objeto com 400", async () => {
+    const POST = await loadPOST();
+    const res = await POST(
+      makeRequest({ projectId: "p", documentId: "d", answers: [] }),
+    );
+    expect(res.status).toBe(400);
+    expect(saveResponse).not.toHaveBeenCalled();
+  });
+
+  it("rejeita notes nao-string com 400", async () => {
+    const POST = await loadPOST();
+    const res = await POST(
+      makeRequest({
+        projectId: "p",
+        documentId: "d",
+        answers: { q1: "a" },
+        notes: 42,
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(saveResponse).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/autosave — delegacao para saveResponse", () => {
+  it("delega com isAutoSave=true e responde 200", async () => {
+    const POST = await loadPOST();
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(saveResponse).toHaveBeenCalledWith(
+      "proj-1",
+      "doc-1",
+      { q1: "a" },
+      { notes: "comentario", isAutoSave: true },
+    );
+  });
+
+  it("nao vaza o erro cru do saveResponse na resposta 500", async () => {
+    vi.mocked(saveResponse).mockResolvedValue({
+      success: false,
+      error: "duplicate key value violates unique constraint",
+    });
+    const POST = await loadPOST();
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Falha ao salvar");
+    expect(json.error).not.toContain("constraint");
+  });
+});

--- a/frontend/src/app/api/autosave/route.ts
+++ b/frontend/src/app/api/autosave/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { saveResponse } from "@/actions/responses";
+
+// Endpoint dedicado ao autosave disparado via navigator.sendBeacon no
+// visibilitychange (#28). Server Actions sao requests POST que o browser pode
+// abortar ao fechar a tab; sendBeacon/keepalive garantem a entrega. A auth
+// continua automatica: sendBeacon envia os cookies do Clerk numa request
+// same-origin, entao saveResponse() resolve o usuario normalmente.
+export async function POST(request: Request) {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalido" }, { status: 400 });
+  }
+
+  if (typeof payload !== "object" || payload === null) {
+    return NextResponse.json({ error: "Body invalido" }, { status: 400 });
+  }
+
+  const { projectId, documentId, answers, notes } = payload as Record<
+    string,
+    unknown
+  >;
+
+  if (typeof projectId !== "string" || typeof documentId !== "string") {
+    return NextResponse.json(
+      { error: "projectId e documentId obrigatorios" },
+      { status: 400 },
+    );
+  }
+  if (typeof answers !== "object" || answers === null || Array.isArray(answers)) {
+    return NextResponse.json({ error: "answers invalido" }, { status: 400 });
+  }
+  if (notes !== undefined && typeof notes !== "string") {
+    return NextResponse.json({ error: "notes invalido" }, { status: 400 });
+  }
+
+  const result = await saveResponse(
+    projectId,
+    documentId,
+    answers as Record<string, unknown>,
+    { notes, isAutoSave: true },
+  );
+
+  if (!result.success) {
+    // sendBeacon e fire-and-forget; o status serve para observabilidade em logs.
+    console.error("[autosave] falhou:", result.error);
+    return NextResponse.json({ error: result.error }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/frontend/src/app/api/autosave/route.ts
+++ b/frontend/src/app/api/autosave/route.ts
@@ -7,6 +7,17 @@ import { saveResponse } from "@/actions/responses";
 // continua automatica: sendBeacon envia os cookies do Clerk numa request
 // same-origin, entao saveResponse() resolve o usuario normalmente.
 export async function POST(request: Request) {
+  // Route handlers nao tem a protecao CSRF embutida das Server Actions. O
+  // autosave so e legitimo same-origin: exigimos que o header Origin exista e
+  // bata com o Host. Na pratica o cookie SameSite=Lax do Clerk e o
+  // Content-Type application/json (nao CORS-safelisted) ja barram o ataque
+  // cross-site, mas o check torna a intencao explicita e a prova de regressao.
+  const origin = request.headers.get("origin");
+  const host = request.headers.get("host");
+  if (!origin || !host || new URL(origin).host !== host) {
+    return NextResponse.json({ error: "Origem invalida" }, { status: 403 });
+  }
+
   let payload: unknown;
   try {
     payload = await request.json();
@@ -45,8 +56,10 @@ export async function POST(request: Request) {
 
   if (!result.success) {
     // sendBeacon e fire-and-forget; o status serve para observabilidade em logs.
+    // O detalhe do erro vai so para o log do server — a resposta devolve uma
+    // mensagem generica para nao vazar mensagens cruas do Postgres.
     console.error("[autosave] falhou:", result.error);
-    return NextResponse.json({ error: result.error }, { status: 500 });
+    return NextResponse.json({ error: "Falha ao salvar" }, { status: 500 });
   }
 
   return NextResponse.json({ success: true });

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -275,9 +275,17 @@ export function CodingPage({
     ) => {
       const body = JSON.stringify({ projectId, documentId, answers, notes });
       const blob = new Blob([body], { type: "application/json" });
-      const queued =
-        typeof navigator.sendBeacon === "function" &&
-        navigator.sendBeacon("/api/autosave", blob);
+      // sendBeacon pode lancar sincronamente em alguns browsers (ex.: payload
+      // acima do limite da fila). Tratamos como "nao enfileirado" para cair no
+      // fallback fetch keepalive em vez de estourar o handler de evento.
+      let queued = false;
+      try {
+        queued =
+          typeof navigator.sendBeacon === "function" &&
+          navigator.sendBeacon("/api/autosave", blob);
+      } catch (err) {
+        console.error("[auto-save] sendBeacon falhou:", err);
+      }
       if (!queued) {
         // Fallback: sendBeacon indisponivel ou fila cheia. keepalive tem o
         // mesmo efeito (sobrevive ao unload) mas permite headers.

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -262,33 +262,43 @@ export function CodingPage({
   }, [mode, currentDoc?.id, selectedBrowseDoc?.id, dirtyDocs]);
 
   // Auto-save when tab loses visibility (fallback for close without confirm).
-  // A aba ja esta hidden — nao da pra mostrar toast, entao logamos no console
-  // para que falhas silenciosas apareçam ao menos em devtools/error tracking.
+  // Usa navigator.sendBeacon -> /api/autosave (#28): Server Actions sao POSTs
+  // normais que o browser pode abortar ao fechar a tab, perdendo o save.
+  // sendBeacon/keepalive sao projetados para entregar dados durante o unload.
+  // A aba ja esta hidden — nao da pra mostrar toast, e o envio e
+  // fire-and-forget, entao falhas so aparecem no console / logs do server.
   useEffect(() => {
-    const logAutoSaveResult = (
-      p: Promise<{ success: boolean; error?: string }>,
+    const beaconSave = (
+      documentId: string,
+      answers: Record<string, unknown>,
+      notes: string,
     ) => {
-      p.then((r) => {
-        if (!r.success) console.error("[auto-save] falhou:", r.error);
-      }).catch((err) => console.error("[auto-save] exceção:", err));
+      const body = JSON.stringify({ projectId, documentId, answers, notes });
+      const blob = new Blob([body], { type: "application/json" });
+      const queued =
+        typeof navigator.sendBeacon === "function" &&
+        navigator.sendBeacon("/api/autosave", blob);
+      if (!queued) {
+        // Fallback: sendBeacon indisponivel ou fila cheia. keepalive tem o
+        // mesmo efeito (sobrevive ao unload) mas permite headers.
+        fetch("/api/autosave", {
+          method: "POST",
+          keepalive: true,
+          headers: { "Content-Type": "application/json" },
+          body,
+        }).catch((err) => console.error("[auto-save] exceção:", err));
+      }
     };
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "hidden") {
-        if (mode === "assigned" && currentDoc && dirtyDocs.has(currentDoc.id)) {
-          logAutoSaveResult(
-            saveResponse(projectId, currentDoc.id, docAnswers, {
-              notes: docNotes,
-              isAutoSave: true,
-            }),
-          );
-        } else if (mode === "browse" && selectedBrowseDoc && dirtyDocs.has(selectedBrowseDoc.id)) {
-          logAutoSaveResult(
-            saveResponse(projectId, selectedBrowseDoc.id, browseAnswers, {
-              notes: browseNotes,
-              isAutoSave: true,
-            }),
-          );
-        }
+      if (document.visibilityState !== "hidden") return;
+      if (mode === "assigned" && currentDoc && dirtyDocs.has(currentDoc.id)) {
+        beaconSave(currentDoc.id, docAnswers, docNotes);
+      } else if (
+        mode === "browse" &&
+        selectedBrowseDoc &&
+        dirtyDocs.has(selectedBrowseDoc.id)
+      ) {
+        beaconSave(selectedBrowseDoc.id, browseAnswers, browseNotes);
       }
     };
     document.addEventListener("visibilitychange", handleVisibilityChange);


### PR DESCRIPTION
## Contexto

Resolve #28. O autosave no `visibilitychange` chamava a Server Action `saveResponse()` diretamente. Server Actions sao requests POST normais, e o browser pode aborta-las durante o fechamento da tab — resultando em perda de dados quando o usuario fecha a tab logo apos editar, ou sob pressao de memoria.

## Mudancas

- **Novo API route `POST /api/autosave`** (`frontend/src/app/api/autosave/route.ts`): valida o body (`projectId`, `documentId`, `answers`, `notes`) e delega para `saveResponse(..., { isAutoSave: true })`. A auth continua automatica — `sendBeacon` envia os cookies do Clerk numa request same-origin, entao `getAuthUser()` resolve o usuario normalmente.
- **`CodingPage.tsx`**: o handler de `visibilitychange` agora usa `navigator.sendBeacon('/api/autosave', blob)`, com fallback para `fetch(..., { keepalive: true })` quando `sendBeacon` esta indisponivel ou a fila esta cheia. Ambas as APIs sao projetadas para entregar dados de forma confiavel durante o unload da pagina.

Saves manuais e de navegacao (`handleSubmit`, `handleDocNavigate`, etc.) continuam usando `saveResponse()` direto — apenas o `visibilitychange` mudou.

## Notas

- Envio e fire-and-forget: a aba ja esta `hidden`, nao da pra mostrar toast. Falhas vao para o `console` e para os logs do server (`[autosave] falhou:`).
- `revalidatePath` nao roda nesse caminho (`isAutoSave: true`), mantendo o comportamento atual de nao re-fetchar o RSC tree em autosave.

## Test plan

- [x] `npx tsc --noEmit` limpo
- [x] `eslint` nos arquivos alterados — sem erros novos (os 2 erros restantes em `CodingPage.tsx` sao pre-existentes na baseline)
- [x] `npm run build` compila, rota `/api/autosave` registrada
- [x] `vitest run` em `responses.test.ts` — 12/12 passando
- [ ] Testar no browser: editar resposta, trocar de tab, confirmar que o save chega (verificar request `/api/autosave` no Network)
- [ ] Testar fechamento real de tab apos edicao

🤖 Generated with [Claude Code](https://claude.com/claude-code)