### PR TITLE
perf(vercel): executa funções serverless em gru1 (São Paulo)

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["gru1"]
+}


### PR DESCRIPTION
## Problema

O site está lento para usuários logados: TTFB de **1,2–1,7s** nas páginas de projeto. Medição em produção (logado, `fetch` com `cache: no-store`) mostrou `x-vercel-id: gru1::iad1::...` — o edge da Vercel fica em São Paulo, mas a **função serverless executa em iad1 (costa leste dos EUA)** e conversa com o Supabase em sa-east-1. Cada página paga ~10 round trips sequenciais de ~140ms.

O banco não é o gargalo: 22 MB de dados, cache hit ratio de 99,98% em tabelas e 99,97% em índices — por isso o upgrade de tier no Supabase não mudou a lentidão percebida.

## Mudança

`frontend/vercel.json` com `"regions": ["gru1"]` — as funções passam a executar em São Paulo, na mesma região do banco. Uma linha, sem mudança de código.

Quando o cutover do frontend para o Fly acontecer, este arquivo deve ser removido junto.

## Verificação

No deploy de preview (ou em produção após o merge), logado:

```js
const r = await fetch('/projects/<id>', { cache: 'no-store' });
r.headers.get('x-vercel-id'); // esperado: gru1::gru1::...
```

TTFB esperado nas páginas de projeto: ~150–300ms (antes: 1,2–1,7s).

⚠️ Caso o root directory do projeto na Vercel não seja `frontend/`, a região não vai mudar — nesse caso o arquivo deve ser movido para a raiz do repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)