### PR TITLE
perf(reviews): banner visível quando fetchReviewBaseData trunca dados

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/reviews/confusion/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/confusion/page.tsx
@@ -6,6 +6,7 @@ import {
   computeConfusionData,
 } from "@/lib/reviews/queries";
 import { ConfusionMatrix } from "@/components/reviews/ConfusionMatrix";
+import { TruncationBanner } from "@/components/reviews/TruncationBanner";
 
 export default async function ConfusionPage({
   params,
@@ -23,15 +24,19 @@ export default async function ConfusionPage({
 
   if (confusionDataList.length === 0) {
     return (
-      <p className="py-12 text-center text-sm text-muted-foreground">
-        Nenhum dado de confusão disponível. Revise documentos na aba Comparar
-        para gerar dados.
-      </p>
+      <div className="mx-auto max-w-5xl space-y-4 p-6">
+        <TruncationBanner truncated={ctx.truncated} />
+        <p className="py-12 text-center text-sm text-muted-foreground">
+          Nenhum dado de confusão disponível. Revise documentos na aba Comparar
+          para gerar dados.
+        </p>
+      </div>
     );
   }
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
+      <TruncationBanner truncated={ctx.truncated} />
       <ConfusionMatrix confusionDataList={confusionDataList} />
     </div>
   );

--- a/frontend/src/app/(app)/projects/[id]/reviews/confusion/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/confusion/page.tsx
@@ -24,7 +24,7 @@ export default async function ConfusionPage({
 
   if (confusionDataList.length === 0) {
     return (
-      <div className="mx-auto max-w-5xl space-y-4 p-6">
+      <div className="mx-auto max-w-5xl p-6 space-y-4">
         <TruncationBanner truncated={ctx.truncated} />
         <p className="py-12 text-center text-sm text-muted-foreground">
           Nenhum dado de confusão disponível. Revise documentos na aba Comparar

--- a/frontend/src/app/(app)/projects/[id]/reviews/difficulty/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/difficulty/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/reviews/queries";
 import { HardestDocuments } from "@/components/reviews/HardestDocuments";
 import { DateSinceFilter } from "@/components/reviews/DateSinceFilter";
+import { TruncationBanner } from "@/components/reviews/TruncationBanner";
 
 export default async function DifficultyPage({
   params,
@@ -49,6 +50,7 @@ export default async function DifficultyPage({
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
+      <TruncationBanner truncated={ctx.truncated} />
       <DateSinceFilter />
       {hardestDocuments.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">

--- a/frontend/src/app/(app)/projects/[id]/reviews/gabarito/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/gabarito/page.tsx
@@ -6,6 +6,7 @@ import {
   computeReviewedDocuments,
 } from "@/lib/reviews/queries";
 import { GabaritoByDocument } from "@/components/reviews/GabaritoByDocument";
+import { TruncationBanner } from "@/components/reviews/TruncationBanner";
 
 export default async function GabaritoPage({
   params,
@@ -23,14 +24,19 @@ export default async function GabaritoPage({
 
   if (reviewedDocuments.length === 0) {
     return (
-      <p className="py-12 text-center text-sm text-muted-foreground">
-        Nenhuma revisão encontrada. Comece revisando documentos na aba Comparar.
-      </p>
+      <div className="mx-auto max-w-5xl space-y-4 p-6">
+        <TruncationBanner truncated={ctx.truncated} />
+        <p className="py-12 text-center text-sm text-muted-foreground">
+          Nenhuma revisão encontrada. Comece revisando documentos na aba
+          Comparar.
+        </p>
+      </div>
     );
   }
 
   return (
-    <div className="mx-auto max-w-5xl p-6">
+    <div className="mx-auto max-w-5xl space-y-4 p-6">
+      <TruncationBanner truncated={ctx.truncated} />
       <GabaritoByDocument
         reviewedDocuments={reviewedDocuments}
         fields={ctx.comparableFields}

--- a/frontend/src/app/(app)/projects/[id]/reviews/gabarito/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/gabarito/page.tsx
@@ -24,7 +24,7 @@ export default async function GabaritoPage({
 
   if (reviewedDocuments.length === 0) {
     return (
-      <div className="mx-auto max-w-5xl space-y-4 p-6">
+      <div className="mx-auto max-w-5xl p-6 space-y-4">
         <TruncationBanner truncated={ctx.truncated} />
         <p className="py-12 text-center text-sm text-muted-foreground">
           Nenhuma revisão encontrada. Comece revisando documentos na aba
@@ -35,7 +35,7 @@ export default async function GabaritoPage({
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-4 p-6">
+    <div className="mx-auto max-w-5xl p-6 space-y-4">
       <TruncationBanner truncated={ctx.truncated} />
       <GabaritoByDocument
         reviewedDocuments={reviewedDocuments}

--- a/frontend/src/app/(app)/projects/[id]/reviews/respondents/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/respondents/page.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/reviews/queries";
 import { RespondentProfile } from "@/components/reviews/RespondentProfile";
 import { DateSinceFilter } from "@/components/reviews/DateSinceFilter";
+import { TruncationBanner } from "@/components/reviews/TruncationBanner";
 
 export default async function RespondentsPage({
   params,
@@ -49,6 +50,7 @@ export default async function RespondentsPage({
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
+      <TruncationBanner truncated={ctx.truncated} />
       <DateSinceFilter />
       {respondentProfiles.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">

--- a/frontend/src/components/reviews/TruncationBanner.tsx
+++ b/frontend/src/components/reviews/TruncationBanner.tsx
@@ -29,7 +29,10 @@ export function TruncationBanner({
   const labels = affected.map((k) => TABLE_LABELS[k]).join(", ");
 
   return (
-    <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2.5 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+    <div
+      role="status"
+      className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2.5 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300"
+    >
       <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
       <div>
         <p className="font-medium">Estatísticas possivelmente incompletas</p>

--- a/frontend/src/components/reviews/TruncationBanner.tsx
+++ b/frontend/src/components/reviews/TruncationBanner.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle } from "lucide-react";
+import {
+  REVIEW_BASE_DATA_LIMIT,
+  type ReviewDataTruncation,
+} from "@/lib/reviews/queries";
+
+const TABLE_LABELS: Record<keyof ReviewDataTruncation, string> = {
+  responses: "respostas",
+  reviews: "revisões",
+  documents: "documentos",
+};
+
+/**
+ * Banner exibido quando alguma das queries de fetchReviewBaseData atingiu o
+ * teto de REVIEW_BASE_DATA_LIMIT linhas. Sem ele, as estatisticas agregadas
+ * das paginas de reviews ficariam silenciosamente erradas. Ver issue #105.
+ */
+export function TruncationBanner({
+  truncated,
+}: {
+  truncated: ReviewDataTruncation;
+}) {
+  const affected = (
+    Object.keys(truncated) as (keyof ReviewDataTruncation)[]
+  ).filter((k) => truncated[k]);
+
+  if (affected.length === 0) return null;
+
+  const labels = affected.map((k) => TABLE_LABELS[k]).join(", ");
+
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2.5 text-sm text-amber-800 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-300">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+      <div>
+        <p className="font-medium">Estatísticas possivelmente incompletas</p>
+        <p className="text-amber-700 dark:text-amber-400">
+          As tabelas de {labels} atingiram o limite de{" "}
+          {REVIEW_BASE_DATA_LIMIT.toLocaleString("pt-BR")} linhas carregadas.
+          Os números abaixo podem estar truncados e não refletir o projeto
+          inteiro.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/reviews/__tests__/queries.test.ts
+++ b/frontend/src/lib/reviews/__tests__/queries.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeTruncation,
+  REVIEW_BASE_DATA_LIMIT,
+} from "@/lib/reviews/queries";
+
+// Array esparso: `.length` e o teto sem alocar 50k elementos.
+const atLimit = () => Array(REVIEW_BASE_DATA_LIMIT);
+const belowLimit = () => Array(REVIEW_BASE_DATA_LIMIT - 1);
+
+describe("computeTruncation — flags do TruncationBanner (issue #105)", () => {
+  it("nenhuma tabela no teto → todas false", () => {
+    expect(computeTruncation(belowLimit(), belowLimit(), belowLimit())).toEqual({
+      responses: false,
+      reviews: false,
+      documents: false,
+    });
+  });
+
+  it("marca apenas a tabela que atingiu o teto", () => {
+    expect(computeTruncation(atLimit(), belowLimit(), belowLimit())).toEqual({
+      responses: true,
+      reviews: false,
+      documents: false,
+    });
+    expect(computeTruncation(belowLimit(), atLimit(), belowLimit())).toEqual({
+      responses: false,
+      reviews: true,
+      documents: false,
+    });
+    expect(computeTruncation(belowLimit(), belowLimit(), atLimit())).toEqual({
+      responses: false,
+      reviews: false,
+      documents: true,
+    });
+  });
+
+  it("todas no teto → todas true", () => {
+    expect(computeTruncation(atLimit(), atLimit(), atLimit())).toEqual({
+      responses: true,
+      reviews: true,
+      documents: true,
+    });
+  });
+
+  it("query que falhou (null) nao conta como truncada", () => {
+    expect(computeTruncation(null, null, null)).toEqual({
+      responses: false,
+      reviews: false,
+      documents: false,
+    });
+  });
+
+  it("array vazio nao conta como truncado", () => {
+    expect(computeTruncation([], [], [])).toEqual({
+      responses: false,
+      reviews: false,
+      documents: false,
+    });
+  });
+});

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -37,6 +37,12 @@ interface ReviewRow {
 
 /* ── Context shared across computations ── */
 
+export interface ReviewDataTruncation {
+  responses: boolean;
+  reviews: boolean;
+  documents: boolean;
+}
+
 export interface ReviewComputationContext {
   fields: PydanticField[];
   comparableFields: PydanticField[];
@@ -47,6 +53,10 @@ export interface ReviewComputationContext {
   responsesByDoc: Map<string, ResponseRow[]>;
   uniqueReviews: ReviewRow[];
   profileMap: Map<string, string>;
+  // true para cada tabela cuja query atingiu REVIEW_BASE_DATA_LIMIT — os
+  // dados agregados podem estar silenciosamente errados. As paginas de
+  // reviews renderizam um TruncationBanner quando alguma flag e true.
+  truncated: ReviewDataTruncation;
 }
 
 /* ── Pure helpers ── */
@@ -140,7 +150,7 @@ function getRespondentDisplayName(
 
 /* ── Fetch base data ── */
 
-const REVIEW_BASE_DATA_LIMIT = 50000;
+export const REVIEW_BASE_DATA_LIMIT = 50000;
 
 export async function fetchReviewBaseData(
   supabase: SupabaseClient,
@@ -187,12 +197,13 @@ export async function fetchReviewBaseData(
       .limit(REVIEW_BASE_DATA_LIMIT),
   ]);
 
-  for (const [name, rows] of [
-    ["responses", responses],
-    ["reviews", reviews],
-    ["documents", documents],
-  ] as const) {
-    if (rows && rows.length === REVIEW_BASE_DATA_LIMIT) {
+  const truncated: ReviewDataTruncation = {
+    responses: responses?.length === REVIEW_BASE_DATA_LIMIT,
+    reviews: reviews?.length === REVIEW_BASE_DATA_LIMIT,
+    documents: documents?.length === REVIEW_BASE_DATA_LIMIT,
+  };
+  for (const [name, isTruncated] of Object.entries(truncated)) {
+    if (isTruncated) {
       console.warn(
         `fetchReviewBaseData: ${name} atingiu o teto de ${REVIEW_BASE_DATA_LIMIT} linhas para o projeto ${projectId} — dados podem estar truncados, considere paginar.`,
       );
@@ -278,6 +289,7 @@ export async function fetchReviewBaseData(
     responsesByDoc,
     uniqueReviews,
     profileMap,
+    truncated,
   };
 }
 

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -152,6 +152,23 @@ function getRespondentDisplayName(
 
 export const REVIEW_BASE_DATA_LIMIT = 50000;
 
+/**
+ * Marca como `true` cada tabela cuja query atingiu o teto de
+ * REVIEW_BASE_DATA_LIMIT linhas. Query que falhou (`null`) nao conta como
+ * truncada — `null?.length` e `undefined`, nunca igual ao teto.
+ */
+export function computeTruncation(
+  responses: unknown[] | null,
+  reviews: unknown[] | null,
+  documents: unknown[] | null,
+): ReviewDataTruncation {
+  return {
+    responses: responses?.length === REVIEW_BASE_DATA_LIMIT,
+    reviews: reviews?.length === REVIEW_BASE_DATA_LIMIT,
+    documents: documents?.length === REVIEW_BASE_DATA_LIMIT,
+  };
+}
+
 export async function fetchReviewBaseData(
   supabase: SupabaseClient,
   projectId: string,
@@ -197,11 +214,7 @@ export async function fetchReviewBaseData(
       .limit(REVIEW_BASE_DATA_LIMIT),
   ]);
 
-  const truncated: ReviewDataTruncation = {
-    responses: responses?.length === REVIEW_BASE_DATA_LIMIT,
-    reviews: reviews?.length === REVIEW_BASE_DATA_LIMIT,
-    documents: documents?.length === REVIEW_BASE_DATA_LIMIT,
-  };
+  const truncated = computeTruncation(responses, reviews, documents);
   for (const [name, isTruncated] of Object.entries(truncated)) {
     if (isTruncated) {
       console.warn(


### PR DESCRIPTION
## Resumo

O teto defensivo de 50k linhas em `fetchReviewBaseData` (`frontend/src/lib/reviews/queries.ts`) só emitia um `console.warn` no servidor quando atingido. Ninguém olha log de produção, então as estatísticas agregadas das 4 páginas de reviews ficariam **silenciosamente erradas** em projetos grandes.

## Decisão

Implementada a **opção 1** da issue (recomendação inicial — mais barata, resolve UX, mantém o teto como safety net):

- `fetchReviewBaseData` agora retorna `truncated: { responses, reviews, documents }` em `ReviewComputationContext`.
- Novo componente `TruncationBanner` (server component) renderiza um banner âmbar listando quais tabelas truncaram.
- As 4 páginas (`gabarito`, `confusion`, `respondents`, `difficulty`) renderizam o banner — inclusive nos estados vazios, já que truncamento + lista vazia também seria enganoso.
- O teto de 50k e o `console.warn` foram mantidos como safety net.
- `REVIEW_BASE_DATA_LIMIT` agora é exportado para o banner exibir o número.

## Test plan

- [ ] Simular projeto com >50k responses (seed/factory) e confirmar que as 4 páginas mostram o banner âmbar
- [ ] Projeto pequeno (abaixo do teto): banner não aparece, páginas renderizam normalmente
- [ ] Estados vazios continuam exibindo a mensagem "Nenhuma revisão encontrada" etc., agora com o banner acima quando aplicável

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)