### PR TITLE
feat(coding): ordenar navegação de Codificar por codificados recentemente

### DIFF
--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -101,6 +101,9 @@ export async function saveResponse(
       version_inferred_from: "live_save",
       round_id: roundIdToPersist,
       is_partial: isPartialToWrite,
+      // Marca a codificacao do pesquisador no tempo — alimenta a ordenacao
+      // "codificados recentemente" da navegacao da aba Codificar (issue #108).
+      updated_at: new Date().toISOString(),
     };
 
     if (existing) {

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -77,7 +77,7 @@ export default async function CodePage({
   const { data: responses } = await supabase
     .from("responses")
     .select(
-      "document_id, answers, justifications, round_id, schema_version_major, schema_version_minor, schema_version_patch, is_partial",
+      "document_id, answers, justifications, round_id, schema_version_major, schema_version_minor, schema_version_patch, is_partial, updated_at",
     )
     .eq("project_id", id)
     .eq("respondent_id", effectiveUserId)
@@ -101,6 +101,13 @@ export default async function CodePage({
       schema_version_patch: r.schema_version_patch,
       is_partial: r.is_partial,
     });
+  });
+
+  // Quando o pesquisador codificou cada documento (responses.updated_at) —
+  // alimenta a ordenacao "codificados recentemente" da navegacao (issue #108).
+  const codedAtByDoc: Record<string, string> = {};
+  responses?.forEach((r) => {
+    if (r.updated_at) codedAtByDoc[r.document_id] = r.updated_at;
   });
 
   const currentVersion: SchemaVersion = {
@@ -223,6 +230,7 @@ export default async function CodePage({
     <CodingPage
       projectId={id}
       documents={filteredDocuments}
+      codedAtByDoc={codedAtByDoc}
       fields={fields}
       existingAnswers={existingAnswers}
       existingJustifications={existingJustifications}

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -24,7 +24,7 @@ import { CopyLinkButton } from "@/components/ui/CopyLinkButton";
 import { RunLlmButton } from "@/components/shared/RunLlmButton";
 import { SuggestExclusionDialog } from "./SuggestExclusionDialog";
 import { CURRENT_FILTER_VALUE, isCurrentFilter } from "@/lib/rounds";
-import type { RoundFilterData } from "./CodingPage";
+import type { RoundFilterData, CodingSortMode } from "./CodingPage";
 
 type DocSection =
   | {
@@ -52,6 +52,8 @@ interface CodingHeaderProps {
   mode: "assigned" | "browse";
   onModeChange: (mode: "assigned" | "browse") => void;
   assignedCount: number;
+  sortMode: CodingSortMode;
+  onSortChange: (mode: CodingSortMode) => void;
   roundFilter?: RoundFilterData;
   doc?: DocSection;
   onToggleFullscreen: () => void;
@@ -61,6 +63,8 @@ export function CodingHeader({
   mode,
   onModeChange,
   assignedCount,
+  sortMode,
+  onSortChange,
   roundFilter,
   doc,
   onToggleFullscreen,
@@ -82,6 +86,13 @@ export function CodingHeader({
           </TabsTrigger>
         </TabsList>
       </Tabs>
+
+      {mode === "assigned" && (
+        <>
+          <Separator orientation="vertical" className="h-4" />
+          <SortSelect value={sortMode} onChange={onSortChange} />
+        </>
+      )}
 
       {showRound && (
         <>
@@ -106,6 +117,32 @@ export function CodingHeader({
           )}
         </>
       )}
+    </div>
+  );
+}
+
+function SortSelect({
+  value,
+  onChange,
+}: {
+  value: CodingSortMode;
+  onChange: (mode: CodingSortMode) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 shrink-0">
+      <span className="text-xs text-muted-foreground">Ordenar:</span>
+      <Select
+        value={value}
+        onValueChange={(v) => onChange(v as CodingSortMode)}
+      >
+        <SelectTrigger size="sm" className="h-6 w-auto min-w-[150px] text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="default">Padrão</SelectItem>
+          <SelectItem value="recent">Codificados recentemente</SelectItem>
+        </SelectContent>
+      </Select>
     </div>
   );
 }

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -139,8 +139,8 @@ function SortSelect({
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="default">Padrão</SelectItem>
           <SelectItem value="recent">Codificados recentemente</SelectItem>
+          <SelectItem value="default">Ordem de atribuição</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -19,6 +19,7 @@ import type { BrowseDocument } from "@/actions/documents";
 import type { PydanticField, Document, Assignment, Round, RoundStrategy } from "@/lib/types";
 import { ProgressBanner, type ProgressBannerData } from "./ProgressBanner";
 import { CodingHeader } from "./CodingHeader";
+import { sortByRecent } from "@/lib/coding-sort";
 import { CURRENT_FILTER_VALUE } from "@/lib/rounds";
 import { toast } from "sonner";
 import { CheckCircle2, FileQuestion, ClipboardList } from "lucide-react";
@@ -34,26 +35,6 @@ export interface RoundFilterData {
 }
 
 export type CodingSortMode = "default" | "recent";
-
-// Ordena documentos pelo timestamp de codificacao do proprio pesquisador
-// (responses.updated_at), do mais recente para o mais antigo. Documentos ainda
-// nao codificados vao para o fim, preservando a ordem original entre si.
-function sortByRecent<T extends { id: string }>(
-  docs: T[],
-  codedAtByDoc: Record<string, string>,
-): T[] {
-  return docs
-    .map((doc, index) => ({ doc, index }))
-    .sort((a, b) => {
-      const ta = codedAtByDoc[a.doc.id];
-      const tb = codedAtByDoc[b.doc.id];
-      if (ta && tb) return tb.localeCompare(ta);
-      if (ta) return -1;
-      if (tb) return 1;
-      return a.index - b.index;
-    })
-    .map((entry) => entry.doc);
-}
 
 interface CodingPageProps {
   projectId: string;
@@ -361,14 +342,19 @@ export function CodingPage({
       markClean(currentDoc.id);
       toast.success("Respostas salvas!");
       if (docIndex < sortedDocuments.length - 1) {
-        setDocIndex(docIndex + 1);
+        const nextIndex = docIndex + 1;
+        setDocIndex(nextIndex);
+        // Mantem a URL em sincronia com o doc exibido — sem isso, um refresh
+        // apos enviar cai no doc recem-enviado (que no modo "recent" pula para
+        // o topo da lista), nao no proximo.
+        updateDocParam(sortedDocuments[nextIndex]?.id ?? null);
       } else {
         setAllDone(true);
       }
     } else {
       toast.error(result.error || "Erro ao salvar respostas");
     }
-  }, [currentDoc, docAnswers, docNotes, projectId, docIndex, sortedDocuments.length, markClean]);
+  }, [currentDoc, docAnswers, docNotes, projectId, docIndex, sortedDocuments, updateDocParam, markClean]);
 
   const handleDocNavigate = useCallback(
     (newIndex: number) => {

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -33,9 +33,32 @@ export interface RoundFilterData {
   selected: string;
 }
 
+export type CodingSortMode = "default" | "recent";
+
+// Ordena documentos pelo timestamp de codificacao do proprio pesquisador
+// (responses.updated_at), do mais recente para o mais antigo. Documentos ainda
+// nao codificados vao para o fim, preservando a ordem original entre si.
+function sortByRecent<T extends { id: string }>(
+  docs: T[],
+  codedAtByDoc: Record<string, string>,
+): T[] {
+  return docs
+    .map((doc, index) => ({ doc, index }))
+    .sort((a, b) => {
+      const ta = codedAtByDoc[a.doc.id];
+      const tb = codedAtByDoc[b.doc.id];
+      if (ta && tb) return tb.localeCompare(ta);
+      if (ta) return -1;
+      if (tb) return 1;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.doc);
+}
+
 interface CodingPageProps {
   projectId: string;
   documents: (Document & { assignment?: Pick<Assignment, "id" | "status"> })[];
+  codedAtByDoc?: Record<string, string>;
   fields: PydanticField[];
   existingAnswers: Record<string, Record<string, any>>;
   existingJustifications?: Record<string, Record<string, unknown>>;
@@ -48,6 +71,7 @@ interface CodingPageProps {
 export function CodingPage({
   projectId,
   documents,
+  codedAtByDoc = {},
   fields,
   existingAnswers,
   existingJustifications = {},
@@ -61,10 +85,23 @@ export function CodingPage({
   const pathname = usePathname();
   const docParam = searchParams.get("doc");
 
+  // Ordenacao da navegacao de documentos atribuidos (issue #108). "recent"
+  // ordena pelo responses.updated_at do proprio pesquisador; "default" mantem
+  // a ordem do servidor (status do assignment).
+  const sortMode: CodingSortMode =
+    searchParams.get("sort") === "recent" ? "recent" : "default";
+  const sortedDocuments = useMemo(
+    () =>
+      sortMode === "recent"
+        ? sortByRecent(documents, codedAtByDoc)
+        : documents,
+    [documents, sortMode, codedAtByDoc],
+  );
+
   // Compute initial state from URL param
   const getInitialState = useCallback(() => {
     if (docParam) {
-      const assignedIdx = documents.findIndex((d) => d.id === docParam);
+      const assignedIdx = sortedDocuments.findIndex((d) => d.id === docParam);
       if (assignedIdx >= 0) {
         return { mode: "assigned" as const, docIndex: assignedIdx };
       }
@@ -244,7 +281,7 @@ export function CodingPage({
   }, [isFullscreen]);
 
   // --- Assigned mode handlers ---
-  const currentDoc = documents[docIndex];
+  const currentDoc = sortedDocuments[docIndex];
   const docAnswers = allAnswers[currentDoc?.id] || {};
   const docNotes = allNotes[currentDoc?.id] ?? "";
 
@@ -322,7 +359,7 @@ export function CodingPage({
     if (result.success) {
       markClean(currentDoc.id);
       toast.success("Respostas salvas!");
-      if (docIndex < documents.length - 1) {
+      if (docIndex < sortedDocuments.length - 1) {
         setDocIndex(docIndex + 1);
       } else {
         setAllDone(true);
@@ -330,7 +367,7 @@ export function CodingPage({
     } else {
       toast.error(result.error || "Erro ao salvar respostas");
     }
-  }, [currentDoc, docAnswers, docNotes, projectId, docIndex, documents.length, markClean]);
+  }, [currentDoc, docAnswers, docNotes, projectId, docIndex, sortedDocuments.length, markClean]);
 
   const handleDocNavigate = useCallback(
     (newIndex: number) => {
@@ -343,11 +380,59 @@ export function CodingPage({
           else toast.error(result.error || "Erro ao salvar respostas");
         });
       }
-      const clampedIndex = Math.max(0, Math.min(newIndex, documents.length - 1));
+      const clampedIndex = Math.max(0, Math.min(newIndex, sortedDocuments.length - 1));
       setDocIndex(clampedIndex);
-      updateDocParam(documents[clampedIndex]?.id ?? null);
+      updateDocParam(sortedDocuments[clampedIndex]?.id ?? null);
     },
-    [currentDoc, docAnswers, docNotes, projectId, documents, updateDocParam, dirtyDocs, markClean]
+    [currentDoc, docAnswers, docNotes, projectId, sortedDocuments, updateDocParam, dirtyDocs, markClean]
+  );
+
+  // Troca o criterio de ordenacao da navegacao de atribuidos. Ao mudar para
+  // "recent", salta direto para o documento codificado mais recentemente — o
+  // objetivo da issue #108 e achar em 1 clique o ultimo que o pesquisador
+  // mexeu. Ao voltar para "default", mantem o documento atual selecionado.
+  const handleSortChange = useCallback(
+    (nextSort: CodingSortMode) => {
+      if (currentDoc && dirtyDocs.has(currentDoc.id)) {
+        saveResponse(projectId, currentDoc.id, docAnswers, {
+          notes: docNotes,
+          isAutoSave: true,
+        }).then((result) => {
+          if (result.success) markClean(currentDoc.id);
+          else toast.error(result.error || "Erro ao salvar respostas");
+        });
+      }
+      const nextDocs =
+        nextSort === "recent"
+          ? sortByRecent(documents, codedAtByDoc)
+          : documents;
+      const targetId =
+        nextSort === "recent" ? nextDocs[0]?.id : currentDoc?.id;
+      const targetIndex = targetId
+        ? nextDocs.findIndex((d) => d.id === targetId)
+        : 0;
+      setDocIndex(Math.max(0, targetIndex));
+
+      const params = new URLSearchParams(searchParams.toString());
+      if (nextSort === "recent") params.set("sort", "recent");
+      else params.delete("sort");
+      if (targetId) params.set("doc", targetId);
+      const qs = params.toString();
+      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+    },
+    [
+      currentDoc,
+      docAnswers,
+      docNotes,
+      projectId,
+      documents,
+      codedAtByDoc,
+      dirtyDocs,
+      markClean,
+      searchParams,
+      router,
+      pathname,
+    ]
   );
 
   // --- Browse mode handlers ---
@@ -508,6 +593,8 @@ export function CodingPage({
             mode={mode}
             onModeChange={setMode}
             assignedCount={documents.length}
+            sortMode={sortMode}
+            onSortChange={handleSortChange}
             roundFilter={roundFilter}
             doc={
               mode === "assigned" && currentDoc

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -85,11 +85,12 @@ export function CodingPage({
   const pathname = usePathname();
   const docParam = searchParams.get("doc");
 
-  // Ordenacao da navegacao de documentos atribuidos (issue #108). "recent"
-  // ordena pelo responses.updated_at do proprio pesquisador; "default" mantem
-  // a ordem do servidor (status do assignment).
+  // Ordenacao da navegacao de documentos atribuidos (issue #108). Padrao e
+  // "recent" — ordena pelo responses.updated_at do proprio pesquisador, para o
+  // pesquisador cair direto no ultimo documento que mexeu. "default" (opt-in
+  // via ?sort=default) mantem a ordem do servidor (status do assignment).
   const sortMode: CodingSortMode =
-    searchParams.get("sort") === "recent" ? "recent" : "default";
+    searchParams.get("sort") === "default" ? "default" : "recent";
   const sortedDocuments = useMemo(
     () =>
       sortMode === "recent"
@@ -414,7 +415,7 @@ export function CodingPage({
       setDocIndex(Math.max(0, targetIndex));
 
       const params = new URLSearchParams(searchParams.toString());
-      if (nextSort === "recent") params.set("sort", "recent");
+      if (nextSort === "default") params.set("sort", "default");
       else params.delete("sort");
       if (targetId) params.set("doc", targetId);
       const qs = params.toString();

--- a/frontend/src/lib/__tests__/coding-sort.test.ts
+++ b/frontend/src/lib/__tests__/coding-sort.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { sortByRecent } from "@/lib/coding-sort";
+
+const ids = (docs: { id: string }[]) => docs.map((d) => d.id);
+
+describe("sortByRecent", () => {
+  it("ordena documentos codificados do mais recente para o mais antigo", () => {
+    const docs = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const codedAt = {
+      a: "2026-05-14T10:00:00.000Z",
+      b: "2026-05-14T12:00:00.000Z",
+      c: "2026-05-14T11:00:00.000Z",
+    };
+    expect(ids(sortByRecent(docs, codedAt))).toEqual(["b", "c", "a"]);
+  });
+
+  it("manda documentos nao codificados para o fim", () => {
+    const docs = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const codedAt = { b: "2026-05-14T12:00:00.000Z" };
+    expect(ids(sortByRecent(docs, codedAt))).toEqual(["b", "a", "c"]);
+  });
+
+  it("preserva a ordem original entre documentos nao codificados", () => {
+    const docs = [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }];
+    const codedAt = { c: "2026-05-14T12:00:00.000Z" };
+    expect(ids(sortByRecent(docs, codedAt))).toEqual(["c", "a", "b", "d"]);
+  });
+
+  it("desempata timestamps iguais pela ordem original", () => {
+    const docs = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const ts = "2026-05-14T12:00:00.000Z";
+    const codedAt = { a: ts, b: ts, c: ts };
+    expect(ids(sortByRecent(docs, codedAt))).toEqual(["a", "b", "c"]);
+  });
+
+  it("retorna a ordem original quando nada foi codificado", () => {
+    const docs = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    expect(ids(sortByRecent(docs, {}))).toEqual(["a", "b", "c"]);
+  });
+
+  it("nao muta o array de entrada", () => {
+    const docs = [{ id: "a" }, { id: "b" }];
+    const codedAt = { b: "2026-05-14T12:00:00.000Z" };
+    sortByRecent(docs, codedAt);
+    expect(ids(docs)).toEqual(["a", "b"]);
+  });
+});

--- a/frontend/src/lib/coding-sort.ts
+++ b/frontend/src/lib/coding-sort.ts
@@ -1,0 +1,25 @@
+// Ordena documentos pelo timestamp de codificacao do proprio pesquisador
+// (responses.updated_at), do mais recente para o mais antigo. Documentos ainda
+// nao codificados vao para o fim, preservando a ordem original entre si.
+//
+// Os timestamps vem do PostgREST em formato ISO consistente, entao a comparacao
+// lexicografica direta (`<`/`>`) ordena corretamente sem precisar de Date/parse.
+export function sortByRecent<T extends { id: string }>(
+  docs: T[],
+  codedAtByDoc: Record<string, string>,
+): T[] {
+  return docs
+    .map((doc, index) => ({ doc, index }))
+    .sort((a, b) => {
+      const ta = codedAtByDoc[a.doc.id];
+      const tb = codedAtByDoc[b.doc.id];
+      if (ta && tb) {
+        if (ta === tb) return a.index - b.index;
+        return tb < ta ? -1 : 1;
+      }
+      if (ta) return -1;
+      if (tb) return 1;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.doc);
+}

--- a/frontend/supabase/migrations/20260514010000_responses_updated_at.sql
+++ b/frontend/supabase/migrations/20260514010000_responses_updated_at.sql
@@ -1,0 +1,18 @@
+-- responses.updated_at: marca a ultima vez que a resposta foi gravada
+-- (insert ou update). saveResponse() faz upsert por (project, document,
+-- respondent), entao created_at so reflete a primeira submissao. updated_at
+-- permite ordenar a navegacao da aba Codificar por "codificados recentemente"
+-- (issue #108) — a data e a da codificacao do proprio pesquisador, nao a do
+-- upload do documento.
+--
+-- Sem trigger: o codebase nao usa triggers de updated_at; saveResponse()
+-- (unico caminho de escrita de responses humanas) seta updated_at explicito,
+-- e o DEFAULT now() cobre os inserts.
+
+ALTER TABLE responses ADD COLUMN updated_at TIMESTAMPTZ;
+
+-- Backfill: melhor sinal disponivel para linhas antigas e a propria criacao.
+UPDATE responses SET updated_at = COALESCE(created_at, now());
+
+ALTER TABLE responses ALTER COLUMN updated_at SET DEFAULT now();
+ALTER TABLE responses ALTER COLUMN updated_at SET NOT NULL;


### PR DESCRIPTION
## Contexto

Pesquisadores relataram que, ao perceber que uma resposta ficou errada, é difícil achar qual foi o último documento que codificaram para voltar e corrigir. A navegação de documentos atribuídos da aba Codificar só seguia o status do assignment, sem dar destaque ao que foi mexido por último.

Closes #108

## Mudanças

- **Migration `20260514010000_responses_updated_at.sql`** — adiciona `responses.updated_at` (`TIMESTAMPTZ NOT NULL DEFAULT now()`), com backfill `= created_at` para linhas existentes. Sem trigger: segue a convenção do codebase (`saveResponse()` seta explícito, `DEFAULT now()` cobre inserts).
- **`saveResponse()`** — grava `updated_at` a cada submit/auto-save, marcando a codificação do próprio pesquisador no tempo.
- **`code/page.tsx`** — busca `updated_at` nas responses do pesquisador e monta `codedAtByDoc` (doc → timestamp de codificação).
- **`CodingHeader`** — novo seletor "Ordenar": **Codificados recentemente** (padrão) / **Ordem de atribuição**, visível na aba Atribuídos.
- **`CodingPage`** — `sortByRecent()` ordena por `responses.updated_at` desc (não codificados vão para o fim, preservando a ordem original entre si). **"Codificados recentemente" é o padrão** — assim o pesquisador já abre a aba no último documento que mexeu, sem clique extra. "Ordem de atribuição" é opt-in via `?sort=default`. Estado vive na URL (igual a `?round=`).

A data usada é a da **codificação do próprio pesquisador**, não a do upload do documento.

> **Trade-off:** com o padrão "recentemente", documentos ainda não codificados ficam no fim da lista. Para quem está tocando a fila pendente do começo, basta trocar para "Ordem de atribuição".

## Ordem de deploy

A migration precisa ser aplicada **antes** do deploy do frontend — `page.tsx` passa a selecionar `responses.updated_at`. Aplicar com:

```bash
cd frontend
export SUPABASE_ACCESS_TOKEN=$(grep SUPABASE_ACCESS_TOKEN .env.local | cut -d= -f2)
npx supabase link --project-ref nryebmwlmxuwvynfuzsv
npx supabase db push
```

## Test plan

- [x] `npx tsc --noEmit` — sem erros
- [x] `npm test` — 186/186 passando
- [x] `eslint` nos arquivos alterados — sem novos problemas (CodingPage mantém erros pré-existentes de `any`/React Compiler)
- [ ] Aplicar a migration no Supabase remoto
- [ ] Aba Codificar → Atribuídos: abre já no último documento codificado; seletor "Ordenar" aparece ao lado das subabas com "Codificados recentemente" selecionado
- [ ] `< >` percorre do mais recente ao mais antigo; documentos não codificados aparecem no fim
- [ ] Trocar para "Ordem de atribuição" → mantém o documento atual selecionado, ordem volta ao status do assignment (`?sort=default` na URL)
- [ ] Voltar para "Codificados recentemente" → salta para o último documento codificado
- [ ] Pesquisador sem nenhuma resposta ainda: ordem cai no fallback (ordem original dos atribuídos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
