### PR TITLE
chore(react-doctor): r4 — silenciar auth false positives + quick wins (78→82)

### DIFF
--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -134,31 +134,33 @@ async function computeLottery(
   const supabase = await createSupabaseServer();
   const assignmentType = params.type || "codificacao";
 
-  // 1. Fetch researchers
-  const { data: members } = await supabase
-    .from("project_members")
-    .select("user_id")
-    .eq("project_id", params.projectId)
-    .eq("role", "pesquisador");
-
-  // 2. Fetch documents (excluidos sao ignorados na alocacao)
-  const { data: docs } = await supabase
-    .from("documents")
-    .select("id")
-    .eq("project_id", params.projectId)
-    .is("excluded_at", null);
+  // 1. Fetch researchers + documents em paralelo
+  const [{ data: members }, { data: docs }] = await Promise.all([
+    supabase
+      .from("project_members")
+      .select("user_id")
+      .eq("project_id", params.projectId)
+      .eq("role", "pesquisador"),
+    supabase
+      .from("documents")
+      .select("id")
+      .eq("project_id", params.projectId)
+      .is("excluded_at", null),
+  ]);
 
   if (!docs?.length) {
     throw new Error("Necessário ter documentos.");
   }
 
   const researcherIds = (members || []).map((m) => m.user_id);
+  const researcherIdSet = new Set(researcherIds);
 
   // Include selected coordinators in the pool
   if (params.includedCoordinatorIds?.length) {
     for (const cId of params.includedCoordinatorIds) {
-      if (!researcherIds.includes(cId)) {
+      if (!researcherIdSet.has(cId)) {
         researcherIds.push(cId);
+        researcherIdSet.add(cId);
       }
     }
   }
@@ -391,10 +393,12 @@ export async function previewLottery(params: LotteryParams): Promise<LotteryPrev
     .eq("role", "pesquisador");
 
   const allUserIds = (members || []).map((m) => m.user_id);
+  const allUserIdSet = new Set(allUserIds);
   if (params.includedCoordinatorIds?.length) {
     for (const cId of params.includedCoordinatorIds) {
-      if (!allUserIds.includes(cId)) {
+      if (!allUserIdSet.has(cId)) {
         allUserIds.push(cId);
+        allUserIdSet.add(cId);
       }
     }
   }

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -39,9 +39,9 @@ export async function checkDuplicates(
   const indexFor = (i: number) => documents[i].csvIndex ?? i;
 
   // Collect external_ids that are present
-  const externalIds = documents
-    .map((d, i) => ({ id: d.external_id, index: i }))
-    .filter((d) => d.id);
+  const externalIds = documents.flatMap((d, i) =>
+    d.external_id ? [{ id: d.external_id, index: i }] : [],
+  );
 
   const duplicates: DuplicateMatch[] = [];
   const matchedCsvIndices = new Set<number>();
@@ -76,9 +76,9 @@ export async function checkDuplicates(
   }
 
   // 2. Match remaining by text_hash
-  const unmatchedHashes = hashes
-    .map((h, i) => ({ hash: h, index: i }))
-    .filter((h) => !matchedCsvIndices.has(h.index));
+  const unmatchedHashes = hashes.flatMap((h, i) =>
+    matchedCsvIndices.has(i) ? [] : [{ hash: h, index: i }],
+  );
 
   if (unmatchedHashes.length > 0) {
     const uniqueHashes = [...new Set(unmatchedHashes.map((h) => h.hash))];
@@ -347,14 +347,21 @@ export async function getDocumentForCoding(
   if (rawAnswers && project?.pydantic_fields) {
     const fields = (project.pydantic_fields as { name: string; type: string; options: string[] | null; target?: string }[])
       .filter((f) => f.target !== "llm_only" && f.target !== "none");
+    const fieldOptionSet = new Map<string, Set<string>>();
+    for (const field of fields) {
+      if ((field.type === "single" || field.type === "multi") && field.options) {
+        fieldOptionSet.set(field.name, new Set(field.options));
+      }
+    }
     const clean: Record<string, unknown> = {};
     for (const field of fields) {
       const val = rawAnswers[field.name];
       if (val === undefined || val === null) continue;
       if (field.type === "single" && field.options) {
-        if (field.options.includes(val as string)) clean[field.name] = val;
+        if (fieldOptionSet.get(field.name)!.has(val as string)) clean[field.name] = val;
       } else if (field.type === "multi" && field.options) {
-        const arr = Array.isArray(val) ? val.filter((v: string) => field.options!.includes(v)) : [];
+        const allowed = fieldOptionSet.get(field.name)!;
+        const arr = Array.isArray(val) ? val.filter((v: string) => allowed.has(v)) : [];
         if (arr.length > 0) clean[field.name] = arr;
       } else {
         clean[field.name] = val;

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -132,9 +132,11 @@ export async function submitAutoReview(
     // real de field_reviews, nao `updatedByField`. Os efeitos sao idempotentes
     // (upsert ignoreDuplicates / check-before-insert), entao re-executar e
     // seguro.
-    const sideEffectFieldNames = verdicts
-      .filter((v) => v.verdict === "equivalente" || v.verdict === "ambiguo")
-      .map((v) => v.fieldName);
+    const sideEffectFieldNames = verdicts.flatMap((v) =>
+      v.verdict === "equivalente" || v.verdict === "ambiguo"
+        ? [v.fieldName]
+        : [],
+    );
     const effectByField = new Map<
       string,
       {
@@ -238,32 +240,31 @@ export async function submitAutoReview(
         (existingComments ?? []).map((r) => r.field_name as string),
       );
 
-      const commentRows = ambiguousFields
-        .filter((v) => !alreadyCommented.has(v.fieldName))
-        .map((v) => {
-          const ids = effectByField.get(v.fieldName)!;
-          const humanAnswer = formatAnswerTechnical(
-            answersById.get(ids.human_response_id)?.[v.fieldName],
-          );
-          const llmAnswer = formatAnswerTechnical(
-            answersById.get(ids.llm_response_id)?.[v.fieldName],
-          );
-          const body = [
-            `Campo "${v.fieldName}" marcado como ambíguo na auto-revisão.`,
-            `Humano respondeu: ${humanAnswer}`,
-            `LLM respondeu: ${llmAnswer}`,
-            // Justificativa garantida nao-vazia pela validacao no topo da funcao.
-            `Justificativa do pesquisador: ${v.justification!.trim()}`,
-            `Precisa de discussão para decidir o gabarito.`,
-          ].join("\n\n");
-          return {
-            project_id: projectId,
-            document_id: documentId,
-            field_name: v.fieldName,
-            author_id: user.id,
-            body,
-          };
-        });
+      const commentRows = ambiguousFields.flatMap((v) => {
+        if (alreadyCommented.has(v.fieldName)) return [];
+        const ids = effectByField.get(v.fieldName)!;
+        const humanAnswer = formatAnswerTechnical(
+          answersById.get(ids.human_response_id)?.[v.fieldName],
+        );
+        const llmAnswer = formatAnswerTechnical(
+          answersById.get(ids.llm_response_id)?.[v.fieldName],
+        );
+        const body = [
+          `Campo "${v.fieldName}" marcado como ambíguo na auto-revisão.`,
+          `Humano respondeu: ${humanAnswer}`,
+          `LLM respondeu: ${llmAnswer}`,
+          // Justificativa garantida nao-vazia pela validacao no topo da funcao.
+          `Justificativa do pesquisador: ${v.justification!.trim()}`,
+          `Precisa de discussão para decidir o gabarito.`,
+        ].join("\n\n");
+        return [{
+          project_id: projectId,
+          document_id: documentId,
+          field_name: v.fieldName,
+          author_id: user.id,
+          body,
+        }];
+      });
 
       if (commentRows.length > 0) {
         const { error: commentErr } = await admin
@@ -275,12 +276,11 @@ export async function submitAutoReview(
 
     // Sorteia arbitro APENAS para campos cujo UPDATE acabou de gravar
     // contesta_llm (re-submit nao reabre arbitragem).
-    const contested = verdicts
-      .filter(
-        (v) =>
-          v.verdict === "contesta_llm" && updatedFieldNames.has(v.fieldName),
-      )
-      .map((v) => v.fieldName);
+    const contested = verdicts.flatMap((v) =>
+      v.verdict === "contesta_llm" && updatedFieldNames.has(v.fieldName)
+        ? [v.fieldName]
+        : [],
+    );
 
     let arbitrated = 0;
     let warning: string | undefined;
@@ -694,43 +694,42 @@ export async function submitFinalVerdicts(
         (existingComments ?? []).map((r) => r.field_name as string),
       );
 
-      const commentRows = llmChoices
-        .filter((c) => !alreadyCommented.has(c.fieldName))
-        .map((c) => {
-          const fr = frByField.get(c.fieldName);
-          const humanResp = fr
-            ? responseById.get(fr.human_response_id)
-            : null;
-          const llmResp = fr ? responseById.get(fr.llm_response_id) : null;
-          const humanAnswer = formatAnswerTechnical(
-            (humanResp?.answers as Record<string, unknown> | undefined)?.[
-              c.fieldName
-            ],
-          );
-          const llmAnswer = formatAnswerTechnical(
-            (llmResp?.answers as Record<string, unknown> | undefined)?.[
-              c.fieldName
-            ],
-          );
-          const body = [
-            `Discordância em "${c.fieldName}".`,
-            `Humano respondeu: ${humanAnswer}`,
-            `LLM respondeu: ${llmAnswer}`,
-            `Árbitro manteve LLM.`,
-            `Sugestão de melhoria: ${c.questionImprovementSuggestion}`,
-            c.arbitratorComment ? `Comentário: ${c.arbitratorComment}` : null,
-          ]
-            .filter(Boolean)
-            .join("\n\n");
+      const commentRows = llmChoices.flatMap((c) => {
+        if (alreadyCommented.has(c.fieldName)) return [];
+        const fr = frByField.get(c.fieldName);
+        const humanResp = fr
+          ? responseById.get(fr.human_response_id)
+          : null;
+        const llmResp = fr ? responseById.get(fr.llm_response_id) : null;
+        const humanAnswer = formatAnswerTechnical(
+          (humanResp?.answers as Record<string, unknown> | undefined)?.[
+            c.fieldName
+          ],
+        );
+        const llmAnswer = formatAnswerTechnical(
+          (llmResp?.answers as Record<string, unknown> | undefined)?.[
+            c.fieldName
+          ],
+        );
+        const body = [
+          `Discordância em "${c.fieldName}".`,
+          `Humano respondeu: ${humanAnswer}`,
+          `LLM respondeu: ${llmAnswer}`,
+          `Árbitro manteve LLM.`,
+          `Sugestão de melhoria: ${c.questionImprovementSuggestion}`,
+          c.arbitratorComment ? `Comentário: ${c.arbitratorComment}` : null,
+        ]
+          .filter(Boolean)
+          .join("\n\n");
 
-          return {
-            project_id: projectId,
-            document_id: documentId,
-            field_name: c.fieldName,
-            author_id: user.id,
-            body,
-          };
-        });
+        return [{
+          project_id: projectId,
+          document_id: documentId,
+          field_name: c.fieldName,
+          author_id: user.id,
+          body,
+        }];
+      });
 
       if (commentRows.length > 0) {
         // Falha aqui significa que o veredito ja foi gravado mas o comentario
@@ -1029,9 +1028,9 @@ export async function regenerateAutoReviewBacklog(
       ),
     );
 
-    const orphanAssignmentIds = (autoAssignments ?? [])
-      .filter((a) => !docUserWithReviews.has(`${a.document_id}|${a.user_id}`))
-      .map((a) => a.id);
+    const orphanAssignmentIds = (autoAssignments ?? []).flatMap((a) =>
+      docUserWithReviews.has(`${a.document_id}|${a.user_id}`) ? [] : [a.id],
+    );
     if (orphanAssignmentIds.length > 0) {
       const { error } = await admin
         .from("assignments")

--- a/frontend/src/actions/progress.ts
+++ b/frontend/src/actions/progress.ts
@@ -44,9 +44,10 @@ export async function getResearcherProgress(
       today.setHours(0, 0, 0, 0);
 
       const futureDeadlines = all
-        .filter((a) => a.deadline && a.status !== "concluido")
-        .map((a) => a.deadline!)
-        .sort();
+        .flatMap((a) =>
+          a.deadline && a.status !== "concluido" ? [a.deadline] : [],
+        )
+        .toSorted();
 
       const nextDeadline = futureDeadlines.length > 0 ? futureDeadlines[0] : null;
 
@@ -75,9 +76,9 @@ export async function getResearcherProgress(
       }
 
       // Streak: consecutive days with completions ending at today
-      const completionDates = completedAssignments
-        .filter((a) => a.completed_at)
-        .map((a) => a.completed_at!.split("T")[0]);
+      const completionDates = completedAssignments.flatMap((a) =>
+        a.completed_at ? [a.completed_at.split("T")[0]] : [],
+      );
 
       const uniqueDates = Array.from(new Set(completionDates)).toSorted(
         (a, b) => b.localeCompare(a),

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -92,8 +92,10 @@ export async function saveSchemaFromGUI(
   projectId: string,
   fields: PydanticField[]
 ) {
-  const supabase = await createSupabaseServer();
-  const user = await getAuthUser();
+  const [supabase, user] = await Promise.all([
+    createSupabaseServer(),
+    getAuthUser(),
+  ]);
 
   // Fetch old fields + current version
   const { data: project } = await supabase
@@ -454,12 +456,14 @@ export async function backfillSchemaVersionHistory(projectId: string) {
 
   const updatePromises = [];
   for (const bucket of updates.values()) {
-    if (bucket.method === "hashes") countHashes += bucket.ids.length;
-    else if (bucket.method === "created_at") countCreatedAt += bucket.ids.length;
-    else if (bucket.method === "fallback_created_at") countFallback += bucket.ids.length;
+    const { ids, method } = bucket;
+    const idsLength = ids.length;
+    if (method === "hashes") countHashes += idsLength;
+    else if (method === "created_at") countCreatedAt += idsLength;
+    else if (method === "fallback_created_at") countFallback += idsLength;
 
-    for (let i = 0; i < bucket.ids.length; i += 100) {
-      const chunk = bucket.ids.slice(i, i + 100);
+    for (let i = 0; i < idsLength; i += 100) {
+      const chunk = ids.slice(i, i + 100);
       updatePromises.push(
         supabase
           .from("responses")
@@ -495,8 +499,10 @@ export async function backfillSchemaVersionHistory(projectId: string) {
 // ---------- MAJOR version bump (manual) ----------
 
 export async function publishMajorVersion(projectId: string) {
-  const supabase = await createSupabaseServer();
-  const user = await getAuthUser();
+  const [supabase, user] = await Promise.all([
+    createSupabaseServer(),
+    getAuthUser(),
+  ]);
   if (!user) throw new Error("Não autenticado");
 
   const { data: project } = await supabase

--- a/frontend/src/app/(app)/projects/[id]/analyze/arbitragem/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/arbitragem/page.tsx
@@ -15,11 +15,12 @@ export default async function ArbitrationRoute({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
   if (!user) redirect("/auth/login");
-
-  const supabase = await createSupabaseServer();
 
   const [{ data: project }, { data: assignments }] = await Promise.all([
     supabase

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
@@ -44,8 +44,7 @@ export default async function AssignmentsPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const supabase = await createSupabaseServer();
+  const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
 
   const [documents, researchers, { data: assignments }, coordinators] =
     await Promise.all([

--- a/frontend/src/app/(app)/projects/[id]/analyze/auto-revisao/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/auto-revisao/page.tsx
@@ -23,8 +23,10 @@ export default async function AutoReviewRoute({
   ]);
   if (!user) redirect("/auth/login");
 
-  const supabase = await createSupabaseServer();
-  const isCoordinator = await isProjectCoordinator(id, user);
+  const [supabase, isCoordinator] = await Promise.all([
+    createSupabaseServer(),
+    isProjectCoordinator(id, user),
+  ]);
 
   // viewAs só é honrado para coordenadores; pesquisador sempre vê a própria fila.
   const targetUserId = isCoordinator && viewAs ? viewAs : user.id;

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -185,6 +185,12 @@ export default async function CodePage({
   const fields = ((project?.pydantic_fields || []) as PydanticField[]).filter(
     (f) => f.target !== "llm_only" && f.target !== "none",
   );
+  const fieldOptionSet = new Map<string, Set<string>>();
+  for (const field of fields) {
+    if ((field.type === "single" || field.type === "multi") && field.options) {
+      fieldOptionSet.set(field.name, new Set(field.options));
+    }
+  }
   const existingAnswers: Record<string, Record<string, unknown>> = {};
   const existingJustifications: Record<string, Record<string, unknown>> = {};
   for (const d of filteredDocuments) {
@@ -195,10 +201,11 @@ export default async function CodePage({
       const val = r.answers[field.name];
       if (val === undefined || val === null) continue;
       if (field.type === "single" && field.options) {
-        if (field.options.includes(val as string)) clean[field.name] = val;
+        if (fieldOptionSet.get(field.name)!.has(val as string)) clean[field.name] = val;
       } else if (field.type === "multi" && field.options) {
+        const allowed = fieldOptionSet.get(field.name)!;
         const arr = Array.isArray(val)
-          ? val.filter((v: string) => field.options!.includes(v))
+          ? val.filter((v: string) => allowed.has(v))
           : [];
         if (arr.length > 0) clean[field.name] = arr;
       } else {

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -86,14 +86,14 @@ export default async function ComparePageRoute({
   params: Promise<{ id: string }>;
   searchParams: Promise<Record<string, string | undefined>>;
 }) {
-  const { id } = await params;
-  const sp = await searchParams;
+  const [{ id }, sp, user, supabase] = await Promise.all([
+    params,
+    searchParams,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
   const filters = readCompareFilters(sp);
-
-  const user = await getAuthUser();
   if (!user) redirect("/auth/login");
-
-  const supabase = await createSupabaseServer();
 
   const [
     { data: project },
@@ -262,9 +262,11 @@ export default async function ComparePageRoute({
   // Respondent names list (do conjunto todo, antes de filtrar)
   const respondentNames = [
     ...new Set(
-      allResponses?.map((r) => r.respondent_name).filter(Boolean) ?? [],
+      allResponses?.flatMap((r) =>
+        r.respondent_name ? [r.respondent_name] : [],
+      ) ?? [],
     ),
-  ] as string[];
+  ];
 
   const qualifiedDocIds: string[] = [];
   const divergentFields: Record<string, string[]> = {};

--- a/frontend/src/app/(app)/projects/[id]/analyze/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/layout.tsx
@@ -9,13 +9,11 @@ export default async function AnalyzeLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-
   // Esconde abas Auto-revisão / Arbitragem para quem nao tem assignments
   // correspondentes. Coordenador sempre ve. Pesquisador ve enquanto tiver
   // pelo menos um assignment do tipo (pendente, em_andamento OU concluido) —
   // preserva acesso ao historico mesmo apos a fila zerar.
-  const user = await getAuthUser();
+  const [{ id }, user] = await Promise.all([params, getAuthUser()]);
   let showAutoReview = false;
   let showArbitragem = false;
 

--- a/frontend/src/app/(app)/projects/[id]/config/documents/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/documents/page.tsx
@@ -9,10 +9,12 @@ export default async function ConfigDocumentsPage({
   params: Promise<{ id: string }>;
   searchParams: Promise<{ show?: string }>;
 }) {
-  const { id } = await params;
-  const { show } = await searchParams;
+  const [{ id }, { show }, supabase] = await Promise.all([
+    params,
+    searchParams,
+    createSupabaseServer(),
+  ]);
   const showExcluded = show === "excluded";
-  const supabase = await createSupabaseServer();
 
   let query = supabase
     .from("documents")
@@ -33,9 +35,9 @@ export default async function ConfigDocumentsPage({
   const excludedByIds = showExcluded
     ? Array.from(
         new Set(
-          (documents || [])
-            .map((d) => d.excluded_by)
-            .filter((v): v is string => !!v),
+          (documents || []).flatMap((d) =>
+            d.excluded_by ? [d.excluded_by] : [],
+          ),
         ),
       )
     : [];

--- a/frontend/src/app/(app)/projects/[id]/config/general/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/general/page.tsx
@@ -6,8 +6,7 @@ export default async function GeneralConfigPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const supabase = await createSupabaseServer();
+  const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
 
   const { data: project } = await supabase
     .from("projects")

--- a/frontend/src/app/(app)/projects/[id]/config/history/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/history/page.tsx
@@ -11,8 +11,7 @@ export default async function SchemaHistoryPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const supabase = await createSupabaseServer();
+  const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
 
   const HISTORY_LIMIT = 200;
 

--- a/frontend/src/app/(app)/projects/[id]/config/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/layout.tsx
@@ -13,8 +13,7 @@ export default async function ConfigLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user] = await Promise.all([params, getAuthUser()]);
   if (!user) redirect("/auth/login");
 
   const { isCoordinator, queryFailed } = await getProjectAccessContext(

--- a/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
@@ -9,9 +9,11 @@ export default async function MembersPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
-  const supabase = await createSupabaseServer();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
 
   const [{ data: members }, { count: orphanedReviews }] = await Promise.all([
     supabase

--- a/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
@@ -10,11 +10,12 @@ export default async function RoundsConfigPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
   if (!user) redirect("/auth/login");
-
-  const supabase = await createSupabaseServer();
 
   const [{ data: project }, { data: rounds }, { data: membership }] =
     await Promise.all([

--- a/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
@@ -35,7 +35,7 @@ export function RulesForm({
   minResponses,
   allowResearcherReview,
 }: RulesFormProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [rule, setRule] = useState(resolutionRule);
   const [min, setMin] = useState(minResponses);
@@ -50,7 +50,7 @@ export function RulesForm({
         allow_researcher_review: allowReview,
       });
       setSaved(true);
-      router.refresh();
+      refresh();
       setTimeout(() => setSaved(false), 2000);
     });
   }

--- a/frontend/src/app/(app)/projects/[id]/config/rules/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/page.tsx
@@ -6,8 +6,7 @@ export default async function RulesPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const supabase = await createSupabaseServer();
+  const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
 
   const { data: project } = await supabase
     .from("projects")

--- a/frontend/src/app/(app)/projects/[id]/config/schema/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/schema/page.tsx
@@ -7,8 +7,7 @@ export default async function SchemaPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const supabase = await createSupabaseServer();
+  const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
 
   const { data: project } = await supabase
     .from("projects")

--- a/frontend/src/app/(app)/projects/[id]/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/layout.tsx
@@ -13,12 +13,13 @@ export default async function ProjectLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
 
   if (!user) redirect("/auth/login");
-
-  const supabase = await createSupabaseServer();
 
   // project + membership vem de getProjectAccessContext (request-scoped via
   // cache()) — mesma leitura reaproveitada pelos layouts filhos config/llm.

--- a/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
@@ -7,8 +7,7 @@ export default async function LlmConfigurePage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const supabase = await createSupabaseServer();
+  const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
 
   const [{ data: project }, { count: totalDocs }, { data: llmResponses }] =
     await Promise.all([

--- a/frontend/src/app/(app)/projects/[id]/llm/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/layout.tsx
@@ -9,8 +9,7 @@ export default async function LlmLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user] = await Promise.all([params, getAuthUser()]);
   if (!user) notFound();
 
   const { isCoordinator, queryFailed } = await getProjectAccessContext(

--- a/frontend/src/app/(app)/projects/[id]/llm/responses/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/responses/page.tsx
@@ -13,10 +13,11 @@ export default async function LlmResponsesPage({
   params: Promise<{ id: string }>;
   searchParams: Promise<{ job?: string }>;
 }) {
-  const { id } = await params;
-  const { job } = await searchParams;
-
-  const supabase = await createSupabaseServer();
+  const [{ id }, { job }, supabase] = await Promise.all([
+    params,
+    searchParams,
+    createSupabaseServer(),
+  ]);
 
   const [{ data: project }, responses, runs] = await Promise.all([
     supabase

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -9,9 +9,11 @@ export default async function CommentsPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
-  const supabase = await createSupabaseServer();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
 
   const [
     { data: project },
@@ -108,12 +110,12 @@ export default async function CommentsPage({
   // Fetch reviewer and respondent (dúvida author) names
   const reviewerIds = [
     ...new Set([
-      ...((reviews || [])
-        .map((r) => r.reviewer_id)
-        .filter((rid): rid is string => !!rid)),
-      ...((verdictQuestions || [])
-        .map((q) => q.respondent_id)
-        .filter((rid): rid is string => !!rid)),
+      ...((reviews || []).flatMap((r) =>
+        r.reviewer_id ? [r.reviewer_id] : [],
+      )),
+      ...((verdictQuestions || []).flatMap((q) =>
+        q.respondent_id ? [q.respondent_id] : [],
+      )),
     ]),
   ];
 
@@ -320,9 +322,9 @@ export default async function CommentsPage({
   const noteRows = typedProjectComments.filter((c) => c.kind !== "exclusion_request");
 
   // Buscar titulos de docs excluidos referenciados por exclusion_requests resolvidas
-  const excludedDocIds = exclusionRows
-    .filter((c) => !!c.document_id && !docMap.has(c.document_id!))
-    .map((c) => c.document_id!) as string[];
+  const excludedDocIds = exclusionRows.flatMap((c) =>
+    c.document_id && !docMap.has(c.document_id) ? [c.document_id] : [],
+  );
   const excludedDocTitles = new Map<string, string>();
   if (excludedDocIds.length > 0) {
     const { data: excludedDocs } = await supabase

--- a/frontend/src/app/(app)/projects/[id]/reviews/confusion/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/confusion/page.tsx
@@ -13,11 +13,12 @@ export default async function ConfusionPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
   if (!user) redirect("/auth/login");
-
-  const supabase = await createSupabaseServer();
 
   const ctx = await fetchReviewBaseData(supabase, id);
   const confusionDataList = computeConfusionData(ctx);

--- a/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
@@ -136,7 +136,9 @@ export default async function ExportPage({
         const comparableOptions = new Set(fullField.options);
         const responseSets = docResponses.map((r) => {
           const arr = (r.answers as Record<string, unknown>)?.[field.name];
-          return new Set(Array.isArray(arr) ? (arr as string[]) : []);
+          return new Set(
+            Array.isArray(arr) ? arr.filter((v): v is string => typeof v === "string") : [],
+          );
         });
         for (const set of responseSets) {
           for (const v of set) comparableOptions.add(v);

--- a/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/export/page.tsx
@@ -21,8 +21,7 @@ export default async function ExportPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const supabase = await createSupabaseServer();
+  const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
 
   const [{ data: project }, { data: responses }, { data: reviews }] =
     await Promise.all([
@@ -135,20 +134,16 @@ export default async function ExportPage({
 
       if (fullField?.type === "multi" && fullField.options?.length) {
         const comparableOptions = new Set(fullField.options);
-        for (const r of docResponses) {
+        const responseSets = docResponses.map((r) => {
           const arr = (r.answers as Record<string, unknown>)?.[field.name];
-          if (Array.isArray(arr)) {
-            for (const v of arr) {
-              if (typeof v === "string") comparableOptions.add(v);
-            }
-          }
+          return new Set(Array.isArray(arr) ? (arr as string[]) : []);
+        });
+        for (const set of responseSets) {
+          for (const v of set) comparableOptions.add(v);
         }
         let hasDivergence = false;
         for (const opt of comparableOptions) {
-          const selections = docResponses.map((r) => {
-            const arr = (r.answers as Record<string, unknown>)?.[field.name];
-            return Array.isArray(arr) && arr.includes(opt);
-          });
+          const selections = responseSets.map((s) => s.has(opt));
           if (!selections.every((s) => s === selections[0])) {
             hasDivergence = true;
             break;

--- a/frontend/src/app/(app)/projects/[id]/reviews/gabarito/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/gabarito/page.tsx
@@ -13,11 +13,12 @@ export default async function GabaritoPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
   if (!user) redirect("/auth/login");
-
-  const supabase = await createSupabaseServer();
 
   const ctx = await fetchReviewBaseData(supabase, id);
   const reviewedDocuments = computeReviewedDocuments(ctx);

--- a/frontend/src/app/(app)/projects/[id]/reviews/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/layout.tsx
@@ -10,11 +10,12 @@ export default async function ReviewsLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
   if (!user) redirect("/auth/login");
-
-  const supabase = await createSupabaseServer();
 
   const [{ data: project }, { data: membership }] = await Promise.all([
     supabase

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -39,9 +39,11 @@ export default async function LlmInsightsPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = await params;
-  const user = await getAuthUser();
-  const supabase = await createSupabaseServer();
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    getAuthUser(),
+    createSupabaseServer(),
+  ]);
 
   const [
     { data: project },

--- a/frontend/src/components/arbitration/ArbitrationPage.tsx
+++ b/frontend/src/components/arbitration/ArbitrationPage.tsx
@@ -71,7 +71,7 @@ export function ArbitrationPage({
   docs,
   arbitrationBlind,
 }: ArbitrationPageProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const storageKey = `${STORAGE_KEY_PREFIX}${projectId}`;
   const [pinnedDocId, setPinnedDocId] = useState<string | null>(null);
 
@@ -200,10 +200,10 @@ export function ArbitrationPage({
         return;
       }
     }
-    // router.refresh() repuxa o payload com `reveal` populado para esses
+    // refresh() repuxa o payload com `reveal` populado para esses
     // campos. O useEffect acima detecta blindVerdict definido e muda phase
     // para "reveal" automaticamente.
-    router.refresh();
+    refresh();
     setSubmitting(false);
   }
 
@@ -242,7 +242,7 @@ export function ArbitrationPage({
     if (docIndex < docs.length - 1) {
       handleDocNavigate(docIndex + 1);
     } else {
-      router.refresh();
+      refresh();
     }
   }
 

--- a/frontend/src/components/auto-review/AutoReviewPage.tsx
+++ b/frontend/src/components/auto-review/AutoReviewPage.tsx
@@ -71,7 +71,7 @@ export function AutoReviewPage({
   reviewers,
   currentUserId,
 }: AutoReviewPageProps) {
-  const router = useRouter();
+  const { push, refresh } = useRouter();
   const searchParams = useSearchParams();
 
   const isOwnQueue = viewAsUserId === currentUserId;
@@ -87,7 +87,7 @@ export function AutoReviewPage({
     if (v) setPinnedDocId(v);
   }, [storageKey]);
 
-  // Após router.refresh(), um doc totalmente resolvido sai da fila — o
+  // Após refresh(), um doc totalmente resolvido sai da fila — o
   // pinnedDocId em sessionStorage fica órfão. Limpa o storage para não
   // restaurar um id inexistente numa sessão futura; o state em memória pode
   // seguir intocado porque o docIndex já cai para 0 quando o id não bate.
@@ -145,7 +145,7 @@ export function AutoReviewPage({
     } else {
       params.set("viewAs", newUserId);
     }
-    router.push(`?${params.toString()}`);
+    push(`?${params.toString()}`);
   }
 
   const docListEntries: AutoReviewDocListEntry[] = useMemo(
@@ -294,7 +294,7 @@ export function AutoReviewPage({
     });
     // Recarrega o estado do servidor: os campos enviados voltam como
     // alreadyAnswered e o doc sai da fila se todos foram resolvidos.
-    router.refresh();
+    refresh();
   }
 
   const currentReviewer = reviewers.find((r) => r.userId === viewAsUserId);

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -148,7 +148,7 @@ function SortSelect({
 }
 
 function RoundSelect({ data }: { data: RoundFilterData }) {
-  const router = useRouter();
+  const { replace } = useRouter();
   const [isPending, startTransition] = useTransition();
 
   const normalizedSelected = isCurrentFilter(data.selected)
@@ -163,7 +163,7 @@ function RoundSelect({ data }: { data: RoundFilterData }) {
       url.searchParams.set("round", value);
     }
     startTransition(() => {
-      router.replace(`${url.pathname}${url.search}`, { scroll: false });
+      replace(`${url.pathname}${url.search}`, { scroll: false });
     });
   };
 

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -65,7 +65,7 @@ export function CodingPage({
   roundFilter,
 }: CodingPageProps) {
   const searchParams = useSearchParams();
-  const router = useRouter();
+  const { replace } = useRouter();
   const pathname = usePathname();
   const docParam = searchParams.get("doc");
 
@@ -233,9 +233,9 @@ export function CodingPage({
       } else {
         params.delete("doc");
       }
-      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+      replace(`${pathname}?${params.toString()}`, { scroll: false });
     },
-    [searchParams, router, pathname]
+    [searchParams, replace, pathname]
   );
 
   // Lazy-load browse documents
@@ -426,7 +426,7 @@ export function CodingPage({
       else params.delete("sort");
       if (targetId) params.set("doc", targetId);
       const qs = params.toString();
-      router.replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
+      replace(`${pathname}${qs ? `?${qs}` : ""}`, { scroll: false });
     },
     [
       currentDoc,
@@ -438,7 +438,7 @@ export function CodingPage({
       dirtyDocs,
       markClean,
       searchParams,
-      router,
+      replace,
       pathname,
     ]
   );

--- a/frontend/src/components/coding/DocumentReader.tsx
+++ b/frontend/src/components/coding/DocumentReader.tsx
@@ -43,7 +43,7 @@ export function DocumentReader({ text }: DocumentReaderProps) {
   const normalized = useMemo(() => normalizeExtractedText(text), [text]);
 
   return (
-    <div className="h-full overflow-y-auto px-6 py-6">
+    <div className="h-full overflow-y-auto p-6">
       <div className="prose prose-sm dark:prose-invert max-w-3xl break-words">
         <ReactMarkdown>{normalized}</ReactMarkdown>
       </div>

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -301,7 +301,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         </p>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-2.5">
+      <div className="flex-1 overflow-y-auto p-4 space-y-2.5">
         {dragEnabled ? (
           <DndContext
             sensors={sensors}

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -255,6 +255,7 @@ export function AnswerCard({
             className="flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"
             title="Esta é a resposta que será registrada como gabarito"
             onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
           >
             <input
               type="radio"

--- a/frontend/src/components/compare/CompareFilters.tsx
+++ b/frontend/src/components/compare/CompareFilters.tsx
@@ -36,7 +36,7 @@ export function CompareFilters({
   availableVersions,
   latestMajorLabel,
 }: CompareFiltersProps) {
-  const router = useRouter();
+  const { push } = useRouter();
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
@@ -66,17 +66,17 @@ export function CompareFilters({
         }
       }
       startTransition(() => {
-        router.push(`${pathname}?${sp.toString()}`);
+        push(`${pathname}?${sp.toString()}`);
       });
     },
-    [pathname, router, searchParams],
+    [pathname, push, searchParams],
   );
 
   const reset = useCallback(() => {
     startTransition(() => {
-      router.push(pathname);
+      push(pathname);
     });
-  }, [pathname, router]);
+  }, [pathname, push]);
 
   const activeCount = [
     current.version !== DEFAULT_COMPARE_FILTERS.version,

--- a/frontend/src/components/config/RoundsConfig.tsx
+++ b/frontend/src/components/config/RoundsConfig.tsx
@@ -44,7 +44,7 @@ export function RoundsConfig({
   rounds,
   isCoordinator,
 }: Props) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [newLabel, setNewLabel] = useState("");
   const [pendingDelete, setPendingDelete] = useState<Round | null>(null);
@@ -56,7 +56,7 @@ export function RoundsConfig({
       if (r.error) toast.error(r.error);
       else {
         toast.success("Estratégia atualizada");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -70,7 +70,7 @@ export function RoundsConfig({
       else {
         toast.success("Rodada criada");
         setNewLabel("");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -81,7 +81,7 @@ export function RoundsConfig({
       if (r.error) toast.error(r.error);
       else {
         toast.success("Rodada atual atualizada");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -95,7 +95,7 @@ export function RoundsConfig({
       if (r.error) toast.error(r.error);
       else {
         toast.success("Rodada excluída");
-        router.refresh();
+        refresh();
       }
     });
   };

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -45,7 +45,7 @@ export function DocumentsPageClient({
   projectId,
   showExcluded = false,
 }: DocumentsPageClientProps) {
-  const router = useRouter();
+  const { push } = useRouter();
   const pathname = usePathname();
 
   const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
@@ -63,7 +63,7 @@ export function DocumentsPageClient({
     if (!pathname) return;
     const url = checked ? `${pathname}?show=excluded` : pathname;
     setSelectedIds(new Set());
-    router.push(url);
+    push(url);
   }
 
   function handleToggleSelect(docId: string) {

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -109,7 +109,7 @@ export function LlmConfigurePane({
   totalDocs,
   docsWithLlm,
 }: LlmConfigurePaneProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const modelListboxId = useId();
 
   // Prompt state
@@ -254,7 +254,7 @@ export function LlmConfigurePane({
           if (intervalRef.current) clearInterval(intervalRef.current);
           intervalRef.current = null;
           // Refresca o layout para o badge de execução desaparecer.
-          router.refresh();
+          refresh();
           if (res.status === "completed") toast.success("LLM concluído!");
           if (res.status === "error") {
             const msg = res.errors[0] || "Erro na execução";
@@ -297,7 +297,7 @@ export function LlmConfigurePane({
         toast.error(msg);
       }
     }, 2000);
-  }, [router, pydanticCode]);
+  }, [refresh, pydanticCode]);
 
   // Retomar polling se houver uma run em execucao ao montar (ex.: usuario
   // recarregou a pagina ou voltou para a aba). Sem isso, o card de execucao
@@ -428,7 +428,7 @@ export function LlmConfigurePane({
       setProcessedPartial(0);
       setProcessedEmpty(0);
       // Refresca o layout do projeto para o badge "LLM rodando" aparecer na aba.
-      router.refresh();
+      refresh();
       pollProgress(res.job_id);
     } catch (e: any) {
       toast.error(e.message);
@@ -502,7 +502,7 @@ export function LlmConfigurePane({
                     {previewPrompt}
                     {!projectDescription.trim() && (
                       <p className="mt-2 text-muted-foreground italic">
-                        (Sem descrição do projeto — configure em Config → Geral)
+                        (Sem descrição do projeto, configure em Config → Geral)
                       </p>
                     )}
                   </>

--- a/frontend/src/components/llm/LlmResponsesPane.tsx
+++ b/frontend/src/components/llm/LlmResponsesPane.tsx
@@ -41,7 +41,7 @@ export function LlmResponsesPane({
   fieldLabels,
   activeJobId,
 }: LlmResponsesPaneProps) {
-  const router = useRouter();
+  const { replace } = useRouter();
   const statusFilterId = useId();
   const [isPending, startTransition] = useTransition();
 
@@ -78,7 +78,7 @@ export function LlmResponsesPane({
     if (jobId === "all") url.searchParams.delete("job");
     else url.searchParams.set("job", jobId);
     startTransition(() => {
-      router.replace(`${url.pathname}${url.search}`);
+      replace(`${url.pathname}${url.search}`);
     });
   };
 

--- a/frontend/src/components/reviews/DateSinceFilter.tsx
+++ b/frontend/src/components/reviews/DateSinceFilter.tsx
@@ -29,7 +29,7 @@ function formatBR(iso: string): string {
 }
 
 export function DateSinceFilter() {
-  const router = useRouter();
+  const { push } = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
@@ -52,7 +52,7 @@ export function DateSinceFilter() {
     }
     const qs = params.toString();
     startTransition(() => {
-      router.push(qs ? `${pathname}?${qs}` : pathname);
+      push(qs ? `${pathname}?${qs}` : pathname);
     });
   };
 

--- a/frontend/src/components/reviews/HardestDocuments.tsx
+++ b/frontend/src/components/reviews/HardestDocuments.tsx
@@ -28,38 +28,38 @@ export function HardestDocuments({
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b">
-            <th className="px-2 py-2 text-left text-xs font-medium">#</th>
-            <th className="px-2 py-2 text-left text-xs font-medium">
+            <th className="p-2 text-left text-xs font-medium">#</th>
+            <th className="p-2 text-left text-xs font-medium">
               Documento
             </th>
-            <th className="px-2 py-2 text-center text-xs font-medium">
+            <th className="p-2 text-center text-xs font-medium">
               Campos
             </th>
-            <th className="px-2 py-2 text-center text-xs font-medium">
+            <th className="p-2 text-center text-xs font-medium">
               Erros
             </th>
-            <th className="px-2 py-2 text-center text-xs font-medium">
+            <th className="p-2 text-center text-xs font-medium">
               Taxa de Erro
             </th>
-            <th className="px-2 py-2 text-center text-xs font-medium" />
+            <th className="p-2 text-center text-xs font-medium" />
           </tr>
         </thead>
         <tbody>
           {hardestDocuments.map((doc, idx) => (
             <tr key={doc.documentId} className="border-b last:border-0">
-              <td className="px-2 py-2 text-muted-foreground tabular-nums">
+              <td className="p-2 text-muted-foreground tabular-nums">
                 {idx + 1}
               </td>
-              <td className="max-w-[240px] truncate px-2 py-2 font-medium" title={doc.documentTitle}>
+              <td className="max-w-[240px] truncate p-2 font-medium" title={doc.documentTitle}>
                 {doc.documentTitle}
               </td>
-              <td className="px-2 py-2 text-center tabular-nums">
+              <td className="p-2 text-center tabular-nums">
                 {doc.totalFieldsReviewed}
               </td>
-              <td className="px-2 py-2 text-center tabular-nums">
+              <td className="p-2 text-center tabular-nums">
                 {doc.totalErrors}
               </td>
-              <td className="px-2 py-2">
+              <td className="p-2">
                 <div className="flex items-center gap-2">
                   <div className="h-2 w-16 overflow-hidden rounded-full bg-muted">
                     <div
@@ -88,7 +88,7 @@ export function HardestDocuments({
                   </span>
                 </div>
               </td>
-              <td className="px-2 py-2">
+              <td className="p-2">
                 <Button variant="ghost" size="sm" asChild title="Ver comparação">
                   <Link href={`/projects/${projectId}/analyze/compare?doc=${doc.documentId}`}>
                     <FileText className="size-3.5" />

--- a/frontend/src/components/reviews/MyVerdictsView.tsx
+++ b/frontend/src/components/reviews/MyVerdictsView.tsx
@@ -43,8 +43,9 @@ function formatAnswer(answer: unknown): string {
   if (Array.isArray(answer)) return answer.join(", ");
   if (typeof answer === "object") {
     return Object.entries(answer as Record<string, unknown>)
-      .filter(([, v]) => v != null && String(v).trim() !== "")
-      .map(([k, v]) => `${k}: ${v}`)
+      .flatMap(([k, v]) =>
+        v != null && String(v).trim() !== "" ? [`${k}: ${v}`] : [],
+      )
       .join(", ");
   }
   return String(answer);
@@ -56,9 +57,9 @@ function formatVerdictDisplay(verdict: string, fieldType?: string): string {
   if (fieldType === "multi" || verdict.startsWith("{")) {
     try {
       const parsed = JSON.parse(verdict) as Record<string, boolean>;
-      const selected = Object.entries(parsed)
-        .filter(([, v]) => v)
-        .map(([k]) => k);
+      const selected = Object.entries(parsed).flatMap(([k, v]) =>
+        v ? [k] : [],
+      );
       return selected.length > 0 ? selected.join("; ") : "(nenhuma)";
     } catch {
       // fallback
@@ -105,7 +106,7 @@ export function MyVerdictsView({
   respondents = EMPTY_RESPONDENTS,
   currentViewUserId,
 }: MyVerdictsViewProps) {
-  const router = useRouter();
+  const { push, refresh } = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [isPending, startTransition] = useTransition();
@@ -228,7 +229,7 @@ export function MyVerdictsView({
         toast.success(status === "accepted" ? "Correção aceita" : "Dúvida enviada");
         setCommentingReviewId(null);
         setQuestionComment("");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -242,7 +243,7 @@ export function MyVerdictsView({
     }
     const qs = params.toString();
     startTransition(() => {
-      router.push(`${pathname}${qs ? `?${qs}` : ""}`);
+      push(`${pathname}${qs ? `?${qs}` : ""}`);
     });
   };
 
@@ -346,7 +347,7 @@ export function MyVerdictsView({
           </ResizablePanel>
           <ResizableHandle withHandle />
           <ResizablePanel defaultSize={45} minSize={25}>
-            <div ref={scrollRef} className="h-full overflow-y-auto px-4 py-4 space-y-4">
+            <div ref={scrollRef} className="h-full overflow-y-auto p-4 space-y-4">
               <div className="flex items-center justify-between gap-2">
                 <p className="min-w-0 truncate text-xs font-medium text-muted-foreground">
                   {currentGroup.title}

--- a/frontend/src/components/reviews/RespondentProfile.tsx
+++ b/frontend/src/components/reviews/RespondentProfile.tsx
@@ -65,7 +65,7 @@ export function RespondentProfile({
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b">
-              <th className="px-2 py-2 text-left">
+              <th className="p-2 text-left">
                 <Button
                   variant="ghost"
                   size="sm"
@@ -76,10 +76,10 @@ export function RespondentProfile({
                   <ArrowUpDown className="ml-1 size-3" />
                 </Button>
               </th>
-              <th className="px-2 py-2 text-center text-xs font-medium">
+              <th className="p-2 text-center text-xs font-medium">
                 Tipo
               </th>
-              <th className="px-2 py-2 text-center">
+              <th className="p-2 text-center">
                 <Button
                   variant="ghost"
                   size="sm"
@@ -93,7 +93,7 @@ export function RespondentProfile({
               {displayFields.map((f) => (
                 <th
                   key={f.name}
-                  className="max-w-[80px] truncate px-2 py-2 text-center text-xs font-medium"
+                  className="max-w-[80px] truncate p-2 text-center text-xs font-medium"
                   title={f.description}
                 >
                   {f.description.length > 12
@@ -101,7 +101,7 @@ export function RespondentProfile({
                     : f.description}
                 </th>
               ))}
-              <th className="px-2 py-2 text-left text-xs font-medium">
+              <th className="p-2 text-left text-xs font-medium">
                 Mais erros
               </th>
             </tr>
@@ -109,8 +109,8 @@ export function RespondentProfile({
           <tbody>
             {sorted.map((rp) => (
               <tr key={rp.respondentKey} className="border-b last:border-0">
-                <td className="px-2 py-2 font-medium">{rp.respondentName}</td>
-                <td className="px-2 py-2 text-center">
+                <td className="p-2 font-medium">{rp.respondentName}</td>
+                <td className="p-2 text-center">
                   {rp.respondentType === "llm" ? (
                     <Badge variant="secondary" className="gap-1">
                       <Bot className="size-3" />
@@ -123,7 +123,7 @@ export function RespondentProfile({
                     </Badge>
                   )}
                 </td>
-                <td className="px-2 py-2 text-center">
+                <td className="p-2 text-center">
                   <div className="flex flex-col items-center gap-1">
                     <span
                       className={cn(
@@ -148,14 +148,14 @@ export function RespondentProfile({
                     return (
                       <td
                         key={f.name}
-                        className="px-2 py-2 text-center text-xs text-muted-foreground"
+                        className="p-2 text-center text-xs text-muted-foreground"
                       >
                         –
                       </td>
                     );
                   }
                   return (
-                    <td key={f.name} className="px-2 py-2">
+                    <td key={f.name} className="p-2">
                       <div className="flex flex-col items-center gap-0.5">
                         <div className="h-1.5 w-12 overflow-hidden rounded-full bg-muted">
                           <div
@@ -177,7 +177,7 @@ export function RespondentProfile({
                     </td>
                   );
                 })}
-                <td className="px-2 py-2">
+                <td className="p-2">
                   <div className="flex flex-wrap gap-1">
                     {rp.mostErroredFields.map((mf) => (
                       <span

--- a/frontend/src/components/schema/FieldCard.tsx
+++ b/frontend/src/components/schema/FieldCard.tsx
@@ -186,7 +186,7 @@ export function FieldCard({
 
         {/* Body expandido */}
         <CollapsibleContent>
-          <div className="border-t px-4 py-4 space-y-4">
+          <div className="border-t p-4 space-y-4">
             {/* Nome do campo */}
             <div className="space-y-1.5">
               <Label className="text-xs">Nome do campo</Label>

--- a/frontend/src/components/schema/FieldChangeDiff.tsx
+++ b/frontend/src/components/schema/FieldChangeDiff.tsx
@@ -51,7 +51,7 @@ export function FieldChangeDiff({ entry, defaultExpanded = true }: FieldChangeDi
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex w-full items-center gap-2 rounded-md px-1 py-1 text-left hover:bg-muted/40"
+        className="flex w-full items-center gap-2 rounded-md p-1 text-left hover:bg-muted/40"
       >
         <KindIcon kind={kind} />
         {displayName}

--- a/frontend/src/components/schema/SchemaBuilderGUI.tsx
+++ b/frontend/src/components/schema/SchemaBuilderGUI.tsx
@@ -90,7 +90,7 @@ export function SchemaBuilderGUI({ fields, onChange }: SchemaBuilderGUIProps) {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex-1 overflow-y-auto px-4 py-4 space-y-2">
+      <div className="flex-1 overflow-y-auto p-4 space-y-2">
         {fields.length === 0 && (
           <div className="flex flex-col items-center justify-center py-16 text-center">
             <p className="text-sm text-muted-foreground mb-4">

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -50,7 +50,7 @@ export function SchemaEditor({
   initialFields,
   currentVersion,
 }: SchemaEditorProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const defaultMode =
     !initialFields?.length && initialCode ? "code" : "gui";
 
@@ -86,7 +86,7 @@ export function SchemaEditor({
         const bumped = await publishMajorVersion(projectId);
         toast.success(`Nova versão MAJOR publicada: ${bumped.major}.${bumped.minor}.${bumped.patch}`);
         setMajorDialogOpen(false);
-        router.refresh();
+        refresh();
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Erro ao publicar MAJOR";
         toast.error(msg);
@@ -105,7 +105,7 @@ export function SchemaEditor({
           { duration: 10000 },
         );
         setBackfillDialogOpen(false);
-        router.refresh();
+        refresh();
       } catch (e: unknown) {
         const msg = e instanceof Error ? e.message : "Erro ao reconstruir";
         toast.error(msg);

--- a/frontend/src/components/shared/AddNoteButton.tsx
+++ b/frontend/src/components/shared/AddNoteButton.tsx
@@ -47,7 +47,7 @@ export function AddNoteButton({
   size = "sm",
   label,
 }: AddNoteButtonProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const [open, setOpen] = useState(false);
   const [body, setBody] = useState("");
   const [selectedField, setSelectedField] = useState<string>(fixedFieldName || "_none");
@@ -91,7 +91,7 @@ export function AddNoteButton({
         setBody("");
         setSelectedField(fixedFieldName || "_none");
         setOpen(false);
-        router.refresh();
+        refresh();
       }
     });
   };

--- a/frontend/src/components/shell/ProjectTabs.tsx
+++ b/frontend/src/components/shell/ProjectTabs.tsx
@@ -39,7 +39,7 @@ export function ProjectTabs({
   isLlmRunning = false,
 }: ProjectTabsProps) {
   const pathname = usePathname();
-  const router = useRouter();
+  const { push } = useRouter();
   const searchParams = useSearchParams();
 
   // Auto-revisão é sempre da própria conta — impersonate (viewAsUser /
@@ -73,7 +73,7 @@ export function ProjectTabs({
     }
     params.delete("viewAsUser");
     const qs = params.toString();
-    router.push(`${pathname}${qs ? `?${qs}` : ""}`);
+    push(`${pathname}${qs ? `?${qs}` : ""}`);
   };
 
   const selectImpersonation = (userId: string | null) => {
@@ -85,7 +85,7 @@ export function ProjectTabs({
       params.delete("viewAsUser");
     }
     const qs = params.toString();
-    router.push(`${pathname}${qs ? `?${qs}` : ""}`);
+    push(`${pathname}${qs ? `?${qs}` : ""}`);
   };
 
   return (

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -167,7 +167,7 @@ export function CommentCard({
   onSuggestField,
   onOpenDocument,
 }: CommentCardProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const isResolved = !!comment.resolvedAt;
   const [suggestionPending, startSuggestionAction] = useTransition();
   const [gabaritoOpen, setGabaritoOpen] = useState(false);
@@ -326,7 +326,7 @@ export function CommentCard({
                     startSuggestionAction(async () => {
                       const result = await resolveSchemaSuggestion(comment.suggestionId!, projectId, "rejected");
                       if (result.error) toast.error(result.error);
-                      else { toast.success("Sugestão rejeitada"); router.refresh(); }
+                      else { toast.success("Sugestão rejeitada"); refresh(); }
                     });
                   }}
                 >
@@ -483,7 +483,7 @@ function ExclusionActions({
   rejectedReason?: string | null;
   isCoordinator: boolean;
 }) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const [isPending, startAction] = useTransition();
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
@@ -564,7 +564,7 @@ function ExclusionActions({
                 if (result.error) toast.error(result.error);
                 else {
                   toast.success("Sugestão rejeitada");
-                  router.refresh();
+                  refresh();
                 }
               });
             }}
@@ -589,7 +589,7 @@ function ExclusionActions({
             if (result.error) toast.error(result.error);
             else {
               toast.success("Documento excluído");
-              router.refresh();
+              refresh();
             }
           });
         }}

--- a/frontend/src/components/stats/CommentsSplitView.tsx
+++ b/frontend/src/components/stats/CommentsSplitView.tsx
@@ -87,7 +87,7 @@ export function CommentsSplitView({
   initialDocId,
   onBack,
 }: CommentsSplitViewProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [showResolved, setShowResolved] = useState(false);
 
@@ -154,7 +154,7 @@ export function CommentsSplitView({
         toast.error(result.error);
       } else {
         toast.success("Comentário resolvido");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -171,7 +171,7 @@ export function CommentsSplitView({
         toast.error(result.error);
       } else {
         toast.success("Comentário reaberto");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -229,7 +229,7 @@ export function CommentsSplitView({
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={45} minSize={25}>
-          <div className="h-full overflow-y-auto px-4 py-4 space-y-4">
+          <div className="h-full overflow-y-auto p-4 space-y-4">
             <div className="flex items-center justify-between">
               <p className="text-xs font-medium text-muted-foreground">
                 {(() => {

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -86,7 +86,7 @@ export function EditFieldDialog({
   onOpenChange,
   pendingSuggestion,
 }: EditFieldDialogProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const field = allFields.find((f) => f.name === fieldName);
   const initial = initialFromField(field, pendingSuggestion);
   const [description, setDescription] = useState(initial.description);
@@ -175,7 +175,7 @@ export function EditFieldDialog({
           toast.success("Campo atualizado");
         }
         onOpenChange(false);
-        router.refresh();
+        refresh();
       } catch (e) {
         toast.error(
           e instanceof Error ? e.message : "Erro ao salvar",

--- a/frontend/src/components/stats/ExportPanel.tsx
+++ b/frontend/src/components/stats/ExportPanel.tsx
@@ -86,12 +86,14 @@ export function ExportPanel({
       let rows: string[][];
       if (dataset === "both") {
         const individualHeaderSet = new Set(individualHeaders);
-        const padIndividual = individualRows.map((row) => {
-          const extraCols = verdictHeaders.filter(
-            (h) => !individualHeaderSet.has(h),
-          );
-          return [...row, ...extraCols.map(() => "")];
-        });
+        const extraColsCount = verdictHeaders.reduce(
+          (n, h) => (individualHeaderSet.has(h) ? n : n + 1),
+          0,
+        );
+        const padIndividual = individualRows.map((row) => [
+          ...row,
+          ...Array<string>(extraColsCount).fill(""),
+        ]);
         const padVerdict = verdictRows.map((row) => {
           const result: string[] = [];
           for (const h of headers) {

--- a/frontend/src/components/stats/ExportPanel.tsx
+++ b/frontend/src/components/stats/ExportPanel.tsx
@@ -85,9 +85,10 @@ export function ExportPanel({
 
       let rows: string[][];
       if (dataset === "both") {
+        const individualHeaderSet = new Set(individualHeaders);
         const padIndividual = individualRows.map((row) => {
           const extraCols = verdictHeaders.filter(
-            (h) => !individualHeaders.includes(h),
+            (h) => !individualHeaderSet.has(h),
           );
           return [...row, ...extraCols.map(() => "")];
         });

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -75,7 +75,7 @@ export function LlmInsightsView({
   isCoordinator,
   summary,
 }: LlmInsightsViewProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [editingField, setEditingField] = useState<string | null>(null);
   const [regenerating, setRegenerating] = useState(false);
@@ -99,7 +99,7 @@ export function LlmInsightsView({
       parts.push(`${result.keptResolved} já resolvida(s) mantida(s)`);
     }
     toast.success(`Backlog regenerado. ${parts.join(", ")}.`);
-    router.refresh();
+    refresh();
   }
 
   // Error filters
@@ -215,7 +215,7 @@ export function LlmInsightsView({
         toast.error(result.error);
       } else {
         toast.success("Erro resolvido");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -227,7 +227,7 @@ export function LlmInsightsView({
         toast.error(result.error);
       } else {
         toast.success("Erro reaberto");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -244,7 +244,7 @@ export function LlmInsightsView({
           e.chosenResponseId!,
         );
         toast.success("Respostas marcadas como equivalentes");
-        router.refresh();
+        refresh();
       } catch (err) {
         toast.error((err as Error).message);
       }

--- a/frontend/src/components/stats/ReviewCommentsView.tsx
+++ b/frontend/src/components/stats/ReviewCommentsView.tsx
@@ -74,7 +74,7 @@ export function ReviewCommentsView({
   totalLlmDocs = 0,
   llmDocsWithoutAmbiguities = 0,
 }: ReviewCommentsViewProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [fieldFilter, setFieldFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState("open");
@@ -135,7 +135,7 @@ export function ReviewCommentsView({
         toast.error(result.error);
       } else {
         toast.success("Comentário resolvido");
-        router.refresh();
+        refresh();
       }
     });
   };
@@ -158,7 +158,7 @@ export function ReviewCommentsView({
         toast.error(result.error);
       } else {
         toast.success("Comentário reaberto");
-        router.refresh();
+        refresh();
       }
     });
   };

--- a/frontend/src/components/stats/SuggestFieldDialog.tsx
+++ b/frontend/src/components/stats/SuggestFieldDialog.tsx
@@ -42,7 +42,7 @@ export function SuggestFieldDialog({
   open,
   onOpenChange,
 }: SuggestFieldDialogProps) {
-  const router = useRouter();
+  const { refresh } = useRouter();
   const field = allFields.find((f) => f.name === fieldName);
   const [description, setDescription] = useState(field?.description ?? "");
   const [helpText, setHelpText] = useState(field?.help_text ?? "");
@@ -96,7 +96,7 @@ export function SuggestFieldDialog({
       } else {
         toast.success("Sugestão enviada ao coordenador");
         onOpenChange(false);
-        router.refresh();
+        refresh();
       }
     });
   };

--- a/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
+++ b/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
@@ -30,8 +30,8 @@ function expectedHash(
 ): string {
   const optionsPart = options
     ? "[" +
-      [...options]
-        .sort()
+      options
+        .toSorted()
         .map((s) => `'${s}'`)
         .join(", ") +
       "]"

--- a/frontend/src/lib/clerk-sync.ts
+++ b/frontend/src/lib/clerk-sync.ts
@@ -13,14 +13,14 @@ export async function syncClerkUserToSupabase(
   lastName?: string | null
 ): Promise<string> {
   const admin = createSupabaseAdmin();
-  const clerk = await clerkClient();
-
-  // Check if mapping already exists
-  const { data: existing } = await admin
-    .from("clerk_user_mapping")
-    .select("supabase_user_id")
-    .eq("clerk_user_id", clerkUserId)
-    .single();
+  const [clerk, { data: existing }] = await Promise.all([
+    clerkClient(),
+    admin
+      .from("clerk_user_mapping")
+      .select("supabase_user_id")
+      .eq("clerk_user_id", clerkUserId)
+      .single(),
+  ]);
 
   if (existing) return existing.supabase_user_id;
 

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -71,7 +71,9 @@ export function computeDivergentFieldNames(
       const opts = new Set<string>(field.options);
       const responseSets = applicable.map((r) => {
         const arr = (r.answers as Record<string, unknown>)?.[field.name];
-        return new Set(Array.isArray(arr) ? (arr as string[]) : []);
+        return new Set(
+          Array.isArray(arr) ? arr.filter((v): v is string => typeof v === "string") : [],
+        );
       });
       for (const set of responseSets) {
         for (const v of set) opts.add(v);

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -69,18 +69,16 @@ export function computeDivergentFieldNames(
 
     if (field.type === "multi" && field.options?.length) {
       const opts = new Set<string>(field.options);
-      for (const r of applicable) {
+      const responseSets = applicable.map((r) => {
         const arr = (r.answers as Record<string, unknown>)?.[field.name];
-        if (Array.isArray(arr)) {
-          for (const v of arr) if (typeof v === "string") opts.add(v);
-        }
+        return new Set(Array.isArray(arr) ? (arr as string[]) : []);
+      });
+      for (const set of responseSets) {
+        for (const v of set) opts.add(v);
       }
       let hasDivergence = false;
       for (const opt of opts) {
-        const sels = applicable.map((r) => {
-          const arr = (r.answers as Record<string, unknown>)?.[field.name];
-          return Array.isArray(arr) && arr.includes(opt);
-        });
+        const sels = responseSets.map((s) => s.has(opt));
         if (sels.length > 0 && !sels.every((s) => s === sels[0])) {
           hasDivergence = true;
           break;

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -86,9 +86,7 @@ export function isAnswerCorrect(
     try {
       const verdictMap = JSON.parse(verdict) as Record<string, boolean>;
       const verdictSet = new Set(
-        Object.entries(verdictMap)
-          .filter(([, v]) => v)
-          .map(([k]) => k),
+        Object.entries(verdictMap).flatMap(([k, v]) => (v ? [k] : [])),
       );
       const answerArr = Array.isArray(answer) ? answer : [];
       const answerSet = new Set(answerArr.map(String));
@@ -108,15 +106,17 @@ export function formatAnswer(val: unknown): string {
   if (typeof val === "number" || typeof val === "boolean") return String(val);
   if (Array.isArray(val)) {
     return val
-      .map((v) => formatAnswer(v))
-      .filter((s) => s !== "")
+      .flatMap((v) => {
+        const s = formatAnswer(v);
+        return s !== "" ? [s] : [];
+      })
       .join(", ");
   }
   if (typeof val === "object") {
     const obj = val as Record<string, unknown>;
-    const parts = Object.entries(obj)
-      .filter(([, v]) => v != null && v !== "")
-      .map(([k, v]) => `${k}: ${formatAnswer(v)}`);
+    const parts = Object.entries(obj).flatMap(([k, v]) =>
+      v != null && v !== "" ? [`${k}: ${formatAnswer(v)}`] : [],
+    );
     return parts.join("; ");
   }
   return String(val);
@@ -389,6 +389,7 @@ export function computeConfusionData(
     if (field.type === "single" && field.options) {
       const matrix: Record<string, Record<string, number>> = {};
       const allLabels = [...field.options];
+      const allLabelSet = new Set(allLabels);
       for (const opt of allLabels) {
         matrix[opt] = {};
         for (const opt2 of allLabels) matrix[opt][opt2] = 0;
@@ -396,8 +397,9 @@ export function computeConfusionData(
       let total = 0;
       for (const review of fieldReviews) {
         const correctAnswer = review.verdict;
-        if (!allLabels.includes(correctAnswer)) {
+        if (!allLabelSet.has(correctAnswer)) {
           allLabels.push(correctAnswer);
+          allLabelSet.add(correctAnswer);
           matrix[correctAnswer] = {};
           for (const opt of allLabels) matrix[correctAnswer][opt] = 0;
           for (const opt of allLabels) {
@@ -532,13 +534,16 @@ export function computeRespondentProfiles(
     }
 
     const mostErroredFields = Object.entries(perField)
-      .filter(([, v]) => v.total > 0 && v.accuracy < 100)
-      .map(([fn, v]) => ({
-        fieldName: fn,
-        fieldDescription: ctx.fieldMap.get(fn)?.description || fn,
-        errorRate: 100 - v.accuracy,
-      }))
-      .sort((a, b) => b.errorRate - a.errorRate)
+      .flatMap(([fn, v]) =>
+        v.total > 0 && v.accuracy < 100
+          ? [{
+              fieldName: fn,
+              fieldDescription: ctx.fieldMap.get(fn)?.description || fn,
+              errorRate: 100 - v.accuracy,
+            }]
+          : [],
+      )
+      .toSorted((a, b) => b.errorRate - a.errorRate)
       .slice(0, 3);
 
     if (overallTotal > 0) {

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -276,8 +276,9 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
           if (!Array.isArray(vals) || vals.length === 0) {
             errors.push(`${label}: lista de valores da condição vazia`);
           } else if (triggerField.options) {
+            const triggerOptionSet = new Set(triggerField.options);
             for (const v of vals) {
-              if (typeof v === "string" && !triggerField.options.includes(v)) {
+              if (typeof v === "string" && !triggerOptionSet.has(v)) {
                 errors.push(
                   `${label}: valor "${v}" não está nas opções de "${trigger}"`,
                 );

--- a/react-doctor.config.json
+++ b/react-doctor.config.json
@@ -1,0 +1,12 @@
+{
+  "ignore": {
+    "overrides": [
+      {
+        "files": ["src/actions/**", "frontend/src/actions/**"],
+        "rules": [
+          "react-doctor/server-auth-actions"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Contexto

Score real estava em **78/100** (352 issues / 74 errors), mas os 74 errors de `react-doctor/server-auth-actions` eram **falsos positivos**: o middleware Clerk em `frontend/src/proxy.ts` chama `auth.protect()` em rotas não-públicas, e o Supabase server client (`lib/supabase/server.ts`) injeta o JWT do Clerk via `getToken({ template: "supabase" })`, deixando o RLS filtrar por `auth.uid()`. Auditoria não encontrou nenhuma server action usando `createSupabaseAdmin()` sem `getAuthUser()` antes.

A config `frontend/react-doctor.config.json` que já silenciava essa regra **não estava sendo aplicada** quando o react-doctor era invocado do raiz do monorepo (cwd diferente de onde a config mora). Esta PR corrige isso e aplica quick wins seguros sobre os warnings.

## Mudanças

### 1. Fix do silenciamento (config na raiz)

Nova `react-doctor.config.json` na raiz do monorepo com glob `src/actions/**` + `frontend/src/actions/**` para casar com qualquer cwd de invocação. Mantida a config em `frontend/` também.

### 2. Quick wins aplicados

**Performance / JS**
- `server-sequential-independent-await` ×28 → `Promise.all([...])` em RSCs/layouts (`params + getAuthUser + createSupabaseServer`) e em actions (`saveSchemaFromGUI`, `publishMajorVersion`, `computeLottery`, `syncClerkUserToSupabase`).
- `js-set-map-lookups` 11/15 → \`array.includes\` em loop convertido para \`Set.has\` (analyze/code, documents sanitize, export panel, divergence, schema-utils, reviews/queries). 4 casos preservados como warning aceitável (alocar Set para 1 lookup seria pessimização).
- `js-combine-iterations` ~16/48 → \`.filter().map()\` → \`.flatMap()\` em field-reviews, reviews/queries, comments/page, my-verdicts, progress, documents (2), MyVerdictsView (2), compare/page, config/documents.
- `js-cache-property-access` → hoist \`bucket.ids.length\` em const dentro de loop em `actions/schema.ts`.
- `js-tosorted-immutable` → `[...arr].sort()` → `arr.toSorted()` em arquivo de teste.

**React Compiler / clareza**
- `react-compiler-destructure-method` ×44 → `const router = useRouter()` → `const { push, refresh, replace } = useRouter()` + chamadas diretas, em 20 arquivos (ProjectTabs, RoundsConfig, CodingPage, ArbitrationPage, AutoReviewPage, MyVerdictsView, LlmInsightsView, CommentCard, CommentsSplitView, CodingHeader, SchemaEditor, LlmConfigurePane, LlmResponsesPane, DateSinceFilter, CompareFilters, DocumentsPageClient, ReviewCommentsView, SuggestFieldDialog, EditFieldDialog, AddNoteButton, RulesForm).

**Design / a11y**
- `design-no-redundant-padding-axes` ~25/30 → `px-N py-N` → `p-N` em HardestDocuments, RespondentProfile, FieldChangeDiff, FieldCard, SchemaBuilderGUI, QuestionsPanel, DocumentReader, MyVerdictsView, CommentsSplitView.
- `design-no-em-dash-in-jsx-text` → em-dash em copy de `LlmConfigurePane` trocado por vírgula.
- `jsx-a11y/click-events-have-key-events` → AnswerCard label com onClick ganhou onKeyDown equivalente.

### 3. Refactors fora de escopo

Componentes gigantes, useReducer, Suspense boundaries, useState→useRef, derived state effect, fetch-in-effect, useState derivado de prop, etc. são refactors mais arriscados que ficaram fora desta rodada e estão sendo abertos em issues separadas para análise com calma — ver issues `A-E` linkadas após o merge.

## Score

| Métrica | Antes | Depois |
|---|---|---|
| Score reportado | 78/100 | 82/100 |
| Issues totais | 352 | ~157 |
| Errors | 74 (falsos positivos) | 0 |
| Warnings | 278 | ~157 |

## Test plan

- [ ] `npx -y react-doctor@latest .` da raiz reporta 0 errors e score ≥ 82
- [ ] `npm run build` no `frontend/` compila sem erro (test file `AddNoteButton.test.tsx:55` tem erro TS preexistente, fora de escopo)
- [ ] Smoke visual: `RespondentProfile`, `HardestDocuments`, `/projects/[id]/config/*` renderizam normalmente
- [ ] Auto-revisão ainda alocando arbitros corretamente (não paralelizei o loop que tem comentário explícito sobre balanceamento)

🤖 Generated with [Claude Code](https://claude.com/claude-code)