### PR TITLE
feat(llm): endpoint de preview do prompt no backend

### DIFF
--- a/backend/routes/llm_routes.py
+++ b/backend/routes/llm_routes.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, BackgroundTasks
 from pydantic import BaseModel
 
 from services.llm_runner import (
+    _build_prompt,
     get_job_status,
     init_job,
     mark_stale_runs_as_error,
@@ -102,6 +103,28 @@ class CleanupRequest(BaseModel):
 
 class CleanupResponse(BaseModel):
     cleaned: int
+
+
+class PreviewPromptRequest(BaseModel):
+    project_description: str | None = None
+    prompt_template: str | None = None
+
+
+class PreviewPromptResponse(BaseModel):
+    prompt: str
+
+
+@router.post("/preview-prompt", response_model=PreviewPromptResponse)
+async def preview_prompt(req: PreviewPromptRequest):
+    """Monta o prompt final igual ao usado na execução real.
+
+    Single source of truth: o frontend (LlmConfigurePane) consome este
+    endpoint em vez de duplicar a lógica de _build_prompt. Se a montagem
+    do prompt mudar no backend, o preview acompanha sem ficar defasado.
+    """
+    return PreviewPromptResponse(
+        prompt=_build_prompt(req.project_description, req.prompt_template)
+    )
 
 
 @router.post("/cleanup-stale", response_model=CleanupResponse)

--- a/backend/tests/test_llm_preview_prompt.py
+++ b/backend/tests/test_llm_preview_prompt.py
@@ -1,0 +1,50 @@
+"""Tests for /api/llm/preview-prompt — single source of truth do prompt.
+
+O endpoint só reusa _build_prompt; estes testes garantem que a rota
+encaminha description + template e que o resultado bate com a função
+usada na execução real (sem a cópia hardcoded do frontend defasar).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from services.llm_runner import _build_prompt
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+def test_preview_matches_build_prompt(client: TestClient) -> None:
+    payload = {
+        "project_description": "Estudo sobre liminares em saúde.",
+        "prompt_template": "Foque no dispositivo da decisão.",
+    }
+    r = client.post("/api/llm/preview-prompt", json=payload)
+    assert r.status_code == 200
+    assert r.json() == {
+        "prompt": _build_prompt(
+            payload["project_description"], payload["prompt_template"]
+        )
+    }
+
+
+def test_preview_omits_optional_sections_when_blank(client: TestClient) -> None:
+    r = client.post(
+        "/api/llm/preview-prompt",
+        json={"project_description": "  ", "prompt_template": ""},
+    )
+    assert r.status_code == 200
+    prompt = r.json()["prompt"]
+    assert "## Contexto do estudo" not in prompt
+    assert "## Instrucoes adicionais" not in prompt
+    assert "## Instrucoes gerais" in prompt
+
+
+def test_preview_accepts_missing_fields(client: TestClient) -> None:
+    r = client.post("/api/llm/preview-prompt", json={})
+    assert r.status_code == 200
+    assert r.json()["prompt"] == _build_prompt(None, None)

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -114,6 +114,13 @@ export function LlmConfigurePane({
   const [prompt, setPrompt] = useState(initialPrompt);
   const [savingPrompt, setSavingPrompt] = useState(false);
 
+  // Preview do prompt final — montado pelo backend (/api/llm/preview-prompt)
+  // para não duplicar a lógica de _build_prompt no frontend.
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const [previewPrompt, setPreviewPrompt] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
   // Config state
   const [config, setConfig] = useState(initialConfig);
 
@@ -167,6 +174,41 @@ export function LlmConfigurePane({
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
   }, []);
+
+  // Busca o preview do prompt no backend enquanto o collapsible está aberto.
+  // Debounce de 300ms porque `prompt` muda a cada tecla na textarea.
+  useEffect(() => {
+    if (!previewOpen) return;
+    let cancelled = false;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetchFastAPI<{ prompt: string }>(
+          "/api/llm/preview-prompt",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              project_description: projectDescription,
+              prompt_template: prompt,
+            }),
+          }
+        );
+        if (!cancelled) setPreviewPrompt(res.prompt);
+      } catch (e) {
+        if (!cancelled)
+          setPreviewError(
+            e instanceof Error ? e.message : "Erro ao carregar preview"
+          );
+      } finally {
+        if (!cancelled) setPreviewLoading(false);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [previewOpen, prompt, projectDescription]);
 
   // useCallback para referência estável — usado como dep do useEffect de
   // retomada de polling abaixo. Sem isso, o lint warning forçava um
@@ -423,35 +465,29 @@ export function LlmConfigurePane({
             para adicionar instruções complementares.
           </p>
 
-          <Collapsible>
+          <Collapsible open={previewOpen} onOpenChange={setPreviewOpen}>
             <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors group">
               <ChevronRight className="h-3 w-3 transition-transform group-data-[state=open]:rotate-90" />
               Ver preview do prompt final
             </CollapsibleTrigger>
             <CollapsibleContent>
               <div className="mt-2 rounded-md border bg-muted/50 p-4 text-sm whitespace-pre-wrap max-h-64 overflow-y-auto">
-                <p>Voce e um assistente de pesquisa especializado em analise de conteudo.</p>
-                <p>Analise o documento fornecido e responda as perguntas de classificacao.</p>
-                <p className="mt-2 font-medium">## Instrucoes gerais</p>
-                <p>- Leia o documento completo antes de classificar.</p>
-                <p>- Baseie suas respostas exclusivamente no conteudo do documento.</p>
-                <p>- Se houver ambiguidade, escolha a opcao mais conservadora.</p>
-                <p>- Para campos de texto, seja conciso e objetivo.</p>
-                {projectDescription.trim() && (
-                  <>
-                    <p className="mt-2 font-medium">## Contexto do estudo</p>
-                    <p>{projectDescription}</p>
-                  </>
-                )}
-                {!projectDescription.trim() && (
-                  <p className="mt-2 text-muted-foreground italic">
-                    (Sem descrição do projeto — configure em Config → Geral)
+                {previewLoading && (
+                  <p className="text-muted-foreground italic">
+                    Carregando preview…
                   </p>
                 )}
-                {prompt.trim() && (
+                {!previewLoading && previewError && (
+                  <p className="text-destructive">{previewError}</p>
+                )}
+                {!previewLoading && !previewError && previewPrompt !== null && (
                   <>
-                    <p className="mt-2 font-medium">## Instrucoes adicionais</p>
-                    <p>{prompt}</p>
+                    {previewPrompt}
+                    {!projectDescription.trim() && (
+                      <p className="mt-2 text-muted-foreground italic">
+                        (Sem descrição do projeto — configure em Config → Geral)
+                      </p>
+                    )}
                   </>
                 )}
               </div>

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -180,9 +180,11 @@ export function LlmConfigurePane({
   useEffect(() => {
     if (!previewOpen) return;
     let cancelled = false;
-    setPreviewLoading(true);
     setPreviewError(null);
     const timer = setTimeout(async () => {
+      // Loading só dentro do debounce: durante a digitação o preview
+      // anterior continua visível em vez de piscar "Carregando…" a cada tecla.
+      if (!cancelled) setPreviewLoading(true);
       try {
         const res = await fetchFastAPI<{ prompt: string }>(
           "/api/llm/preview-prompt",
@@ -472,7 +474,7 @@ export function LlmConfigurePane({
             </CollapsibleTrigger>
             <CollapsibleContent>
               <div className="mt-2 rounded-md border bg-muted/50 p-4 text-sm whitespace-pre-wrap max-h-64 overflow-y-auto">
-                {previewLoading && (
+                {(previewLoading || (previewPrompt === null && !previewError)) && (
                   <p className="text-muted-foreground italic">
                     Carregando preview…
                   </p>


### PR DESCRIPTION
## Summary
- Adiciona endpoint `POST /api/llm/preview-prompt` que monta o prompt final via `_build_prompt` (mesma lógica da execução real)
- `LlmConfigurePane` agora consome esse endpoint em vez de duplicar a estrutura do prompt em JSX hardcoded — fetch debounced (300ms) enquanto o collapsible está aberto
- Testes do endpoint em `backend/tests/test_llm_preview_prompt.py`

## Motivo
O preview era uma cópia hardcoded de `_build_prompt()`; se a lógica do backend mudasse, o preview ficava defasado silenciosamente. Agora há single source of truth.

## Test plan
- [x] `pytest` backend — 94 testes passam (3 novos)
- [x] `vitest run src/components/llm` — 12 testes passam
- [ ] Verificar UI: abrir aba LLM -> Config -> "Ver preview do prompt final" carrega do backend e reflete edições nas instruções adicionais

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)