### PR TITLE
feat(frontend): deploy do Next.js no Fly.io (paralelo à Vercel)

### DIFF
--- a/.github/workflows/frontend-fly-deploy.yml
+++ b/.github/workflows/frontend-fly-deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy frontend (Fly.io)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/frontend-fly-deploy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: fly-deploy-frontend
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: flyctl deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Pin a SHA (tag 1.5) por supply-chain safety — @master é floating ref.
+      - uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be
+      - run: flyctl deploy --remote-only -a gui-analise-sistematica-frontend
+        working-directory: frontend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+.git
+.env*
+.vercel
+npm-debug.log*
+*.log
+coverage
+playwright-report
+test-results
+.DS_Store
+README.md

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,11 @@ COPY . .
 ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG NEXT_PUBLIC_API_URL
+# Variaveis NEXT_PUBLIC_* sao embutidas no bundle em build time; sem as do
+# Clerk aqui, o cliente quebra em producao.
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+ARG NEXT_PUBLIC_CLERK_SIGN_IN_URL
+ARG NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL
 
 RUN npm run build
 

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -1,0 +1,38 @@
+# Frontend Next.js 16 (standalone) no Fly.io.
+# Secrets de runtime (CLERK_SECRET_KEY, SUPABASE_SERVICE_ROLE_KEY,
+# CLERK_WEBHOOK_SECRET) sao setadas via `fly secrets set`, nunca aqui.
+# As NEXT_PUBLIC_* ficam em [build.args] porque precisam estar presentes em
+# build time (sao embutidas no bundle do browser) e sao todas publicas por
+# design (anon key e publishable key vao para o cliente de qualquer forma).
+app = "gui-analise-sistematica-frontend"
+primary_region = "gru"
+
+[build]
+  dockerfile = "Dockerfile"
+
+  [build.args]
+    NEXT_PUBLIC_SUPABASE_URL = "https://nryebmwlmxuwvynfuzsv.supabase.co"
+    NEXT_PUBLIC_SUPABASE_ANON_KEY = "sb_publishable_nqJGyzUd0ackkC9jSDTo3w_0xjg1hDd"
+    NEXT_PUBLIC_API_URL = "https://gui-analise-sistematica-api.fly.dev"
+    NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_aW5ub2NlbnQtZm94aG91bmQtODguY2xlcmsuYWNjb3VudHMuZGV2JA"
+    NEXT_PUBLIC_CLERK_SIGN_IN_URL = "/auth/login"
+    NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL = "/dashboard"
+
+[deploy]
+  strategy = "bluegreen"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  # Frontend e stateless (nao roda jobs em background como o backend), entao
+  # pode escalar a zero quando ocioso. Cold start do Next standalone e leve.
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    timeout = "5s"
+    path = "/api/health"

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Build standalone para rodar em container (Fly.io). O Dockerfile copia
+  // .next/standalone; sem este output, esse COPY falha. A Vercel ignora.
+  output: "standalone",
   experimental: {
     serverActions: {
       bodySizeLimit: "10mb",

--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+// Health check para o Fly.io. Endpoint leve, sem auth nem DB, sempre 200.
+// Necessario porque "/" redireciona (307) via Clerk e o check do Fly falharia.
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ status: "ok" });
+}

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -3,6 +3,7 @@ import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 const isPublicRoute = createRouteMatcher([
   "/auth/(.*)",
   "/api/webhooks(.*)",
+  "/api/health",
 ]);
 
 export default clerkMiddleware(async (auth, request) => {


### PR DESCRIPTION
## Contexto

Migra o frontend Next.js 16 da Vercel para o **Fly.io**, onde o backend FastAPI já roda (`gui-analise-sistematica-api`, região `gru`). Motivo: permitir que outras pessoas colaborem/commitem no projeto sem depender de plano **Vercel Pro/Team**.

A migração é feita **em paralelo**: este PR sobe o app em `gui-analise-sistematica-frontend.fly.dev` sem tocar na Vercel nem no domínio. O cutover do domínio novo e o desligamento da Vercel ficam para uma fase posterior.

## Bugs latentes corrigidos

O `frontend/Dockerfile` nunca foi usado em produção (a Vercel não usa Dockerfile), e tinha dois problemas que impediam o build do container:

- **`next.config.ts` sem `output: "standalone"`** → o `COPY .next/standalone` falhava.
- **Faltavam as build args `NEXT_PUBLIC_CLERK_*`** → como `NEXT_PUBLIC_*` são embutidas no bundle em build time, o Clerk quebraria no browser.

## Mudanças

- `next.config.ts`: adiciona `output: "standalone"`.
- `Dockerfile`: adiciona as 3 build args `NEXT_PUBLIC_CLERK_*`.
- `public/.gitkeep`: o Dockerfile faz `COPY /app/public` e a pasta não existia.
- `src/app/api/health/route.ts`: health check leve (200) para o Fly.
- `src/proxy.ts`: libera `/api/health` no middleware Clerk (senão o check segue o redirect 307 de `/`).
- `fly.toml`: app na região `gru`, estratégia `bluegreen`, scale-to-zero (frontend é stateless), `NEXT_PUBLIC_*` em `[build.args]` (públicas por design).
- `.dockerignore`: novo.
- `.github/workflows/frontend-fly-deploy.yml`: deploy automático em push em `frontend/**`, espelhando o do backend (mesmo `FLY_API_TOKEN`).

## Validação

Build local do container + smoke test, e deploy real no Fly validado ao vivo:

- `/api/health` → `200 {"status":"ok"}`
- `/` sem auth → `307` para `/auth/login` (middleware Clerk ativo)
- `/auth/login` → `200`, script do Clerk carregando (`clerk.accounts.dev`)
- 2 máquinas em `gru`, health checks passando.

Os secrets de runtime (`CLERK_SECRET_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `CLERK_WEBHOOK_SECRET`) já foram setados no app via `fly secrets`, com os mesmos valores que rodam hoje na Vercel (instância Clerk de desenvolvimento, `pk_test`).

## Próximos passos (fora deste PR)

1. Cutover do domínio novo: `fly certs add`, DNS, allowed origins no Clerk, atualizar `CORS_ORIGINS` do backend, endpoint do webhook Clerk.
2. Validar no domínio novo.
3. Só então aposentar a Vercel e atualizar o `README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)