### PR TITLE
test(e2e): smoke do dialog de sorteio + login por ticket nos specs autenticados

### DIFF
--- a/frontend/.env.e2e.example
+++ b/frontend/.env.e2e.example
@@ -30,9 +30,12 @@ E2E_MASTER_PASSWORD=
 E2E_PROJECT_ID=
 
 # Projeto onde o usuário E2E_COORDINATOR_* é coordenador, com documentos e
-# membros cadastrados. Usado pelo lottery.smoke.spec.ts (dialog de sorteio,
-# spec 001 / PR #179) — o teste é somente leitura (abre o dialog e computa
-# a prévia, sem sortear).
+# pelo menos um pesquisador (role "membro"). Usado pelo lottery.smoke.spec.ts
+# (dialog de sorteio, spec 001 / PR #179) — o teste é somente leitura (abre o
+# dialog e computa a prévia, sem sortear). O pesquisador é obrigatório: no
+# sorteio os pesquisadores começam ligados e os coordenadores desligados,
+# então um projeto só com coordenadores deixa a contagem de elegíveis sem
+# renderizar e o teste estoura por timeout em vez de pular.
 E2E_LOTTERY_PROJECT_ID=
 
 # Opcional: URL base se o dev server não estiver em http://localhost:3000.

--- a/frontend/.env.e2e.example
+++ b/frontend/.env.e2e.example
@@ -4,6 +4,13 @@
 #
 # CLERK_SECRET_KEY e NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY são lidos de
 # .env.local automaticamente — não precisam ser repetidos aqui.
+#
+# Os specs autenticam por ticket (token de sign-in criado server-side com a
+# CLERK_SECRET_KEY), então só o e-mail de cada usuário é necessário. As
+# variáveis *_PASSWORD são opcionais — úteis apenas para login manual no
+# browser com os mesmos usuários. Dica: e-mails `*+clerk_test@example.com`
+# são fictícios na instância dev e aceitam o código de verificação fixo
+# 424242 em qualquer challenge.
 
 # Usuário com role "coordenador" em algum projeto de teste.
 E2E_COORDINATOR_EMAIL=
@@ -21,6 +28,12 @@ E2E_MASTER_PASSWORD=
 # coordenador). Usado pelo config-guard.smoke.spec.ts para verificar que
 # pesquisador é redirecionado ao acessar config/* direto. Ver issue #27.
 E2E_PROJECT_ID=
+
+# Projeto onde o usuário E2E_COORDINATOR_* é coordenador, com documentos e
+# membros cadastrados. Usado pelo lottery.smoke.spec.ts (dialog de sorteio,
+# spec 001 / PR #179) — o teste é somente leitura (abre o dialog e computa
+# a prévia, sem sortear).
+E2E_LOTTERY_PROJECT_ID=
 
 # Opcional: URL base se o dev server não estiver em http://localhost:3000.
 # E2E_BASE_URL=http://localhost:3000

--- a/frontend/e2e/config-guard.smoke.spec.ts
+++ b/frontend/e2e/config-guard.smoke.spec.ts
@@ -3,31 +3,24 @@ import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
 
 // Valida o guard server-side de #27: um pesquisador (role "membro") que conheça
 // a URL de uma rota `config/*` é redirecionado para `my-progress`.
-// Requer, além das credenciais do usuário membro, E2E_PROJECT_ID — um projeto
+// Requer, além do e-mail do usuário membro, E2E_PROJECT_ID — um projeto
 // onde esse usuário é pesquisador (NÃO coordenador). Pulado se faltar qualquer
 // um, para não quebrar CI sem o tenant de teste configurado.
+// Login por ticket — ver nota em dashboard.smoke.spec.ts.
 test("pesquisador é redirecionado de config/* para my-progress", async ({
   page,
 }) => {
   const identifier = process.env.E2E_MEMBER_EMAIL;
-  const password = process.env.E2E_MEMBER_PASSWORD;
   const projectId = process.env.E2E_PROJECT_ID;
   test.skip(
-    !identifier || !password || !projectId,
-    "defina E2E_MEMBER_EMAIL, E2E_MEMBER_PASSWORD e E2E_PROJECT_ID em .env.e2e",
+    !identifier || !projectId,
+    "defina E2E_MEMBER_EMAIL e E2E_PROJECT_ID em .env.e2e",
   );
 
   await setupClerkTestingToken({ page });
 
   await page.goto("/auth/login");
-  await clerk.signIn({
-    page,
-    signInParams: {
-      strategy: "password",
-      identifier: identifier!,
-      password: password!,
-    },
-  });
+  await clerk.signIn({ page, emailAddress: identifier! });
 
   try {
     await page.goto(`/projects/${projectId}/config/schema`);

--- a/frontend/e2e/dashboard.smoke.spec.ts
+++ b/frontend/e2e/dashboard.smoke.spec.ts
@@ -2,49 +2,31 @@ import { test, expect } from "@playwright/test";
 import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
 
 // Cada papel mapeia para um usuário Clerk de teste real (no tenant de dev).
-// As credenciais ficam em .env.e2e (não versionado) — ver .env.e2e.example.
-// Sem as credenciais o teste é pulado em vez de falhar, para não quebrar CI
-// em forks/ambientes que não têm o tenant de teste configurado.
+// Os e-mails ficam em .env.e2e (não versionado) — ver .env.e2e.example.
+// Sem eles o teste é pulado em vez de falhar, para não quebrar CI em
+// forks/ambientes que não têm o tenant de teste configurado.
+//
+// Login por ticket (token de sign-in criado server-side com a
+// CLERK_SECRET_KEY): dispensa senha e não esbarra na verificação de "novo
+// dispositivo" da instância, que bloqueia a estratégia password em contexto
+// headless — cada contexto Playwright é um dispositivo novo.
 const roles = [
-  {
-    role: "coordenador",
-    emailEnv: "E2E_COORDINATOR_EMAIL",
-    passwordEnv: "E2E_COORDINATOR_PASSWORD",
-  },
-  {
-    role: "membro",
-    emailEnv: "E2E_MEMBER_EMAIL",
-    passwordEnv: "E2E_MEMBER_PASSWORD",
-  },
-  {
-    role: "master",
-    emailEnv: "E2E_MASTER_EMAIL",
-    passwordEnv: "E2E_MASTER_PASSWORD",
-  },
+  { role: "coordenador", emailEnv: "E2E_COORDINATOR_EMAIL" },
+  { role: "membro", emailEnv: "E2E_MEMBER_EMAIL" },
+  { role: "master", emailEnv: "E2E_MASTER_EMAIL" },
 ] as const;
 
-for (const { role, emailEnv, passwordEnv } of roles) {
+for (const { role, emailEnv } of roles) {
   test(`dashboard carrega autenticado como ${role}`, async ({ page }) => {
     const identifier = process.env[emailEnv];
-    const password = process.env[passwordEnv];
-    test.skip(
-      !identifier || !password,
-      `defina ${emailEnv} e ${passwordEnv} em .env.e2e`,
-    );
+    test.skip(!identifier, `defina ${emailEnv} em .env.e2e`);
 
     // Injeta o Testing Token nas requisições da página, dispensando o
     // challenge anti-bot do Clerk.
     await setupClerkTestingToken({ page });
 
     await page.goto("/auth/login");
-    await clerk.signIn({
-      page,
-      signInParams: {
-        strategy: "password",
-        identifier: identifier!,
-        password: password!,
-      },
-    });
+    await clerk.signIn({ page, emailAddress: identifier! });
 
     try {
       await page.goto("/dashboard");

--- a/frontend/e2e/lottery.smoke.spec.ts
+++ b/frontend/e2e/lottery.smoke.spec.ts
@@ -6,7 +6,9 @@ import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
 // funcionando — tudo somente leitura (previewLottery não grava nada; o
 // sorteio de fato não é executado para não mutar o projeto de teste).
 // Requer credenciais de um coordenador e E2E_LOTTERY_PROJECT_ID — um
-// projeto onde esse usuário é coordenador, com documentos e membros.
+// projeto onde esse usuário é coordenador, com documentos e pelo menos um
+// pesquisador (sem pesquisador a contagem de elegíveis não renderiza e o
+// teste estoura por timeout em vez de pular — ver .env.e2e.example).
 // Pulado se faltar qualquer um, para não quebrar CI sem o tenant de teste.
 test("dialog de sorteio abre com filtros, modos e prévia funcionais", async ({
   page,

--- a/frontend/e2e/lottery.smoke.spec.ts
+++ b/frontend/e2e/lottery.smoke.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "@playwright/test";
+import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
+
+// Smoke do dialog de sorteio v2 (spec 001, PR #179): seções de filtros,
+// modos e participantes presentes, contagem de elegíveis ao vivo e prévia
+// funcionando — tudo somente leitura (previewLottery não grava nada; o
+// sorteio de fato não é executado para não mutar o projeto de teste).
+// Requer credenciais de um coordenador e E2E_LOTTERY_PROJECT_ID — um
+// projeto onde esse usuário é coordenador, com documentos e membros.
+// Pulado se faltar qualquer um, para não quebrar CI sem o tenant de teste.
+test("dialog de sorteio abre com filtros, modos e prévia funcionais", async ({
+  page,
+}) => {
+  // Primeira visita compila /analyze/assignments no dev server — folga acima
+  // dos 30s default para o teste não estourar durante o fluxo
+  test.setTimeout(60_000);
+
+  const identifier = process.env.E2E_COORDINATOR_EMAIL;
+  const projectId = process.env.E2E_LOTTERY_PROJECT_ID;
+  test.skip(
+    !identifier || !projectId,
+    "defina E2E_COORDINATOR_EMAIL e E2E_LOTTERY_PROJECT_ID em .env.e2e",
+  );
+
+  await setupClerkTestingToken({ page });
+
+  await page.goto("/auth/login");
+  // Estratégia ticket (token de sign-in criado server-side com a
+  // CLERK_SECRET_KEY): dispensa senha e não esbarra na verificação de
+  // "novo dispositivo" da instância, que bloqueia a estratégia password
+  // em contexto headless (cada contexto Playwright é um dispositivo novo)
+  await clerk.signIn({ page, emailAddress: identifier! });
+
+  try {
+    await page.goto(`/projects/${projectId}/analyze/assignments`);
+    await page
+      .getByRole("main")
+      .getByRole("button", { name: "Sortear" })
+      .click();
+
+    const dialog = page.getByRole("dialog", { name: /Sortear/ });
+    await expect(dialog).toBeVisible();
+
+    // Seções do dialog v2
+    await expect(
+      dialog.getByRole("heading", { name: "Documentos elegíveis" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Atribuições pendentes" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Distribuição" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("heading", { name: "Participantes" }),
+    ).toBeVisible();
+
+    // Defaults dos modos novos: acrescentar + equilíbrio da rodada
+    await expect(
+      dialog.getByRole("radio", { name: "Acrescentar ao existente" }),
+    ).toBeChecked();
+    await expect(
+      dialog.getByRole("radio", { name: "Equilibrar só esta rodada" }),
+    ).toBeChecked();
+
+    // Seção Prazo não existe mais (US6 — guarda de regressão)
+    await expect(dialog.getByText("Prazo", { exact: true })).toHaveCount(0);
+
+    // Stats carregam e a contagem de elegíveis aparece
+    await expect(dialog.getByText(/\d+ documentos elegíveis/)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Prévia computa e exibe totais + tabela por participante, sem coluna Prazo
+    await dialog.getByRole("button", { name: "Visualizar prévia" }).click();
+    await expect(dialog.getByText(/novas atribuições/)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      dialog.getByRole("columnheader", { name: "Participante" }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole("columnheader", { name: "Prazo" }),
+    ).toHaveCount(0);
+  } finally {
+    // signOut na própria página de atribuições trava no waitForFunction de
+    // window.Clerk.loaded — fechar o dialog e voltar ao dashboard antes
+    await page.keyboard.press("Escape");
+    await page.goto("/dashboard");
+    await clerk.signOut({ page });
+  }
+});


### PR DESCRIPTION
## Resumo

Versiona a validação E2E do sorteio v2 feita no PR #179 e desbloqueia a suíte autenticada inteira.

### `e2e/lottery.smoke.spec.ts` (novo)

Smoke do dialog de sorteio com coordenador real: seções Documentos elegíveis / Atribuições pendentes / Distribuição / Participantes presentes; defaults novos marcados (acrescentar + equilibrar só esta rodada); **ausência da seção Prazo e da coluna Prazo na prévia** (guarda de regressão da US6); contagem de elegíveis carrega; prévia computa e exibe a tabela por participante. **Somente leitura** — computa a prévia mas não sorteia, então não muta o projeto de teste. Requer `E2E_LOTTERY_PROJECT_ID` (novo no `.env.e2e.example`): projeto onde o coordenador de teste é coordenador, com docs e membros.

### Login por ticket nos 3 specs

`dashboard.smoke` e `config-guard.smoke` usavam `clerk.signIn` com estratégia **password**, que a verificação de "novo dispositivo" da instância bloqueia em contexto headless (cada contexto Playwright é um dispositivo novo) — os specs autenticados nunca passavam de fato. Migrados (junto com o spec novo) para a estratégia **ticket** (`clerk.signIn({ emailAddress })`), que cria o token de sign-in server-side com a `CLERK_SECRET_KEY` e dispensa senha e verificação. As variáveis `*_PASSWORD` viram opcionais (login manual), documentado no `.env.e2e.example` — incluindo o código fixo `424242` dos e-mails `+clerk_test`.

## Resultado

```
✓ config-guard.smoke — pesquisador é redirecionado de config/* para my-progress (10.2s)
✓ dashboard.smoke — coordenador (5.8s)
✓ dashboard.smoke — membro (5.8s)
✓ lottery.smoke — dialog de sorteio (9.4s)
- dashboard.smoke — master (skipped: sem usuário de teste master)
5 passed, 1 skipped (14.1s)
```

Primeira execução em que a suíte autenticada passa por inteiro. Usuários de teste: `coordenador2/pesquisador1+clerk_test@example.com` no tenant dev; projeto de teste "Validação Sorteio (spec 001) — teste E2E".

🤖 Generated with [Claude Code](https://claude.com/claude-code)