### PR TITLE
fix(rls): trigger restringe resolver a resolved_at/resolved_by em project_comments

### DIFF
--- a/frontend/supabase/migrations/20260527130000_project_comments_resolver_column_guard.sql
+++ b/frontend/supabase/migrations/20260527130000_project_comments_resolver_column_guard.sql
@@ -1,0 +1,72 @@
+-- Restringe resolvers-puros (com can_resolve=true mas sem ser coordenador
+-- nem autor do comentário) a alterar APENAS resolved_at / resolved_by em
+-- project_comments. A policy "Resolvers can update project comments" criada
+-- em 20260527120000_project_members_can_resolve.sql usa só WITH CHECK, que
+-- não consegue comparar OLD vs NEW; sem este guard, um resolver hostil
+-- poderia, via REST direta do Supabase, modificar body/author_id/kind/etc.
+-- de comentários de outros pesquisadores. Trigger BEFORE UPDATE preenche
+-- essa lacuna.
+--
+-- Caminhos NÃO bloqueados (mantêm permissão ampla):
+--   - coordenador do projeto (via auth_user_coordinator_or_creator_project_ids)
+--   - autor do próprio comentário (OLD.author_id = clerk_uid())
+--   - master (is_master())
+--   - service role / migrations (clerk_uid() retorna NULL)
+
+CREATE OR REPLACE FUNCTION enforce_resolver_column_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  uid UUID;
+BEGIN
+  uid := public.clerk_uid();
+
+  -- Sem JWT do Clerk (service role, migrations, cron internas) bypassa.
+  IF uid IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Coord / autor / master mantêm permissão ampla. As policies de cada
+  -- caminho já autorizaram o UPDATE em si; este trigger só adiciona o gate
+  -- para o caminho de resolver puro.
+  IF public.is_master()
+     OR OLD.author_id = uid
+     OR NEW.project_id IN (
+       SELECT public.auth_user_coordinator_or_creator_project_ids()
+     )
+  THEN
+    RETURN NEW;
+  END IF;
+
+  -- Caminho restante: resolver puro (chegou aqui via policy
+  -- "Resolvers can update project comments"). Bloqueia qualquer mudança
+  -- fora de resolved_at / resolved_by.
+  IF NEW.body IS DISTINCT FROM OLD.body
+     OR NEW.kind IS DISTINCT FROM OLD.kind
+     OR NEW.parent_id IS DISTINCT FROM OLD.parent_id
+     OR NEW.author_id IS DISTINCT FROM OLD.author_id
+     OR NEW.document_id IS DISTINCT FROM OLD.document_id
+     OR NEW.field_name IS DISTINCT FROM OLD.field_name
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+     OR NEW.rejected_at IS DISTINCT FROM OLD.rejected_at
+     OR NEW.rejected_reason IS DISTINCT FROM OLD.rejected_reason
+     OR NEW.project_id IS DISTINCT FROM OLD.project_id
+     OR NEW.id IS DISTINCT FROM OLD.id
+  THEN
+    RAISE EXCEPTION
+      'Resolvers can only change resolved_at / resolved_by on project_comments'
+      USING ERRCODE = '42501';  -- insufficient_privilege
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_resolver_column_guard_trigger ON project_comments;
+CREATE TRIGGER enforce_resolver_column_guard_trigger
+  BEFORE UPDATE ON project_comments
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_resolver_column_guard();


### PR DESCRIPTION
## Contexto

Followup imediato de #159. O scanner automático de segurança apontou um
problema MEDIUM real na policy `"Resolvers can update project comments"`
criada por #159:

> Authorization / over-broad RLS policy — a policy permite UPDATE em todas
> as colunas, não só `resolved_at`/`resolved_by`. Um resolver hostil
> poderia, via REST direta do Supabase (bypassando os server actions do
> app), modificar `body`, `author_id`, `kind`, `parent_id` etc. de
> comentários de outros pesquisadores.

O sintoma é real: RLS `WITH CHECK` não tem acesso a `OLD`, então não dá
para restringir colunas em policy pura. As duas saídas eram:

- **(a)** trigger `BEFORE UPDATE` que compara `OLD` × `NEW` e levanta
  exceção se resolver-puro tentar mexer fora das colunas de resolução; ou
- **(b)** mover resolve/reopen para `SECURITY DEFINER` RPCs e revogar a
  policy ampla.

Optei por **(a)**. (b) exigiria reescrever `resolveProjectComment` /
`reopenProjectComment` para chamar RPC ao invés de `UPDATE`, mais churn
sem ganho de segurança comparado ao trigger.

## Mudança

`20260527130000_project_comments_resolver_column_guard.sql` cria função
`enforce_resolver_column_guard()` + trigger `BEFORE UPDATE` em
`project_comments`. A função:

1. **Bypassa** se `clerk_uid()` é NULL (service role / migrations).
2. **Bypassa** se o caller é master, coordenador do projeto, ou autor do
   próprio comentário — esses caminhos já tinham permissão ampla legítima
   por outras policies.
3. **Para o caminho restante (resolver-puro)**, levanta `42501
   insufficient_privilege` se houve mudança em qualquer coluna além de
   `resolved_at` / `resolved_by`.

## Compatibilidade

Auditei as quatro actions que fazem UPDATE em `project_comments`:

- `resolveProjectComment` → só toca `resolved_at`/`resolved_by` ✓
- `reopenProjectComment` → só toca `resolved_at`/`resolved_by` ✓
- `approveExclusionRequest` → toca `resolved_at`/`resolved_by`, é
  coord-only no app ✓ (trigger libera coord)
- `rejectExclusionRequest` → toca `rejected_at`/`rejected_reason`/`resolved_by`,
  é coord-only no app ✓ (trigger libera coord)

Nenhuma quebra esperada.

## Test plan

- [ ] `cd frontend && export SUPABASE_ACCESS_TOKEN=… && npx supabase db push`
      aplica esta migration junto com a de #159.
- [ ] Como **pesquisador-resolver** (não coord, não autor):
      `resolveProjectComment` em um comentário de outro → marca resolvido OK.
- [ ] Mesmo pesquisador, via curl direto:
      `PATCH /rest/v1/project_comments?id=eq.<id>` com `{"body":"hack"}`
      → erro `42501 insufficient_privilege`, body intacto.
- [ ] Como **coordenador**: `rejectExclusionRequest` muda `rejected_at`+`rejected_reason` OK.
- [ ] Como **autor**: edit do próprio comentário (se houver UI) continua OK.
- [ ] `npm run test` verde (311 testes — sem mudança esperada, migration é SQL).

Closes a finding MEDIUM levantada após o merge de #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)