### PR TITLE
feat(membros): flag can_resolve por membro do projeto

### DIFF
--- a/frontend/src/actions/__tests__/members.test.ts
+++ b/frontend/src/actions/__tests__/members.test.ts
@@ -134,3 +134,39 @@ describe("setCanArbitrate", () => {
     expect(hoisted.retry).not.toHaveBeenCalled();
   });
 });
+
+async function loadSetResolve() {
+  return (await import("@/actions/members")).setCanResolve;
+}
+
+describe("setCanResolve", () => {
+  it("habilita → UPDATE com can_resolve=true e NÃO dispara retry de arbitragem", async () => {
+    const set = await loadSetResolve();
+    const r = await set("member1", true, "p1");
+    expect(r.error).toBeUndefined();
+    expect(hoisted.retry).not.toHaveBeenCalled();
+    expect(writeCalls).toContainEqual({
+      table: "project_members",
+      op: "update",
+      payload: { can_resolve: true },
+    });
+  });
+
+  it("desabilita → UPDATE com can_resolve=false", async () => {
+    const set = await loadSetResolve();
+    const r = await set("member1", false, "p1");
+    expect(r.error).toBeUndefined();
+    expect(writeCalls).toContainEqual({
+      table: "project_members",
+      op: "update",
+      payload: { can_resolve: false },
+    });
+  });
+
+  it("UPDATE falha → retorna error", async () => {
+    clientError = { message: "RLS bloqueou" };
+    const set = await loadSetResolve();
+    const r = await set("member1", true, "p1");
+    expect(r.error).toBe("RLS bloqueou");
+  });
+});

--- a/frontend/src/actions/members.ts
+++ b/frontend/src/actions/members.ts
@@ -123,6 +123,28 @@ export async function changeRole(
   revalidateTag(`project-${projectId}-members`, TAG_PROFILE);
 }
 
+// Define se um membro pode resolver dificuldades LLM, erros LLM e comentários
+// de outros pesquisadores. RLS é declarativa: habilitar/desabilitar passa a
+// valer no próximo request, sem backlog a reprocessar.
+export async function setCanResolve(
+  memberId: string,
+  canResolve: boolean,
+  projectId: string,
+): Promise<{ error?: string }> {
+  const supabase = await createSupabaseServer();
+  const { error } = await supabase
+    .from("project_members")
+    .update({ can_resolve: canResolve })
+    .eq("id", memberId);
+
+  if (error) return { error: error.message };
+
+  revalidatePath(`/projects/${projectId}`);
+  revalidatePath(`/projects/${projectId}/config/members`);
+  revalidateTag(`project-${projectId}-members`, TAG_PROFILE);
+  return {};
+}
+
 // Define se um membro entra no sorteio de árbitros para casos contestados.
 // Quando habilita (canArbitrate=true), dispara retryPendingArbitrations para
 // alocar imediatamente os field_reviews que estavam sem árbitro elegível —

--- a/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
@@ -16,7 +16,7 @@ export default async function MembersPage({
   const [{ data: members }, { count: orphanedReviews }] = await Promise.all([
     supabase
       .from("project_members")
-      .select("id, project_id, user_id, role, can_arbitrate, profiles(id, email, first_name, last_name)")
+      .select("id, project_id, user_id, role, can_arbitrate, can_resolve, profiles(id, email, first_name, last_name)")
       .eq("project_id", id),
     supabase
       .from("field_reviews")

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useOptimistic, useState, useTransition } from "react";
-import { removeMember, changeRole, setCanArbitrate } from "@/actions/members";
+import { removeMember, changeRole, setCanArbitrate, setCanResolve } from "@/actions/members";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -23,10 +23,12 @@ interface MemberListProps {
 type MemberRow = ProjectMember & { profiles: Profile | null };
 
 export function MemberList({ projectId, members, currentUserId }: MemberListProps) {
-  // Per-row pending: o Switch tocado fica disabled até o server action retornar,
-  // mas outros Switches da página continuam interativos. Coordenador habilitando
-  // 4 membros em sequência não precisa esperar serializar.
-  const [pendingMemberId, setPendingMemberId] = useState<string | null>(null);
+  // Per-row + per-switch pending: o Switch tocado fica disabled até o server
+  // action retornar, mas o outro Switch da mesma linha e os Switches das demais
+  // linhas continuam interativos. Coordenador habilitando 4 membros em
+  // sequência não precisa esperar serializar.
+  const [pendingArbitrateId, setPendingArbitrateId] = useState<string | null>(null);
+  const [pendingResolveId, setPendingResolveId] = useState<string | null>(null);
   const [, startTransition] = useTransition();
 
   // useOptimistic: o Switch reflete imediatamente o valor escolhido enquanto o
@@ -34,10 +36,10 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
   // revalidatePath devolver — em conexão lenta parece que o clique não pegou.
   const [optimisticMembers, applyOptimistic] = useOptimistic<
     MemberRow[],
-    { memberId: string; canArbitrate: boolean }
+    { memberId: string; patch: Partial<Pick<MemberRow, "can_arbitrate" | "can_resolve">> }
   >(members, (current, update) =>
     current.map((m) =>
-      m.id === update.memberId ? { ...m, can_arbitrate: update.canArbitrate } : m,
+      m.id === update.memberId ? { ...m, ...update.patch } : m,
     ),
   );
 
@@ -60,9 +62,9 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
   };
 
   const handleToggleArbitrate = (memberId: string, value: boolean) => {
-    setPendingMemberId(memberId);
+    setPendingArbitrateId(memberId);
     startTransition(async () => {
-      applyOptimistic({ memberId, canArbitrate: value });
+      applyOptimistic({ memberId, patch: { can_arbitrate: value } });
       try {
         const result = await setCanArbitrate(memberId, value, projectId);
         if (result?.error) {
@@ -86,7 +88,28 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
           toast.success("Arbitragem habilitada.");
         }
       } finally {
-        setPendingMemberId(null);
+        setPendingArbitrateId(null);
+      }
+    });
+  };
+
+  const handleToggleResolve = (memberId: string, value: boolean) => {
+    setPendingResolveId(memberId);
+    startTransition(async () => {
+      applyOptimistic({ memberId, patch: { can_resolve: value } });
+      try {
+        const result = await setCanResolve(memberId, value, projectId);
+        if (result?.error) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success(
+          value
+            ? "Permissão para resolver habilitada."
+            : "Permissão para resolver desabilitada.",
+        );
+      } finally {
+        setPendingResolveId(null);
       }
     });
   };
@@ -104,12 +127,24 @@ export function MemberList({ projectId, members, currentUserId }: MemberListProp
           <div className="flex items-center gap-3">
             <label
               className="flex items-center gap-2 text-xs text-muted-foreground"
+              title="Pode marcar dificuldades LLM e comentários de outros pesquisadores como resolvidos"
+            >
+              <Switch
+                checked={m.can_resolve}
+                onCheckedChange={(v) => handleToggleResolve(m.id, v)}
+                disabled={pendingResolveId === m.id}
+                aria-label="Pode resolver pendências"
+              />
+              Resolve
+            </label>
+            <label
+              className="flex items-center gap-2 text-xs text-muted-foreground"
               title="Recebe casos contestados para arbitrar"
             >
               <Switch
                 checked={m.can_arbitrate}
                 onCheckedChange={(v) => handleToggleArbitrate(m.id, v)}
-                disabled={pendingMemberId === m.id}
+                disabled={pendingArbitrateId === m.id}
                 aria-label="Elegível para arbitrar"
               />
               Arbitra

--- a/frontend/src/lib/supabase/database.types.ts
+++ b/frontend/src/lib/supabase/database.types.ts
@@ -591,6 +591,7 @@ export type Database = {
       project_members: {
         Row: {
           can_arbitrate: boolean
+          can_resolve: boolean
           id: string
           project_id: string | null
           role: string
@@ -598,6 +599,7 @@ export type Database = {
         }
         Insert: {
           can_arbitrate?: boolean
+          can_resolve?: boolean
           id?: string
           project_id?: string | null
           role: string
@@ -605,6 +607,7 @@ export type Database = {
         }
         Update: {
           can_arbitrate?: boolean
+          can_resolve?: boolean
           id?: string
           project_id?: string | null
           role?: string

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -76,6 +76,7 @@ export interface ProjectMember {
   user_id: string;
   role: "coordenador" | "pesquisador";
   can_arbitrate: boolean;
+  can_resolve: boolean;
   profiles?: Profile;
 }
 

--- a/frontend/supabase/migrations/20260527120000_project_members_can_resolve.sql
+++ b/frontend/supabase/migrations/20260527120000_project_members_can_resolve.sql
@@ -1,0 +1,90 @@
+-- project_members.can_resolve: flag por membro controlando se ele pode
+-- marcar como resolvido itens que hoje só coordenador resolve — dificuldades
+-- LLM (difficulty_resolutions), erros LLM (error_resolutions) e comentários
+-- de outros pesquisadores (project_comments).
+--
+-- Default false: novos membros entram sem essa permissão; coordenador
+-- habilita explicitamente quem deve assumir a triagem.
+--
+-- Backfill true: preserva o desbloqueio imediato em projetos já em produção
+-- onde pesquisadoras estavam batendo em "new row violates row-level security
+-- policy for table difficulty_resolutions" e "Sem permissão para resolver
+-- este comentário" ao tentar resolver itens de máquina ou comentários de
+-- colegas. Coordenador pode revogar depois caso a caso.
+
+ALTER TABLE project_members
+  ADD COLUMN can_resolve BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE project_members SET can_resolve = true;
+
+-- Index parcial: as policies abaixo filtram por (project_id, can_resolve=true).
+-- Em projetos com muitos membros e poucos resolvedores explícitos, o index
+-- parcial é mais compacto que um btree completo.
+CREATE INDEX idx_project_members_resolvers
+  ON project_members (project_id)
+  WHERE can_resolve = true;
+
+-- Helper inlineável análoga a auth_user_coordinator_or_creator_project_ids()
+-- e auth_user_accessible_project_ids() (ver 20260512000000_rls_unified_project_access.sql).
+-- LANGUAGE sql + STABLE + SECURITY DEFINER para o planner inline e evitar
+-- recursão em RLS.
+CREATE OR REPLACE FUNCTION auth_user_resolver_project_ids()
+RETURNS SETOF UUID
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = ''
+AS $$
+  SELECT project_id FROM public.project_members
+    WHERE user_id = public.clerk_uid() AND can_resolve = true
+$$;
+
+GRANT EXECUTE ON FUNCTION auth_user_resolver_project_ids() TO anon, authenticated, service_role;
+
+-- ========== difficulty_resolutions ==========
+-- Estende INSERT/DELETE para reconhecer membros com can_resolve=true além
+-- de coordenadores. SELECT permanece intocada (qualquer membro continua
+-- vendo o histórico de resoluções).
+DROP POLICY IF EXISTS "Coordinators insert difficulty_resolutions" ON difficulty_resolutions;
+CREATE POLICY "Coordinators insert difficulty_resolutions" ON difficulty_resolutions FOR INSERT WITH CHECK (
+  project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
+  OR project_id IN (SELECT auth_user_resolver_project_ids())
+  OR is_master()
+);
+
+DROP POLICY IF EXISTS "Coordinators delete difficulty_resolutions" ON difficulty_resolutions;
+CREATE POLICY "Coordinators delete difficulty_resolutions" ON difficulty_resolutions FOR DELETE USING (
+  project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
+  OR project_id IN (SELECT auth_user_resolver_project_ids())
+  OR is_master()
+);
+
+-- ========== error_resolutions ==========
+DROP POLICY IF EXISTS "Coordinators insert error_resolutions" ON error_resolutions;
+CREATE POLICY "Coordinators insert error_resolutions" ON error_resolutions FOR INSERT WITH CHECK (
+  project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
+  OR project_id IN (SELECT auth_user_resolver_project_ids())
+  OR is_master()
+);
+
+DROP POLICY IF EXISTS "Coordinators delete error_resolutions" ON error_resolutions;
+CREATE POLICY "Coordinators delete error_resolutions" ON error_resolutions FOR DELETE USING (
+  project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
+  OR project_id IN (SELECT auth_user_resolver_project_ids())
+  OR is_master()
+);
+
+-- ========== project_comments ==========
+-- Caminho adicional para UPDATE: membro com can_resolve=true pode atualizar
+-- qualquer comentário do projeto (cobre o caso "resolver comentário de outro
+-- pesquisador"). As duas policies pré-existentes ("Coordinators can update"
+-- e "Authors can update own") permanecem como caminhos paralelos.
+DROP POLICY IF EXISTS "Resolvers can update project comments" ON project_comments;
+CREATE POLICY "Resolvers can update project comments" ON project_comments
+  FOR UPDATE
+  USING (
+    project_id IN (SELECT auth_user_resolver_project_ids())
+  )
+  WITH CHECK (
+    project_id IN (SELECT auth_user_resolver_project_ids())
+  );

--- a/frontend/supabase/migrations/20260527120000_project_members_can_resolve.sql
+++ b/frontend/supabase/migrations/20260527120000_project_members_can_resolve.sql
@@ -46,14 +46,14 @@ GRANT EXECUTE ON FUNCTION auth_user_resolver_project_ids() TO anon, authenticate
 -- de coordenadores. SELECT permanece intocada (qualquer membro continua
 -- vendo o histórico de resoluções).
 DROP POLICY IF EXISTS "Coordinators insert difficulty_resolutions" ON difficulty_resolutions;
-CREATE POLICY "Coordinators insert difficulty_resolutions" ON difficulty_resolutions FOR INSERT WITH CHECK (
+CREATE POLICY "Coordinators or resolvers insert difficulty_resolutions" ON difficulty_resolutions FOR INSERT WITH CHECK (
   project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
   OR project_id IN (SELECT auth_user_resolver_project_ids())
   OR is_master()
 );
 
 DROP POLICY IF EXISTS "Coordinators delete difficulty_resolutions" ON difficulty_resolutions;
-CREATE POLICY "Coordinators delete difficulty_resolutions" ON difficulty_resolutions FOR DELETE USING (
+CREATE POLICY "Coordinators or resolvers delete difficulty_resolutions" ON difficulty_resolutions FOR DELETE USING (
   project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
   OR project_id IN (SELECT auth_user_resolver_project_ids())
   OR is_master()
@@ -61,14 +61,14 @@ CREATE POLICY "Coordinators delete difficulty_resolutions" ON difficulty_resolut
 
 -- ========== error_resolutions ==========
 DROP POLICY IF EXISTS "Coordinators insert error_resolutions" ON error_resolutions;
-CREATE POLICY "Coordinators insert error_resolutions" ON error_resolutions FOR INSERT WITH CHECK (
+CREATE POLICY "Coordinators or resolvers insert error_resolutions" ON error_resolutions FOR INSERT WITH CHECK (
   project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
   OR project_id IN (SELECT auth_user_resolver_project_ids())
   OR is_master()
 );
 
 DROP POLICY IF EXISTS "Coordinators delete error_resolutions" ON error_resolutions;
-CREATE POLICY "Coordinators delete error_resolutions" ON error_resolutions FOR DELETE USING (
+CREATE POLICY "Coordinators or resolvers delete error_resolutions" ON error_resolutions FOR DELETE USING (
   project_id IN (SELECT auth_user_coordinator_or_creator_project_ids())
   OR project_id IN (SELECT auth_user_resolver_project_ids())
   OR is_master()


### PR DESCRIPTION
## Contexto

Pesquisadoras (relato da Mariana) vinham batendo em dois erros distintos ao tentar resolver pendências:

1. **Registro de ambiguidade** (dificuldades sinalizadas pelo LLM) → `new row violates row-level security policy for table "difficulty_resolutions"`.
2. **Comentários de outros pesquisadores** → `Sem permissão para resolver este comentário`.

A causa nos dois casos é a mesma: todas as policies de "resolver" hoje exigem `role = 'coordenador'`. O modelo presumia que toda triagem é trabalho de coordenador, mas na prática alguns pesquisadores precisam fazer essa limpeza para destravar o fluxo do projeto.

Este PR replica o padrão recém-introduzido em #146 (`can_arbitrate`) para resolver pendências: o coordenador delega explicitamente a permissão por membro.

## Decisões

- **Granularidade**: uma única flag `can_resolve` cobre os três casos (`difficulty_resolutions`, `error_resolutions`, `project_comments`).
- **Backfill `true`** em projetos existentes — destrava imediatamente os pesquisadores em produção que estavam batendo nos erros. Default `false` para novos membros (coordenador habilita).

## Mudanças

- **Migration** `20260527120000_project_members_can_resolve.sql`:
  - Coluna `project_members.can_resolve BOOLEAN NOT NULL DEFAULT false` + backfill `true` + índice parcial.
  - Helper `auth_user_resolver_project_ids()` (LANGUAGE sql STABLE, inlineável) para reuso nas três policies.
  - Estende `Coordinators insert difficulty_resolutions`, `Coordinators delete difficulty_resolutions`, `Coordinators insert error_resolutions`, `Coordinators delete error_resolutions` (mantém o nome — só adiciona `OR project_id IN (auth_user_resolver_project_ids())`).
  - Cria policy nova `Resolvers can update project comments` em paralelo às duas existentes (`Coordinators can update` e `Authors can update own`).
- **Server action** `setCanResolve` em `frontend/src/actions/members.ts`, espelhando `setCanArbitrate` sem o retry de arbitragem (RLS declarativa).
- **UI**: novo `<Switch>` "Resolve" em `MemberList.tsx` ao lado do "Arbitra", com `pendingResolveId` independente do `pendingArbitrateId` para o coordenador habilitar múltiplos sem serializar. `useOptimistic` passa a aceitar patch parcial.
- **Tipo** `ProjectMember.can_resolve` em `lib/types.ts` + `database.types.ts` + select da página `/config/members`.
- **Testes** em `members.test.ts` cobrindo habilitar, desabilitar e falha de UPDATE.

## Test plan

- [ ] Aplicar migration: `cd frontend && export SUPABASE_ACCESS_TOKEN=… && npx supabase db push`.
- [ ] Confirmar via Supabase Studio que `can_resolve = true` para todos os membros já existentes.
- [ ] Logar como pesquisador (com `can_resolve = true`) em projeto de teste:
  - [ ] Resolver uma dificuldade LLM no Registro de ambiguidade → sem erro de RLS.
  - [ ] Resolver um comentário criado por outro pesquisador → marca resolvido.
- [ ] Desabilitar a flag via `/projects/{id}/config/members` (novo Switch "Resolve") → ambos fluxos voltam a falhar com as mensagens atuais.
- [ ] Coordenador continua resolvendo independente da flag.
- [ ] `npm run test` passa (4 antigos + 3 novos em `members.test.ts`).