### PR TITLE
refactor(db): rename responses.is_current → is_latest

### DIFF
--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -565,7 +565,7 @@ def _filter_docs(
             .select("document_id")
             .eq("project_id", project_id)
             .eq("respondent_type", "llm")
-            .eq("is_current", True)
+            .eq("is_latest", True)
             .execute()
             .data
         )
@@ -795,7 +795,7 @@ async def run_llm(
 
         # Mark all old LLM responses as not current in one batch
         doc_ids = [d["id"] for d in docs]
-        sb.table("responses").update({"is_current": False}).eq(
+        sb.table("responses").update({"is_latest": False}).eq(
             "project_id", project_id
         ).in_("document_id", doc_ids).eq("respondent_type", "llm").execute()
 
@@ -961,11 +961,11 @@ async def run_llm(
                 "respondent_name": f"{llm_provider}/{llm_model}",
                 "answers": answers,
                 "justifications": justifications if justifications else None,
-                # is_current: respostas parciais já nascem como False para não
+                # is_latest: respostas parciais já nascem como False para não
                 # poluírem Comparar (ver PR #65). Uma run posterior sobre os
                 # mesmos docs também vai marcar esta resposta como False via
                 # bulk update logo acima.
-                "is_current": not is_partial,
+                "is_latest": not is_partial,
                 # is_partial: imutável após o insert. Preserva o classificador
                 # "cobertura baixa" mesmo depois que uma run posterior supersede
                 # esta resposta (ver migration 20260425000000).
@@ -999,7 +999,7 @@ async def run_llm(
             sections = [
                 f"Run comprometida: {len(partial_warnings)}/{total_processed} "
                 f"docs ({int(partial_ratio * 100)}%) com resposta parcial. "
-                f"Respostas gravadas com is_current=false."
+                f"Respostas gravadas com is_latest=false."
             ]
             if error_examples:
                 sections.append(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,7 +63,7 @@ FastAPI (Fly.io)  ---------------> |
 ### Invalidacao LLM
 1. Coordenador altera Pydantic e salva
 2. Novo hash calculado: sha256(code)[:16]
-3. Respostas LLM com hash antigo: is_current = false
+3. Respostas LLM com hash antigo: is_latest = false
 4. UI mostra badge "Desatualizada"
 5. Coordenador pode re-rodar campos afetados
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -92,7 +92,7 @@ CREATE TABLE responses (
   respondent_name TEXT,
   answers         JSONB NOT NULL,
   justifications  JSONB,
-  is_current      BOOLEAN DEFAULT true,
+  is_latest      BOOLEAN DEFAULT true,
   pydantic_hash   TEXT,
   created_at      TIMESTAMPTZ DEFAULT now()
 );
@@ -163,14 +163,14 @@ CREATE POLICY "Coordinators manage members" ON project_members FOR ALL USING (
 ```sql
 WITH response_answers AS (
   SELECT r.document_id, r.respondent_name, r.respondent_type, r.id as response_id,
-    r.is_current, r.justifications, key as field_name, value as answer
+    r.is_latest, r.justifications, key as field_name, value as answer
   FROM responses r, jsonb_each_text(r.answers)
   WHERE r.project_id = $1 AND r.document_id = $2
 ),
 field_stats AS (
   SELECT field_name, COUNT(DISTINCT answer) as distinct_answers, COUNT(*) as total_responses
   FROM response_answers
-  WHERE is_current = true OR respondent_type = 'humano'
+  WHERE is_latest = true OR respondent_type = 'humano'
   GROUP BY field_name
 )
 SELECT field_name FROM field_stats

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -180,7 +180,7 @@ async function computeLottery(
         .from("responses")
         .select("document_id")
         .eq("project_id", params.projectId)
-        .eq("is_current", true),
+        .eq("is_latest", true),
     ]);
 
     const minResponses = project?.min_responses_for_comparison || 2;

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -824,7 +824,7 @@ export async function regenerateAutoReviewBacklog(
         .select("id, document_id, answers")
         .eq("project_id", projectId)
         .eq("respondent_type", "llm")
-        .eq("is_current", true),
+        .eq("is_latest", true),
       admin
         .from("response_equivalences")
         .select("document_id, field_name, response_a_id, response_b_id")

--- a/frontend/src/actions/llm.ts
+++ b/frontend/src/actions/llm.ts
@@ -24,7 +24,7 @@ export async function getEligibleDocCount(
       .select("document_id")
       .eq("project_id", projectId)
       .eq("respondent_type", "llm")
-      .eq("is_current", true),
+      .eq("is_latest", true),
   ]);
 
   if (totalError) throw new Error(totalError.message);
@@ -124,8 +124,8 @@ export async function getLlmRunStats(
   jobId: string
 ): Promise<{ current: number; partial: number }> {
   const supabase = await createSupabaseServer();
-  // Usa is_partial (imutável) em vez de is_current para distinguir complete vs
-  // partial. is_current muda quando uma run posterior roda nos mesmos docs, o
+  // Usa is_partial (imutável) em vez de is_latest para distinguir complete vs
+  // partial. is_latest muda quando uma run posterior roda nos mesmos docs, o
   // que inflaria artificialmente a contagem de parciais de runs antigas.
   const [
     { count: complete, error: completeError },
@@ -151,7 +151,7 @@ export interface LlmResponseRecord {
   id: string;
   document_id: string;
   llm_job_id: string | null;
-  is_current: boolean;
+  is_latest: boolean;
   is_partial: boolean;
   answers: Record<string, unknown>;
   justifications: Record<string, string> | null;
@@ -179,7 +179,7 @@ export async function getLlmResponsesForProject(
   let query = supabase
     .from("responses")
     .select(
-      "id, document_id, llm_job_id, is_current, is_partial, answers, " +
+      "id, document_id, llm_job_id, is_latest, is_partial, answers, " +
         "justifications, respondent_name, created_at, llm_error, " +
         "documents(id, title, external_id)"
     )
@@ -198,7 +198,7 @@ export async function getLlmResponsesForProject(
     id: string;
     document_id: string;
     llm_job_id: string | null;
-    is_current: boolean;
+    is_latest: boolean;
     is_partial: boolean;
     answers: Record<string, unknown> | null;
     justifications: Record<string, string> | null;
@@ -212,7 +212,7 @@ export async function getLlmResponsesForProject(
     id: r.id,
     document_id: r.document_id,
     llm_job_id: r.llm_job_id,
-    is_current: r.is_current,
+    is_latest: r.is_latest,
     is_partial: r.is_partial,
     answers: r.answers ?? {},
     justifications: r.justifications,
@@ -307,7 +307,7 @@ export async function getDocumentsForSelection(
       .from("responses")
       .select("document_id, respondent_type")
       .eq("project_id", projectId)
-      .eq("is_current", true),
+      .eq("is_latest", true),
   ]);
 
   if (docsError) throw new Error(docsError.message);

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -119,7 +119,7 @@ export async function saveResponse(
         respondent_id: user.id,
         respondent_type: "humano",
         respondent_name: respondentName,
-        is_current: true,
+        is_latest: true,
         ...responsePayload,
       });
       if (insertErr) return { success: false, error: insertErr.message };

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -57,7 +57,7 @@ export async function saveSchema(
 
   if (error) throw new Error(error.message);
 
-  // is_current não é flipado para false aqui — staleness é detectada no
+  // is_latest não é flipado para false aqui — staleness é detectada no
   // display via answer_field_hashes (lib/reviews/queries.ts:isFieldStale).
   // Caso contrário, ajustar schema durante uma revisão de erros LLM apaga as
   // respostas antigas e perde o contexto da investigação. Ver #85.

--- a/frontend/src/actions/stats.ts
+++ b/frontend/src/actions/stats.ts
@@ -252,7 +252,7 @@ export async function fetchGabaritoForComment(
       .select("id, respondent_name, respondent_type, answers")
       .eq("project_id", projectId)
       .eq("document_id", documentId)
-      .or("is_current.eq.true,respondent_type.eq.humano");
+      .or("is_latest.eq.true,respondent_type.eq.humano");
 
     if (!responses) return { answers: [] };
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -25,7 +25,7 @@ interface CompareResponse {
   respondent_id: string | null;
   answers: Record<string, unknown>;
   justifications: Record<string, string> | null;
-  is_current: boolean;
+  is_latest: boolean;
   pydantic_hash: string | null;
   answer_field_hashes: Record<string, string> | null;
   schema_version_major: number | null;
@@ -118,7 +118,7 @@ export default async function ComparePageRoute({
     supabase
       .from("responses")
       .select(
-        "id, document_id, respondent_type, respondent_name, respondent_id, answers, justifications, is_current, pydantic_hash, answer_field_hashes, schema_version_major, schema_version_minor, schema_version_patch, created_at, documents(id, title, external_id)",
+        "id, document_id, respondent_type, respondent_name, respondent_id, answers, justifications, is_latest, pydantic_hash, answer_field_hashes, schema_version_major, schema_version_minor, schema_version_patch, created_at, documents(id, title, external_id)",
       )
       .eq("project_id", id)
       .limit(5000),
@@ -276,8 +276,8 @@ export default async function ComparePageRoute({
 
     // Apply version + since + respondent filters per response
     const qualifiedResponses = docResponses.filter((r) => {
-      // Keep only active (is_current) OR human responses — antigos (is_current=false) do LLM ficam fora
-      if (!r.is_current && r.respondent_type !== "humano") return false;
+      // Keep only active (is_latest) OR human responses — antigos (is_latest=false) do LLM ficam fora
+      if (!r.is_latest && r.respondent_type !== "humano") return false;
 
       // Respostas pré-versionamento (pydantic_hash NULL) foram gravadas antes
       // da migration 20260420 que introduziu schema_version_*. Elas têm

--- a/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
@@ -29,7 +29,7 @@ export default async function LlmConfigurePage({
         .select("document_id")
         .eq("project_id", id)
         .eq("respondent_type", "llm")
-        .eq("is_current", true),
+        .eq("is_latest", true),
     ]);
 
   const docsWithLlm = new Set(llmResponses?.map((r) => r.document_id)).size;

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -68,7 +68,7 @@ export default async function CommentsPage({
       .select("id, document_id, answers, respondent_name, created_at")
       .eq("project_id", id)
       .eq("respondent_type", "llm")
-      .eq("is_current", true),
+      .eq("is_latest", true),
     supabase
       .from("difficulty_resolutions")
       .select("response_id, resolved_at")

--- a/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
@@ -37,7 +37,7 @@ export default async function ExportPage({
           "id, document_id, respondent_name, respondent_type, answers, documents(external_id, title)",
         )
         .eq("project_id", id)
-        .eq("is_current", true),
+        .eq("is_latest", true),
       supabase
         .from("reviews")
         .select("document_id, field_name, verdict, comment")

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -64,7 +64,7 @@ export default async function LlmInsightsPage({
       )
       .eq("project_id", id)
       .eq("respondent_type", "llm")
-      .eq("is_current", true),
+      .eq("is_latest", true),
     supabase
       .from("reviews")
       .select(

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -68,7 +68,7 @@ export default async function MyVerdictsPage({
     .eq("project_id", id)
     .eq("respondent_id", effectiveUserId)
     .eq("respondent_type", "humano")
-    .eq("is_current", true);
+    .eq("is_latest", true);
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];
   const fieldDescMap = new Map(fields.map((f) => [f.name, f.description]));
@@ -113,7 +113,7 @@ export default async function MyVerdictsPage({
           .select("respondent_id, respondent_name")
           .eq("project_id", id)
           .eq("respondent_type", "humano")
-          .eq("is_current", true)
+          .eq("is_latest", true)
       : Promise.resolve({ data: null }),
   ]);
 

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -15,7 +15,7 @@ interface AgreementResponse {
   respondent_name: string;
   answer: unknown;
   justification?: string;
-  is_current: boolean;
+  is_latest: boolean;
   isFieldStale: boolean;
   schemaVersion?: string | null;
 }

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -40,7 +40,7 @@ interface CompareResponse {
   respondent_name: string;
   answers: Record<string, unknown>;
   justifications: Record<string, string> | null;
-  is_current: boolean;
+  is_latest: boolean;
   pydantic_hash: string | null;
   answer_field_hashes: Record<string, string> | null;
   schema_version_major: number | null;
@@ -242,7 +242,7 @@ export function ComparePage({
         ? r.answers[currentFieldName]
         : undefined,
       justification: r.justifications?.[currentFieldName],
-      is_current: r.is_current,
+      is_latest: r.is_latest,
       isFieldStale,
       schemaVersion: version,
     };

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -36,7 +36,7 @@ interface ComparisonResponse {
   respondent_name: string;
   answer: unknown;
   justification?: string;
-  is_current: boolean;
+  is_latest: boolean;
   isFieldStale: boolean;
   schemaVersion?: string | null;
 }
@@ -195,7 +195,7 @@ export function ComparisonPanel({
               respondent_name: r.respondent_name,
               answer: r.answer,
               justification: r.justification,
-              is_current: r.is_current,
+              is_latest: r.is_latest,
               isFieldStale: r.isFieldStale,
               schemaVersion: r.schemaVersion,
             }))}

--- a/frontend/src/components/compare/MultiOptionReview.tsx
+++ b/frontend/src/components/compare/MultiOptionReview.tsx
@@ -16,7 +16,7 @@ interface MultiOptionResponse {
   respondent_type: "humano" | "llm";
   respondent_name: string;
   answer: unknown;
-  is_current: boolean;
+  is_latest: boolean;
   isFieldStale: boolean;
 }
 

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -783,7 +783,7 @@ export function LlmConfigurePane({
                   }}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Abaixo disso, a resposta entra como <code>is_current=false</code> e aparece marcada como parcial na aba Respostas.
+                  Abaixo disso, a resposta entra como <code>is_latest=false</code> e aparece marcada como parcial na aba Respostas.
                 </p>
               </div>
               <div className="space-y-1.5">

--- a/frontend/src/components/llm/__tests__/classify.test.ts
+++ b/frontend/src/components/llm/__tests__/classify.test.ts
@@ -13,7 +13,7 @@ function record(
     id: "r1",
     document_id: "d1",
     llm_job_id: null,
-    is_current: true,
+    is_latest: true,
     justifications: null,
     respondent_name: null,
     created_at: "2026-05-04T00:00:00Z",

--- a/frontend/src/lib/auto-review.ts
+++ b/frontend/src/lib/auto-review.ts
@@ -57,7 +57,7 @@ export async function createAutoReviewIfDiverges(
       .eq("project_id", projectId)
       .eq("document_id", documentId)
       .eq("respondent_type", "llm")
-      .eq("is_current", true)
+      .eq("is_latest", true)
       .maybeSingle(),
     admin
       .from("response_equivalences")

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -41,7 +41,7 @@ export async function syncCompareAssignment(
       .single(),
     supabase
       .from("responses")
-      .select("id, respondent_type, is_current, answers")
+      .select("id, respondent_type, is_latest, answers")
       .eq("project_id", projectId)
       .eq("document_id", documentId),
     supabase
@@ -75,7 +75,7 @@ export async function syncCompareAssignment(
     answers: Record<string, unknown>;
   };
   const activeResponses: ActiveResponse[] = (responses ?? [])
-    .filter((r) => r.is_current || r.respondent_type === "humano")
+    .filter((r) => r.is_latest || r.respondent_type === "humano")
     .map((r) => ({
       id: r.id,
       answers: (r.answers ?? {}) as Record<string, unknown>,

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -177,10 +177,10 @@ export async function fetchReviewBaseData(
   let responsesQuery = supabase
     .from("responses")
     .select(
-      "id, document_id, respondent_id, respondent_type, respondent_name, answers, justifications, is_current, pydantic_hash, answer_field_hashes, created_at",
+      "id, document_id, respondent_id, respondent_type, respondent_name, answers, justifications, is_latest, pydantic_hash, answer_field_hashes, created_at",
     )
     .eq("project_id", projectId)
-    .eq("is_current", true)
+    .eq("is_latest", true)
     .limit(REVIEW_BASE_DATA_LIMIT);
 
   if (options?.since) {

--- a/frontend/src/lib/supabase/database.types.ts
+++ b/frontend/src/lib/supabase/database.types.ts
@@ -849,7 +849,7 @@ export type Database = {
           created_at: string | null
           document_id: string | null
           id: string
-          is_current: boolean | null
+          is_latest: boolean | null
           is_partial: boolean
           justifications: Json | null
           llm_error: string | null
@@ -871,7 +871,7 @@ export type Database = {
           created_at?: string | null
           document_id?: string | null
           id?: string
-          is_current?: boolean | null
+          is_latest?: boolean | null
           is_partial?: boolean
           justifications?: Json | null
           llm_error?: string | null
@@ -893,7 +893,7 @@ export type Database = {
           created_at?: string | null
           document_id?: string | null
           id?: string
-          is_current?: boolean | null
+          is_latest?: boolean | null
           is_partial?: boolean
           justifications?: Json | null
           llm_error?: string | null

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -133,7 +133,7 @@ export interface Response {
   respondent_name: string | null;
   answers: Record<string, unknown>;
   justifications: Record<string, string> | null;
-  is_current: boolean;
+  is_latest: boolean;
   pydantic_hash: string | null;
   answer_field_hashes: Record<string, string> | null;
   created_at: string;

--- a/frontend/supabase/migrations/20260514190000_rename_is_current_to_is_latest.sql
+++ b/frontend/supabase/migrations/20260514190000_rename_is_current_to_is_latest.sql
@@ -1,0 +1,25 @@
+-- Renomeia responses.is_current → responses.is_latest (follow-up de #85).
+--
+-- Apos #85 a semantica ficou estavel: "ultima run LLM ou resposta humana
+-- ativa", sem invalidar por schema bump. O nome is_current sugeria algo
+-- relativo ao schema que a coluna nao promete mais — is_latest descreve
+-- melhor o que ela representa.
+--
+-- RENAME COLUMN propaga automaticamente para objetos dependentes:
+--   - final_answers_view passa a referenciar is_latest
+--   - o indice parcial idx_responses_project_is_current tem seu predicado
+--     reescrito para WHERE is_latest = true
+-- O indice e renomeado abaixo so para manter o nome coerente com a coluna.
+--
+-- Timestamp 20260514190000: esta migration precisa rodar DEPOIS de
+-- 20260514180000_field_reviews_self_verdict_equivalente_ambiguo.sql, que
+-- recria final_answers_view referenciando responses.is_current. Se o rename
+-- rodasse antes, aquela migration falharia (coluna ja renomeada).
+--
+-- Deploy: a coluna deixa de existir com o nome antigo, entao esta migration
+-- e o deploy de codigo (frontend + backend) precisam sair no mesmo PR.
+
+ALTER TABLE responses RENAME COLUMN is_current TO is_latest;
+
+ALTER INDEX IF EXISTS idx_responses_project_is_current
+  RENAME TO idx_responses_project_is_latest;


### PR DESCRIPTION
## Resumo

Após #85, a semântica de `responses.is_current` ficou estável: "última run LLM ou resposta humana ativa", sem invalidar por schema bump. O nome `is_current` sugeria algo relativo ao schema que a coluna não promete mais — `is_latest` descreve melhor.

## Mudanças

- **Nova migration** `20260514000000_rename_is_current_to_is_latest.sql`:
  - `ALTER TABLE responses RENAME COLUMN is_current TO is_latest`
  - `ALTER INDEX ... RENAME` para manter o nome do índice parcial coerente
  - `RENAME COLUMN` propaga automaticamente para `final_answers_view` e para o predicado do índice — nada mais a fazer no SQL.
- **Rename mecânico** `is_current` → `is_latest` em 25 arquivos: TS frontend (queries, actions, páginas de reviews/compare, componentes), `backend/services/llm_runner.py`, `database.types.ts`, além de comentários, mensagens de UI (`LlmConfigurePane`) e docs (`DATABASE.md`, `ARCHITECTURE.md`).
- **Migrations já aplicadas não foram editadas** — são registro histórico; o `is_current` que aparece nelas (inclusive em comentários) é intencional.

## Notas

- Os scripts `comentarios-relatorio/` e `erros-llm-relatorio/` citados na issue **não existem neste repo** (são skills externas) — nada a fazer.
- Migration + deploy de código saem juntos: a coluna deixa de existir com o nome antigo. Em deploy single-instância (Vercel + Fly) o rename atômico está OK.
- **Ordem de merge:** este PR toca `actions/llm.ts` (também em #119) e `lib/reviews/queries.ts` (também em #128). Mergear depois desses dois, ou esperar um rebase trivial nas linhas renomeadas.

## Test plan

- [ ] `npx supabase db push` aplica a migration sem erro
- [ ] Aba Comparar, Execuções, Reviews (gabarito/confusão/respondentes/dificuldade) continuam funcionando
- [ ] Rodar LLM grava respostas com `is_latest` correto; run posterior nos mesmos docs flipa as antigas para `false`
- [x] `tsc --noEmit` limpo (fora de erros pré-existentes de `@dnd-kit`)
- [x] `vitest run classify.test.ts` — 12 passed

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)