### PR TITLE
feat(auto-revisao): veredito ambiguo tambem exige justificativa

### DIFF
--- a/frontend/src/actions/__tests__/field-reviews.test.ts
+++ b/frontend/src/actions/__tests__/field-reviews.test.ts
@@ -175,7 +175,28 @@ describe("submitAutoReview — vereditos equivalente e ambiguo", () => {
     ]);
   });
 
-  it("ambiguo → insere project_comments com o contraste humano vs LLM", async () => {
+  it("ambiguo sem justificativa → erro e nenhum UPDATE", async () => {
+    const submitAutoReview = await loadSubmit();
+    const r = await submitAutoReview("p1", "doc1", [
+      { fieldName: "q1", verdict: "ambiguo" },
+    ]);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("justificativa obrigatória");
+    expect(r.error).toContain("ambíguo");
+    expect(updateCallsOf()).toHaveLength(0);
+  });
+
+  it("ambiguo com justificativa só de espaços → erro e nenhum UPDATE", async () => {
+    const submitAutoReview = await loadSubmit();
+    const r = await submitAutoReview("p1", "doc1", [
+      { fieldName: "q1", verdict: "ambiguo", justification: "   \n\t" },
+    ]);
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("justificativa obrigatória");
+    expect(updateCallsOf()).toHaveLength(0);
+  });
+
+  it("ambiguo → grava self_justification trimada e insere project_comments com o contraste e a justificativa", async () => {
     const submitAutoReview = await loadSubmit();
     tableData.field_reviews = [
       {
@@ -186,12 +207,19 @@ describe("submitAutoReview — vereditos equivalente e ambiguo", () => {
       },
     ];
     const r = await submitAutoReview("p1", "doc1", [
-      { fieldName: "q1", verdict: "ambiguo" },
+      {
+        fieldName: "q1",
+        verdict: "ambiguo",
+        justification: "  o enunciado não define a unidade  ",
+      },
     ]);
     expect(r.success).toBe(true);
 
     const frUpdate = updateCallsOf("field_reviews")[0];
-    expect(frUpdate?.payload).toMatchObject({ self_verdict: "ambiguo" });
+    expect(frUpdate?.payload).toMatchObject({
+      self_verdict: "ambiguo",
+      self_justification: "o enunciado não define a unidade",
+    });
 
     const commentInsert = writeCalls.find(
       (c) => c.op === "insert" && c.table === "project_comments",
@@ -207,6 +235,9 @@ describe("submitAutoReview — vereditos equivalente e ambiguo", () => {
     });
     expect(String(rows[0].body)).toContain("ambíguo");
     expect(String(rows[0].body)).toContain("Adalimumabe");
+    expect(String(rows[0].body)).toContain(
+      "Justificativa do pesquisador: o enunciado não define a unidade",
+    );
   });
 
   it("equivalente em retry (UPDATE casa 0 linhas) ainda registra a equivalencia", async () => {

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -6,6 +6,7 @@ import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import { canonicalPair, type EquivalencePair } from "@/lib/equivalence";
 import { resolveBlindVerdict } from "@/lib/arbitration-order";
+import { verdictRequiresJustification } from "@/lib/auto-review-decided";
 import { formatAnswerTechnical } from "@/lib/format-answer";
 import { revalidatePath } from "next/cache";
 import type {
@@ -17,8 +18,10 @@ import type {
 export interface SelfVerdictInput {
   fieldName: string;
   verdict: SelfVerdict;
-  // Obrigatoria quando verdict='contesta_llm': o pesquisador registra por que
-  // acha que sua resposta esta correta. Exibida ao arbitro na fase de revelacao.
+  // Obrigatoria quando verdict='contesta_llm' ou 'ambiguo'. Em contesta_llm o
+  // pesquisador registra por que acha que sua resposta esta correta (exibida ao
+  // arbitro na revelacao); em ambiguo registra por que o campo e ambiguo
+  // (anexada ao project_comments de discussao).
   justification?: string;
 }
 
@@ -47,13 +50,16 @@ export async function submitAutoReview(
     const user = await getAuthUser();
     if (!user) return { success: false, error: "Não autenticado" };
 
-    // Contestar o LLM exige justificativa — o arbitro precisa do contraponto
-    // humano na fase de revelacao.
+    // contesta_llm e ambiguo exigem justificativa — o arbitro precisa do
+    // contraponto humano na revelacao; ambiguo leva o porque para a discussao.
     for (const v of verdicts) {
-      if (v.verdict === "contesta_llm" && !v.justification?.trim()) {
+      if (verdictRequiresJustification(v.verdict) && !v.justification?.trim()) {
         return {
           success: false,
-          error: `Campo "${v.fieldName}": justificativa obrigatória quando você contesta o LLM.`,
+          error:
+            v.verdict === "ambiguo"
+              ? `Campo "${v.fieldName}": justificativa obrigatória quando você marca como ambíguo.`
+              : `Campo "${v.fieldName}": justificativa obrigatória quando você contesta o LLM.`,
         };
       }
     }
@@ -71,10 +77,9 @@ export async function submitAutoReview(
           .update({
             self_verdict: v.verdict,
             self_reviewed_at: now,
-            self_justification:
-              v.verdict === "contesta_llm"
-                ? (v.justification?.trim() ?? null)
-                : null,
+            self_justification: verdictRequiresJustification(v.verdict)
+              ? (v.justification?.trim() ?? null)
+              : null,
           })
           .eq("project_id", projectId)
           .eq("document_id", documentId)
@@ -233,6 +238,8 @@ export async function submitAutoReview(
             `Campo "${v.fieldName}" marcado como ambíguo na auto-revisão.`,
             `Humano respondeu: ${humanAnswer}`,
             `LLM respondeu: ${llmAnswer}`,
+            // Justificativa garantida nao-vazia pela validacao no topo da funcao.
+            `Justificativa do pesquisador: ${v.justification!.trim()}`,
             `Precisa de discussão para decidir o gabarito.`,
           ].join("\n\n");
           return {

--- a/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
+++ b/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { Keyboard, ChevronDown, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatAnswerDisplay } from "@/lib/format-answer";
+import { verdictRequiresJustification } from "@/lib/auto-review-decided";
 import type { SelfVerdict } from "@/lib/types";
 
 export interface AutoReviewField {
@@ -79,13 +80,13 @@ export function AutoReviewFieldPanel({
     setShowJustification(true);
   }, [field.fieldName]);
 
-  // Foca o textarea ao escolher contesta_llm — sem isto, teclar "1" abre o
-  // campo mas deixa o foco para tras. Keyed so em `choice`: navegar entre dois
-  // campos ambos contesta_llm nao rerroda o effect (mesmo valor), entao o foco
-  // so vai para o textarea no ato de escolher.
+  // Foca o textarea ao escolher um verdict que exige justificativa — sem isto,
+  // teclar o atalho abre o campo mas deixa o foco para tras. Keyed so em
+  // `choice`: navegar entre dois campos com o mesmo verdict nao rerroda o effect
+  // (mesmo valor), entao o foco so vai para o textarea no ato de escolher.
   const justificationRef = useRef<HTMLTextAreaElement>(null);
   useEffect(() => {
-    if (choice === "contesta_llm") justificationRef.current?.focus();
+    if (verdictRequiresJustification(choice)) justificationRef.current?.focus();
   }, [choice]);
 
   // Auto-advance pós-decisão: armazena handle do timeout num ref para poder
@@ -135,9 +136,9 @@ export function AutoReviewFieldPanel({
 
   function handleChoose(v: SelfVerdict) {
     onChoose(v);
-    // contesta_llm exige justificativa: não auto-avança, senão o pesquisador
-    // perderia o campo de texto que acabou de abrir.
-    if (v === "contesta_llm") return;
+    // contesta_llm e ambiguo exigem justificativa: não auto-avança, senão o
+    // pesquisador perderia o campo de texto que acabou de abrir.
+    if (verdictRequiresJustification(v)) return;
     // Pula campos já respondidos no auto-advance pós-clique (P/N manuais
     // continuam navegando livremente para permitir re-conferência).
     const nextUnanswered = answered.findIndex((a, i) => i > fieldIndex && !a);
@@ -286,7 +287,9 @@ export function AutoReviewFieldPanel({
           </div>
         )}
 
-        {!readOnly && !field.alreadyAnswered && choice === "contesta_llm" ? (
+        {!readOnly &&
+        !field.alreadyAnswered &&
+        verdictRequiresJustification(choice) ? (
           <div className="space-y-1.5">
             <Label htmlFor="self-justification" className="text-sm">
               Justificativa <span className="text-destructive">*</span>
@@ -297,7 +300,11 @@ export function AutoReviewFieldPanel({
               rows={3}
               value={justification}
               onChange={(e) => onJustificationChange(e.target.value)}
-              placeholder="Por que você acha que sua resposta está correta? O árbitro verá isto."
+              placeholder={
+                choice === "ambiguo"
+                  ? "Por que este campo é ambíguo? Isto será incluído no comentário de discussão."
+                  : "Por que você acha que sua resposta está correta? O árbitro verá isto."
+              }
             />
           </div>
         ) : null}

--- a/frontend/src/components/auto-review/AutoReviewPage.tsx
+++ b/frontend/src/components/auto-review/AutoReviewPage.tsx
@@ -100,7 +100,8 @@ export function AutoReviewPage({
   // Sem o prefixo do docId, escolher "q1" no doc A pre-selecionaria "q1" do
   // doc B na navegação. O composto garante isolamento por (doc, campo).
   const [choices, setChoices] = useState<Record<string, SelfVerdict>>({});
-  // Justificativa por (doc, campo) — só usada quando a escolha é contesta_llm.
+  // Justificativa por (doc, campo) — obrigatória quando a escolha é
+  // contesta_llm ou ambiguo.
   const [justifications, setJustifications] = useState<Record<string, string>>(
     {},
   );
@@ -205,7 +206,7 @@ export function AutoReviewPage({
   const doc = docs[docIndex];
   const currentField = doc.fields[fieldIndex];
   // Campo "decidido" = já respondido OU com escolha local; se a escolha for
-  // contesta_llm, a justificativa também precisa estar preenchida.
+  // contesta_llm ou ambiguo, a justificativa também precisa estar preenchida.
   const isFieldDecided = (f: AutoReviewField) => {
     const key = choiceKey(doc.docId, f.fieldName);
     return isAutoReviewFieldDecided(

--- a/frontend/src/lib/__tests__/auto-review-decided.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-decided.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { isAutoReviewFieldDecided } from "@/lib/auto-review-decided";
+import {
+  isAutoReviewFieldDecided,
+  verdictRequiresJustification,
+} from "@/lib/auto-review-decided";
 
 describe("isAutoReviewFieldDecided", () => {
   it("alreadyAnswered → decidido independente de choice/justificativa", () => {
@@ -12,8 +15,20 @@ describe("isAutoReviewFieldDecided", () => {
     expect(isAutoReviewFieldDecided(false, undefined, undefined)).toBe(false);
   });
 
-  it("admite_erro → decidido sem precisar de justificativa", () => {
+  it("admite_erro e equivalente → decididos sem precisar de justificativa", () => {
     expect(isAutoReviewFieldDecided(false, "admite_erro", undefined)).toBe(true);
+    expect(isAutoReviewFieldDecided(false, "equivalente", undefined)).toBe(true);
+  });
+
+  it("ambiguo sem justificativa → não decidido", () => {
+    expect(isAutoReviewFieldDecided(false, "ambiguo", undefined)).toBe(false);
+    expect(isAutoReviewFieldDecided(false, "ambiguo", "   ")).toBe(false);
+  });
+
+  it("ambiguo com justificativa preenchida → decidido", () => {
+    expect(isAutoReviewFieldDecided(false, "ambiguo", "campo ambíguo")).toBe(
+      true,
+    );
   });
 
   it("contesta_llm sem justificativa → não decidido", () => {
@@ -33,5 +48,19 @@ describe("isAutoReviewFieldDecided", () => {
       isAutoReviewFieldDecided(false, "contesta_llm", "minha resposta confere"),
     ).toBe(true);
     expect(isAutoReviewFieldDecided(false, "contesta_llm", "  ok  ")).toBe(true);
+  });
+});
+
+describe("verdictRequiresJustification", () => {
+  it("contesta_llm e ambiguo exigem justificativa", () => {
+    expect(verdictRequiresJustification("contesta_llm")).toBe(true);
+    expect(verdictRequiresJustification("ambiguo")).toBe(true);
+  });
+
+  it("admite_erro, equivalente e nulo não exigem justificativa", () => {
+    expect(verdictRequiresJustification("admite_erro")).toBe(false);
+    expect(verdictRequiresJustification("equivalente")).toBe(false);
+    expect(verdictRequiresJustification(null)).toBe(false);
+    expect(verdictRequiresJustification(undefined)).toBe(false);
   });
 });

--- a/frontend/src/lib/auto-review-decided.ts
+++ b/frontend/src/lib/auto-review-decided.ts
@@ -1,9 +1,20 @@
 import type { SelfVerdict } from "@/lib/types";
 
+// Vereditos que exigem justificativa do pesquisador: contesta_llm (o arbitro
+// precisa do contraponto humano na revelacao) e ambiguo (o porque vai para o
+// project_comments de discussao). Predicado compartilhado entre a UI e a
+// validacao server-side de submitAutoReview para evitar drift.
+export function verdictRequiresJustification(
+  verdict: SelfVerdict | null | undefined,
+): boolean {
+  return verdict === "contesta_llm" || verdict === "ambiguo";
+}
+
 // Um campo da auto-revisao esta "decidido" quando ja foi respondido em sessao
 // anterior, ou quando o pesquisador escolheu um verdict local. Excecao:
-// contesta_llm so conta como decidido se a justificativa obrigatoria estiver
-// preenchida (espelha a validacao server-side de submitAutoReview).
+// contesta_llm e ambiguo so contam como decididos se a justificativa
+// obrigatoria estiver preenchida (espelha a validacao server-side de
+// submitAutoReview).
 //
 // Modulo separado de lib/auto-review.ts de proposito: aquele importa o
 // supabase admin client (server-only) e nao pode ser puxado para um client
@@ -15,6 +26,6 @@ export function isAutoReviewFieldDecided(
 ): boolean {
   if (alreadyAnswered) return true;
   if (choice == null) return false;
-  if (choice === "contesta_llm") return !!justification?.trim();
+  if (verdictRequiresJustification(choice)) return !!justification?.trim();
   return true;
 }


### PR DESCRIPTION
## Summary
- O veredito `ambiguo` na auto-revisão passa a exigir justificativa obrigatória, igual a `contesta_llm`.
- A justificativa é gravada em `field_reviews.self_justification` e **anexada ao corpo do `project_comments`** gerado para discussão (`Justificativa do pesquisador: ...`), para que quem for discutir o campo já veja o raciocínio de quem levantou a ambiguidade.
- Novo predicado compartilhado `verdictRequiresJustification` em `lib/auto-review-decided.ts`, usado pela validação server-side (`submitAutoReview`) e pela UI (`AutoReviewFieldPanel`) para evitar drift entre as ~4 ocorrências da regra.
- UI: textarea de justificativa aparece para `ambiguo` com placeholder específico; foco e supressão de auto-advance estendidos ao novo caso.

Sem migration: a coluna `self_justification` e a constraint de `self_verdict` já aceitam `ambiguo`.

## Test plan
- [x] `npx vitest run field-reviews auto-review-decided` — 19 testes passam, incluindo novos casos de `ambiguo` (sem justificativa → erro; só espaços → erro; com justificativa → grava trimada + comment body contém a justificativa).
- [ ] Manual: abrir auto-revisão com divergência, escolher "Ambíguo (discutir)" → textarea obrigatória aparece, "Enviar" desabilitado sem justificativa; ao enviar, conferir `field_reviews.self_justification` e o corpo do `project_comments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)