### PR TITLE
fix(rls): conserta brecha cross-project no enforce_resolver_column_guard

### DIFF
--- a/frontend/supabase/migrations/20260527140000_resolver_column_guard_cross_project_fix.sql
+++ b/frontend/supabase/migrations/20260527140000_resolver_column_guard_cross_project_fix.sql
@@ -1,0 +1,72 @@
+-- Conserta brecha no enforce_resolver_column_guard() introduzido em
+-- 20260527130000. O gate de coordenador conferia NEW.project_id, então um
+-- resolver-puro no projeto A que também fosse coordenador no projeto B
+-- poderia setar NEW.project_id = B e o trigger liberava a edição —
+-- sequestrando o comentário para outro projeto e burlando o gate de colunas.
+--
+-- Conserto:
+--   1. Confere coord usando OLD.project_id (a casa onde o comentário vive).
+--   2. project_id passa a ser imutável para qualquer caller não-master.
+--   3. Ordem dos checks reescrita em early-returns para ficar mais óbvia.
+
+CREATE OR REPLACE FUNCTION enforce_resolver_column_guard()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  uid UUID;
+BEGIN
+  uid := public.clerk_uid();
+
+  -- Sem JWT do Clerk (service role, migrations) bypassa.
+  IF uid IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Master mantém permissão ampla.
+  IF public.is_master() THEN
+    RETURN NEW;
+  END IF;
+
+  -- project_id é imutável para qualquer não-master. Bloqueia a tentativa
+  -- de mover o comentário entre projetos (vetor da brecha conserto).
+  IF NEW.project_id IS DISTINCT FROM OLD.project_id THEN
+    RAISE EXCEPTION 'project_id is immutable on project_comments'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Coord do projeto onde o comentário vive (OLD.project_id, não NEW).
+  IF OLD.project_id IN (
+    SELECT public.auth_user_coordinator_or_creator_project_ids()
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Autor do próprio comentário.
+  IF OLD.author_id = uid THEN
+    RETURN NEW;
+  END IF;
+
+  -- Caminho restante: resolver-puro. Bloqueia mudança fora de
+  -- resolved_at / resolved_by.
+  IF NEW.body IS DISTINCT FROM OLD.body
+     OR NEW.kind IS DISTINCT FROM OLD.kind
+     OR NEW.parent_id IS DISTINCT FROM OLD.parent_id
+     OR NEW.author_id IS DISTINCT FROM OLD.author_id
+     OR NEW.document_id IS DISTINCT FROM OLD.document_id
+     OR NEW.field_name IS DISTINCT FROM OLD.field_name
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+     OR NEW.rejected_at IS DISTINCT FROM OLD.rejected_at
+     OR NEW.rejected_reason IS DISTINCT FROM OLD.rejected_reason
+     OR NEW.id IS DISTINCT FROM OLD.id
+  THEN
+    RAISE EXCEPTION
+      'Resolvers can only change resolved_at / resolved_by on project_comments'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Contexto

Followup imediato de #161. O scanner automático apontou (HIGH) que o
trigger de #161 tinha um bug:

> Gate/action field mismatch — coordinator gate keyed on NEW.project_id
> instead of OLD.project_id.

Cenário de exploração:
- Resolver-puro (sem ser coord nem autor) no projeto A
- Mesma conta é coordenadora no projeto B
- Via REST direto:
  \`PATCH /rest/v1/project_comments?id=eq.<id> { "project_id": "<B>", "body": "hack" }\`
- O \`UPDATE\` é autorizado pela policy de resolver (\`NEW.project_id IN
  resolver_projects\` falha, mas a policy "Resolvers can update project
  comments" é uma das alternativas; e a policy de coord no projeto B
  poderia liberar via \`auth_user_coordinator_or_creator_project_ids()\`).
- O trigger chega e confere \`NEW.project_id IN coord_projects\` → libera,
  porque o caller É coord no projeto B.
- Resultado: comentário sequestrado para o projeto B, com body modificado.

## Mudança

\`20260527140000_resolver_column_guard_cross_project_fix.sql\` faz
\`CREATE OR REPLACE FUNCTION enforce_resolver_column_guard()\`. Mudanças
versus #161:

1. **Gate de coord usa \`OLD.project_id\`**, não \`NEW.project_id\`. Coord
   precisa ser do projeto onde o comentário vive.
2. **\`project_id\` é imutável para qualquer não-master.** Bloqueia o vetor
   do bug acima na origem — comentário não muda de projeto via REST.
3. Estrutura reescrita em early-returns para deixar a ordem dos checks
   óbvia (clerk_uid NULL → master → project_id imutável → coord OLD →
   author → resolver puro).

## Test plan

- [ ] \`npx supabase db push\` aplica a migration limpo.
- [ ] Como coordenador do projeto onde o comentário vive: UPDATE em qualquer
      coluna continua OK.
- [ ] Como autor do comentário: UPDATE em qualquer coluna continua OK.
- [ ] Como resolver-puro tentando \`PATCH .../project_comments?id=eq.<id>
      { "project_id": "<outro>" }\` via REST → \`42501\` "project_id is
      immutable".
- [ ] Como resolver-puro tentando mexer em \`body\` etc. → \`42501\`
      "Resolvers can only change resolved_at / resolved_by".
- [ ] \`npm run test\` verde (311).

🤖 Generated with [Claude Code](https://claude.com/claude-code)