### PR TITLE
feat(coding): scroll suave automatico para pergunta condicional revelada

### DIFF
--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { isFieldVisible } from "@/lib/conditional";
 import { reorderFullList } from "@/lib/field-order";
+import { getScrollBehavior } from "@/lib/scroll";
 import type { PydanticField } from "@/lib/types";
 import {
   DndContext,
@@ -142,8 +143,8 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
   // Rastreia quais campos estavam visíveis no render anterior para detectar
-  // condicionais que acabaram de aparecer. `null` = ainda não hidratado.
-  const prevVisibleNamesRef = useRef<Set<string> | null>(null);
+  // condicionais que acabaram de aparecer.
+  const prevVisibleNamesRef = useRef<Set<string>>(new Set());
   // Mudança de schema (prop `fields`) também muda `visibleNames`; este flag
   // evita scrollar nesse caso — só queremos scrollar em resposta do usuário.
   const skipScrollRef = useRef(false);
@@ -190,7 +191,6 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
       skipScrollRef.current = false;
       return;
     }
-    if (prev === null) return; // hidratação inicial
     if (readOnly) return;
 
     const newIdx = visibleFields.findIndex(
@@ -199,7 +199,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     if (newIdx < 0) return;
 
     questionRefs.current[newIdx]?.scrollIntoView({
-      behavior: "smooth",
+      behavior: getScrollBehavior(),
       block: "center",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -238,7 +238,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     if (unanswered.length > 0) {
       setHighlightedFields(new Set(unanswered));
       const firstIdx = visibleFields.findIndex((f) => unanswered.includes(f.name));
-      questionRefs.current[firstIdx]?.scrollIntoView({ behavior: "smooth", block: "center" });
+      questionRefs.current[firstIdx]?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" });
       toast.warning("Preencha todas as perguntas obrigatórias");
       return;
     }

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -141,9 +141,16 @@ function SortableQuestion({
 export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false, onReorder }: QuestionsPanelProps) {
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
+  // Rastreia quais campos estavam visíveis no render anterior para detectar
+  // condicionais que acabaram de aparecer. `null` = ainda não hidratado.
+  const prevVisibleNamesRef = useRef<Set<string> | null>(null);
+  // Mudança de schema (prop `fields`) também muda `visibleNames`; este flag
+  // evita scrollar nesse caso — só queremos scrollar em resposta do usuário.
+  const skipScrollRef = useRef(false);
 
   useEffect(() => {
     setHighlightedFields(new Set());
+    skipScrollRef.current = true;
   }, [fields]);
 
   const visibleFields = useMemo(
@@ -168,6 +175,33 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         onAnswer(f.name, null);
       }
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleNames]);
+
+  // Quando uma resposta libera uma pergunta condicional, o DOM atualiza
+  // in-place e o scroll fica parado — o pesquisador pode não perceber a nova
+  // pergunta fora da viewport. Detecta o campo condicional que passou de
+  // invisível para visível e rola suavemente até ele.
+  useEffect(() => {
+    const prev = prevVisibleNamesRef.current;
+    prevVisibleNamesRef.current = visibleNames;
+
+    if (skipScrollRef.current) {
+      skipScrollRef.current = false;
+      return;
+    }
+    if (prev === null) return; // hidratação inicial
+    if (readOnly) return;
+
+    const newIdx = visibleFields.findIndex(
+      (f) => f.condition && !prev.has(f.name),
+    );
+    if (newIdx < 0) return;
+
+    questionRefs.current[newIdx]?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visibleNames]);
 

--- a/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
+++ b/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
@@ -35,11 +35,14 @@ beforeEach(() => {
   Element.prototype.scrollIntoView = vi.fn(function (this: Element) {
     scrolledInto.push(this);
   });
+  // jsdom não implementa matchMedia; getScrollBehavior() depende dele.
+  window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as never;
 });
 
 function renderPanel(props: {
   fields?: PydanticField[];
   answers: Record<string, unknown>;
+  readOnly?: boolean;
 }) {
   return render(
     <QuestionsPanel
@@ -47,6 +50,7 @@ function renderPanel(props: {
       answers={props.answers}
       onAnswer={vi.fn()}
       onSubmit={vi.fn()}
+      readOnly={props.readOnly}
     />,
   );
 }
@@ -138,5 +142,22 @@ describe("QuestionsPanel — scroll automático em condicional (issue #71)", () 
 
     expect(scrolledInto).toHaveLength(1);
     expect(scrolledInto[0].textContent).toContain("Pergunta condicional");
+  });
+
+  it("não scrolla em readOnly mesmo quando uma condicional é liberada", () => {
+    const { rerender } = renderPanel({ answers: {}, readOnly: true });
+    expect(scrolledInto).toHaveLength(0);
+
+    rerender(
+      <QuestionsPanel
+        fields={baseFields}
+        answers={{ q1: "sim" }}
+        onAnswer={vi.fn()}
+        onSubmit={vi.fn()}
+        readOnly
+      />,
+    );
+
+    expect(scrolledInto).toHaveLength(0);
   });
 });

--- a/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
+++ b/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { QuestionsPanel } from "@/components/coding/QuestionsPanel";
+import type { PydanticField } from "@/lib/types";
+
+afterEach(cleanup);
+
+const q1: PydanticField = {
+  name: "q1",
+  type: "single",
+  options: ["sim", "não"],
+  description: "Pergunta gatilho",
+};
+const q2Conditional: PydanticField = {
+  name: "q2",
+  type: "single",
+  options: ["a", "b"],
+  description: "Pergunta condicional",
+  condition: { field: "q1", equals: "sim" },
+};
+const q3: PydanticField = {
+  name: "q3",
+  type: "text",
+  options: null,
+  description: "Pergunta final",
+};
+
+const baseFields = [q1, q2Conditional, q3];
+
+let scrolledInto: Element[];
+
+beforeEach(() => {
+  scrolledInto = [];
+  Element.prototype.scrollIntoView = vi.fn(function (this: Element) {
+    scrolledInto.push(this);
+  });
+});
+
+function renderPanel(props: {
+  fields?: PydanticField[];
+  answers: Record<string, unknown>;
+}) {
+  return render(
+    <QuestionsPanel
+      fields={props.fields ?? baseFields}
+      answers={props.answers}
+      onAnswer={vi.fn()}
+      onSubmit={vi.fn()}
+    />,
+  );
+}
+
+describe("QuestionsPanel — scroll automático em condicional (issue #71)", () => {
+  it("não scrolla na hidratação inicial, mesmo com condicional já visível", () => {
+    renderPanel({ answers: { q1: "sim" } });
+    expect(scrolledInto).toHaveLength(0);
+  });
+
+  it("scrolla até a pergunta condicional quando uma resposta a libera", () => {
+    const { rerender } = renderPanel({ answers: {} });
+    expect(scrolledInto).toHaveLength(0);
+
+    rerender(
+      <QuestionsPanel
+        fields={baseFields}
+        answers={{ q1: "sim" }}
+        onAnswer={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(scrolledInto).toHaveLength(1);
+    expect(scrolledInto[0].textContent).toContain("Pergunta condicional");
+  });
+
+  it("não scrolla ao mudar resposta de pergunta cuja condicional já estava visível", () => {
+    const { rerender } = renderPanel({ answers: { q1: "sim" } });
+    expect(scrolledInto).toHaveLength(0);
+
+    // q2 continua visível (condição ainda satisfeita); só q2 ganhou resposta.
+    rerender(
+      <QuestionsPanel
+        fields={baseFields}
+        answers={{ q1: "sim", q2: "a" }}
+        onAnswer={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(scrolledInto).toHaveLength(0);
+  });
+
+  it("não scrolla quando a prop fields muda (mudança de schema)", () => {
+    const { rerender } = renderPanel({ answers: { q1: "sim" } });
+    expect(scrolledInto).toHaveLength(0);
+
+    // Novo array de fields introduz outra condicional já satisfeita: como o
+    // gatilho foi mudança de schema (não resposta do usuário), não deve rolar.
+    const q4Conditional: PydanticField = {
+      name: "q4",
+      type: "text",
+      options: null,
+      description: "Outra condicional",
+      condition: { field: "q1", equals: "sim" },
+    };
+    rerender(
+      <QuestionsPanel
+        fields={[q1, q2Conditional, q4Conditional, q3]}
+        answers={{ q1: "sim" }}
+        onAnswer={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(scrolledInto).toHaveLength(0);
+  });
+
+  it("scrolla para a primeira condicional quando várias aparecem de uma vez", () => {
+    const q2b: PydanticField = {
+      name: "q2b",
+      type: "text",
+      options: null,
+      description: "Segunda condicional",
+      condition: { field: "q1", equals: "sim" },
+    };
+    const fields = [q1, q2Conditional, q2b, q3];
+    const { rerender } = renderPanel({ fields, answers: {} });
+
+    rerender(
+      <QuestionsPanel
+        fields={fields}
+        answers={{ q1: "sim" }}
+        onAnswer={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    expect(scrolledInto).toHaveLength(1);
+    expect(scrolledInto[0].textContent).toContain("Pergunta condicional");
+  });
+});

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -36,6 +36,7 @@ import {
   getRunningLlmJob,
 } from "@/actions/llm";
 import { fetchFastAPI } from "@/lib/api";
+import { getScrollBehavior } from "@/lib/scroll";
 import { LLM_AMBIGUITIES_FIELD } from "@/lib/standard-questions";
 import {
   getModelsForProvider,
@@ -229,7 +230,7 @@ export function LlmConfigurePane({
                 onClick: () =>
                   document
                     .getElementById("llm-error-card")
-                    ?.scrollIntoView({ behavior: "smooth", block: "center" }),
+                    ?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" }),
               },
             });
           }

--- a/frontend/src/lib/scroll.ts
+++ b/frontend/src/lib/scroll.ts
@@ -1,0 +1,9 @@
+// Retorna "auto" quando o usuário pediu menos animação (prefers-reduced-motion),
+// senão "smooth". Usar nos call sites de scrollIntoView para respeitar a
+// preferência de acessibilidade.
+export function getScrollBehavior(): ScrollBehavior {
+  if (typeof window === "undefined") return "auto";
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ? "auto"
+    : "smooth";
+}


### PR DESCRIPTION
## Resumo

- Quando o pesquisador responde uma pergunta que libera outra condicional, a tela agora rola suavemente ate a nova pergunta — antes o DOM atualizava in-place e o scroll ficava parado, deixando a pergunta facilmente despercebida fora da viewport.
- Implementado em `QuestionsPanel.tsx` via `useEffect` que compara `visibleNames` com o render anterior (`useRef`) e chama `scrollIntoView({ behavior: "smooth", block: "center" })` no primeiro campo condicional que passou de invisivel para visivel.
- Guardas: nao dispara na hidratacao inicial (`prevVisibleNamesRef === null`), em `readOnly`, nem em mudanca de schema (flag `skipScrollRef` setado pelo effect de `[fields]`). Nao scrolla quando o campo ja estava visivel (evita jitter ao trocar resposta).
- Como `QuestionsPanel` e o componente compartilhado entre os modos `assigned` e `browse` do `CodingPage`, o comportamento cobre todas as telas de codificacao automaticamente.

## Testes

- Novo `QuestionsPanel.test.tsx` com 5 casos: sem scroll na hidratacao, scroll ao liberar condicional, sem scroll ao re-responder condicional ja visivel, sem scroll em mudanca de schema, e scroll para a primeira quando varias aparecem juntas.
- `npx vitest run` — 191 testes passando (16 arquivos).
- `npx tsc --noEmit` — limpo.

## Test plan

- [ ] Em um projeto com perguntas condicionais (ex: Zolgensma q11→q10), responder a pergunta gatilho e confirmar que a tela rola suavemente ate a nova pergunta.
- [ ] Trocar a resposta de uma pergunta cuja condicional ja estava visivel — nao deve haver jitter.
- [ ] Testar condicionais aninhadas (ex: q26 depende de q25 que aparece quando q21 muda).

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)