### PR TITLE
fix(react-doctor): correctness + a11y (combobox, hydration, suspense, setstate funcional)

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/auto-revisao/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/auto-revisao/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
 import { redirect } from "next/navigation";
@@ -158,14 +159,16 @@ export default async function AutoReviewRoute({
   );
 
   return (
-    <AutoReviewPage
-      projectId={id}
-      fields={fieldsMeta}
-      docs={docsToReview}
-      isCoordinator={isCoordinator}
-      viewAsUserId={targetUserId}
-      reviewers={reviewers}
-      currentUserId={user.id}
-    />
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Carregando…</div>}>
+      <AutoReviewPage
+        projectId={id}
+        fields={fieldsMeta}
+        docs={docsToReview}
+        isCoordinator={isCoordinator}
+        viewAsUserId={targetUserId}
+        reviewers={reviewers}
+        currentUserId={user.id}
+      />
+    </Suspense>
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
 import { redirect } from "next/navigation";
@@ -227,24 +228,26 @@ export default async function CodePage({
     effectiveRound !== CURRENT_FILTER_VALUE && effectiveRound !== "all";
 
   return (
-    <CodingPage
-      projectId={id}
-      documents={filteredDocuments}
-      codedAtByDoc={codedAtByDoc}
-      fields={fields}
-      existingAnswers={existingAnswers}
-      existingJustifications={existingJustifications}
-      hasAssignments={allDocuments.length > 0}
-      progress={progress}
-      readOnly={isImpersonating || isViewingPreviousRound}
-      roundFilter={{
-        strategy,
-        currentRoundKey,
-        currentRoundLabel,
-        rounds: ctx.rounds,
-        previousVersions,
-        selected: effectiveRound,
-      }}
-    />
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Carregando…</div>}>
+      <CodingPage
+        projectId={id}
+        documents={filteredDocuments}
+        codedAtByDoc={codedAtByDoc}
+        fields={fields}
+        existingAnswers={existingAnswers}
+        existingJustifications={existingJustifications}
+        hasAssignments={allDocuments.length > 0}
+        progress={progress}
+        readOnly={isImpersonating || isViewingPreviousRound}
+        roundFilter={{
+          strategy,
+          currentRoundKey,
+          currentRoundLabel,
+          rounds: ctx.rounds,
+          previousVersions,
+          selected: effectiveRound,
+        }}
+      />
+    </Suspense>
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
 import { redirect } from "next/navigation";
@@ -454,24 +455,26 @@ export default async function ComparePageRoute({
   }
 
   return (
-    <ComparePage
-      projectId={id}
-      documents={documentsForCompare}
-      responses={responsesMap}
-      divergentFields={divergentFields}
-      fields={fields}
-      existingReviews={existingReviews}
-      projectPydanticHash={project?.pydantic_hash ?? null}
-      respondentNames={respondentNames}
-      coverageByDoc={coverageByDoc}
-      commentCountsByKey={commentCountsByKey}
-      suggestionCountsByField={suggestionCountsByField}
-      availableVersions={availableVersions}
-      latestMajorLabel={latestMajorLabel}
-      currentProjectVersion={`${projectVersion.major}.${projectVersion.minor}.${projectVersion.patch}`}
-      equivalencesByDocField={equivalencesByDocField}
-      currentUserId={user.id}
-      canManageAnyPair={isCoordinator}
-    />
+    <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Carregando…</div>}>
+      <ComparePage
+        projectId={id}
+        documents={documentsForCompare}
+        responses={responsesMap}
+        divergentFields={divergentFields}
+        fields={fields}
+        existingReviews={existingReviews}
+        projectPydanticHash={project?.pydantic_hash ?? null}
+        respondentNames={respondentNames}
+        coverageByDoc={coverageByDoc}
+        commentCountsByKey={commentCountsByKey}
+        suggestionCountsByField={suggestionCountsByField}
+        availableVersions={availableVersions}
+        latestMajorLabel={latestMajorLabel}
+        currentProjectVersion={`${projectVersion.major}.${projectVersion.minor}.${projectVersion.patch}`}
+        equivalencesByDocField={equivalencesByDocField}
+        currentUserId={user.id}
+        canManageAnyPair={isCoordinator}
+      />
+    </Suspense>
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { getRunningLlmCount } from "@/actions/llm";
@@ -69,13 +70,15 @@ export default async function ProjectLayout({
         projectName={project.name}
         user={{ email: user.email, firstName: profile?.first_name }}
       />
-      <ProjectTabs
-        projectId={id}
-        isCoordinator={isCoordinator}
-        isMaster={user.isMaster}
-        projectMembers={projectMembers}
-        isLlmRunning={runningLlmCount > 0}
-      />
+      <Suspense fallback={<div className="h-12 border-b" />}>
+        <ProjectTabs
+          projectId={id}
+          isCoordinator={isCoordinator}
+          isMaster={user.isMaster}
+          projectMembers={projectMembers}
+          isLlmRunning={runningLlmCount > 0}
+        />
+      </Suspense>
       <main className="flex-1">{children}</main>
     </div>
   );

--- a/frontend/src/app/(app)/projects/[id]/reviews/difficulty/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/difficulty/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
 import { redirect } from "next/navigation";
@@ -51,7 +52,9 @@ export default async function DifficultyPage({
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
       <TruncationBanner truncated={ctx.truncated} />
-      <DateSinceFilter />
+      <Suspense fallback={<div className="h-9" />}>
+        <DateSinceFilter />
+      </Suspense>
       {hardestDocuments.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">
           {since

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
 import { MyVerdictsView } from "@/components/reviews/MyVerdictsView";
@@ -169,15 +170,17 @@ export default async function MyVerdictsPage({
 
   return (
     <div className="mx-auto max-w-6xl p-6">
-      <MyVerdictsView
-        projectId={id}
-        items={verdictItems}
-        fields={fields}
-        userName={[user.firstName, user.lastName].filter(Boolean).join(" ") || "Você"}
-        isCoordinator={isCoordinator}
-        respondents={respondentsList}
-        currentViewUserId={effectiveUserId !== user.id ? effectiveUserId : undefined}
-      />
+      <Suspense fallback={<div className="text-sm text-muted-foreground">Carregando…</div>}>
+        <MyVerdictsView
+          projectId={id}
+          items={verdictItems}
+          fields={fields}
+          userName={[user.firstName, user.lastName].filter(Boolean).join(" ") || "Você"}
+          isCoordinator={isCoordinator}
+          respondents={respondentsList}
+          currentViewUserId={effectiveUserId !== user.id ? effectiveUserId : undefined}
+        />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/reviews/respondents/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/respondents/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
 import { redirect } from "next/navigation";
@@ -51,7 +52,9 @@ export default async function RespondentsPage({
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
       <TruncationBanner truncated={ctx.truncated} />
-      <DateSinceFilter />
+      <Suspense fallback={<div className="h-9" />}>
+        <DateSinceFilter />
+      </Suspense>
       {respondentProfiles.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">
           {since

--- a/frontend/src/components/assignments/AssignmentTable.tsx
+++ b/frontend/src/components/assignments/AssignmentTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useOptimistic, useTransition } from "react";
+import { useEffect, useOptimistic, useState, useTransition } from "react";
 import { cycleAssignment } from "@/actions/assignments";
 import { cn } from "@/lib/utils";
 import {
@@ -93,8 +93,14 @@ export function AssignmentTable({ projectId, documents, researchers, assignments
     });
   };
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  // Hidratado client-only para evitar mismatch entre server (timezone do server)
+  // e client (timezone do navegador) no cálculo de `isOverdue`.
+  const [today, setToday] = useState<Date | null>(null);
+  useEffect(() => {
+    const t = new Date();
+    t.setHours(0, 0, 0, 0);
+    setToday(t);
+  }, []);
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -132,6 +138,7 @@ export function AssignmentTable({ projectId, documents, researchers, assignments
                   const deadlines = [cod?.deadline, comp?.deadline].filter(Boolean) as string[];
                   const nearestDeadline = deadlines.sort()[0];
                   const isOverdue =
+                    today &&
                     nearestDeadline &&
                     status !== "concluido" &&
                     new Date(nearestDeadline + "T00:00:00") < today;

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -54,6 +54,14 @@ export function LotteryDialog({
   const [open, setOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [previewing, setPreviewing] = useState(false);
+  // Hidratado client-only para o "disabled date in past" do Calendar não
+  // produzir mismatch entre server e cliente.
+  const [todayMidnight, setTodayMidnight] = useState<Date | null>(null);
+  useEffect(() => {
+    const t = new Date();
+    t.setHours(0, 0, 0, 0);
+    setTodayMidnight(t);
+  }, []);
 
   // Tipo do sorteio (codificação ou comparação)
   const [type, setType] = useState<"codificacao" | "comparacao">("codificacao");
@@ -370,7 +378,7 @@ export function LotteryDialog({
                       selected={deadlineDate}
                       onSelect={setDeadlineDate}
                       locale={ptBR}
-                      disabled={(date) => date < new Date()}
+                      disabled={todayMidnight ? (date) => date < todayMidnight : undefined}
                     />
                   </PopoverContent>
                 </Popover>

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTransition } from "react";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import {
   ArrowLeft,
   ChevronLeft,
@@ -149,8 +149,6 @@ function SortSelect({
 
 function RoundSelect({ data }: { data: RoundFilterData }) {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
 
   const normalizedSelected = isCurrentFilter(data.selected)
@@ -158,15 +156,14 @@ function RoundSelect({ data }: { data: RoundFilterData }) {
     : data.selected;
 
   const handleChange = (value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
+    const url = new URL(window.location.href);
     if (isCurrentFilter(value)) {
-      params.delete("round");
+      url.searchParams.delete("round");
     } else {
-      params.set("round", value);
+      url.searchParams.set("round", value);
     }
-    const qs = params.toString();
     startTransition(() => {
-      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+      router.replace(`${url.pathname}${url.search}`, { scroll: false });
     });
   };
 

--- a/frontend/src/components/coding/SuggestExclusionDialog.tsx
+++ b/frontend/src/components/coding/SuggestExclusionDialog.tsx
@@ -101,7 +101,6 @@ export function SuggestExclusionDialog({
             onChange={(e) => setReason(e.target.value)}
             placeholder="Ex: parecer trata de medicamento diferente do estudado"
             rows={4}
-            autoFocus
           />
         </div>
         <DialogFooter>

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -103,13 +103,11 @@ export function AnswerCard({
     >
       <div className="flex items-start gap-2">
         {selectable && (
-          <div
-            className="flex h-5 shrink-0 items-center"
-            onClick={(e) => e.stopPropagation()}
-          >
+          <div className="flex h-5 shrink-0 items-center">
             <Checkbox
               checked={selected}
               onCheckedChange={() => onSelectionToggle?.()}
+              onClick={(e) => e.stopPropagation()}
               aria-label="Selecionar para marcar como equivalente"
               title="Selecionar como equivalente"
             />
@@ -255,13 +253,13 @@ export function AnswerCard({
         {showGabarito && (
           <label
             className="flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"
-            onClick={(e) => e.stopPropagation()}
             title="Esta é a resposta que será registrada como gabarito"
           >
             <input
               type="radio"
               checked={isGabarito}
               onChange={() => onSetGabarito?.()}
+              onClick={(e) => e.stopPropagation()}
               className="h-3 w-3 accent-brand"
             />
             <span className={cn(isGabarito && "font-medium text-brand")}>

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -254,6 +254,7 @@ export function AnswerCard({
           <label
             className="flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"
             title="Esta é a resposta que será registrada como gabarito"
+            onClick={(e) => e.stopPropagation()}
           >
             <input
               type="radio"

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -314,7 +314,7 @@ export function ComparePage({
       if (allFieldsReviewed) {
         toast.success("Revisão do documento concluída!");
       } else if (fieldIndex < docFields.length - 1) {
-        setFieldIndex(fieldIndex + 1);
+        setFieldIndex((idx) => idx + 1);
       }
     },
     [projectId, currentDoc, currentFieldName, isCurrentFieldDivergent, fieldIndex, docFields, allDocDivergent, localReviews, comment, fieldResponses]
@@ -397,7 +397,7 @@ export function ComparePage({
         if (allFieldsReviewed) {
           toast.success("Revisão do documento concluída!");
         } else if (fieldIndex < docFields.length - 1) {
-          setFieldIndex(fieldIndex + 1);
+          setFieldIndex((idx) => idx + 1);
         }
       } catch (err) {
         toast.error(
@@ -447,8 +447,8 @@ export function ComparePage({
         return;
       }
 
-      if (e.key === "n" && fieldIndex < docFields.length - 1) { setFieldIndex(fieldIndex + 1); return; }
-      if (e.key === "p" && fieldIndex > 0) { setFieldIndex(fieldIndex - 1); return; }
+      if (e.key === "n" && fieldIndex < docFields.length - 1) { setFieldIndex((idx) => idx + 1); return; }
+      if (e.key === "p" && fieldIndex > 0) { setFieldIndex((idx) => idx - 1); return; }
 
       // Doc concluído: o avanço é por ação explícita (botão "Próximo parecer"
       // recebe foco; Enter nele é nativo). Não deixar 1-9/a/s re-disparar

--- a/frontend/src/components/documents/DocumentUpload.tsx
+++ b/frontend/src/components/documents/DocumentUpload.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useId, useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -77,6 +77,9 @@ function chunkByBytes(
 }
 
 export function DocumentUpload({ projectId }: DocumentUploadProps) {
+  const textColumnId = useId();
+  const titleColumnId = useId();
+  const externalIdColumnId = useId();
   const [step, setStep] = useState<UploadStep>("idle");
   const [loading, setLoading] = useState(false);
   const [parsedData, setParsedData] = useState<Record<string, string>[] | null>(null);
@@ -300,9 +303,10 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
         <div className="space-y-4">
           <div className="grid grid-cols-3 gap-4">
             <div>
-              <label className="text-sm font-medium">Coluna de texto *</label>
+              <label htmlFor={textColumnId} className="text-sm font-medium">Coluna de texto *</label>
               <p className="text-xs text-muted-foreground">Conteúdo principal do documento que será analisado pelos pesquisadores</p>
               <select
+                id={textColumnId}
                 value={mapping.text}
                 onChange={(e) => setMapping((m) => ({ ...m, text: e.target.value }))}
                 className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"
@@ -312,9 +316,10 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
               </select>
             </div>
             <div>
-              <label className="text-sm font-medium">Coluna de título</label>
+              <label htmlFor={titleColumnId} className="text-sm font-medium">Coluna de título</label>
               <p className="text-xs text-muted-foreground">Nome curto para identificar o documento na interface (opcional)</p>
               <select
+                id={titleColumnId}
                 value={mapping.title}
                 onChange={(e) => setMapping((m) => ({ ...m, title: e.target.value }))}
                 className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"
@@ -324,9 +329,10 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
               </select>
             </div>
             <div>
-              <label className="text-sm font-medium">Coluna de ID externo</label>
+              <label htmlFor={externalIdColumnId} className="text-sm font-medium">Coluna de ID externo</label>
               <p className="text-xs text-muted-foreground">Identificador do dataset original, ex: número do processo, DOI (opcional)</p>
               <select
+                id={externalIdColumnId}
                 value={mapping.external_id}
                 onChange={(e) => setMapping((m) => ({ ...m, external_id: e.target.value }))}
                 className="mt-1 w-full rounded-md border bg-background px-2 py-1.5 text-sm"

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -303,7 +303,6 @@ export function DocumentsPageClient({
               onChange={(e) => setExcludeReason(e.target.value)}
               placeholder="Ex: parecer fora do escopo do projeto"
               rows={3}
-              autoFocus
             />
           </div>
 

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useTransition, useCallback } from "react";
+import { useId, useState, useRef, useEffect, useTransition, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -110,6 +110,7 @@ export function LlmConfigurePane({
   docsWithLlm,
 }: LlmConfigurePaneProps) {
   const router = useRouter();
+  const modelListboxId = useId();
 
   // Prompt state
   const [prompt, setPrompt] = useState(initialPrompt);
@@ -558,6 +559,7 @@ export function LlmConfigurePane({
                   variant="outline"
                   role="combobox"
                   aria-expanded={modelOpen}
+                  aria-controls={modelListboxId}
                   className="w-full justify-between font-normal"
                 >
                   {capabilities.label || config.llm_model || "Selecionar modelo..."}
@@ -567,7 +569,7 @@ export function LlmConfigurePane({
               <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
                 <Command>
                   <CommandInput placeholder="Buscar modelo..." value={modelSearch} onValueChange={setModelSearch} />
-                  <CommandList>
+                  <CommandList id={modelListboxId}>
                     <CommandEmpty>
                       <button
                         className="w-full text-left px-2 py-1.5 text-sm hover:bg-accent rounded-sm"

--- a/frontend/src/components/llm/LlmResponsesPane.tsx
+++ b/frontend/src/components/llm/LlmResponsesPane.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useId, useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import {
@@ -42,8 +42,7 @@ export function LlmResponsesPane({
   activeJobId,
 }: LlmResponsesPaneProps) {
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+  const statusFilterId = useId();
   const [isPending, startTransition] = useTransition();
 
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -75,12 +74,11 @@ export function LlmResponsesPane({
   }, [responses, statusFilter, search]);
 
   const setJobFilter = (jobId: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (jobId === "all") params.delete("job");
-    else params.set("job", jobId);
-    const qs = params.toString();
+    const url = new URL(window.location.href);
+    if (jobId === "all") url.searchParams.delete("job");
+    else url.searchParams.set("job", jobId);
     startTransition(() => {
-      router.replace(`${pathname}${qs ? `?${qs}` : ""}`);
+      router.replace(`${url.pathname}${url.search}`);
     });
   };
 
@@ -135,12 +133,12 @@ export function LlmResponsesPane({
         </div>
 
         <div className="flex items-center gap-2">
-          <label className="text-xs text-muted-foreground">Status</label>
+          <label htmlFor={statusFilterId} className="text-xs text-muted-foreground">Status</label>
           <Select
             value={statusFilter}
             onValueChange={(v) => setStatusFilter(v as StatusFilter)}
           >
-            <SelectTrigger className="h-8 w-36 text-xs">
+            <SelectTrigger id={statusFilterId} className="h-8 w-36 text-xs">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>

--- a/frontend/src/components/progress/ActivityCalendar.tsx
+++ b/frontend/src/components/progress/ActivityCalendar.tsx
@@ -96,7 +96,7 @@ export function ActivityCalendar({ activityMap }: ActivityCalendarProps) {
                         )}
                       />
                     </TooltipTrigger>
-                    <TooltipContent side="top" className="text-xs">
+                    <TooltipContent side="top" className="text-xs" suppressHydrationWarning>
                       {entry.count} documento{entry.count !== 1 ? "s" : ""} em{" "}
                       {formatted}
                     </TooltipContent>

--- a/frontend/src/components/progress/NextDeliveries.tsx
+++ b/frontend/src/components/progress/NextDeliveries.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
@@ -8,6 +9,15 @@ interface NextDeliveriesProps {
 }
 
 export function NextDeliveries({ deadlines }: NextDeliveriesProps) {
+  // Hidratado client-only: comparar com `today` no server (timezone do server)
+  // vs no client (timezone do navegador) causa mismatch no badge "Atrasado".
+  const [today, setToday] = useState<Date | null>(null);
+  useEffect(() => {
+    const t = new Date();
+    t.setHours(0, 0, 0, 0);
+    setToday(t);
+  }, []);
+
   if (deadlines.length === 0) {
     return (
       <div className="space-y-2">
@@ -17,16 +27,13 @@ export function NextDeliveries({ deadlines }: NextDeliveriesProps) {
     );
   }
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-
   return (
     <div className="space-y-2">
       <h3 className="text-sm font-semibold">Próximas Entregas</h3>
       <div className="space-y-2">
         {deadlines.map((dl) => {
           const d = new Date(dl.date + "T00:00:00");
-          const isOverdue = d < today && dl.pending > 0;
+          const isOverdue = today != null && d < today && dl.pending > 0;
           const formatted = d.toLocaleDateString("pt-BR", {
             day: "numeric",
             month: "short",

--- a/frontend/src/components/reviews/MyVerdictsView.tsx
+++ b/frontend/src/components/reviews/MyVerdictsView.tsx
@@ -305,7 +305,7 @@ export function MyVerdictsView({
                   size="icon"
                   className="h-7 w-7"
                   disabled={docIndex === 0}
-                  onClick={() => setDocIndex(docIndex - 1)}
+                  onClick={() => setDocIndex((i) => i - 1)}
                 >
                   <ChevronLeft className="h-4 w-4" />
                 </Button>
@@ -317,7 +317,7 @@ export function MyVerdictsView({
                   size="icon"
                   className="h-7 w-7"
                   disabled={docIndex === docGroups.length - 1}
-                  onClick={() => setDocIndex(docIndex + 1)}
+                  onClick={() => setDocIndex((i) => i + 1)}
                 >
                   <ChevronRight className="h-4 w-4" />
                 </Button>

--- a/frontend/src/components/schema/SchemaBuilderGUI.tsx
+++ b/frontend/src/components/schema/SchemaBuilderGUI.tsx
@@ -58,7 +58,7 @@ export function SchemaBuilderGUI({ fields, onChange }: SchemaBuilderGUIProps) {
     onChange(fields.filter((_, i) => i !== index));
     if (expandedIndex === index) setExpandedIndex(null);
     else if (expandedIndex !== null && expandedIndex > index) {
-      setExpandedIndex(expandedIndex - 1);
+      setExpandedIndex((idx) => (idx === null ? null : idx - 1));
     }
   };
 
@@ -72,9 +72,9 @@ export function SchemaBuilderGUI({ fields, onChange }: SchemaBuilderGUIProps) {
     else if (expandedIndex !== null) {
       // Ajusta indice expandido para acompanhar o item que se moveu por cima dele
       if (from < expandedIndex && to >= expandedIndex) {
-        setExpandedIndex(expandedIndex - 1);
+        setExpandedIndex((idx) => (idx === null ? null : idx - 1));
       } else if (from > expandedIndex && to <= expandedIndex) {
-        setExpandedIndex(expandedIndex + 1);
+        setExpandedIndex((idx) => (idx === null ? null : idx + 1));
       }
     }
   };

--- a/frontend/src/components/schema/SchemaChangeGroup.tsx
+++ b/frontend/src/components/schema/SchemaChangeGroup.tsx
@@ -82,7 +82,10 @@ export function SchemaChangeGroup({ group }: SchemaChangeGroupProps) {
         <span className="text-xs text-muted-foreground">
           <span className="font-medium text-foreground">{group.changedBy}</span>
           <span className="mx-1.5">·</span>
-          <span title={new Date(group.createdAt).toLocaleString("pt-BR")}>
+          <span
+            suppressHydrationWarning
+            title={new Date(group.createdAt).toLocaleString("pt-BR")}
+          >
             {formatRelativeDate(group.createdAt)}
           </span>
         </span>

--- a/frontend/src/components/shared/AddNoteButton.tsx
+++ b/frontend/src/components/shared/AddNoteButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import {
   Dialog,
@@ -52,8 +52,21 @@ export function AddNoteButton({
   const [body, setBody] = useState("");
   const [selectedField, setSelectedField] = useState<string>(fixedFieldName || "_none");
   const [isPending, startTransition] = useTransition();
+  const bodyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   const showFieldSelect = !fixedFieldName && fields && fields.length > 0;
+
+  // Mantem o foco inicial na textarea quando o dialog abre. Sem isso, o
+  // Radix Dialog foca o primeiro tabbable do FocusScope, que vira o
+  // SelectTrigger quando `showFieldSelect=true`.
+  useEffect(() => {
+    if (open) {
+      const id = window.requestAnimationFrame(() => {
+        bodyTextareaRef.current?.focus();
+      });
+      return () => window.cancelAnimationFrame(id);
+    }
+  }, [open]);
 
   // Build contextual subtitle
   const contextParts: string[] = [];
@@ -124,6 +137,7 @@ export function AddNoteButton({
             </Select>
           )}
           <Textarea
+            ref={bodyTextareaRef}
             value={body}
             onChange={(e) => setBody(e.target.value)}
             placeholder="Escreva sua nota..."

--- a/frontend/src/components/shared/AddNoteButton.tsx
+++ b/frontend/src/components/shared/AddNoteButton.tsx
@@ -128,7 +128,6 @@ export function AddNoteButton({
             onChange={(e) => setBody(e.target.value)}
             placeholder="Escreva sua nota..."
             className="min-h-28 text-sm"
-            autoFocus
           />
           <div className="flex justify-end gap-2">
             <Button

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -429,7 +429,7 @@ export function CommentCard({
         </Collapsible>}
 
         <div className="flex items-center justify-between">
-          <p className="text-xs text-muted-foreground">
+          <p className="text-xs text-muted-foreground" suppressHydrationWarning>
             {comment.reviewerName} &middot;{" "}
             {new Date(comment.createdAt).toLocaleDateString("pt-BR")}
             {isResolved && (
@@ -487,6 +487,13 @@ function ExclusionActions({
   const [isPending, startAction] = useTransition();
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
+  const rejectTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (showRejectInput) {
+      rejectTextareaRef.current?.focus();
+    }
+  }, [showRejectInput]);
 
   if (status === "approved") {
     return (
@@ -522,12 +529,12 @@ function ExclusionActions({
     return (
       <div className="flex flex-col gap-2">
         <Textarea
+          ref={rejectTextareaRef}
           className="text-xs"
           placeholder="Motivo da rejeição"
           value={rejectReason}
           onChange={(e) => setRejectReason(e.target.value)}
           rows={2}
-          autoFocus
         />
         <div className="flex gap-2">
           <Button

--- a/frontend/src/components/stats/CommentsSplitView.tsx
+++ b/frontend/src/components/stats/CommentsSplitView.tsx
@@ -197,7 +197,7 @@ export function CommentsSplitView({
             size="icon"
             className="h-7 w-7"
             disabled={docIndex === 0}
-            onClick={() => setDocIndex(docIndex - 1)}
+            onClick={() => setDocIndex((i) => i - 1)}
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
@@ -209,7 +209,7 @@ export function CommentsSplitView({
             size="icon"
             className="h-7 w-7"
             disabled={docIndex === docGroups.length - 1}
-            onClick={() => setDocIndex(docIndex + 1)}
+            onClick={() => setDocIndex((i) => i + 1)}
           >
             <ChevronRight className="h-4 w-4" />
           </Button>
@@ -354,7 +354,7 @@ export function CommentsSplitView({
 
                   {/* Footer */}
                   <div className="flex items-center justify-between">
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-xs text-muted-foreground" suppressHydrationWarning>
                       {comment.reviewerName} &middot;{" "}
                       {new Date(comment.createdAt).toLocaleDateString("pt-BR")}
                       {isResolved && (


### PR DESCRIPTION
## Summary

Segunda PR da rodada `/react-doctor` (escopo "Tudo prático"). Foco: a11y reais, hydration mismatch e anti-patterns de rerender. **Depende da PR #143** para o react-doctor.config.json (silenciar falsos positivos).

### A11y
- `LlmConfigurePane`: combobox de modelo agora declara `aria-controls` vinculado ao `CommandList` (via `useId()`)
- `DocumentUpload`: 3 labels de mapeamento de colunas com `htmlFor` + `id` no `select`
- `LlmResponsesPane`: label "Status" com `htmlFor` no `SelectTrigger`
- `AnswerCard`: `stopPropagation` movido do wrapper `div`/`label` para o `Checkbox`/`input`, remove interative-without-keyboard
- 4× `autoFocus` removidos (Radix Dialog/AlertDialog gerencia foco inicial); `CommentCard` converte para `useRef` + `useEffect` no input inline

### Hydration mismatch (`new Date()` em render path)
- `AssignmentTable`, `NextDeliveries`, `LotteryDialog`: `today` via `useState` + `useEffect` (timezone do server divergia do cliente em `isOverdue` e no `disabled` do Calendar)
- `SchemaChangeGroup`, `ActivityCalendar`, `CommentCard`, `CommentsSplitView`: `suppressHydrationWarning` em formatos `pt-BR` determinísticos

### Suspense boundaries (`useSearchParams` sem bail out CSR)
- `ProjectTabs` no layout do projeto
- `CodingPage`, `ComparePage`, `MyVerdictsView`, `AutoReviewPage` nas suas pages
- `DateSinceFilter` em difficulty e respondents
- `LlmResponsesPane` e `CodingHeader`: removido `useSearchParams`/`usePathname` e movido leitura de URL para dentro do handler (`rerender-defer-reads-hook`)

### Rerender / state
- `setFieldIndex`/`setDocIndex`/`setExpandedIndex` agora usam functional updater em `ComparePage` (4), `SchemaBuilderGUI` (3), `MyVerdictsView` (2), `CommentsSplitView` (2)

### Não nesta PR
- `no-derived-useState` (13), `no-cascading-set-state` (7), `no-effect-chain` / `no-derived-state-effect` / `no-prop-callback-in-effect` (8): refactors maiores que beneficiam-se de PR dedicada
- `rerender-state-only-in-handlers` (6): após análise, parecem falsos positivos (state lido em render path mas após early-return — a heurística não detecta)
- `no-array-index-as-key` (8): caso a caso (alguns são OK em listas estáticas)
- `no-fetch-in-effect` (2): vou avaliar se SWR/react-query justifica em PR separada

## Test plan

- [x] `npm run build` passa
- [ ] Smoke: abrir `/llm/configure` e validar combobox de modelo com leitor de tela / Tab navega correto
- [ ] Smoke: `/documents` (upload .csv → mapping screen), labels associados aos selects
- [ ] Smoke: `/analyze/assignments` — célula com prazo passado mostra `ring-destructive` no client (after hydration)
- [ ] Smoke: `/my-progress` — próximas entregas mostram badge "Atrasado" client-only sem console error
- [ ] Smoke: `/analyze/compare` — atalhos `n`/`p` continuam navegando entre fields
- [ ] DevTools console: nenhum hydration warning ao abrir cada rota

🤖 Generated with [Claude Code](https://claude.com/claude-code)