### PR TITLE
feat(compare): botao "Proximo parecer" no lugar do timer cego de 1.5s

### DIFF
--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -18,7 +18,11 @@ import {
 } from "@/actions/equivalences";
 import { toast } from "sonner";
 import { normalizeForComparison } from "@/lib/utils";
-import { isFreeTextField } from "@/lib/compare-divergence";
+import {
+  isFreeTextField,
+  isDocComplete,
+  findNextPendingDocIndex,
+} from "@/lib/compare-divergence";
 import { buildResponseGroupKeys } from "@/lib/equivalence";
 import type { PydanticField } from "@/lib/types";
 import type { DocCoverage } from "@/app/(app)/projects/[id]/analyze/compare/page";
@@ -160,32 +164,46 @@ export function ComparePage({
 
   const reviewed = docFields.map((fn) => !!localReviews[currentDoc?.id]?.[fn]);
 
-  const reviewedDocsCount = useMemo(() => {
-    return documents.filter((doc) => {
-      const fieldsForDoc = divergentFields[doc.id] || [];
-      if (fieldsForDoc.length === 0) return false;
-      return fieldsForDoc.every((fn) => !!localReviews[doc.id]?.[fn]);
-    }).length;
-  }, [documents, divergentFields, localReviews]);
+  const reviewedDocsCount = useMemo(
+    () =>
+      documents.filter((doc) =>
+        isDocComplete(divergentFields[doc.id], localReviews[doc.id]),
+      ).length,
+    [documents, divergentFields, localReviews],
+  );
 
   // Documento "concluído" = todos os campos divergentes têm veredito. Quando
   // verdadeiro, a UI mostra o botão "Próximo parecer" (com foco automático)
   // em vez de avançar por timer cego.
-  const isCurrentDocComplete = useMemo(() => {
-    if (!currentDoc || allDocDivergent.length === 0) return false;
-    const docReviews = localReviews[currentDoc.id];
-    if (!docReviews) return false;
-    return allDocDivergent.every((fn) => !!docReviews[fn]);
-  }, [currentDoc, allDocDivergent, localReviews]);
+  const isCurrentDocComplete = useMemo(
+    () =>
+      !!currentDoc && isDocComplete(allDocDivergent, localReviews[currentDoc.id]),
+    [currentDoc, allDocDivergent, localReviews],
+  );
 
-  const hasNextDoc = docIndex < documents.length - 1;
+  // `documents` é reordenado pelo servidor a cada revalidate (docs concluídos
+  // afundam para o fim da fila), então o "próximo parecer" precisa ser o
+  // próximo doc com pendências — não `docIndex + 1`, que apontaria para fora
+  // da fila assim que o doc atual fosse concluído.
+  const nextPendingDocIndex = useMemo(
+    () =>
+      findNextPendingDocIndex(
+        documents.map((d) => d.id),
+        divergentFields,
+        localReviews,
+        currentDoc?.id,
+      ),
+    [documents, divergentFields, localReviews, currentDoc],
+  );
+
+  const hasNextDoc = nextPendingDocIndex >= 0;
 
   const handleNextDoc = useCallback(() => {
-    if (docIndex < documents.length - 1) {
-      setPinnedDocId(documents[docIndex + 1].id);
+    if (nextPendingDocIndex >= 0) {
+      setPinnedDocId(documents[nextPendingDocIndex].id);
       setFieldIndex(0);
     }
-  }, [docIndex, documents]);
+  }, [nextPendingDocIndex, documents]);
 
   const currentVerdict = currentDoc && currentFieldName
     ? localReviews[currentDoc.id]?.[currentFieldName] ?? null
@@ -432,6 +450,11 @@ export function ComparePage({
       if (e.key === "n" && fieldIndex < docFields.length - 1) { setFieldIndex(fieldIndex + 1); return; }
       if (e.key === "p" && fieldIndex > 0) { setFieldIndex(fieldIndex - 1); return; }
 
+      // Doc concluído: o avanço é por ação explícita (botão "Próximo parecer"
+      // recebe foco; Enter nele é nativo). Não deixar 1-9/a/s re-disparar
+      // veredito sobre um documento já fechado.
+      if (isCurrentDocComplete) return;
+
       if (!isCurrentFieldDivergent) return;
 
       const isMultiField = currentField?.type === "multi" && currentField.options?.length;
@@ -455,7 +478,7 @@ export function ComparePage({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [answerGroups, handleVerdict, fieldIndex, docFields.length, isFullscreen, isCurrentFieldDivergent, currentField]);
+  }, [answerGroups, handleVerdict, fieldIndex, docFields.length, isFullscreen, isCurrentFieldDivergent, isCurrentDocComplete, currentField]);
 
   const docListEntries: DocListEntry[] = documents.map((d) => {
     const c = coverageByDoc[d.id];

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -111,21 +111,6 @@ export function ComparePage({
     Record<string, Record<string, ExistingVerdictInfo>>
   >(existingReviews);
 
-  const documentsRef = useRef(documents);
-  useEffect(() => {
-    documentsRef.current = documents;
-  }, [documents]);
-
-  const advanceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(() => {
-    return () => {
-      if (advanceTimerRef.current) {
-        clearTimeout(advanceTimerRef.current);
-        advanceTimerRef.current = null;
-      }
-    };
-  }, []);
-
   // O parecer atual é derivado de `pinnedDocId` (última escolha explícita do
   // usuário). `documents` é reordenado pelo Server Component a cada
   // `revalidatePath` (sort por pendências); rastrear por índice numérico
@@ -159,7 +144,10 @@ export function ComparePage({
   }, [pinnedDocId, documents]);
 
   const currentDoc = documents[docIndex];
-  const allDocDivergent = currentDoc ? (divergentFields[currentDoc.id] || []) : [];
+  const allDocDivergent = useMemo(
+    () => (currentDoc ? divergentFields[currentDoc.id] || [] : []),
+    [currentDoc, divergentFields],
+  );
   const divergentSet = useMemo(() => new Set(allDocDivergent), [allDocDivergent]);
 
   const docFields = filter === "all"
@@ -179,6 +167,25 @@ export function ComparePage({
       return fieldsForDoc.every((fn) => !!localReviews[doc.id]?.[fn]);
     }).length;
   }, [documents, divergentFields, localReviews]);
+
+  // Documento "concluído" = todos os campos divergentes têm veredito. Quando
+  // verdadeiro, a UI mostra o botão "Próximo parecer" (com foco automático)
+  // em vez de avançar por timer cego.
+  const isCurrentDocComplete = useMemo(() => {
+    if (!currentDoc || allDocDivergent.length === 0) return false;
+    const docReviews = localReviews[currentDoc.id];
+    if (!docReviews) return false;
+    return allDocDivergent.every((fn) => !!docReviews[fn]);
+  }, [currentDoc, allDocDivergent, localReviews]);
+
+  const hasNextDoc = docIndex < documents.length - 1;
+
+  const handleNextDoc = useCallback(() => {
+    if (docIndex < documents.length - 1) {
+      setPinnedDocId(documents[docIndex + 1].id);
+      setFieldIndex(0);
+    }
+  }, [docIndex, documents]);
 
   const currentVerdict = currentDoc && currentFieldName
     ? localReviews[currentDoc.id]?.[currentFieldName] ?? null
@@ -288,17 +295,6 @@ export function ComparePage({
 
       if (allFieldsReviewed) {
         toast.success("Revisão do documento concluída!");
-        const completedDocId = currentDoc.id;
-        if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
-        advanceTimerRef.current = setTimeout(() => {
-          advanceTimerRef.current = null;
-          const docs = documentsRef.current;
-          const idx = docs.findIndex((d) => d.id === completedDocId);
-          if (idx >= 0 && idx < docs.length - 1) {
-            setPinnedDocId(docs[idx + 1].id);
-            setFieldIndex(0);
-          }
-        }, 1500);
       } else if (fieldIndex < docFields.length - 1) {
         setFieldIndex(fieldIndex + 1);
       }
@@ -382,16 +378,6 @@ export function ComparePage({
         );
         if (allFieldsReviewed) {
           toast.success("Revisão do documento concluída!");
-          if (advanceTimerRef.current) clearTimeout(advanceTimerRef.current);
-          advanceTimerRef.current = setTimeout(() => {
-            advanceTimerRef.current = null;
-            const docs = documentsRef.current;
-            const idx = docs.findIndex((d) => d.id === docId);
-            if (idx >= 0 && idx < docs.length - 1) {
-              setPinnedDocId(docs[idx + 1].id);
-              setFieldIndex(0);
-            }
-          }, 1500);
         } else if (fieldIndex < docFields.length - 1) {
           setFieldIndex(fieldIndex + 1);
         }
@@ -585,6 +571,9 @@ export function ComparePage({
               existingVerdict={currentVerdict}
               reviewed={reviewed}
               isDivergent={isCurrentFieldDivergent}
+              isDocComplete={isCurrentDocComplete}
+              hasNextDoc={hasNextDoc}
+              onNextDoc={handleNextDoc}
               onFieldNavigate={setFieldIndex}
               onVerdict={handleVerdict}
               onMarkReviewed={handleMarkReviewed}

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -123,7 +123,7 @@ export function ComparisonPanel({
   const nextDocButtonRef = useRef<HTMLButtonElement>(null);
   useEffect(() => {
     if (isDocComplete && hasNextDoc) {
-      nextDocButtonRef.current?.focus();
+      nextDocButtonRef.current?.focus({ preventScroll: true });
     }
   }, [isDocComplete, hasNextDoc, documentId]);
 

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ProgressDots } from "../coding/ProgressDots";
 import { AgreementGroup, type FieldEquivalencePair } from "./AgreementGroup";
 import { MultiOptionReview } from "./MultiOptionReview";
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { cn, normalizeForComparison } from "@/lib/utils";
 import { buildResponseGroupKeys } from "@/lib/equivalence";
-import { CheckCircle2, MessageSquare, Lightbulb } from "lucide-react";
+import { ArrowRight, CheckCircle2, MessageSquare, Lightbulb } from "lucide-react";
 import { AddNoteButton } from "@/components/shared/AddNoteButton";
 import { SuggestFieldDialog } from "@/components/stats/SuggestFieldDialog";
 import type { PydanticField } from "@/lib/types";
@@ -62,6 +62,9 @@ interface ComparisonPanelProps {
   existingVerdict: ExistingVerdict | null;
   reviewed: boolean[];
   isDivergent: boolean;
+  isDocComplete: boolean;
+  hasNextDoc: boolean;
+  onNextDoc: () => void;
   onFieldNavigate: (index: number) => void;
   onVerdict: (verdict: string, chosenResponseId?: string) => void;
   onMarkReviewed: () => void;
@@ -96,6 +99,9 @@ export function ComparisonPanel({
   existingVerdict,
   reviewed,
   isDivergent,
+  isDocComplete,
+  hasNextDoc,
+  onNextDoc,
   onFieldNavigate,
   onVerdict,
   onMarkReviewed,
@@ -111,6 +117,15 @@ export function ComparisonPanel({
   canManageAnyPair,
 }: ComparisonPanelProps) {
   const [suggestOpen, setSuggestOpen] = useState(false);
+
+  // Quando o documento é concluído, o botão "Próximo parecer" recebe foco
+  // automático para que um único Enter avance — sem timer cego.
+  const nextDocButtonRef = useRef<HTMLButtonElement>(null);
+  useEffect(() => {
+    if (isDocComplete && hasNextDoc) {
+      nextDocButtonRef.current?.focus();
+    }
+  }, [isDocComplete, hasNextDoc, documentId]);
 
   const isMulti = fieldType === "multi" && fieldOptions && fieldOptions.length > 0;
   const groupCount = useMemo(() => {
@@ -281,6 +296,30 @@ export function ComparisonPanel({
           </div>
         )}
       </div>
+
+      {isDocComplete && (
+        <div className="flex shrink-0 items-center justify-between gap-2 border-t border-green-500/20 bg-green-500/5 px-4 py-2">
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
+            Revisão do documento concluída.
+          </span>
+          {hasNextDoc ? (
+            <Button
+              ref={nextDocButtonRef}
+              size="sm"
+              className="gap-1"
+              onClick={onNextDoc}
+            >
+              Próximo parecer
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Button>
+          ) : (
+            <span className="text-xs font-medium text-green-700">
+              Fila concluída.
+            </span>
+          )}
+        </div>
+      )}
 
       {isDivergent && (
         <KeyboardHints

--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   computeDivergentFieldNames,
   isFreeTextField,
+  isDocComplete,
+  findNextPendingDocIndex,
 } from "@/lib/compare-divergence";
 import type { EquivalencePair } from "@/lib/equivalence";
 import type { PydanticField } from "@/lib/types";
@@ -141,5 +143,59 @@ describe("computeDivergentFieldNames", () => {
       { id: "2", answers: { tags: ["y", "x"] } },
     ];
     expect(computeDivergentFieldNames(fields, responses)).toEqual([]);
+  });
+});
+
+describe("isDocComplete", () => {
+  it("false when there are no divergent fields", () => {
+    expect(isDocComplete([], { a: {} })).toBe(false);
+    expect(isDocComplete(undefined, { a: {} })).toBe(false);
+  });
+
+  it("false when there are no reviews for the doc", () => {
+    expect(isDocComplete(["a", "b"], undefined)).toBe(false);
+  });
+
+  it("false when some divergent field is still unreviewed", () => {
+    expect(isDocComplete(["a", "b"], { a: {} })).toBe(false);
+  });
+
+  it("true when every divergent field has a verdict", () => {
+    expect(isDocComplete(["a", "b"], { a: {}, b: {} })).toBe(true);
+  });
+});
+
+describe("findNextPendingDocIndex", () => {
+  const divergentFields = { d1: ["a"], d2: ["a"], d3: ["a"] };
+
+  it("returns the first pending doc, skipping the current one", () => {
+    const reviews = {};
+    expect(
+      findNextPendingDocIndex(["d1", "d2", "d3"], divergentFields, reviews, "d1"),
+    ).toBe(1);
+  });
+
+  it("finds a pending doc at the top after the queue was re-sorted", () => {
+    // Server re-sorts completed docs to the bottom: the just-finished doc (d1)
+    // is now last, pending docs are at the top. `currentIndex + 1` would point
+    // past the end — the helper must still find d2 at index 0.
+    const reviews = { d1: { a: {} } };
+    expect(
+      findNextPendingDocIndex(["d2", "d3", "d1"], divergentFields, reviews, "d1"),
+    ).toBe(0);
+  });
+
+  it("skips docs that are already complete", () => {
+    const reviews = { d1: { a: {} }, d2: { a: {} } };
+    expect(
+      findNextPendingDocIndex(["d2", "d3", "d1"], divergentFields, reviews, "d1"),
+    ).toBe(1);
+  });
+
+  it("returns -1 when every other doc is complete", () => {
+    const reviews = { d1: { a: {} }, d2: { a: {} }, d3: { a: {} } };
+    expect(
+      findNextPendingDocIndex(["d2", "d3", "d1"], divergentFields, reviews, "d1"),
+    ).toBe(-1);
   });
 });

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -95,3 +95,31 @@ export function computeDivergentFieldNames(
 
   return divergent;
 }
+
+// A document is "complete" in the Compare queue when it has at least one
+// divergent field and every divergent field already has a verdict.
+export function isDocComplete(
+  divergentForDoc: string[] | undefined,
+  reviewsForDoc: Record<string, unknown> | undefined,
+): boolean {
+  if (!divergentForDoc || divergentForDoc.length === 0) return false;
+  if (!reviewsForDoc) return false;
+  return divergentForDoc.every((fn) => !!reviewsForDoc[fn]);
+}
+
+// Index of the next document that still has unreviewed divergences, scanning
+// the queue in its current order and skipping `currentDocId`. Returns -1 when
+// every other document is complete. The server re-sorts the queue on each
+// revalidate (completed docs sink to the bottom), so "next parecer" must be
+// found by completion state — never by `currentIndex + 1`.
+export function findNextPendingDocIndex(
+  docIds: string[],
+  divergentFields: Record<string, string[]>,
+  reviews: Record<string, Record<string, unknown>>,
+  currentDocId: string | undefined,
+): number {
+  return docIds.findIndex(
+    (id) =>
+      id !== currentDocId && !isDocComplete(divergentFields[id], reviews[id]),
+  );
+}


### PR DESCRIPTION
## Resumo

Resolve a issue #72 (aba Comparar pulava de parecer sozinha).

- **Remove o `setTimeout` de 1.5s** que trocava de documento automaticamente ao concluir a revisão do último campo divergente (`advanceTimerRef` + `documentsRef` eliminados de `ComparePage.tsx`).
- **Adiciona um botão "Próximo parecer →"** no rodapé do `ComparisonPanel`, que aparece quando todos os campos divergentes do documento têm veredito e **recebe foco automático** — um clique ou Enter avança. No último documento da fila o botão dá lugar ao aviso "Fila concluída.".
- O critério "documentos sem divergência não aparecem na aba Comparar" **já estava atendido**: `compare/page.tsx` descarta docs com `divergent.length === 0` antes de montar a fila. Nenhuma mudança necessária ali.

## Detalhes

- `isCurrentDocComplete` (memo) deriva o estado "documento concluído" de `localReviews`, então o botão também aparece ao navegar para um doc já totalmente revisado.
- `allDocDivergent` foi envolvido em `useMemo` para eliminar warnings de `react-hooks/exhaustive-deps` (a nova dependência exigia isso).
- O avanço entre campos intermediários continua imediato, como antes.

## Critério de aceite

- [x] Documentos sem divergência não aparecem na aba Comparar (já era o caso).
- [x] Ao terminar a revisão de um documento, o avanço acontece por ação explícita do revisor (clique/Enter no botão), não por timer.

## Test plan

- [ ] Rever um documento até o último campo divergente → botão "Próximo parecer" aparece focado; Enter avança para o próximo doc.
- [ ] Concluir o último documento da fila → mostra "Fila concluída." em vez do botão.
- [ ] Navegar manualmente para um doc já totalmente revisado → botão "Próximo parecer" aparece.
- [ ] Campos intermediários continuam avançando na hora, sem delay.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)