### PR TITLE
fix(auto-revisao): campo novo do schema aparecendo como resposta "(vazio)"

### DIFF
--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -771,15 +771,21 @@ export async function submitFinalVerdicts(
 }
 
 // Coordenador-only: varre todas as respostas humanas concluidas do projeto e
-// materializa o backlog de auto-revisao + field_reviews. Usado quando a chamada
-// inline em saveResponse falhou silenciosamente (ver log "[auto-review]") ou
-// apos importar respostas em lote.
+// reconcilia o backlog de auto-revisao + field_reviews. Usado quando a chamada
+// inline em saveResponse falhou silenciosamente (ver log "[auto-review]"), apos
+// importar respostas em lote, ou apos uma edicao de schema que tornou campos
+// antigos "stale" (campos adicionados depois de uma codificacao geravam
+// field_reviews espurios com a resposta humana aparecendo como "(vazio)").
 //
-// Bulk-otimizado: 3 queries (project + humanos + LLMs) + 2 upserts em batch,
-// independente do numero de respostas. Antes era N+1 (3 queries por response).
+// Reconcile (nao so insert): alem de inserir o conjunto correto, remove
+// field_reviews que nao deveriam mais existir — mas SO os ainda pendentes
+// (self_verdict IS NULL). Linhas que o pesquisador ja resolveu nunca sao
+// apagadas (apagar perderia trabalho); sao apenas contadas em `keptResolved`.
+// Assignments auto_revisao que ficam sem nenhum field_review e ainda estao
+// `pendente` sao removidos.
 //
-// Idempotente: upserts usam ignoreDuplicates em chaves unicas
-// (assignments: doc+user+type; field_reviews: doc+field).
+// Bulk-otimizado: queries em batch + upserts/deletes em batch, independente do
+// numero de respostas.
 export async function regenerateAutoReviewBacklog(
   projectId: string,
 ): Promise<{
@@ -787,6 +793,8 @@ export async function regenerateAutoReviewBacklog(
   error?: string;
   scanned?: number;
   regenerated?: number;
+  removed?: number;
+  keptResolved?: number;
 }> {
   try {
     const user = await getAuthUser();
@@ -815,13 +823,13 @@ export async function regenerateAutoReviewBacklog(
         .single(),
       admin
         .from("responses")
-        .select("id, document_id, respondent_id, answers")
+        .select("id, document_id, respondent_id, answers, answer_field_hashes")
         .eq("project_id", projectId)
         .eq("respondent_type", "humano")
         .eq("is_partial", false),
       admin
         .from("responses")
-        .select("id, document_id, answers")
+        .select("id, document_id, answers, answer_field_hashes")
         .eq("project_id", projectId)
         .eq("respondent_type", "llm")
         .eq("is_latest", true),
@@ -889,10 +897,16 @@ export async function regenerateAutoReviewBacklog(
           {
             id: human.id,
             answers: (human.answers as Record<string, unknown>) ?? {},
+            answerFieldHashes: human.answer_field_hashes as
+              | Record<string, string>
+              | null,
           },
           {
             id: llm.id,
             answers: (llm.answers as Record<string, unknown>) ?? {},
+            answerFieldHashes: llm.answer_field_hashes as
+              | Record<string, string>
+              | null,
           },
         ],
         equivByDoc.get(human.document_id),
@@ -919,6 +933,40 @@ export async function regenerateAutoReviewBacklog(
       }
     }
 
+    // --- Reconcile: remove field_reviews que nao deveriam mais existir ---
+    // O conjunto correto e o que acabou de ser computado em fieldReviewRows.
+    // Linhas pendentes (self_verdict IS NULL) fora desse conjunto sao espurias
+    // — tipicamente campos que ficaram "stale" apos edicao de schema — e podem
+    // ser apagadas. Linhas ja resolvidas pelo pesquisador sao preservadas.
+    const correctKeys = new Set(
+      fieldReviewRows.map((r) => `${r.document_id}|${r.field_name}`),
+    );
+
+    const { data: existingReviews, error: existingErr } = await admin
+      .from("field_reviews")
+      .select("id, document_id, field_name, self_verdict")
+      .eq("project_id", projectId);
+    if (existingErr) return { success: false, error: existingErr.message };
+
+    const idsToDelete: string[] = [];
+    let keptResolved = 0;
+    for (const fr of existingReviews ?? []) {
+      if (correctKeys.has(`${fr.document_id}|${fr.field_name}`)) continue;
+      if (fr.self_verdict == null) {
+        idsToDelete.push(fr.id);
+      } else {
+        keptResolved++;
+      }
+    }
+
+    if (idsToDelete.length > 0) {
+      const { error } = await admin
+        .from("field_reviews")
+        .delete()
+        .in("id", idsToDelete);
+      if (error) return { success: false, error: error.message };
+    }
+
     if (assignmentRows.length > 0) {
       const { error } = await admin.from("assignments").upsert(assignmentRows, {
         onConflict: "document_id,user_id,type",
@@ -936,12 +984,46 @@ export async function regenerateAutoReviewBacklog(
       if (error) return { success: false, error: error.message };
     }
 
+    // Remove assignments auto_revisao orfaos: sem nenhum field_review restante
+    // para o doc+pesquisador e ainda `pendente`. Assignments ja iniciados ou
+    // concluidos sao preservados.
+    const { data: remainingReviews, error: remainingErr } = await admin
+      .from("field_reviews")
+      .select("document_id, self_reviewer_id")
+      .eq("project_id", projectId);
+    if (remainingErr) return { success: false, error: remainingErr.message };
+    const docUserWithReviews = new Set(
+      (remainingReviews ?? []).map(
+        (r) => `${r.document_id}|${r.self_reviewer_id}`,
+      ),
+    );
+
+    const { data: autoAssignments, error: autoErr } = await admin
+      .from("assignments")
+      .select("id, document_id, user_id")
+      .eq("project_id", projectId)
+      .eq("type", "auto_revisao")
+      .eq("status", "pendente");
+    if (autoErr) return { success: false, error: autoErr.message };
+    const orphanAssignmentIds = (autoAssignments ?? [])
+      .filter((a) => !docUserWithReviews.has(`${a.document_id}|${a.user_id}`))
+      .map((a) => a.id);
+    if (orphanAssignmentIds.length > 0) {
+      const { error } = await admin
+        .from("assignments")
+        .delete()
+        .in("id", orphanAssignmentIds);
+      if (error) return { success: false, error: error.message };
+    }
+
     revalidatePath(`/projects/${projectId}/analyze/auto-revisao`);
     revalidatePath(`/projects/${projectId}/analyze/arbitragem`);
     return {
       success: true,
       scanned: queue.length,
       regenerated,
+      removed: idsToDelete.length,
+      keptResolved,
     };
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : "Erro" };

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -815,6 +815,7 @@ export async function regenerateAutoReviewBacklog(
       { data: humanResponses, error: humanErr },
       { data: llmResponses, error: llmErr },
       { data: equivalences, error: equivErr },
+      { data: existingReviews, error: existingErr },
     ] = await Promise.all([
       admin
         .from("projects")
@@ -837,12 +838,19 @@ export async function regenerateAutoReviewBacklog(
         .from("response_equivalences")
         .select("document_id, field_name, response_a_id, response_b_id")
         .eq("project_id", projectId),
+      // Estado atual de field_reviews — usado no reconcile abaixo. Independe
+      // do conjunto recem-computado, entao buscamos junto do batch inicial.
+      admin
+        .from("field_reviews")
+        .select("id, document_id, field_name, self_verdict")
+        .eq("project_id", projectId),
     ]);
 
     if (projErr) return { success: false, error: projErr.message };
     if (humanErr) return { success: false, error: humanErr.message };
     if (llmErr) return { success: false, error: llmErr.message };
     if (equivErr) return { success: false, error: equivErr.message };
+    if (existingErr) return { success: false, error: existingErr.message };
 
     const fields = (project?.pydantic_fields as PydanticField[]) ?? [];
     if (fields.length === 0) {
@@ -942,12 +950,6 @@ export async function regenerateAutoReviewBacklog(
       fieldReviewRows.map((r) => `${r.document_id}|${r.field_name}`),
     );
 
-    const { data: existingReviews, error: existingErr } = await admin
-      .from("field_reviews")
-      .select("id, document_id, field_name, self_verdict")
-      .eq("project_id", projectId);
-    if (existingErr) return { success: false, error: existingErr.message };
-
     const idsToDelete: string[] = [];
     let keptResolved = 0;
     for (const fr of existingReviews ?? []) {
@@ -975,6 +977,10 @@ export async function regenerateAutoReviewBacklog(
       if (error) return { success: false, error: error.message };
     }
     if (fieldReviewRows.length > 0) {
+      // NB: ignoreDuplicates reconcilia o *conjunto* de field_reviews
+      // (doc+field), nao os ponteiros. Uma linha ja existente mantem seus
+      // human_response_id/llm_response_id antigos mesmo que o LLM tenha
+      // re-rodado desde entao — atualizar FKs stale fica fora deste reconcile.
       const { error } = await admin
         .from("field_reviews")
         .upsert(fieldReviewRows, {
@@ -986,25 +992,31 @@ export async function regenerateAutoReviewBacklog(
 
     // Remove assignments auto_revisao orfaos: sem nenhum field_review restante
     // para o doc+pesquisador e ainda `pendente`. Assignments ja iniciados ou
-    // concluidos sao preservados.
-    const { data: remainingReviews, error: remainingErr } = await admin
-      .from("field_reviews")
-      .select("document_id, self_reviewer_id")
-      .eq("project_id", projectId);
+    // concluidos sao preservados. As duas leituras refletem o estado pos-
+    // delete/upsert e sao independentes entre si — buscadas em paralelo.
+    const [
+      { data: remainingReviews, error: remainingErr },
+      { data: autoAssignments, error: autoErr },
+    ] = await Promise.all([
+      admin
+        .from("field_reviews")
+        .select("document_id, self_reviewer_id")
+        .eq("project_id", projectId),
+      admin
+        .from("assignments")
+        .select("id, document_id, user_id")
+        .eq("project_id", projectId)
+        .eq("type", "auto_revisao")
+        .eq("status", "pendente"),
+    ]);
     if (remainingErr) return { success: false, error: remainingErr.message };
+    if (autoErr) return { success: false, error: autoErr.message };
     const docUserWithReviews = new Set(
       (remainingReviews ?? []).map(
         (r) => `${r.document_id}|${r.self_reviewer_id}`,
       ),
     );
 
-    const { data: autoAssignments, error: autoErr } = await admin
-      .from("assignments")
-      .select("id, document_id, user_id")
-      .eq("project_id", projectId)
-      .eq("type", "auto_revisao")
-      .eq("status", "pendente");
-    if (autoErr) return { success: false, error: autoErr.message };
     const orphanAssignmentIds = (autoAssignments ?? [])
       .filter((a) => !docUserWithReviews.has(`${a.document_id}|${a.user_id}`))
       .map((a) => a.id);

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -10,6 +10,7 @@ import { verdictRequiresJustification } from "@/lib/auto-review-decided";
 import { formatAnswerTechnical } from "@/lib/format-answer";
 import { revalidatePath } from "next/cache";
 import type {
+  AnswerFieldHashes,
   PydanticField,
   SelfVerdict,
   ArbitrationVerdict,
@@ -905,16 +906,12 @@ export async function regenerateAutoReviewBacklog(
           {
             id: human.id,
             answers: (human.answers as Record<string, unknown>) ?? {},
-            answerFieldHashes: human.answer_field_hashes as
-              | Record<string, string>
-              | null,
+            answerFieldHashes: human.answer_field_hashes as AnswerFieldHashes,
           },
           {
             id: llm.id,
             answers: (llm.answers as Record<string, unknown>) ?? {},
-            answerFieldHashes: llm.answer_field_hashes as
-              | Record<string, string>
-              | null,
+            answerFieldHashes: llm.answer_field_hashes as AnswerFieldHashes,
           },
         ],
         equivByDoc.get(human.document_id),
@@ -961,12 +958,21 @@ export async function regenerateAutoReviewBacklog(
       }
     }
 
+    // Defesa em profundidade: `.is("self_verdict", null)` fecha a janela TOCTOU
+    // entre a leitura de `existingReviews` (Promise.all inicial) e este DELETE.
+    // Se um pesquisador resolver um campo nesse intervalo, o DB recusa a linha
+    // mesmo que o id esteja em `idsToDelete`. `.select("id")` devolve as linhas
+    // efetivamente apagadas, fonte da contagem `removed` retornada.
+    let actuallyRemoved = 0;
     if (idsToDelete.length > 0) {
-      const { error } = await admin
+      const { data: deleted, error } = await admin
         .from("field_reviews")
         .delete()
-        .in("id", idsToDelete);
+        .in("id", idsToDelete)
+        .is("self_verdict", null)
+        .select("id");
       if (error) return { success: false, error: error.message };
+      actuallyRemoved = deleted?.length ?? 0;
     }
 
     if (assignmentRows.length > 0) {
@@ -1034,7 +1040,7 @@ export async function regenerateAutoReviewBacklog(
       success: true,
       scanned: queue.length,
       regenerated,
-      removed: idsToDelete.length,
+      removed: actuallyRemoved,
       keptResolved,
     };
   } catch (e) {

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -322,9 +322,15 @@ export default async function ComparePageRoute({
 
     // Equivalence-aware divergence detection (free-text fields can have
     // responses fused via the reviewer's "marcar como equivalentes" action).
+    // `answerFieldHashes` torna a comparação consciente de staleness: campos
+    // adicionados ao schema depois de uma codificação não geram falso "(vazio)".
     const divergent = computeDivergentFieldNames(
       fields,
-      qualifiedResponses,
+      qualifiedResponses.map((r) => ({
+        id: r.id,
+        answers: r.answers,
+        answerFieldHashes: r.answer_field_hashes,
+      })),
       equivByDocField.get(docId),
     );
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -8,7 +8,7 @@ import {
   readCompareFilters,
   type CompareFiltersValue,
 } from "@/lib/compare-filters";
-import type { PydanticField } from "@/lib/types";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 interface CompareDoc {
   id: string;
@@ -27,7 +27,7 @@ interface CompareResponse {
   justifications: Record<string, string> | null;
   is_latest: boolean;
   pydantic_hash: string | null;
-  answer_field_hashes: Record<string, string> | null;
+  answer_field_hashes: AnswerFieldHashes;
   schema_version_major: number | null;
   schema_version_minor: number | null;
   schema_version_patch: number | null;

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -88,9 +88,17 @@ export function LlmInsightsView({
       toast.error(result.error ?? "Falha ao regenerar backlog");
       return;
     }
-    toast.success(
-      `Backlog regenerado. ${result.scanned ?? 0} resposta(s) escaneada(s), ${result.regenerated ?? 0} doc(s) com divergência.`,
-    );
+    const parts = [
+      `${result.scanned ?? 0} resposta(s) escaneada(s)`,
+      `${result.regenerated ?? 0} doc(s) com divergência`,
+    ];
+    if (result.removed) {
+      parts.push(`${result.removed} revisão(ões) obsoleta(s) removida(s)`);
+    }
+    if (result.keptResolved) {
+      parts.push(`${result.keptResolved} já resolvida(s) mantida(s)`);
+    }
+    toast.success(`Backlog regenerado. ${parts.join(", ")}.`);
     router.refresh();
   }
 

--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -184,6 +184,18 @@ describe("computeDivergentFieldNames", () => {
     ];
     expect(computeDivergentFieldNames(fields, responses)).toEqual(["a"]);
   });
+
+  it("staleness: empty answerFieldHashes {} is treated as legacy, not 'no fields'", () => {
+    // Um objeto vazio (ex: PydanticFields sem `.hash` populado) não pode
+    // excluir todos os campos silenciosamente — deve cair no comportamento
+    // legacy de comparar tudo.
+    const fields = [field({ name: "a" })];
+    const responses = [
+      { id: "1", answers: { a: "alpha" }, answerFieldHashes: {} },
+      { id: "2", answers: { a: "beta" }, answerFieldHashes: {} },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual(["a"]);
+  });
 });
 
 describe("isDocComplete", () => {

--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -144,6 +144,46 @@ describe("computeDivergentFieldNames", () => {
     ];
     expect(computeDivergentFieldNames(fields, responses)).toEqual([]);
   });
+
+  it("staleness: a field absent from a response's answerFieldHashes is excluded from comparison", () => {
+    // `b` foi adicionado ao schema depois que a response 1 foi codificada:
+    // o answerFieldHashes dela não tem a chave `b`. Sem a resposta 1, sobra
+    // só 1 response aplicável para `b` → não pode divergir (não vira "(vazio)").
+    const fields = [field({ name: "a" }), field({ name: "b" })];
+    const responses = [
+      {
+        id: "1",
+        answers: { a: "same" },
+        answerFieldHashes: { a: "ha" } as Record<string, string>,
+      },
+      {
+        id: "2",
+        answers: { a: "same", b: "novo" },
+        answerFieldHashes: { a: "ha", b: "hb" } as Record<string, string>,
+      },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual([]);
+  });
+
+  it("staleness: field present in both responses' hashes still diverges normally", () => {
+    const fields = [field({ name: "a" })];
+    const responses = [
+      { id: "1", answers: { a: "alpha" }, answerFieldHashes: { a: "ha" } },
+      { id: "2", answers: { a: "beta" }, answerFieldHashes: { a: "ha" } },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual(["a"]);
+  });
+
+  it("staleness: null/absent answerFieldHashes (legacy) preserves old behavior", () => {
+    // Sem o snapshot de hashes não dá para inferir staleness — mantém o
+    // comportamento antigo de comparar tudo (undefined vs valor = divergente).
+    const fields = [field({ name: "a" })];
+    const responses = [
+      { id: "1", answers: {}, answerFieldHashes: null },
+      { id: "2", answers: { a: "valor" } },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual(["a"]);
+  });
 });
 
 describe("isDocComplete", () => {

--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -196,6 +196,24 @@ describe("computeDivergentFieldNames", () => {
     ];
     expect(computeDivergentFieldNames(fields, responses)).toEqual(["a"]);
   });
+
+  it("staleness: asymmetric legacy human + modern LLM without the field — does not diverge", () => {
+    // Cenário real de migração: humano codificou antes da coluna
+    // `answer_field_hashes` existir (hashes=null, legacy → considera-se que
+    // tinha o campo); LLM re-rodou depois com hashes modernos mas o campo
+    // não está nos hashes dele (campo foi removido do schema antes do LLM
+    // re-rodar). Só 1 response aplicável → não diverge.
+    const fields = [field({ name: "removido" })];
+    const responses = [
+      { id: "1", answers: { removido: "humano" }, answerFieldHashes: null },
+      {
+        id: "2",
+        answers: { removido: "llm" },
+        answerFieldHashes: { outro: "h" } as Record<string, string>,
+      },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual([]);
+  });
 });
 
 describe("isDocComplete", () => {

--- a/frontend/src/lib/auto-review.ts
+++ b/frontend/src/lib/auto-review.ts
@@ -45,7 +45,7 @@ export async function createAutoReviewIfDiverges(
       .single(),
     admin
       .from("responses")
-      .select("id, answers")
+      .select("id, answers, answer_field_hashes")
       .eq("project_id", projectId)
       .eq("document_id", documentId)
       .eq("respondent_id", humanUserId)
@@ -53,7 +53,7 @@ export async function createAutoReviewIfDiverges(
       .maybeSingle(),
     admin
       .from("responses")
-      .select("id, answers")
+      .select("id, answers, answer_field_hashes")
       .eq("project_id", projectId)
       .eq("document_id", documentId)
       .eq("respondent_type", "llm")
@@ -100,8 +100,20 @@ export async function createAutoReviewIfDiverges(
   const divergent = computeDivergentFieldNames(
     fields,
     [
-      { id: humanResponse.id, answers: humanResponse.answers ?? {} },
-      { id: llmResponse.id, answers: llmResponse.answers ?? {} },
+      {
+        id: humanResponse.id,
+        answers: humanResponse.answers ?? {},
+        answerFieldHashes: humanResponse.answer_field_hashes as
+          | Record<string, string>
+          | null,
+      },
+      {
+        id: llmResponse.id,
+        answers: llmResponse.answers ?? {},
+        answerFieldHashes: llmResponse.answer_field_hashes as
+          | Record<string, string>
+          | null,
+      },
     ],
     equivalencesByField,
   );

--- a/frontend/src/lib/auto-review.ts
+++ b/frontend/src/lib/auto-review.ts
@@ -1,7 +1,7 @@
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import type { EquivalencePair } from "@/lib/equivalence";
-import type { PydanticField } from "@/lib/types";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 // Log estruturado JSON com prefixo "[auto-review]" — pesquisavel em logs
 // Vercel/Fly via `grep '[auto-review]'`. Campos minimos: event, projectId,
@@ -103,16 +103,12 @@ export async function createAutoReviewIfDiverges(
       {
         id: humanResponse.id,
         answers: humanResponse.answers ?? {},
-        answerFieldHashes: humanResponse.answer_field_hashes as
-          | Record<string, string>
-          | null,
+        answerFieldHashes: humanResponse.answer_field_hashes as AnswerFieldHashes,
       },
       {
         id: llmResponse.id,
         answers: llmResponse.answers ?? {},
-        answerFieldHashes: llmResponse.answer_field_hashes as
-          | Record<string, string>
-          | null,
+        answerFieldHashes: llmResponse.answer_field_hashes as AnswerFieldHashes,
       },
     ],
     equivalencesByField,

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -17,18 +17,23 @@ interface ResponseLike {
   id: string;
   answers: Record<string, unknown> | null | undefined;
   // Snapshot per-campo do schema contra o qual a response foi codificada
-  // (1 chave por campo existente na época). Quando presente e a chave do campo
-  // não está nele, aquele campo não existia quando a response foi codificada —
-  // comparar geraria um falso "(vazio)" divergente. Ausente/null = legacy
-  // (antes do mecanismo de hashes): não dá para inferir, mantém comportamento
-  // antigo de incluir a response.
+  // (1 chave por campo existente na época). Quando presente, não-vazio e a
+  // chave do campo não está nele, aquele campo não existia quando a response
+  // foi codificada — comparar geraria um falso "(vazio)" divergente.
+  // Ausente/null/{} = legacy: não dá para inferir, mantém comportamento antigo
+  // de incluir a response.
   answerFieldHashes?: Record<string, string> | null;
 }
 
 // True a menos que a response comprovadamente não tivesse o campo no schema
-// contra o qual foi codificada (answer_field_hashes presente e sem a chave).
+// contra o qual foi codificada (answer_field_hashes presente, não-vazio e sem
+// a chave). Um objeto vazio é tratado como legacy: ou o projeto não tinha
+// campos, ou os PydanticFields não tinham `.hash` populado — em ambos os casos
+// não dá para inferir staleness, então a response permanece na comparação (não
+// excluir todos os campos silenciosamente).
 function responseHadField(r: ResponseLike, fieldName: string): boolean {
   if (!r.answerFieldHashes) return true;
+  if (Object.keys(r.answerFieldHashes).length === 0) return true;
   return Object.prototype.hasOwnProperty.call(r.answerFieldHashes, fieldName);
 }
 

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -16,6 +16,20 @@ export function isFreeTextField(field: PydanticField): boolean {
 interface ResponseLike {
   id: string;
   answers: Record<string, unknown> | null | undefined;
+  // Snapshot per-campo do schema contra o qual a response foi codificada
+  // (1 chave por campo existente na época). Quando presente e a chave do campo
+  // não está nele, aquele campo não existia quando a response foi codificada —
+  // comparar geraria um falso "(vazio)" divergente. Ausente/null = legacy
+  // (antes do mecanismo de hashes): não dá para inferir, mantém comportamento
+  // antigo de incluir a response.
+  answerFieldHashes?: Record<string, string> | null;
+}
+
+// True a menos que a response comprovadamente não tivesse o campo no schema
+// contra o qual foi codificada (answer_field_hashes presente e sem a chave).
+function responseHadField(r: ResponseLike, fieldName: string): boolean {
+  if (!r.answerFieldHashes) return true;
+  return Object.prototype.hasOwnProperty.call(r.answerFieldHashes, fieldName);
 }
 
 // Returns the names of fields whose responses diverge.
@@ -37,11 +51,15 @@ export function computeDivergentFieldNames(
     )
       continue;
 
-    const applicable = field.condition
-      ? responses.filter((r) =>
-          isFieldVisible(field, (r.answers as Record<string, unknown>) ?? {}),
-        )
-      : responses;
+    const applicable = responses.filter((r) => {
+      if (!responseHadField(r, field.name)) return false;
+      if (
+        field.condition &&
+        !isFieldVisible(field, (r.answers as Record<string, unknown>) ?? {})
+      )
+        return false;
+      return true;
+    });
     if (applicable.length < 2) continue;
 
     if (field.type === "multi" && field.options?.length) {

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -1,7 +1,7 @@
 import { normalizeForComparison } from "@/lib/utils";
 import { isFieldVisible } from "@/lib/conditional";
 import { buildResponseGroupKeys, type EquivalencePair } from "@/lib/equivalence";
-import type { PydanticField } from "@/lib/types";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 // A field is free-text when there is no fixed option set —
 // equivalence makes sense only here. Multi/single-with-options have
@@ -22,7 +22,7 @@ interface ResponseLike {
   // foi codificada — comparar geraria um falso "(vazio)" divergente.
   // Ausente/null/{} = legacy: não dá para inferir, mantém comportamento antigo
   // de incluir a response.
-  answerFieldHashes?: Record<string, string> | null;
+  answerFieldHashes?: AnswerFieldHashes;
 }
 
 // True a menos que a response comprovadamente não tivesse o campo no schema

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -41,7 +41,7 @@ export async function syncCompareAssignment(
       .single(),
     supabase
       .from("responses")
-      .select("id, respondent_type, is_latest, answers")
+      .select("id, respondent_type, is_latest, answers, answer_field_hashes")
       .eq("project_id", projectId)
       .eq("document_id", documentId),
     supabase
@@ -73,12 +73,14 @@ export async function syncCompareAssignment(
   type ActiveResponse = {
     id: string;
     answers: Record<string, unknown>;
+    answerFieldHashes: Record<string, string> | null;
   };
   const activeResponses: ActiveResponse[] = (responses ?? [])
     .filter((r) => r.is_latest || r.respondent_type === "humano")
     .map((r) => ({
       id: r.id,
       answers: (r.answers ?? {}) as Record<string, unknown>,
+      answerFieldHashes: r.answer_field_hashes as Record<string, string> | null,
     }));
 
   const equivalencesByField = new Map<string, EquivalencePair[]>();

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import type { createSupabaseServer } from "@/lib/supabase/server";
-import type { PydanticField } from "@/lib/types";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import {
   computeDivergentFieldNames,
   isFreeTextField,
@@ -73,14 +73,14 @@ export async function syncCompareAssignment(
   type ActiveResponse = {
     id: string;
     answers: Record<string, unknown>;
-    answerFieldHashes: Record<string, string> | null;
+    answerFieldHashes: AnswerFieldHashes;
   };
   const activeResponses: ActiveResponse[] = (responses ?? [])
     .filter((r) => r.is_latest || r.respondent_type === "humano")
     .map((r) => ({
       id: r.id,
       answers: (r.answers ?? {}) as Record<string, unknown>,
-      answerFieldHashes: r.answer_field_hashes as Record<string, string> | null,
+      answerFieldHashes: r.answer_field_hashes as AnswerFieldHashes,
     }));
 
   const equivalencesByField = new Map<string, EquivalencePair[]>();

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -1,6 +1,6 @@
 import { normalizeForComparison } from "@/lib/utils";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { PydanticField } from "@/lib/types";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import type {
   ReviewedDocument,
   ReviewedField,
@@ -21,7 +21,7 @@ interface ResponseRow {
   answers: Record<string, unknown>;
   justifications: Record<string, string> | null;
   pydantic_hash: string | null;
-  answer_field_hashes: Record<string, string> | null;
+  answer_field_hashes: AnswerFieldHashes;
   created_at: string;
 }
 
@@ -62,7 +62,7 @@ export interface ReviewComputationContext {
 /* ── Pure helpers ── */
 
 function isFieldStale(
-  answerFieldHashes: Record<string, string> | null,
+  answerFieldHashes: AnswerFieldHashes,
   pydanticHash: string | null,
   fieldName: string,
   currentFieldHashes: Record<string, string>,
@@ -268,10 +268,7 @@ export async function fetchReviewBaseData(
       answers: r.answers as Record<string, unknown>,
       justifications: r.justifications as Record<string, string> | null,
       pydantic_hash: r.pydantic_hash,
-      answer_field_hashes: r.answer_field_hashes as Record<
-        string,
-        string
-      > | null,
+      answer_field_hashes: r.answer_field_hashes as AnswerFieldHashes,
       created_at: r.created_at,
     });
     responsesByDoc.set(r.document_id, list);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -124,6 +124,15 @@ export interface AssignmentBatch {
   label: string | null;
 }
 
+// Snapshot por-campo do schema contra o qual a response foi codificada
+// (1 chave por campo existente na época, valor = field.hash). Gravado em
+// saveResponse iterando o schema completo (não os campos respondidos), então
+// "chave ausente" significa "campo não existia no schema na época" — base
+// para a heurística de staleness em compare-divergence e reviews/queries.
+// `null`/`{}` significam legacy (response pré-coluna ou schema sem hashes):
+// não dá para inferir staleness.
+export type AnswerFieldHashes = Record<string, string> | null;
+
 export interface Response {
   id: string;
   project_id: string;
@@ -135,7 +144,7 @@ export interface Response {
   justifications: Record<string, string> | null;
   is_latest: boolean;
   pydantic_hash: string | null;
-  answer_field_hashes: Record<string, string> | null;
+  answer_field_hashes: AnswerFieldHashes;
   created_at: string;
 }
 


### PR DESCRIPTION
## Contexto

Um pesquisador relatou que, na auto-revisão (humano vs LLM), várias respostas dele apareciam como **"(vazio)"** e eram marcadas como discordância com o LLM — mesmo todas tendo sido perguntas obrigatórias que ele não conseguiria pular na codificação. Não era específico dele: atingia **qualquer pessoa que codificou o documento antes de o schema do projeto ser editado**.

### Causa raiz

O schema do projeto era editado **depois** que o pesquisador codificava — um campo novo era adicionado (ou renomeado). O fluxo de auto-revisão não tinha consciência de versão de schema:

1. `createAutoReviewIfDiverges` usava o schema **atual** do projeto.
2. `computeDivergentFieldNames` comparava `human.answers[campo]` vs `llm.answers[campo]`. Para um campo que não existia quando o humano codificou, `human.answers[campo]` era `undefined`.
3. `undefined` ≠ valor do LLM → o campo virava divergente e gerava uma linha em `field_reviews`.
4. O painel renderizava `formatAnswerDisplay(undefined)` → **"(vazio)"**.

A validação de campos obrigatórios só checa os campos que existiam no momento da codificação — por isso o "obrigatórias, não dava pra pular".

## Mudanças

- **`computeDivergentFieldNames` consciente de staleness**: reaproveita `answer_field_hashes` (snapshot por-campo do schema na época da codificação, já gravado para humanos e LLM). Uma response é excluída da comparação **de um campo específico** quando comprovadamente não tinha esse campo no schema contra o qual foi codificada. Se sobram < 2 responses aplicáveis, o campo não diverge.
- **Threading de `answer_field_hashes`** nos 4 callers: `auto-review.ts`, `field-reviews.ts`, `compare-sync.ts`, `compare/page.tsx`.
- **`regenerateAutoReviewBacklog` vira reconcile**: além de inserir o conjunto correto, remove `field_reviews` espúrios — mas **somente os ainda pendentes** (`self_verdict IS NULL`). Linhas já resolvidas pelo pesquisador são preservadas e contadas em `keptResolved` (apagá-las perderia trabalho). Assignments `auto_revisao` órfãos e ainda `pendente` são removidos. O toast da aba LLM Insights reporta as contagens.
- Sem migration de banco — a limpeza dos dados existentes é feita rodando "Regenerar backlog" na aba LLM Insights.

## Test plan

- [x] `npm run test` — 287 testes passam, incluindo 3 casos novos em `compare-divergence.test.ts` (campo ausente no snapshot não diverge; campo presente nos dois ainda diverge; `answerFieldHashes` null/legacy preserva comportamento antigo).
- [x] `npx tsc --noEmit` — limpo (erro pré-existente não relacionado em `AddNoteButton.test.tsx`).
- [x] `npm run lint` — sem novos problemas nos arquivos alterados.
- [ ] Reproduzir manualmente: projeto com 1 doc já codificado, adicionar campo novo ao schema, re-rodar LLM, abrir a auto-revisão → o campo novo **não** deve aparecer como divergência "(vazio)".
- [ ] Rodar "Regenerar backlog" na aba LLM Insights → conferir que os `field_reviews` espúrios pendentes somem e o toast reporta a contagem removida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)