### PR TITLE
feat(arbitragem): flag can_arbitrate por membro do projeto

### DIFF
--- a/frontend/src/actions/__tests__/arbitration-retry.test.ts
+++ b/frontend/src/actions/__tests__/arbitration-retry.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock supabase chainable — mesmo padrão de field-reviews.test.ts. Captura
+// payloads de write para validar o comportamento de retryPendingArbitrations
+// e assignArbitrator sem subir Postgres.
+type WriteCall = { table: string; op: string; payload: unknown };
+let writeCalls: WriteCall[];
+let tableData: Record<string, unknown>;
+
+const updateCallsOf = (table?: string) =>
+  writeCalls.filter((c) => c.op === "update" && (!table || c.table === table));
+const upsertCallsOf = (table?: string) =>
+  writeCalls.filter((c) => c.op === "upsert" && (!table || c.table === table));
+
+function makeClient() {
+  return {
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      let op = "select";
+      for (const m of ["select", "eq", "is", "in", "neq", "limit"]) {
+        builder[m] = () => builder;
+      }
+      builder.update = (payload: unknown) => {
+        writeCalls.push({ table, op: "update", payload });
+        op = "update";
+        return builder;
+      };
+      builder.upsert = (payload: unknown) => {
+        writeCalls.push({ table, op: "upsert", payload });
+        op = "upsert";
+        return builder;
+      };
+      builder.insert = (payload: unknown) => {
+        writeCalls.push({ table, op: "insert", payload });
+        op = "insert";
+        return builder;
+      };
+      builder.then = (resolve: (v: unknown) => unknown) =>
+        resolve({
+          data: tableData[`${table}:${op}`] ?? tableData[table] ?? null,
+          error: null,
+        });
+      return builder;
+    },
+  };
+}
+
+// isProjectCoordinator: hoisted para permitir override por teste.
+const hoisted = vi.hoisted(() => ({
+  isCoord: vi.fn<() => Promise<boolean>>(async () => true),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "userCoord" }),
+  isProjectCoordinator: () => hoisted.isCoord(),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () => makeClient(),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createSupabaseAdmin: () => makeClient(),
+}));
+
+beforeEach(() => {
+  writeCalls = [];
+  tableData = {
+    field_reviews: [],
+    project_members: [],
+    assignments: [],
+  };
+  hoisted.isCoord.mockResolvedValue(true);
+});
+
+async function loadRetry() {
+  return (await import("@/actions/field-reviews")).retryPendingArbitrations;
+}
+
+describe("retryPendingArbitrations — guards", () => {
+  it("não-coordenador → erro, sem efeito colateral", async () => {
+    hoisted.isCoord.mockResolvedValueOnce(false);
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("coordenadores");
+    expect(r.assigned).toBe(0);
+    expect(writeCalls).toHaveLength(0);
+  });
+
+  it("sem field_reviews pendentes → assigned 0 e nenhum UPDATE", async () => {
+    tableData.field_reviews = [];
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    expect(r.assigned).toBe(0);
+    expect(r.stillNoPool).toBe(0);
+    expect(updateCallsOf("field_reviews")).toHaveLength(0);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+});
+
+describe("retryPendingArbitrations — agrupamento por (document_id, self_reviewer_id)", () => {
+  it("dois fields do mesmo doc/self_reviewer → 1 chamada de assignArbitrator (1 UPDATE em field_reviews)", async () => {
+    tableData.field_reviews = [
+      { document_id: "doc1", field_name: "q1", self_reviewer_id: "userA" },
+      { document_id: "doc1", field_name: "q2", self_reviewer_id: "userA" },
+    ];
+    // Pool com 1 árbitro elegível (assignArbitrator pode sortear)
+    tableData.project_members = [
+      { user_id: "userB", role: "pesquisador" },
+    ];
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    // 1 grupo → 1 UPDATE em field_reviews atribuindo arbitrator_id
+    expect(updateCallsOf("field_reviews")).toHaveLength(1);
+    expect(updateCallsOf("field_reviews")[0].payload).toMatchObject({
+      arbitrator_id: "userB",
+    });
+    // 1 grupo concluído → 1 upsert em assignments (arbitragem)
+    expect(upsertCallsOf("assignments")).toHaveLength(1);
+    expect(upsertCallsOf("assignments")[0].payload).toMatchObject({
+      project_id: "p1",
+      document_id: "doc1",
+      user_id: "userB",
+      type: "arbitragem",
+    });
+  });
+
+  it("dois docs distintos → 2 chamadas de assignArbitrator (2 UPDATEs)", async () => {
+    tableData.field_reviews = [
+      { document_id: "doc1", field_name: "q1", self_reviewer_id: "userA" },
+      { document_id: "doc2", field_name: "q1", self_reviewer_id: "userC" },
+    ];
+    tableData.project_members = [
+      { user_id: "userB", role: "pesquisador" },
+    ];
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    expect(updateCallsOf("field_reviews")).toHaveLength(2);
+    expect(upsertCallsOf("assignments")).toHaveLength(2);
+  });
+
+  it("self_reviewers diferentes no mesmo doc → 2 grupos (caso raro mas suportado)", async () => {
+    tableData.field_reviews = [
+      { document_id: "doc1", field_name: "q1", self_reviewer_id: "userA" },
+      { document_id: "doc1", field_name: "q2", self_reviewer_id: "userC" },
+    ];
+    tableData.project_members = [
+      { user_id: "userB", role: "pesquisador" },
+    ];
+    const retry = await loadRetry();
+    await retry("p1");
+    expect(updateCallsOf("field_reviews")).toHaveLength(2);
+  });
+});
+
+describe("retryPendingArbitrations — pool vazio", () => {
+  it("nenhum membro elegível → stillNoPool incrementa, sem UPDATE", async () => {
+    tableData.field_reviews = [
+      { document_id: "doc1", field_name: "q1", self_reviewer_id: "userA" },
+    ];
+    tableData.project_members = [];
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    expect(r.assigned).toBe(0);
+    expect(r.stillNoPool).toBe(1);
+    expect(updateCallsOf("field_reviews")).toHaveLength(0);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+});

--- a/frontend/src/actions/__tests__/members.test.ts
+++ b/frontend/src/actions/__tests__/members.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock supabase chainable enxuto. setCanArbitrate só executa um UPDATE em
+// project_members e dispara retryPendingArbitrations (mockado abaixo).
+type WriteCall = { table: string; op: string; payload: unknown };
+let writeCalls: WriteCall[];
+
+function makeClient(updateError?: { message: string }) {
+  return {
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      for (const m of ["eq", "is", "in", "neq", "select"]) {
+        builder[m] = () => builder;
+      }
+      builder.update = (payload: unknown) => {
+        writeCalls.push({ table, op: "update", payload });
+        return builder;
+      };
+      builder.then = (resolve: (v: unknown) => unknown) =>
+        resolve({ data: null, error: updateError ?? null });
+      return builder;
+    },
+  };
+}
+
+let clientError: { message: string } | undefined;
+
+// hoisted mocks — retryPendingArbitrations precisa ser observável por teste
+// para distinguir "habilita dispara retry" vs "desabilita não dispara".
+const hoisted = vi.hoisted(() => ({
+  retry: vi.fn<(projectId: string) => Promise<{
+    success: boolean;
+    assigned: number;
+    stillNoPool: number;
+    error?: string;
+  }>>(async () => ({
+    success: true,
+    assigned: 0,
+    stillNoPool: 0,
+  })),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+  revalidateTag: () => {},
+}));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "userCoord" }),
+  isProjectCoordinator: async () => true,
+}));
+vi.mock("@/lib/clerk-sync", () => ({
+  syncClerkUserToSupabase: async () => "userX",
+}));
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: async () => ({
+    users: { getUserList: async () => ({ data: [] }), createUser: async () => ({ id: "x" }) },
+  }),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () => makeClient(clientError),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createSupabaseAdmin: () => makeClient(clientError),
+}));
+vi.mock("@/actions/field-reviews", () => ({
+  retryPendingArbitrations: hoisted.retry,
+}));
+
+beforeEach(() => {
+  writeCalls = [];
+  clientError = undefined;
+  hoisted.retry.mockReset();
+  hoisted.retry.mockResolvedValue({ success: true, assigned: 0, stillNoPool: 0 });
+});
+
+async function loadSet() {
+  return (await import("@/actions/members")).setCanArbitrate;
+}
+
+describe("setCanArbitrate", () => {
+  it("habilita → dispara retryPendingArbitrations e devolve contagem", async () => {
+    hoisted.retry.mockResolvedValueOnce({
+      success: true,
+      assigned: 3,
+      stillNoPool: 1,
+    });
+    const set = await loadSet();
+    const r = await set("member1", true, "p1");
+    expect(r.error).toBeUndefined();
+    expect(r.retried).toEqual({ assigned: 3, stillNoPool: 1 });
+    expect(hoisted.retry).toHaveBeenCalledWith("p1");
+    // UPDATE em project_members com can_arbitrate=true
+    expect(writeCalls).toContainEqual({
+      table: "project_members",
+      op: "update",
+      payload: { can_arbitrate: true },
+    });
+  });
+
+  it("desabilita → NÃO dispara retry", async () => {
+    const set = await loadSet();
+    const r = await set("member1", false, "p1");
+    expect(r.error).toBeUndefined();
+    expect(r.retried).toBeUndefined();
+    expect(hoisted.retry).not.toHaveBeenCalled();
+    expect(writeCalls).toContainEqual({
+      table: "project_members",
+      op: "update",
+      payload: { can_arbitrate: false },
+    });
+  });
+
+  it("habilita mas retry falha → result.retried undefined, sem propagar erro", async () => {
+    hoisted.retry.mockResolvedValueOnce({
+      success: false,
+      error: "kaboom",
+      assigned: 0,
+      stillNoPool: 0,
+    });
+    const set = await loadSet();
+    const r = await set("member1", true, "p1");
+    // setCanArbitrate em si não falha — o UPDATE em project_members deu certo.
+    // O retry rodou em best-effort. Coordenador vê "habilitado" mas o banner
+    // continua mostrando pendências se houver.
+    expect(r.error).toBeUndefined();
+    expect(r.retried).toBeUndefined();
+  });
+
+  it("UPDATE falha → retorna error e NÃO dispara retry", async () => {
+    clientError = { message: "RLS bloqueou" };
+    const set = await loadSet();
+    const r = await set("member1", true, "p1");
+    expect(r.error).toBe("RLS bloqueou");
+    expect(hoisted.retry).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -1117,6 +1117,12 @@ export async function retryPendingArbitrations(
       groups.set(key, g);
     }
 
+    // Sequencial intencionalmente: cada assignArbitrator lê openCounts
+    // recalculado, preservando o balanceamento entre grupos. Paralelizar com
+    // Promise.all faria todos os groups verem o mesmo minLoad e sortearem
+    // dentro do mesmo pool — degrada a distribuição (mesma race tolerada em
+    // submitAutoReview concorrente para docs diferentes, mas aqui evitável
+    // a custo zero porque o loop está dentro de uma única chamada).
     let assigned = 0;
     let stillNoPool = 0;
     for (const g of groups.values()) {

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -293,11 +293,13 @@ export async function submitAutoReview(
       );
       arbitrated = result.count;
       // Pool vazio: o submit completa (self_verdict gravado) mas os campos
-      // contestados ficam sem árbitro. Avisa o pesquisador para que o
-      // coordenador adicione mais membros ao projeto — sem este warning, os
-      // campos ficariam invisíveis em estado "aguarda_arbitragem" indefinidamente.
+      // contestados ficam sem árbitro. Pode ser falta de outros membros ou
+      // que nenhum dos demais foi marcado como elegível (can_arbitrate). Sem
+      // este warning, os campos ficariam invisíveis em estado
+      // "aguarda_arbitragem" indefinidamente. O retryPendingArbitrations
+      // do setCanArbitrate cobre o caso de o coordenador habilitar alguém depois.
       if (result.noPool) {
-        warning = `Não há outros membros no projeto disponíveis para arbitrar ${contested.length} campo(s) contestado(s). Peça ao coordenador para adicionar pesquisadores ao projeto.`;
+        warning = `Não há árbitros elegíveis para ${contested.length} campo(s) contestado(s). Peça ao coordenador para marcar membros como elegíveis em Configuração → Equipe.`;
       }
     }
 
@@ -340,11 +342,15 @@ async function assignArbitrator(
 ): Promise<{ count: number; noPool: boolean }> {
   const admin = createSupabaseAdmin();
 
-  // Pool: membros do projeto exceto o humano original
+  // Pool: membros do projeto exceto o humano original, restrito a quem o
+  // coordenador marcou como elegível para arbitrar (can_arbitrate). Quando
+  // ninguém está marcado, noPool=true → o chamador alerta o usuário e o
+  // banner em /config/members orienta o coordenador a habilitar alguém.
   const { data: members } = await admin
     .from("project_members")
     .select("user_id, role")
     .eq("project_id", projectId)
+    .eq("can_arbitrate", true)
     .neq("user_id", excludeUserId);
 
   if (!members || members.length === 0) return { count: 0, noPool: true };
@@ -1045,6 +1051,95 @@ export async function regenerateAutoReviewBacklog(
     };
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : "Erro" };
+  }
+}
+
+// Re-tenta alocar árbitro para todo field_review do projeto que está pendente
+// (self_verdict='contesta_llm' AND arbitrator_id IS NULL). Disparada quando o
+// coordenador habilita um novo membro como elegível em setCanArbitrate, para
+// drenar o backlog acumulado enquanto não havia ninguém.
+//
+// Agrupa por (document_id, self_reviewer_id) e chama assignArbitrator para
+// cada grupo — preserva a regra "todos os campos contestados do mesmo doc
+// recebem o MESMO árbitro" e a exclusão do auto-revisor original do pool.
+export async function retryPendingArbitrations(
+  projectId: string,
+): Promise<{
+  success: boolean;
+  error?: string;
+  assigned: number;
+  stillNoPool: number;
+}> {
+  try {
+    const user = await getAuthUser();
+    if (!user)
+      return {
+        success: false,
+        error: "Não autenticado",
+        assigned: 0,
+        stillNoPool: 0,
+      };
+    const isCoord = await isProjectCoordinator(projectId, user);
+    if (!isCoord)
+      return {
+        success: false,
+        error: "Apenas coordenadores podem reprocessar arbitragens.",
+        assigned: 0,
+        stillNoPool: 0,
+      };
+
+    const admin = createSupabaseAdmin();
+    const { data: pending, error } = await admin
+      .from("field_reviews")
+      .select("document_id, field_name, self_reviewer_id")
+      .eq("project_id", projectId)
+      .eq("self_verdict", "contesta_llm")
+      .is("arbitrator_id", null);
+    if (error)
+      return { success: false, error: error.message, assigned: 0, stillNoPool: 0 };
+    if (!pending || pending.length === 0)
+      return { success: true, assigned: 0, stillNoPool: 0 };
+
+    const groups = new Map<
+      string,
+      { documentId: string; selfReviewerId: string; fieldNames: string[] }
+    >();
+    for (const p of pending) {
+      const key = `${p.document_id}|${p.self_reviewer_id}`;
+      const g =
+        groups.get(key) ??
+        {
+          documentId: p.document_id as string,
+          selfReviewerId: p.self_reviewer_id as string,
+          fieldNames: [] as string[],
+        };
+      g.fieldNames.push(p.field_name as string);
+      groups.set(key, g);
+    }
+
+    let assigned = 0;
+    let stillNoPool = 0;
+    for (const g of groups.values()) {
+      const result = await assignArbitrator(
+        projectId,
+        g.documentId,
+        g.selfReviewerId,
+        g.fieldNames,
+      );
+      assigned += result.count;
+      if (result.noPool) stillNoPool++;
+    }
+
+    revalidatePath(`/projects/${projectId}/analyze/arbitragem`);
+    revalidatePath(`/projects/${projectId}/config/members`);
+    return { success: true, assigned, stillNoPool };
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "Erro",
+      assigned: 0,
+      stillNoPool: 0,
+    };
   }
 }
 

--- a/frontend/src/actions/members.ts
+++ b/frontend/src/actions/members.ts
@@ -4,6 +4,7 @@ import { createSupabaseServer } from "@/lib/supabase/server";
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { getAuthUser } from "@/lib/auth";
 import { syncClerkUserToSupabase } from "@/lib/clerk-sync";
+import { retryPendingArbitrations } from "@/actions/field-reviews";
 import { clerkClient } from "@clerk/nextjs/server";
 import { revalidatePath, revalidateTag } from "next/cache";
 
@@ -120,4 +121,36 @@ export async function changeRole(
   if (error) return { error: error.message };
   revalidatePath(`/projects/${projectId}`);
   revalidateTag(`project-${projectId}-members`, TAG_PROFILE);
+}
+
+// Define se um membro entra no sorteio de árbitros para casos contestados.
+// Quando habilita (canArbitrate=true), dispara retryPendingArbitrations para
+// alocar imediatamente os field_reviews que estavam sem árbitro elegível —
+// se o coordenador habilitou alguém em resposta ao banner de pool vazio,
+// o backlog não precisa esperar o próximo submitAutoReview para ser drenado.
+export async function setCanArbitrate(
+  memberId: string,
+  canArbitrate: boolean,
+  projectId: string,
+): Promise<{ error?: string; retried?: { assigned: number; stillNoPool: number } }> {
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase
+    .from("project_members")
+    .update({ can_arbitrate: canArbitrate })
+    .eq("id", memberId);
+
+  if (error) return { error: error.message };
+
+  let retried: { assigned: number; stillNoPool: number } | undefined;
+  if (canArbitrate) {
+    const result = await retryPendingArbitrations(projectId);
+    if (result.success) {
+      retried = { assigned: result.assigned, stillNoPool: result.stillNoPool };
+    }
+  }
+
+  revalidatePath(`/projects/${projectId}`);
+  revalidatePath(`/projects/${projectId}/config/members`);
+  revalidateTag(`project-${projectId}-members`, TAG_PROFILE);
+  return { retried };
 }

--- a/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
@@ -13,10 +13,18 @@ export default async function MembersPage({
   const user = await getAuthUser();
   const supabase = await createSupabaseServer();
 
-  const { data: members } = await supabase
-    .from("project_members")
-    .select("id, project_id, user_id, role, profiles(id, email, first_name, last_name)")
-    .eq("project_id", id);
+  const [{ data: members }, { count: orphanedReviews }] = await Promise.all([
+    supabase
+      .from("project_members")
+      .select("id, project_id, user_id, role, can_arbitrate, profiles(id, email, first_name, last_name)")
+      .eq("project_id", id),
+    supabase
+      .from("field_reviews")
+      .select("id", { count: "exact", head: true })
+      .eq("project_id", id)
+      .eq("self_verdict", "contesta_llm")
+      .is("arbitrator_id", null),
+  ]);
 
   const typedMembers = (members || []) as unknown as (ProjectMember & { profiles: Profile })[];
 
@@ -26,6 +34,11 @@ export default async function MembersPage({
         <h2 className="text-lg font-semibold">Membros</h2>
         <AddMemberDialog projectId={id} />
       </div>
+      {orphanedReviews && orphanedReviews > 0 ? (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+          {orphanedReviews} caso(s) aguardando arbitragem sem árbitro elegível. Marque ao menos um membro como <strong>Arbitra</strong> abaixo para alocá-los.
+        </div>
+      ) : null}
       <MemberList
         projectId={id}
         members={typedMembers}

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTransition } from "react";
+import { useOptimistic, useState, useTransition } from "react";
 import { removeMember, changeRole, setCanArbitrate } from "@/actions/members";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,8 +20,26 @@ interface MemberListProps {
   currentUserId: string;
 }
 
+type MemberRow = ProjectMember & { profiles: Profile | null };
+
 export function MemberList({ projectId, members, currentUserId }: MemberListProps) {
-  const [isPending, startTransition] = useTransition();
+  // Per-row pending: o Switch tocado fica disabled até o server action retornar,
+  // mas outros Switches da página continuam interativos. Coordenador habilitando
+  // 4 membros em sequência não precisa esperar serializar.
+  const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
+  const [, startTransition] = useTransition();
+
+  // useOptimistic: o Switch reflete imediatamente o valor escolhido enquanto o
+  // server action roda. Sem isso, o `checked` permanece no valor antigo até o
+  // revalidatePath devolver — em conexão lenta parece que o clique não pegou.
+  const [optimisticMembers, applyOptimistic] = useOptimistic<
+    MemberRow[],
+    { memberId: string; canArbitrate: boolean }
+  >(members, (current, update) =>
+    current.map((m) =>
+      m.id === update.memberId ? { ...m, can_arbitrate: update.canArbitrate } : m,
+    ),
+  );
 
   const handleRemove = async (memberId: string) => {
     const result = await removeMember(projectId, memberId);
@@ -42,27 +60,40 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
   };
 
   const handleToggleArbitrate = (memberId: string, value: boolean) => {
+    setPendingMemberId(memberId);
     startTransition(async () => {
-      const result = await setCanArbitrate(memberId, value, projectId);
-      if (result?.error) {
-        toast.error(result.error);
-        return;
-      }
-      if (value && result.retried && result.retried.assigned > 0) {
-        toast.success(
-          `Arbitragem habilitada. ${result.retried.assigned} caso(s) pendente(s) alocados.`,
-        );
-      } else if (value) {
-        toast.success("Arbitragem habilitada.");
-      } else {
-        toast.success("Arbitragem desabilitada.");
+      applyOptimistic({ memberId, canArbitrate: value });
+      try {
+        const result = await setCanArbitrate(memberId, value, projectId);
+        if (result?.error) {
+          toast.error(result.error);
+          return;
+        }
+        if (!value) {
+          toast.success("Arbitragem desabilitada.");
+          return;
+        }
+        const retried = result.retried;
+        if (retried && retried.assigned > 0 && retried.stillNoPool > 0) {
+          toast.success(
+            `Arbitragem habilitada. ${retried.assigned} caso(s) alocado(s); ${retried.stillNoPool} ainda sem árbitro elegível.`,
+          );
+        } else if (retried && retried.assigned > 0) {
+          toast.success(
+            `Arbitragem habilitada. ${retried.assigned} caso(s) pendente(s) alocado(s).`,
+          );
+        } else {
+          toast.success("Arbitragem habilitada.");
+        }
+      } finally {
+        setPendingMemberId(null);
       }
     });
   };
 
   return (
     <div className="space-y-2">
-      {members.map((m) => (
+      {optimisticMembers.map((m) => (
         <div key={m.id} className="flex items-center justify-between rounded-lg border p-3">
           <div>
             <p className="text-sm font-medium">
@@ -78,7 +109,7 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
               <Switch
                 checked={m.can_arbitrate}
                 onCheckedChange={(v) => handleToggleArbitrate(m.id, v)}
-                disabled={isPending}
+                disabled={pendingMemberId === m.id}
                 aria-label="Elegível para arbitrar"
               />
               Arbitra

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { removeMember, changeRole } from "@/actions/members";
+import { useTransition } from "react";
+import { removeMember, changeRole, setCanArbitrate } from "@/actions/members";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   Select,
   SelectContent,
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import type { ProjectMember, Profile } from "@/lib/types";
 
@@ -20,6 +21,8 @@ interface MemberListProps {
 }
 
 export function MemberList({ projectId, members, currentUserId }: MemberListProps) {
+  const [isPending, startTransition] = useTransition();
+
   const handleRemove = async (memberId: string) => {
     const result = await removeMember(projectId, memberId);
     if (result?.error) {
@@ -38,6 +41,25 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
     }
   };
 
+  const handleToggleArbitrate = (memberId: string, value: boolean) => {
+    startTransition(async () => {
+      const result = await setCanArbitrate(memberId, value, projectId);
+      if (result?.error) {
+        toast.error(result.error);
+        return;
+      }
+      if (value && result.retried && result.retried.assigned > 0) {
+        toast.success(
+          `Arbitragem habilitada. ${result.retried.assigned} caso(s) pendente(s) alocados.`,
+        );
+      } else if (value) {
+        toast.success("Arbitragem habilitada.");
+      } else {
+        toast.success("Arbitragem desabilitada.");
+      }
+    });
+  };
+
   return (
     <div className="space-y-2">
       {members.map((m) => (
@@ -48,7 +70,19 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
             </p>
             <p className="text-xs text-muted-foreground">{m.profiles?.email}</p>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-3">
+            <label
+              className="flex items-center gap-2 text-xs text-muted-foreground"
+              title="Recebe casos contestados para arbitrar"
+            >
+              <Switch
+                checked={m.can_arbitrate}
+                onCheckedChange={(v) => handleToggleArbitrate(m.id, v)}
+                disabled={isPending}
+                aria-label="Elegível para arbitrar"
+              />
+              Arbitra
+            </label>
             <Select
               value={m.role}
               onValueChange={(v) => handleChangeRole(m.id, v as "coordenador" | "pesquisador")}

--- a/frontend/src/lib/supabase/database.types.ts
+++ b/frontend/src/lib/supabase/database.types.ts
@@ -590,18 +590,21 @@ export type Database = {
       }
       project_members: {
         Row: {
+          can_arbitrate: boolean
           id: string
           project_id: string | null
           role: string
           user_id: string | null
         }
         Insert: {
+          can_arbitrate?: boolean
           id?: string
           project_id?: string | null
           role: string
           user_id?: string | null
         }
         Update: {
+          can_arbitrate?: boolean
           id?: string
           project_id?: string | null
           role?: string

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -75,6 +75,7 @@ export interface ProjectMember {
   project_id: string;
   user_id: string;
   role: "coordenador" | "pesquisador";
+  can_arbitrate: boolean;
   profiles?: Profile;
 }
 

--- a/frontend/supabase/migrations/20260518213849_project_members_can_arbitrate.sql
+++ b/frontend/supabase/migrations/20260518213849_project_members_can_arbitrate.sql
@@ -1,0 +1,24 @@
+-- project_members.can_arbitrate: flag por membro controlando se ele entra no
+-- sorteio de árbitros em assignArbitrator() (actions/field-reviews.ts).
+--
+-- Default false: novos membros entram NÃO elegíveis para arbitrar; o
+-- coordenador habilita explicitamente quem deve receber casos. Decisão de
+-- design para evitar a sobrecarga atual em que todo membro do projeto era
+-- candidato automaticamente.
+--
+-- Backfill true: preserva o comportamento atual em projetos já em produção
+-- — todo mundo continua elegível até o coordenador desmarcar. Sem esse
+-- backfill, casos pendentes de arbitragem nos projetos existentes ficariam
+-- sem árbitro elegível assim que a migration aplicasse.
+
+ALTER TABLE project_members
+  ADD COLUMN can_arbitrate BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE project_members SET can_arbitrate = true;
+
+-- Index parcial: assignArbitrator() filtra por (project_id, can_arbitrate=true).
+-- Em projetos com muitos membros e muitos desabilitados, o index parcial é mais
+-- compacto e mantém o lookup rápido.
+CREATE INDEX idx_project_members_arbiters
+  ON project_members (project_id)
+  WHERE can_arbitrate = true;


### PR DESCRIPTION
## Resumo

- Adiciona coluna `project_members.can_arbitrate` controlando quem entra no sorteio de árbitros para casos contestados (`contesta_llm`).
- Antes: todo `project_member` era candidato automaticamente — só o auto-revisor original era excluído. O coordenador não tinha como dizer "esse pesquisador não recebe casos para arbitrar".
- Agora: novos membros entram **não-elegíveis por padrão** (`DEFAULT false`); coordenador habilita explicitamente via Switch em **Configuração → Equipe**.
- Backfill `true` para todos os membros existentes preserva o comportamento atual em projetos em produção até o coordenador desmarcar quem não deve arbitrar.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `frontend/supabase/migrations/20260518213849_project_members_can_arbitrate.sql` | `ALTER TABLE` + backfill + index parcial em `(project_id) WHERE can_arbitrate=true` |
| `frontend/src/actions/field-reviews.ts` | `assignArbitrator()` filtra pool por `can_arbitrate=true`; nova `retryPendingArbitrations()` drena backlog |
| `frontend/src/actions/members.ts` | nova `setCanArbitrate()` (dispara retry ao habilitar) |
| `frontend/src/components/members/MemberList.tsx` | `Switch` "Arbitra" por linha |
| `frontend/src/app/(app)/projects/[id]/config/members/page.tsx` | inclui `can_arbitrate` na query + banner quando há `field_reviews` pendentes sem árbitro elegível |
| `frontend/src/lib/types.ts` + `database.types.ts` | adiciona `can_arbitrate: boolean` |

### Pool vazio

Quando ninguém é elegível, `assignArbitrator()` retorna `noPool: true` (já existia). Agora:
- `submitAutoReview()` propaga warning ao pesquisador apontando para Configuração → Equipe;
- A página de membros exibe banner amarelo contando `field_reviews` em `contesta_llm` sem `arbitrator_id`;
- Ao habilitar alguém via Switch, `setCanArbitrate()` chama `retryPendingArbitrations()` para alocar imediatamente o backlog acumulado.

## Test plan

- [ ] Rodar `npx supabase db push` para aplicar a migration
- [ ] Confirmar via `SELECT can_arbitrate, COUNT(*) FROM project_members GROUP BY 1;` que membros existentes ficaram com `true`
- [ ] Como coordenador, abrir `/projects/{id}/config/members` — Switch "Arbitra" aparece marcado para todos
- [ ] Desmarcar 2 membros, recarregar — persistência OK
- [ ] Criar discordância humano vs LLM, fazer `contesta_llm` na auto-revisão — confirmar que `field_reviews.arbitrator_id` cai apenas em quem tem `can_arbitrate=true`
- [ ] Desmarcar todos exceto o auto-revisor, submeter outra contestação — `arbitrator_id IS NULL`, warning aparece e banner em `/config/members` mostra contagem
- [ ] Marcar 1 membro de volta — toast informa que casos pendentes foram alocados; banner some
- [ ] Pesquisador desmarcado abre `/analyze/arbitragem` — lista vazia