### PR TITLE
fix(actions): detecção de 0-rows em UPDATE/DELETE via RLS (#178)

### DIFF
--- a/frontend/src/actions/__tests__/members.test.ts
+++ b/frontend/src/actions/__tests__/members.test.ts
@@ -1,67 +1,35 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// Mock supabase chainable enxuto. setCanArbitrate executa um UPDATE em
-// project_members com .select("user_id").single() e dispara
-// releaseArbitrationsFromUser / retryPendingArbitrations (mockados abaixo).
-// `tableResults` permite a testes (addMember) fixarem o retorno por tabela e
-// por cliente (server vs admin); sem entrada, vale o default histórico.
-type WriteCall = { table: string; op: string; payload: unknown };
+// Mock supabase chainable compartilhado (supabase-mock.ts). setCanArbitrate
+// executa um UPDATE em project_members com .select("user_id").single() e
+// dispara releaseArbitrationsFromUser / retryPendingArbitrations (mockados
+// abaixo). `tableResults` permite a testes (addMember) fixarem o retorno por
+// tabela e por cliente (server vs admin); sem entrada, vale o default
+// histórico ({ user_id: "userMemberX" }, ou erro quando clientError é setado).
+import {
+  makeSupabaseMock,
+  type TableResults,
+  type WriteCall,
+} from "./supabase-mock";
+
 let writeCalls: WriteCall[];
 
-type TableResult = {
-  data?: unknown;
-  error?: { message: string; code?: string } | null;
-  count?: number;
-};
-
-// Por tabela: um resultado fixo, ou uma fila (array) consumida na ordem das
-// queries — necessário quando a action consulta a mesma tabela mais de uma
-// vez com expectativas diferentes (ex.: linkMemberEmail e project_members).
 function makeClient(
   updateError?: { message: string },
-  tableResults?: Record<string, TableResult | TableResult[]>,
+  tableResults?: TableResults,
 ) {
-  return {
-    from: (table: string) => {
-      const builder: Record<string, unknown> = {};
-      for (const m of ["eq", "is", "in", "neq", "select", "single", "maybeSingle", "order", "limit"]) {
-        builder[m] = () => builder;
-      }
-      builder.update = (payload: unknown) => {
-        writeCalls.push({ table, op: "update", payload });
-        return builder;
-      };
-      builder.insert = (payload: unknown) => {
-        writeCalls.push({ table, op: "insert", payload });
-        return builder;
-      };
-      builder.delete = () => {
-        writeCalls.push({ table, op: "delete", payload: null });
-        return builder;
-      };
-      builder.then = (resolve: (v: unknown) => unknown) => {
-        const entry = tableResults?.[table];
-        const fixed = Array.isArray(entry) ? entry.shift() : entry;
-        if (fixed) {
-          return resolve({
-            data: fixed.data ?? null,
-            error: fixed.error ?? null,
-            count: fixed.count ?? null,
-          });
-        }
-        return resolve({
-          data: updateError ? null : { user_id: "userMemberX" },
-          error: updateError ?? null,
-        });
-      };
-      return builder;
-    },
-  };
+  return makeSupabaseMock({
+    tableResults,
+    defaultResult: updateError
+      ? { data: null, error: updateError }
+      : { data: { user_id: "userMemberX" } },
+    writeCalls,
+  });
 }
 
 let clientError: { message: string } | undefined;
-let serverTableResults: Record<string, TableResult | TableResult[]> | undefined;
-let adminTableResults: Record<string, TableResult | TableResult[]> | undefined;
+let serverTableResults: TableResults | undefined;
+let adminTableResults: TableResults | undefined;
 
 // hoisted mocks — release/retry precisam ser observáveis por teste para
 // distinguir o caminho de habilitar vs desabilitar.

--- a/frontend/src/actions/__tests__/rounds.test.ts
+++ b/frontend/src/actions/__tests__/rounds.test.ts
@@ -2,50 +2,17 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // Testes da detecção de 0-rows nos UPDATEs de rounds/projects (#178): o
 // PostgREST devolve sucesso com 0 linhas quando a RLS filtra — as actions
-// devem devolver { error } em vez de sucesso falso. Mock no padrão de
-// members.test.ts (fila de resultados por tabela).
+// devem devolver { error } em vez de sucesso falso. Mock compartilhado
+// (supabase-mock.ts), fila de resultados por tabela.
+import {
+  makeSupabaseMock,
+  type TableResult,
+  type TableResults,
+  type WriteCall,
+} from "./supabase-mock";
 
-type WriteCall = { table: string; op: string; payload: unknown };
 let writeCalls: WriteCall[];
-
-type TableResult = {
-  data?: unknown;
-  error?: { message: string; code?: string } | null;
-};
-
-function makeClient(tableResults?: Record<string, TableResult | TableResult[]>) {
-  return {
-    from: (table: string) => {
-      const builder: Record<string, unknown> = {};
-      for (const m of ["eq", "is", "in", "neq", "match", "select", "single", "maybeSingle", "order", "limit"]) {
-        builder[m] = () => builder;
-      }
-      builder.update = (payload: unknown) => {
-        writeCalls.push({ table, op: "update", payload });
-        return builder;
-      };
-      builder.insert = (payload: unknown) => {
-        writeCalls.push({ table, op: "insert", payload });
-        return builder;
-      };
-      builder.delete = () => {
-        writeCalls.push({ table, op: "delete", payload: null });
-        return builder;
-      };
-      builder.then = (resolve: (v: unknown) => unknown) => {
-        const entry = tableResults?.[table];
-        const fixed = Array.isArray(entry) ? entry.shift() : entry;
-        return resolve({
-          data: fixed?.data ?? null,
-          error: fixed?.error ?? null,
-        });
-      };
-      return builder;
-    },
-  };
-}
-
-let serverTableResults: Record<string, TableResult | TableResult[]> | undefined;
+let serverTableResults: TableResults | undefined;
 
 vi.mock("next/cache", () => ({
   revalidatePath: () => {},
@@ -57,7 +24,8 @@ vi.mock("@/lib/auth", () => ({
   getAuthUser: async () => ({ id: "userCoord", isMaster: false }),
 }));
 vi.mock("@/lib/supabase/server", () => ({
-  createSupabaseServer: async () => makeClient(serverTableResults),
+  createSupabaseServer: async () =>
+    makeSupabaseMock({ tableResults: serverTableResults, writeCalls }),
 }));
 
 import {

--- a/frontend/src/actions/__tests__/rounds.test.ts
+++ b/frontend/src/actions/__tests__/rounds.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Testes da detecção de 0-rows nos UPDATEs de rounds/projects (#178): o
+// PostgREST devolve sucesso com 0 linhas quando a RLS filtra — as actions
+// devem devolver { error } em vez de sucesso falso. Mock no padrão de
+// members.test.ts (fila de resultados por tabela).
+
+type WriteCall = { table: string; op: string; payload: unknown };
+let writeCalls: WriteCall[];
+
+type TableResult = {
+  data?: unknown;
+  error?: { message: string; code?: string } | null;
+};
+
+function makeClient(tableResults?: Record<string, TableResult | TableResult[]>) {
+  return {
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      for (const m of ["eq", "is", "in", "neq", "match", "select", "single", "maybeSingle", "order", "limit"]) {
+        builder[m] = () => builder;
+      }
+      builder.update = (payload: unknown) => {
+        writeCalls.push({ table, op: "update", payload });
+        return builder;
+      };
+      builder.insert = (payload: unknown) => {
+        writeCalls.push({ table, op: "insert", payload });
+        return builder;
+      };
+      builder.delete = () => {
+        writeCalls.push({ table, op: "delete", payload: null });
+        return builder;
+      };
+      builder.then = (resolve: (v: unknown) => unknown) => {
+        const entry = tableResults?.[table];
+        const fixed = Array.isArray(entry) ? entry.shift() : entry;
+        return resolve({
+          data: fixed?.data ?? null,
+          error: fixed?.error ?? null,
+        });
+      };
+      return builder;
+    },
+  };
+}
+
+let serverTableResults: Record<string, TableResult | TableResult[]> | undefined;
+
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+  revalidateTag: () => {},
+}));
+vi.mock("@/lib/auth", () => ({
+  // Criador do projeto: assertCoordinator dá short-circuit na 1ª query de
+  // projects (created_by === user.id).
+  getAuthUser: async () => ({ id: "userCoord", isMaster: false }),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () => makeClient(serverTableResults),
+}));
+
+import {
+  createRound,
+  renameRound,
+  setCurrentRound,
+  setRoundStrategy,
+} from "../rounds";
+
+// 1ª query de projects em toda action: o select de created_by do assertCoordinator.
+const ASSERT_COORD: TableResult = { data: { created_by: "userCoord" } };
+
+beforeEach(() => {
+  writeCalls = [];
+  serverTableResults = undefined;
+});
+
+describe("setCurrentRound", () => {
+  it("retorna erro quando o UPDATE de projects é filtrado (0 linhas)", async () => {
+    serverTableResults = { projects: [ASSERT_COORD, { data: [] }] };
+    const r = await setCurrentRound("p1", null);
+    expect(r.error).toMatch(/Sem permissão/);
+  });
+
+  it("caminho feliz: sem erro quando o UPDATE afeta 1 linha", async () => {
+    serverTableResults = { projects: [ASSERT_COORD, { data: [{ id: "p1" }] }] };
+    const r = await setCurrentRound("p1", null);
+    expect(r.error).toBeUndefined();
+  });
+});
+
+describe("setRoundStrategy", () => {
+  it("retorna erro em 0 linhas", async () => {
+    serverTableResults = { projects: [ASSERT_COORD, { data: [] }] };
+    const r = await setRoundStrategy("p1", "manual");
+    expect(r.error).toMatch(/Sem permissão/);
+  });
+});
+
+describe("renameRound", () => {
+  it("retorna erro quando o UPDATE de rounds não casa nenhuma linha", async () => {
+    serverTableResults = {
+      projects: [ASSERT_COORD],
+      rounds: { data: [] },
+    };
+    const r = await renameRound("p1", "r1", "Rodada 2");
+    expect(r.error).toMatch(/Sem permissão/);
+  });
+});
+
+describe("createRound(setAsCurrent=true)", () => {
+  it("estado parcial: rodada criada mas current_round_id não setado → devolve id E erro", async () => {
+    serverTableResults = {
+      projects: [ASSERT_COORD, { data: [] }],
+      rounds: { data: { id: "r1" } },
+    };
+    const r = await createRound("p1", "Rodada 1", true);
+    expect(r.id).toBe("r1");
+    expect(r.error).toMatch(/não foi possível defini-la como atual/);
+  });
+
+  it("caminho feliz: devolve id sem erro", async () => {
+    serverTableResults = {
+      projects: [ASSERT_COORD, { data: [{ id: "p1" }] }],
+      rounds: { data: { id: "r1" } },
+    };
+    const r = await createRound("p1", "Rodada 1", true);
+    expect(r.id).toBe("r1");
+    expect(r.error).toBeUndefined();
+  });
+});

--- a/frontend/src/actions/__tests__/schema.test.ts
+++ b/frontend/src/actions/__tests__/schema.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PydanticField } from "@/lib/types";
+
+// Testes do conserto da #178: o UPDATE de projects filtrado pela RLS retorna
+// sucesso com 0 linhas no PostgREST — antes, saveSchemaFromGUI seguia em
+// frente e inseria entradas em schema_change_log, gerando histórico fantasma.
+// O mock segue o padrão de members.test.ts: builder chainable + thenable, com
+// fila de resultados por tabela consumida na ordem das queries.
+
+type WriteCall = { table: string; op: string; payload: unknown };
+let writeCalls: WriteCall[];
+
+type TableResult = {
+  data?: unknown;
+  error?: { message: string; code?: string } | null;
+};
+
+function makeClient(tableResults?: Record<string, TableResult | TableResult[]>) {
+  return {
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      for (const m of ["eq", "is", "in", "neq", "match", "select", "single", "maybeSingle", "order", "limit"]) {
+        builder[m] = () => builder;
+      }
+      builder.update = (payload: unknown) => {
+        writeCalls.push({ table, op: "update", payload });
+        return builder;
+      };
+      builder.insert = (payload: unknown) => {
+        writeCalls.push({ table, op: "insert", payload });
+        return builder;
+      };
+      builder.delete = () => {
+        writeCalls.push({ table, op: "delete", payload: null });
+        return builder;
+      };
+      builder.then = (resolve: (v: unknown) => unknown) => {
+        const entry = tableResults?.[table];
+        const fixed = Array.isArray(entry) ? entry.shift() : entry;
+        return resolve({
+          data: fixed?.data ?? null,
+          error: fixed?.error ?? null,
+        });
+      };
+      return builder;
+    },
+  };
+}
+
+let serverTableResults: Record<string, TableResult | TableResult[]> | undefined;
+
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+  revalidateTag: () => {},
+}));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "userCoord" }),
+}));
+vi.mock("@/lib/api", () => ({
+  fetchFastAPI: async () => ({ valid: true, fields: [], model_name: null, errors: [] }),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () => makeClient(serverTableResults),
+}));
+
+import {
+  saveSchemaFromGUI,
+  savePrompt,
+  publishMajorVersion,
+  saveLlmConfig,
+} from "../schema";
+
+const FIELD: PydanticField = {
+  name: "q1",
+  type: "text",
+  options: null,
+  description: "Pergunta 1",
+};
+
+// Estado prévio do projeto lido por saveSchemaFromGUI (schema vazio, v0.1.0).
+const PROJECT_SELECT: TableResult = {
+  data: {
+    pydantic_fields: [],
+    schema_version_major: 0,
+    schema_version_minor: 1,
+    schema_version_patch: 0,
+  },
+};
+
+beforeEach(() => {
+  writeCalls = [];
+  serverTableResults = undefined;
+});
+
+describe("saveSchemaFromGUI", () => {
+  it("o caso da #178: UPDATE de projects filtrado (0 linhas) rejeita e NÃO grava histórico fantasma", async () => {
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [] }],
+    };
+
+    await expect(saveSchemaFromGUI("p1", [FIELD])).rejects.toThrow(/sem permissão/i);
+
+    const logInserts = writeCalls.filter(
+      (c) => c.table === "schema_change_log" && c.op === "insert",
+    );
+    expect(logInserts).toHaveLength(0);
+  });
+
+  it("caminho feliz: update de projects confirmado antes do insert do log, com versão bumpada", async () => {
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [{ id: "p1" }] }],
+      schema_change_log: { data: null, error: null },
+    };
+
+    await expect(saveSchemaFromGUI("p1", [FIELD])).resolves.toBeUndefined();
+
+    const ops = writeCalls.map((c) => `${c.table}:${c.op}`);
+    expect(ops.indexOf("projects:update")).toBeLessThan(
+      ops.indexOf("schema_change_log:insert"),
+    );
+
+    const logInsert = writeCalls.find(
+      (c) => c.table === "schema_change_log" && c.op === "insert",
+    );
+    const entries = logInsert?.payload as Array<Record<string, unknown>>;
+    expect(entries).toHaveLength(1);
+    // Campo adicionado = mudança estrutural → MINOR (0.1.0 → 0.2.0)
+    expect(entries[0]).toMatchObject({
+      project_id: "p1",
+      changed_by: "userCoord",
+      field_name: "q1",
+      change_type: "minor",
+      version_major: 0,
+      version_minor: 2,
+      version_patch: 0,
+    });
+  });
+
+  it("erro no insert do log rejeita com mensagem de histórico (schema já salvo)", async () => {
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [{ id: "p1" }] }],
+      schema_change_log: { data: null, error: { message: "log boom" } },
+    };
+
+    await expect(saveSchemaFromGUI("p1", [FIELD])).rejects.toThrow(/histórico.*log boom/);
+    // O update de projects aconteceu antes da falha do log.
+    expect(writeCalls.some((c) => c.table === "projects" && c.op === "update")).toBe(true);
+  });
+});
+
+describe("publishMajorVersion", () => {
+  it("0 linhas no bump rejeita e não grava entrada MAJOR fantasma", async () => {
+    serverTableResults = {
+      projects: [
+        { data: { schema_version_major: 0, schema_version_minor: 18, schema_version_patch: 0 } },
+        { data: [] },
+      ],
+    };
+
+    await expect(publishMajorVersion("p1")).rejects.toThrow(/sem permissão/i);
+    expect(
+      writeCalls.filter((c) => c.table === "schema_change_log" && c.op === "insert"),
+    ).toHaveLength(0);
+  });
+});
+
+describe("savePrompt / saveLlmConfig", () => {
+  it("savePrompt rejeita em 0 linhas com a copy específica", async () => {
+    serverTableResults = { projects: { data: [] } };
+    await expect(savePrompt("p1", "novo prompt")).rejects.toThrow(
+      /Não foi possível salvar o prompt/,
+    );
+  });
+
+  it("saveLlmConfig rejeita em 0 linhas com a copy específica", async () => {
+    serverTableResults = { projects: { data: [] } };
+    await expect(
+      saveLlmConfig("p1", { llm_provider: "google", llm_model: "gemini", llm_kwargs: {} }),
+    ).rejects.toThrow(/configuração do LLM/);
+  });
+});

--- a/frontend/src/actions/__tests__/schema.test.ts
+++ b/frontend/src/actions/__tests__/schema.test.ts
@@ -1,53 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { PydanticField } from "@/lib/types";
+import {
+  makeSupabaseMock,
+  type TableResult,
+  type TableResults,
+  type WriteCall,
+} from "./supabase-mock";
 
 // Testes do conserto da #178: o UPDATE de projects filtrado pela RLS retorna
 // sucesso com 0 linhas no PostgREST — antes, saveSchemaFromGUI seguia em
 // frente e inseria entradas em schema_change_log, gerando histórico fantasma.
-// O mock segue o padrão de members.test.ts: builder chainable + thenable, com
-// fila de resultados por tabela consumida na ordem das queries.
+// As actions retornam { error } (não lançam): o Next mascara a message de
+// erros lançados em Server Actions em produção.
 
-type WriteCall = { table: string; op: string; payload: unknown };
 let writeCalls: WriteCall[];
-
-type TableResult = {
-  data?: unknown;
-  error?: { message: string; code?: string } | null;
-};
-
-function makeClient(tableResults?: Record<string, TableResult | TableResult[]>) {
-  return {
-    from: (table: string) => {
-      const builder: Record<string, unknown> = {};
-      for (const m of ["eq", "is", "in", "neq", "match", "select", "single", "maybeSingle", "order", "limit"]) {
-        builder[m] = () => builder;
-      }
-      builder.update = (payload: unknown) => {
-        writeCalls.push({ table, op: "update", payload });
-        return builder;
-      };
-      builder.insert = (payload: unknown) => {
-        writeCalls.push({ table, op: "insert", payload });
-        return builder;
-      };
-      builder.delete = () => {
-        writeCalls.push({ table, op: "delete", payload: null });
-        return builder;
-      };
-      builder.then = (resolve: (v: unknown) => unknown) => {
-        const entry = tableResults?.[table];
-        const fixed = Array.isArray(entry) ? entry.shift() : entry;
-        return resolve({
-          data: fixed?.data ?? null,
-          error: fixed?.error ?? null,
-        });
-      };
-      return builder;
-    },
-  };
-}
-
-let serverTableResults: Record<string, TableResult | TableResult[]> | undefined;
+let serverTableResults: TableResults | undefined;
 
 vi.mock("next/cache", () => ({
   revalidatePath: () => {},
@@ -60,7 +27,8 @@ vi.mock("@/lib/api", () => ({
   fetchFastAPI: async () => ({ valid: true, fields: [], model_name: null, errors: [] }),
 }));
 vi.mock("@/lib/supabase/server", () => ({
-  createSupabaseServer: async () => makeClient(serverTableResults),
+  createSupabaseServer: async () =>
+    makeSupabaseMock({ tableResults: serverTableResults, writeCalls }),
 }));
 
 import {
@@ -93,12 +61,13 @@ beforeEach(() => {
 });
 
 describe("saveSchemaFromGUI", () => {
-  it("o caso da #178: UPDATE de projects filtrado (0 linhas) rejeita e NÃO grava histórico fantasma", async () => {
+  it("o caso da #178: UPDATE de projects filtrado (0 linhas) retorna erro e NÃO grava histórico fantasma", async () => {
     serverTableResults = {
       projects: [PROJECT_SELECT, { data: [] }],
     };
 
-    await expect(saveSchemaFromGUI("p1", [FIELD])).rejects.toThrow(/sem permissão/i);
+    const r = await saveSchemaFromGUI("p1", [FIELD]);
+    expect(r.error).toMatch(/sem permissão/i);
 
     const logInserts = writeCalls.filter(
       (c) => c.table === "schema_change_log" && c.op === "insert",
@@ -112,7 +81,8 @@ describe("saveSchemaFromGUI", () => {
       schema_change_log: { data: null, error: null },
     };
 
-    await expect(saveSchemaFromGUI("p1", [FIELD])).resolves.toBeUndefined();
+    const r = await saveSchemaFromGUI("p1", [FIELD]);
+    expect(r.error).toBeUndefined();
 
     const ops = writeCalls.map((c) => `${c.table}:${c.op}`);
     expect(ops.indexOf("projects:update")).toBeLessThan(
@@ -136,20 +106,21 @@ describe("saveSchemaFromGUI", () => {
     });
   });
 
-  it("erro no insert do log rejeita com mensagem de histórico (schema já salvo)", async () => {
+  it("erro no insert do log retorna erro com mensagem de histórico (schema já salvo)", async () => {
     serverTableResults = {
       projects: [PROJECT_SELECT, { data: [{ id: "p1" }] }],
       schema_change_log: { data: null, error: { message: "log boom" } },
     };
 
-    await expect(saveSchemaFromGUI("p1", [FIELD])).rejects.toThrow(/histórico.*log boom/);
+    const r = await saveSchemaFromGUI("p1", [FIELD]);
+    expect(r.error).toMatch(/histórico.*log boom/);
     // O update de projects aconteceu antes da falha do log.
     expect(writeCalls.some((c) => c.table === "projects" && c.op === "update")).toBe(true);
   });
 });
 
 describe("publishMajorVersion", () => {
-  it("0 linhas no bump rejeita e não grava entrada MAJOR fantasma", async () => {
+  it("0 linhas no bump retorna erro e não grava entrada MAJOR fantasma", async () => {
     serverTableResults = {
       projects: [
         { data: { schema_version_major: 0, schema_version_minor: 18, schema_version_patch: 0 } },
@@ -157,25 +128,57 @@ describe("publishMajorVersion", () => {
       ],
     };
 
-    await expect(publishMajorVersion("p1")).rejects.toThrow(/sem permissão/i);
+    const r = await publishMajorVersion("p1");
+    expect(r.error).toMatch(/sem permissão/i);
+    expect(r.bumped).toBeUndefined();
     expect(
       writeCalls.filter((c) => c.table === "schema_change_log" && c.op === "insert"),
     ).toHaveLength(0);
   });
+
+  it("falha parcial: MAJOR publicada mas log falhou → retorna bumped E erro", async () => {
+    serverTableResults = {
+      projects: [
+        { data: { schema_version_major: 0, schema_version_minor: 18, schema_version_patch: 0 } },
+        { data: [{ id: "p1" }] },
+      ],
+      schema_change_log: { data: null, error: { message: "log boom" } },
+    };
+
+    const r = await publishMajorVersion("p1");
+    expect(r.bumped).toEqual({ major: 1, minor: 0, patch: 0 });
+    expect(r.error).toMatch(/MAJOR publicada.*log boom/);
+  });
+
+  it("caminho feliz: retorna a versão bumpada sem erro", async () => {
+    serverTableResults = {
+      projects: [
+        { data: { schema_version_major: 0, schema_version_minor: 18, schema_version_patch: 0 } },
+        { data: [{ id: "p1" }] },
+      ],
+      schema_change_log: { data: null, error: null },
+    };
+
+    const r = await publishMajorVersion("p1");
+    expect(r.error).toBeUndefined();
+    expect(r.bumped).toEqual({ major: 1, minor: 0, patch: 0 });
+  });
 });
 
 describe("savePrompt / saveLlmConfig", () => {
-  it("savePrompt rejeita em 0 linhas com a copy específica", async () => {
+  it("savePrompt retorna erro em 0 linhas com a copy específica", async () => {
     serverTableResults = { projects: { data: [] } };
-    await expect(savePrompt("p1", "novo prompt")).rejects.toThrow(
-      /Não foi possível salvar o prompt/,
-    );
+    const r = await savePrompt("p1", "novo prompt");
+    expect(r.error).toMatch(/Não foi possível salvar o prompt/);
   });
 
-  it("saveLlmConfig rejeita em 0 linhas com a copy específica", async () => {
+  it("saveLlmConfig retorna erro em 0 linhas com a copy específica", async () => {
     serverTableResults = { projects: { data: [] } };
-    await expect(
-      saveLlmConfig("p1", { llm_provider: "google", llm_model: "gemini", llm_kwargs: {} }),
-    ).rejects.toThrow(/configuração do LLM/);
+    const r = await saveLlmConfig("p1", {
+      llm_provider: "google",
+      llm_model: "gemini",
+      llm_kwargs: {},
+    });
+    expect(r.error).toMatch(/configuração do LLM/);
   });
 });

--- a/frontend/src/actions/__tests__/suggestions.test.ts
+++ b/frontend/src/actions/__tests__/suggestions.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PydanticField } from "@/lib/types";
+import {
+  makeSupabaseMock,
+  type TableResult,
+  type TableResults,
+  type WriteCall,
+} from "./supabase-mock";
+
+// Cobertura dos dois lados da divergência sugestão × schema (#178):
+// (a) schema não aplicado → sugestão não pode virar "approved";
+// (b) schema aplicado mas UPDATE de schema_suggestions filtrado pela RLS
+//     (0 linhas) → a action não pode retornar sucesso com a sugestão pendente.
+
+let writeCalls: WriteCall[];
+let serverTableResults: TableResults | undefined;
+
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+  revalidateTag: () => {},
+}));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "userCoord" }),
+  isProjectCoordinator: async () => true,
+}));
+vi.mock("@/lib/api", () => ({
+  fetchFastAPI: async () => ({ valid: true, fields: [], model_name: null, errors: [] }),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () =>
+    makeSupabaseMock({ tableResults: serverTableResults, writeCalls }),
+}));
+
+import {
+  approveSchemaSuggestionWithEdits,
+  resolveSchemaSuggestion,
+} from "../suggestions";
+
+const FIELD: PydanticField = {
+  name: "q1",
+  type: "text",
+  options: null,
+  description: "Pergunta 1",
+};
+
+// Estado prévio do projeto lido por saveSchemaFromGUI (schema vazio, v0.1.0).
+const PROJECT_SELECT: TableResult = {
+  data: {
+    pydantic_fields: [],
+    schema_version_major: 0,
+    schema_version_minor: 1,
+    schema_version_patch: 0,
+  },
+};
+
+beforeEach(() => {
+  writeCalls = [];
+  serverTableResults = undefined;
+});
+
+describe("approveSchemaSuggestionWithEdits", () => {
+  it("schema não aplicado (0 linhas em projects) → erro e sugestão NÃO marcada como aprovada", async () => {
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [] }],
+    };
+
+    const r = await approveSchemaSuggestionWithEdits("s1", "p1", [FIELD]);
+    expect(r.error).toMatch(/sem permissão/i);
+    expect(
+      writeCalls.some((c) => c.table === "schema_suggestions" && c.op === "update"),
+    ).toBe(false);
+  });
+
+  it("schema aplicado mas UPDATE de schema_suggestions filtrado (0 linhas) → erro, não sucesso falso", async () => {
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [{ id: "p1" }] }],
+      schema_change_log: { data: null, error: null },
+      schema_suggestions: { data: [] },
+    };
+
+    const r = await approveSchemaSuggestionWithEdits("s1", "p1", [FIELD]);
+    expect(r.error).toMatch(/Schema aplicado.*sem permissão/);
+  });
+
+  it("caminho feliz: schema aplicado e sugestão marcada como aprovada", async () => {
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [{ id: "p1" }] }],
+      schema_change_log: { data: null, error: null },
+      schema_suggestions: { data: [{ id: "s1" }] },
+    };
+
+    const r = await approveSchemaSuggestionWithEdits("s1", "p1", [FIELD]);
+    expect(r.error).toBeUndefined();
+    const suggestionUpdate = writeCalls.find(
+      (c) => c.table === "schema_suggestions" && c.op === "update",
+    );
+    expect(suggestionUpdate?.payload).toMatchObject({ status: "approved" });
+  });
+});
+
+describe("resolveSchemaSuggestion (rejected)", () => {
+  it("UPDATE de schema_suggestions filtrado (0 linhas) → erro", async () => {
+    serverTableResults = {
+      schema_suggestions: { data: [] },
+    };
+
+    const r = await resolveSchemaSuggestion("s1", "p1", "rejected", "fora de escopo");
+    expect(r.error).toMatch(/Sem permissão para resolver/);
+  });
+
+  it("caminho feliz: rejeição persiste com rejection_reason", async () => {
+    serverTableResults = {
+      schema_suggestions: { data: [{ id: "s1" }] },
+    };
+
+    const r = await resolveSchemaSuggestion("s1", "p1", "rejected", "fora de escopo");
+    expect(r.error).toBeUndefined();
+    const upd = writeCalls.find(
+      (c) => c.table === "schema_suggestions" && c.op === "update",
+    );
+    expect(upd?.payload).toMatchObject({
+      status: "rejected",
+      rejection_reason: "fora de escopo",
+    });
+  });
+});

--- a/frontend/src/actions/__tests__/supabase-mock.ts
+++ b/frontend/src/actions/__tests__/supabase-mock.ts
@@ -1,0 +1,66 @@
+// Mock chainable do client Supabase para testes de Server Actions, extraído
+// dos mocks duplicados de members/schema/rounds.test.ts. Não é coletado pelo
+// vitest (include cobre apenas *.test.ts).
+//
+// Builder: qualquer método de filtro/modificador devolve o próprio builder;
+// update/insert/delete registram a chamada em `writeCalls`; o await (thenable)
+// resolve com o resultado fixado por tabela em `tableResults` — um valor fixo
+// ou uma fila (array) consumida na ordem das queries, necessária quando a
+// action consulta a mesma tabela mais de uma vez com expectativas diferentes.
+// Sem entrada para a tabela, vale `defaultResult` (ou data/error/count nulos).
+
+export type WriteCall = {
+  table: string;
+  op: "update" | "insert" | "delete";
+  payload: unknown;
+};
+
+export type TableResult = {
+  data?: unknown;
+  error?: { message: string; code?: string } | null;
+  count?: number;
+};
+
+export type TableResults = Record<string, TableResult | TableResult[]>;
+
+export function makeSupabaseMock(opts?: {
+  tableResults?: TableResults;
+  defaultResult?: TableResult;
+  writeCalls?: WriteCall[];
+}) {
+  const { tableResults, defaultResult, writeCalls } = opts ?? {};
+  return {
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      for (const m of [
+        "eq", "is", "in", "neq", "match", "select", "single",
+        "maybeSingle", "order", "limit", "range",
+      ]) {
+        builder[m] = () => builder;
+      }
+      builder.update = (payload: unknown) => {
+        writeCalls?.push({ table, op: "update", payload });
+        return builder;
+      };
+      builder.insert = (payload: unknown) => {
+        writeCalls?.push({ table, op: "insert", payload });
+        return builder;
+      };
+      builder.delete = () => {
+        writeCalls?.push({ table, op: "delete", payload: null });
+        return builder;
+      };
+      builder.then = (resolve: (v: unknown) => unknown) => {
+        const entry = tableResults?.[table];
+        const fixed = Array.isArray(entry) ? entry.shift() : entry;
+        const result = fixed ?? defaultResult;
+        return resolve({
+          data: result?.data ?? null,
+          error: result?.error ?? null,
+          count: result?.count ?? null,
+        });
+      };
+      return builder;
+    },
+  };
+}

--- a/frontend/src/actions/members.ts
+++ b/frontend/src/actions/members.ts
@@ -269,12 +269,15 @@ export async function changeRole(
   projectId: string
 ) {
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("project_members")
     .update({ role })
-    .eq("id", memberId);
+    .eq("id", memberId)
+    .select("id");
 
   if (error) return { error: error.message };
+  if (!data || data.length === 0)
+    return { error: "Sem permissão para alterar papéis neste projeto." };
   revalidatePath(`/projects/${projectId}`);
   revalidateTag(`project-${projectId}-members`, TAG_PROFILE);
 }
@@ -288,12 +291,15 @@ export async function setCanResolve(
   projectId: string,
 ): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("project_members")
     .update({ can_resolve: canResolve })
-    .eq("id", memberId);
+    .eq("id", memberId)
+    .select("id");
 
   if (error) return { error: error.message };
+  if (!data || data.length === 0)
+    return { error: "Sem permissão para alterar permissões neste projeto." };
 
   revalidatePath(`/projects/${projectId}`);
   revalidatePath(`/projects/${projectId}/config/members`);

--- a/frontend/src/actions/projects.ts
+++ b/frontend/src/actions/projects.ts
@@ -2,6 +2,7 @@
 
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
+import { updateOrThrow, deleteOrThrow } from "@/lib/supabase/rls-guard";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
@@ -49,23 +50,17 @@ export async function updateProject(
   }
 ) {
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
-    .from("projects")
-    .update(data)
-    .eq("id", projectId);
-
-  if (error) throw new Error(error.message);
+  await updateOrThrow(supabase, "projects", data, { id: projectId }, {
+    message: "Sem permissão para alterar as configurações deste projeto.",
+  });
   revalidatePath(`/projects/${projectId}`);
 }
 
 export async function deleteProject(projectId: string) {
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
-    .from("projects")
-    .delete()
-    .eq("id", projectId);
-
-  if (error) throw new Error(error.message);
+  await deleteOrThrow(supabase, "projects", { id: projectId }, {
+    message: "Sem permissão para excluir este projeto.",
+  });
   revalidatePath("/dashboard");
   redirect("/dashboard");
 }

--- a/frontend/src/actions/projects.ts
+++ b/frontend/src/actions/projects.ts
@@ -38,6 +38,9 @@ export async function createProject(_prev: unknown, formData: FormData) {
   redirect(`/projects/${project.id}/documents`);
 }
 
+// Retorno { error } em vez de throw: o Next mascara a message de erros
+// lançados em Server Actions em produção (o client recebe mensagem genérica
+// + digest), então a copy pt-BR só chega ao toast pelo retorno.
 export async function updateProject(
   projectId: string,
   data: {
@@ -48,19 +51,28 @@ export async function updateProject(
     allow_researcher_review?: boolean;
     arbitration_blind?: boolean;
   }
-) {
+): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();
-  await updateOrThrow(supabase, "projects", data, { id: projectId }, {
-    message: "Sem permissão para alterar as configurações deste projeto.",
-  });
+  try {
+    await updateOrThrow(supabase, "projects", data, { id: projectId }, {
+      message: "Sem permissão para alterar as configurações deste projeto.",
+    });
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "Erro ao salvar o projeto" };
+  }
   revalidatePath(`/projects/${projectId}`);
+  return {};
 }
 
-export async function deleteProject(projectId: string) {
+export async function deleteProject(projectId: string): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();
-  await deleteOrThrow(supabase, "projects", { id: projectId }, {
-    message: "Sem permissão para excluir este projeto.",
-  });
+  try {
+    await deleteOrThrow(supabase, "projects", { id: projectId }, {
+      message: "Sem permissão para excluir este projeto.",
+    });
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "Erro ao excluir o projeto" };
+  }
   revalidatePath("/dashboard");
   redirect("/dashboard");
 }

--- a/frontend/src/actions/reviews.ts
+++ b/frontend/src/actions/reviews.ts
@@ -68,13 +68,16 @@ export async function submitVerdict(
       .maybeSingle();
 
     if (!existingAmbiguity) {
+      // author_id é a conta autenticada, não o id efetivo: a policy de INSERT
+      // de project_comments exige author_id = clerk_uid() — com effectiveId,
+      // uma conta-alias (spec 002) tomaria 42501 aqui.
       const { error: commentError } = await supabase
         .from("project_comments")
         .insert({
           project_id: projectId,
           document_id: documentId,
           field_name: fieldName,
-          author_id: effectiveId,
+          author_id: user.id,
           body: comment?.trim()
             ? `Campo marcado como ambíguo na revisão (aba Comparar): ${comment.trim()}`
             : "Campo marcado como ambíguo na revisão (aba Comparar).",

--- a/frontend/src/actions/rounds.ts
+++ b/frontend/src/actions/rounds.ts
@@ -68,11 +68,20 @@ export async function createRound(
     // Nao-transacional: se este update falhar, a rodada ja foi criada e o
     // coordenador precisa marca-la como atual manualmente em /config/rounds.
     // Uma RPC com transacao seria overkill para a baixa frequencia da operacao.
-    const { error: updErr } = await supabase
+    // O id volta junto com o erro para a UI refletir o estado parcial.
+    const { data: updated, error: updErr } = await supabase
       .from("projects")
       .update({ current_round_id: data.id })
-      .eq("id", projectId);
-    if (updErr) return { error: updErr.message };
+      .eq("id", projectId)
+      .select("id");
+    if (updErr) return { id: data.id, error: updErr.message };
+    if (!updated || updated.length === 0) {
+      return {
+        id: data.id,
+        error:
+          "Rodada criada, mas não foi possível defini-la como atual (sem permissão). Selecione-a manualmente em Configurações → Rodadas.",
+      };
+    }
   }
 
   revalidatePath(`/projects/${projectId}/config/rounds`);
@@ -92,12 +101,16 @@ export async function renameRound(
   if (auth.error) return { error: auth.error };
 
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("rounds")
     .update({ label: trimmed })
     .eq("id", roundId)
-    .eq("project_id", projectId);
+    .eq("project_id", projectId)
+    .select("id");
   if (error) return { error: mapRoundsError(error) };
+  if (!data || data.length === 0) {
+    return { error: "Sem permissão para renomear esta rodada (ou ela não existe)." };
+  }
 
   revalidatePath(`/projects/${projectId}/config/rounds`);
   revalidatePath(`/projects/${projectId}/analyze/code`);
@@ -126,11 +139,15 @@ export async function setCurrentRound(
     if (!round) return { error: "Rodada inválida para este projeto." };
   }
 
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("projects")
     .update({ current_round_id: roundId })
-    .eq("id", projectId);
+    .eq("id", projectId)
+    .select("id");
   if (error) return { error: error.message };
+  if (!data || data.length === 0) {
+    return { error: "Sem permissão para alterar a rodada atual deste projeto." };
+  }
 
   revalidatePath(`/projects/${projectId}/config/rounds`);
   revalidatePath(`/projects/${projectId}/analyze/code`);
@@ -145,12 +162,16 @@ export async function deleteRound(
   if (auth.error) return { error: auth.error };
 
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("rounds")
     .delete()
     .eq("id", roundId)
-    .eq("project_id", projectId);
+    .eq("project_id", projectId)
+    .select("id");
   if (error) return { error: error.message };
+  if (!data || data.length === 0) {
+    return { error: "Sem permissão para excluir esta rodada (ou ela não existe)." };
+  }
 
   revalidatePath(`/projects/${projectId}/config/rounds`);
   revalidatePath(`/projects/${projectId}/analyze/code`);
@@ -176,11 +197,15 @@ export async function setRoundStrategy(
   if (auth.error) return { error: auth.error };
 
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("projects")
     .update({ round_strategy: strategy })
-    .eq("id", projectId);
+    .eq("id", projectId)
+    .select("id");
   if (error) return { error: error.message };
+  if (!data || data.length === 0) {
+    return { error: "Sem permissão para alterar a estratégia de rodadas deste projeto." };
+  }
 
   revalidatePath(`/projects/${projectId}/config/rounds`);
   revalidatePath(`/projects/${projectId}/analyze/code`);

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -14,6 +14,7 @@ import {
   fieldDiffIsStructural,
   type ChangeType,
 } from "@/lib/schema-utils";
+import { updateOrThrow } from "@/lib/supabase/rls-guard";
 import crypto from "crypto";
 
 interface ValidateResponse {
@@ -50,12 +51,10 @@ export async function saveSchema(
     updatePayload.schema_version_patch = versionBump.patch;
   }
 
-  const { error } = await supabase
-    .from("projects")
-    .update(updatePayload)
-    .eq("id", projectId);
-
-  if (error) throw new Error(error.message);
+  await updateOrThrow(supabase, "projects", updatePayload, { id: projectId }, {
+    message:
+      "Não foi possível salvar o schema: sem permissão para alterar este projeto.",
+  });
 
   // is_latest não é flipado para false aqui — staleness é detectada no
   // display via answer_field_hashes (lib/reviews/queries.ts:isFieldStale).
@@ -71,12 +70,13 @@ export async function saveSchema(
 
 export async function savePrompt(projectId: string, promptTemplate: string) {
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
-    .from("projects")
-    .update({ prompt_template: promptTemplate })
-    .eq("id", projectId);
-
-  if (error) throw new Error(error.message);
+  await updateOrThrow(
+    supabase,
+    "projects",
+    { prompt_template: promptTemplate },
+    { id: projectId },
+    { message: "Não foi possível salvar o prompt: sem permissão para alterar este projeto." },
+  );
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/llm/configure`);
 }
@@ -128,9 +128,12 @@ export async function saveSchemaFromGUI(
   }));
   await saveSchema(projectId, code, fieldsWithHash, changeType ? bumped : undefined);
 
-  // Insert audit log entries com change_type + versão alvo
+  // Insert audit log entries com change_type + versão alvo. Só roda depois
+  // que saveSchema confirmou ≥1 linha atualizada (lança em 0-rows) — antes o
+  // log era gravado mesmo com o UPDATE de projects filtrado pela RLS, gerando
+  // histórico fantasma (#178).
   if (logEntries.length > 0 && user) {
-    await supabase.from("schema_change_log").insert(
+    const { error: logErr } = await supabase.from("schema_change_log").insert(
       logEntries.map((e) => ({
         project_id: projectId,
         changed_by: user.id,
@@ -141,6 +144,11 @@ export async function saveSchemaFromGUI(
         ...e,
       })),
     );
+    if (logErr) {
+      throw new Error(
+        `Schema salvo, mas falha ao registrar o histórico: ${logErr.message}`,
+      );
+    }
   }
 }
 
@@ -247,7 +255,7 @@ export async function backfillSchemaVersionHistory(projectId: string) {
   }
 
   // 2) Update each log entry with classification + version
-  await Promise.all(
+  const logUpdateResults = await Promise.all(
     enriched.map((e) =>
       supabase
         .from("schema_change_log")
@@ -257,19 +265,33 @@ export async function backfillSchemaVersionHistory(projectId: string) {
           version_minor: e.version.minor,
           version_patch: e.version.patch,
         })
-        .eq("id", e.id),
+        .eq("id", e.id)
+        .select("id"),
     ),
   );
+  const logUpdateFailures = logUpdateResults.filter(
+    (r) => r.error || !r.data || r.data.length === 0,
+  );
+  if (logUpdateFailures.length > 0) {
+    const firstErr = logUpdateFailures.find((r) => r.error)?.error;
+    throw new Error(
+      `Backfill: ${logUpdateFailures.length} de ${enriched.length} entradas do histórico não puderam ser atualizadas` +
+        (firstErr ? ` (${firstErr.message})` : " (sem permissão de UPDATE em schema_change_log)"),
+    );
+  }
 
   // 3) Set project current version
-  await supabase
-    .from("projects")
-    .update({
+  await updateOrThrow(
+    supabase,
+    "projects",
+    {
       schema_version_major: current.major,
       schema_version_minor: current.minor,
       schema_version_patch: current.patch,
-    })
-    .eq("id", projectId);
+    },
+    { id: projectId },
+    { message: "Backfill: sem permissão para atualizar a versão do projeto." },
+  );
 
   // 4) Reconstruct snapshots at each version, walking log in reverse.
   // Current project fields = snapshot of the "current" version after all entries applied.
@@ -473,11 +495,24 @@ export async function backfillSchemaVersionHistory(projectId: string) {
             schema_version_patch: bucket.version.patch,
             version_inferred_from: bucket.method,
           })
-          .in("id", chunk),
+          .in("id", chunk)
+          .select("id")
+          .then((r) => ({ result: r, expected: chunk.length })),
       );
     }
   }
-  await Promise.all(updatePromises);
+  const responseUpdateResults = await Promise.all(updatePromises);
+  for (const { result, expected } of responseUpdateResults) {
+    if (result.error) {
+      throw new Error(`Backfill: falha ao versionar respostas (${result.error.message})`);
+    }
+    const affected = result.data?.length ?? 0;
+    if (affected < expected) {
+      throw new Error(
+        `Backfill: ${expected - affected} resposta(s) não puderam ser versionadas (sem permissão de UPDATE em responses).`,
+      );
+    }
+  }
 
   revalidatePath(`/projects/${projectId}/analyze/compare`);
   revalidatePath(`/projects/${projectId}/config/schema`);
@@ -520,18 +555,19 @@ export async function publishMajorVersion(projectId: string) {
   };
   const bumped = bumpVersion(current, "major");
 
-  const { error } = await supabase
-    .from("projects")
-    .update({
+  await updateOrThrow(
+    supabase,
+    "projects",
+    {
       schema_version_major: bumped.major,
       schema_version_minor: bumped.minor,
       schema_version_patch: bumped.patch,
-    })
-    .eq("id", projectId);
+    },
+    { id: projectId },
+    { message: "Não foi possível publicar a MAJOR: sem permissão para alterar este projeto." },
+  );
 
-  if (error) throw new Error(error.message);
-
-  await supabase.from("schema_change_log").insert({
+  const { error: logErr } = await supabase.from("schema_change_log").insert({
     project_id: projectId,
     changed_by: user.id,
     field_name: "(projeto)",
@@ -543,6 +579,11 @@ export async function publishMajorVersion(projectId: string) {
     version_minor: bumped.minor,
     version_patch: bumped.patch,
   });
+  if (logErr) {
+    throw new Error(
+      `MAJOR publicada, mas falha ao registrar o histórico: ${logErr.message}`,
+    );
+  }
 
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/analyze/compare`);
@@ -585,12 +626,10 @@ export async function saveLlmConfig(
   }
 ) {
   const supabase = await createSupabaseServer();
-  const { error } = await supabase
-    .from("projects")
-    .update(config)
-    .eq("id", projectId);
-
-  if (error) throw new Error(error.message);
+  await updateOrThrow(supabase, "projects", config, { id: projectId }, {
+    message:
+      "Não foi possível salvar a configuração do LLM: sem permissão para alterar este projeto.",
+  });
   revalidatePath(`/projects/${projectId}/llm/configure`);
   revalidatePath(`/projects/${projectId}/config`);
 }

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -31,12 +31,21 @@ export async function validateSchema(code: string): Promise<ValidateResponse> {
   });
 }
 
+// As actions deste arquivo retornam { error } em vez de lançar: o Next mascara
+// a message de erros lançados em Server Actions em produção (o client recebe
+// mensagem genérica + digest), então a copy pt-BR só chega ao toast pelo
+// retorno. Os helpers de rls-guard continuam lançando — o catch fica na
+// fronteira da action.
+function errorMessage(e: unknown, fallback: string): string {
+  return e instanceof Error ? e.message : fallback;
+}
+
 export async function saveSchema(
   projectId: string,
   code: string,
   fields: PydanticField[],
   versionBump?: { major: number; minor: number; patch: number },
-) {
+): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();
   const hash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
 
@@ -51,10 +60,14 @@ export async function saveSchema(
     updatePayload.schema_version_patch = versionBump.patch;
   }
 
-  await updateOrThrow(supabase, "projects", updatePayload, { id: projectId }, {
-    message:
-      "Não foi possível salvar o schema: sem permissão para alterar este projeto.",
-  });
+  try {
+    await updateOrThrow(supabase, "projects", updatePayload, { id: projectId }, {
+      message:
+        "Não foi possível salvar o schema: sem permissão para alterar este projeto.",
+    });
+  } catch (e) {
+    return { error: errorMessage(e, "Erro ao salvar o schema") };
+  }
 
   // is_latest não é flipado para false aqui — staleness é detectada no
   // display via answer_field_hashes (lib/reviews/queries.ts:isFieldStale).
@@ -66,19 +79,28 @@ export async function saveSchema(
   revalidatePath(`/projects/${projectId}/reviews`);
   revalidatePath(`/projects/${projectId}/llm/configure`);
   revalidateTag(`project-${projectId}-progress`, { expire: 60 });
+  return {};
 }
 
-export async function savePrompt(projectId: string, promptTemplate: string) {
+export async function savePrompt(
+  projectId: string,
+  promptTemplate: string,
+): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();
-  await updateOrThrow(
-    supabase,
-    "projects",
-    { prompt_template: promptTemplate },
-    { id: projectId },
-    { message: "Não foi possível salvar o prompt: sem permissão para alterar este projeto." },
-  );
+  try {
+    await updateOrThrow(
+      supabase,
+      "projects",
+      { prompt_template: promptTemplate },
+      { id: projectId },
+      { message: "Não foi possível salvar o prompt: sem permissão para alterar este projeto." },
+    );
+  } catch (e) {
+    return { error: errorMessage(e, "Erro ao salvar o prompt") };
+  }
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/llm/configure`);
+  return {};
 }
 
 // ---------- Save from GUI ----------
@@ -91,7 +113,7 @@ export async function savePrompt(projectId: string, promptTemplate: string) {
 export async function saveSchemaFromGUI(
   projectId: string,
   fields: PydanticField[]
-) {
+): Promise<{ error?: string }> {
   const [supabase, user] = await Promise.all([
     createSupabaseServer(),
     getAuthUser(),
@@ -126,10 +148,11 @@ export async function saveSchemaFromGUI(
     ...f,
     hash: computeFieldHash(f.name, f.type, f.options, f.description),
   }));
-  await saveSchema(projectId, code, fieldsWithHash, changeType ? bumped : undefined);
+  const saved = await saveSchema(projectId, code, fieldsWithHash, changeType ? bumped : undefined);
+  if (saved.error) return saved;
 
   // Insert audit log entries com change_type + versão alvo. Só roda depois
-  // que saveSchema confirmou ≥1 linha atualizada (lança em 0-rows) — antes o
+  // que saveSchema confirmou ≥1 linha atualizada (erro em 0-rows) — antes o
   // log era gravado mesmo com o UPDATE de projects filtrado pela RLS, gerando
   // histórico fantasma (#178).
   if (logEntries.length > 0 && user) {
@@ -145,11 +168,12 @@ export async function saveSchemaFromGUI(
       })),
     );
     if (logErr) {
-      throw new Error(
-        `Schema salvo, mas falha ao registrar o histórico: ${logErr.message}`,
-      );
+      return {
+        error: `Schema salvo, mas falha ao registrar o histórico: ${logErr.message}`,
+      };
     }
   }
+  return {};
 }
 
 // ---------- Backfill retroativo usando schema_change_log ----------
@@ -194,7 +218,32 @@ function computeHashesFromSnapshot(snap: Map<string, FieldSnapshot>): Record<str
   return hashes;
 }
 
-export async function backfillSchemaVersionHistory(projectId: string) {
+type BackfillStats = {
+  finalVersion: { major: number; minor: number; patch: number };
+  logEntriesUpdated: number;
+  responsesProcessed: number;
+  byMethod: {
+    hashes: number;
+    created_at: number;
+    fallback_created_at: number;
+    live_save: number;
+  };
+};
+
+// Fronteira da action: runBackfill lança nos vários pontos de falha (leituras,
+// updates filtrados, permissões) e aqui o throw vira { error } para a copy
+// chegar ao client em produção.
+export async function backfillSchemaVersionHistory(
+  projectId: string,
+): Promise<{ stats?: BackfillStats; error?: string }> {
+  try {
+    return { stats: await runBackfill(projectId) };
+  } catch (e) {
+    return { error: errorMessage(e, "Erro ao reconstruir o histórico de versões") };
+  }
+}
+
+async function runBackfill(projectId: string): Promise<BackfillStats> {
   const user = await getAuthUser();
   if (!user) throw new Error("Não autenticado");
 
@@ -533,12 +582,16 @@ export async function backfillSchemaVersionHistory(projectId: string) {
 
 // ---------- MAJOR version bump (manual) ----------
 
-export async function publishMajorVersion(projectId: string) {
+// Em sucesso retorna { bumped }; em falha parcial (versão publicada mas log
+// não gravado) retorna { bumped, error } para a UI poder refletir o estado.
+export async function publishMajorVersion(
+  projectId: string,
+): Promise<{ bumped?: { major: number; minor: number; patch: number }; error?: string }> {
   const [supabase, user] = await Promise.all([
     createSupabaseServer(),
     getAuthUser(),
   ]);
-  if (!user) throw new Error("Não autenticado");
+  if (!user) return { error: "Não autenticado" };
 
   const { data: project } = await supabase
     .from("projects")
@@ -555,17 +608,21 @@ export async function publishMajorVersion(projectId: string) {
   };
   const bumped = bumpVersion(current, "major");
 
-  await updateOrThrow(
-    supabase,
-    "projects",
-    {
-      schema_version_major: bumped.major,
-      schema_version_minor: bumped.minor,
-      schema_version_patch: bumped.patch,
-    },
-    { id: projectId },
-    { message: "Não foi possível publicar a MAJOR: sem permissão para alterar este projeto." },
-  );
+  try {
+    await updateOrThrow(
+      supabase,
+      "projects",
+      {
+        schema_version_major: bumped.major,
+        schema_version_minor: bumped.minor,
+        schema_version_patch: bumped.patch,
+      },
+      { id: projectId },
+      { message: "Não foi possível publicar a MAJOR: sem permissão para alterar este projeto." },
+    );
+  } catch (e) {
+    return { error: errorMessage(e, "Erro ao publicar a MAJOR") };
+  }
 
   const { error: logErr } = await supabase.from("schema_change_log").insert({
     project_id: projectId,
@@ -579,24 +636,26 @@ export async function publishMajorVersion(projectId: string) {
     version_minor: bumped.minor,
     version_patch: bumped.patch,
   });
-  if (logErr) {
-    throw new Error(
-      `MAJOR publicada, mas falha ao registrar o histórico: ${logErr.message}`,
-    );
-  }
 
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/analyze/compare`);
   revalidatePath(`/projects/${projectId}/reviews`);
   revalidatePath(`/projects/${projectId}/llm/configure`);
-  return bumped;
+
+  if (logErr) {
+    return {
+      bumped,
+      error: `MAJOR publicada, mas falha ao registrar o histórico: ${logErr.message}`,
+    };
+  }
+  return { bumped };
 }
 
 export async function toggleLlmField(
   projectId: string,
   fieldDef: PydanticField,
   enabled: boolean
-) {
+): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();
   const { data: project } = await supabase
     .from("projects")
@@ -614,7 +673,7 @@ export async function toggleLlmField(
     fields = fields.filter((f) => f.name !== fieldDef.name);
   }
 
-  await saveSchemaFromGUI(projectId, fields);
+  return saveSchemaFromGUI(projectId, fields);
 }
 
 export async function saveLlmConfig(
@@ -624,12 +683,17 @@ export async function saveLlmConfig(
     llm_model: string;
     llm_kwargs: Record<string, unknown>;
   }
-) {
+): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();
-  await updateOrThrow(supabase, "projects", config, { id: projectId }, {
-    message:
-      "Não foi possível salvar a configuração do LLM: sem permissão para alterar este projeto.",
-  });
+  try {
+    await updateOrThrow(supabase, "projects", config, { id: projectId }, {
+      message:
+        "Não foi possível salvar a configuração do LLM: sem permissão para alterar este projeto.",
+    });
+  } catch (e) {
+    return { error: errorMessage(e, "Erro ao salvar a configuração do LLM") };
+  }
   revalidatePath(`/projects/${projectId}/llm/configure`);
   revalidatePath(`/projects/${projectId}/config`);
+  return {};
 }

--- a/frontend/src/actions/stats.ts
+++ b/frontend/src/actions/stats.ts
@@ -14,15 +14,18 @@ export async function resolveReviewComment(
 
     const supabase = await createSupabaseServer();
 
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("reviews")
       .update({
         resolved_at: new Date().toISOString(),
         resolved_by: user.id,
       })
-      .eq("id", reviewId);
+      .eq("id", reviewId)
+      .select("id");
 
     if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0)
+      return { success: false, error: "Sem permissão para resolver este comentário" };
 
     revalidatePath(`/projects/${projectId}/reviews`);
     return { success: true };
@@ -41,15 +44,18 @@ export async function reopenReviewComment(
 
     const supabase = await createSupabaseServer();
 
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("reviews")
       .update({
         resolved_at: null,
         resolved_by: null,
       })
-      .eq("id", reviewId);
+      .eq("id", reviewId)
+      .select("id");
 
     if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0)
+      return { success: false, error: "Sem permissão para reabrir este comentário" };
 
     revalidatePath(`/projects/${projectId}/reviews`);
     return { success: true };
@@ -95,13 +101,16 @@ export async function reopenNote(
 
     const supabase = await createSupabaseServer();
 
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("note_resolutions")
       .delete()
       .eq("project_id", projectId)
-      .eq("response_id", responseId);
+      .eq("response_id", responseId)
+      .select("response_id");
 
     if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0)
+      return { success: false, error: "Nada reaberto: sem permissão ou anotação já reaberta" };
 
     revalidatePath(`/projects/${projectId}/reviews`);
     return { success: true };
@@ -213,13 +222,16 @@ export async function reopenDifficulty(
 
     const supabase = await createSupabaseServer();
 
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("difficulty_resolutions")
       .delete()
       .eq("project_id", projectId)
-      .eq("response_id", responseId);
+      .eq("response_id", responseId)
+      .select("response_id");
 
     if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0)
+      return { success: false, error: "Nada reaberto: sem permissão ou dificuldade já reaberta" };
 
     revalidatePath(`/projects/${projectId}/reviews`);
     return { success: true };
@@ -309,14 +321,17 @@ export async function reopenError(
 
     const supabase = await createSupabaseServer();
 
-    const { error } = await supabase
+    const { data, error } = await supabase
       .from("error_resolutions")
       .delete()
       .eq("project_id", projectId)
       .eq("document_id", documentId)
-      .eq("field_name", fieldName);
+      .eq("field_name", fieldName)
+      .select("document_id");
 
     if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0)
+      return { success: false, error: "Nada reaberto: sem permissão ou erro já reaberto" };
 
     revalidatePath(`/projects/${projectId}/reviews`);
     return { success: true };

--- a/frontend/src/actions/suggestions.ts
+++ b/frontend/src/actions/suggestions.ts
@@ -78,15 +78,15 @@ export async function resolveSchemaSuggestion(
     // Save schema (triggers audit log). Em falha (ex.: RLS filtrou o UPDATE
     // de projects — #178), retorna sem marcar a sugestão como aprovada,
     // evitando a divergência "Aprovada" com schema não aplicado.
-    try {
-      await saveSchemaFromGUI(projectId, updatedFields);
-    } catch (e) {
-      return { error: e instanceof Error ? e.message : "Erro ao aplicar a sugestão ao schema" };
-    }
+    const saved = await saveSchemaFromGUI(projectId, updatedFields);
+    if (saved.error) return { error: saved.error };
   }
 
-  // Mark suggestion as resolved
-  const { error } = await supabase
+  // Mark suggestion as resolved. O .select() detecta o caso inverso ao da
+  // #178: schema já aplicado mas UPDATE de schema_suggestions filtrado pela
+  // RLS (0 linhas) — sem o guard, a action retornaria sucesso com a sugestão
+  // ainda "pendente".
+  const { data: updated, error } = await supabase
     .from("schema_suggestions")
     .update({
       status: action,
@@ -94,9 +94,18 @@ export async function resolveSchemaSuggestion(
       resolved_at: new Date().toISOString(),
       ...(rejectionReason && { rejection_reason: rejectionReason }),
     })
-    .eq("id", suggestionId);
+    .eq("id", suggestionId)
+    .select("id");
 
   if (error) return { error: error.message };
+  if (!updated || updated.length === 0) {
+    return {
+      error:
+        action === "approved"
+          ? "Schema aplicado, mas sem permissão para marcar a sugestão como aprovada."
+          : "Sem permissão para resolver esta sugestão.",
+    };
+  }
   revalidatePath(`/projects/${projectId}/reviews/comments`);
   return {};
 }
@@ -116,22 +125,25 @@ export async function approveSchemaSuggestionWithEdits(
 
   // Mesma proteção de resolveSchemaSuggestion: sugestão só vira "approved"
   // depois que o schema persistiu de fato.
-  try {
-    await saveSchemaFromGUI(projectId, editedFields);
-  } catch (e) {
-    return { error: e instanceof Error ? e.message : "Erro ao aplicar a sugestão ao schema" };
-  }
+  const saved = await saveSchemaFromGUI(projectId, editedFields);
+  if (saved.error) return { error: saved.error };
 
-  const { error } = await supabase
+  const { data: updated, error } = await supabase
     .from("schema_suggestions")
     .update({
       status: "approved",
       resolved_by: user.id,
       resolved_at: new Date().toISOString(),
     })
-    .eq("id", suggestionId);
+    .eq("id", suggestionId)
+    .select("id");
 
   if (error) return { error: error.message };
+  if (!updated || updated.length === 0) {
+    return {
+      error: "Schema aplicado, mas sem permissão para marcar a sugestão como aprovada.",
+    };
+  }
   revalidatePath(`/projects/${projectId}/reviews/comments`);
   return {};
 }

--- a/frontend/src/actions/suggestions.ts
+++ b/frontend/src/actions/suggestions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
 import { revalidatePath } from "next/cache";
 import { saveSchemaFromGUI } from "./schema";
 import type { PydanticField } from "@/lib/types";
@@ -38,6 +38,9 @@ export async function resolveSchemaSuggestion(
 ): Promise<{ error?: string }> {
   const user = await getAuthUser();
   if (!user) return { error: "Não autenticado" };
+  if (!(await isProjectCoordinator(projectId, user))) {
+    return { error: "Apenas coordenadores podem resolver sugestões de schema." };
+  }
 
   const supabase = await createSupabaseServer();
 
@@ -72,8 +75,14 @@ export async function resolveSchemaSuggestion(
       };
     });
 
-    // Save schema (triggers audit log)
-    await saveSchemaFromGUI(projectId, updatedFields);
+    // Save schema (triggers audit log). Em falha (ex.: RLS filtrou o UPDATE
+    // de projects — #178), retorna sem marcar a sugestão como aprovada,
+    // evitando a divergência "Aprovada" com schema não aplicado.
+    try {
+      await saveSchemaFromGUI(projectId, updatedFields);
+    } catch (e) {
+      return { error: e instanceof Error ? e.message : "Erro ao aplicar a sugestão ao schema" };
+    }
   }
 
   // Mark suggestion as resolved
@@ -99,10 +108,19 @@ export async function approveSchemaSuggestionWithEdits(
 ): Promise<{ error?: string }> {
   const user = await getAuthUser();
   if (!user) return { error: "Não autenticado" };
+  if (!(await isProjectCoordinator(projectId, user))) {
+    return { error: "Apenas coordenadores podem aprovar sugestões de schema." };
+  }
 
   const supabase = await createSupabaseServer();
 
-  await saveSchemaFromGUI(projectId, editedFields);
+  // Mesma proteção de resolveSchemaSuggestion: sugestão só vira "approved"
+  // depois que o schema persistiu de fato.
+  try {
+    await saveSchemaFromGUI(projectId, editedFields);
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : "Erro ao aplicar a sugestão ao schema" };
+  }
 
   const { error } = await supabase
     .from("schema_suggestions")

--- a/frontend/src/app/(app)/projects/[id]/config/general/GeneralForm.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/general/GeneralForm.tsx
@@ -37,12 +37,13 @@ export function GeneralForm({
     }
     setSaving(true);
     try {
-      await updateProject(projectId, {
+      const r = await updateProject(projectId, {
         name: trimmedName,
         description,
         arbitration_blind: arbitrationBlind,
       });
-      toast.success("Projeto atualizado!");
+      if (r?.error) toast.error(r.error);
+      else toast.success("Projeto atualizado!");
     } catch (e) {
       toast.error(e instanceof Error ? e.message : "Erro ao salvar");
     }

--- a/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
@@ -46,11 +46,15 @@ export function RulesForm({
   function handleSave() {
     startTransition(async () => {
       try {
-        await updateProject(projectId, {
+        const r = await updateProject(projectId, {
           resolution_rule: rule,
           min_responses_for_comparison: min,
           allow_researcher_review: allowReview,
         });
+        if (r?.error) {
+          toast.error(r.error);
+          return;
+        }
       } catch (e) {
         toast.error(e instanceof Error ? e.message : "Erro ao salvar as regras");
         return;

--- a/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { updateProject } from "@/actions/projects";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -44,11 +45,16 @@ export function RulesForm({
 
   function handleSave() {
     startTransition(async () => {
-      await updateProject(projectId, {
-        resolution_rule: rule,
-        min_responses_for_comparison: min,
-        allow_researcher_review: allowReview,
-      });
+      try {
+        await updateProject(projectId, {
+          resolution_rule: rule,
+          min_responses_for_comparison: min,
+          allow_researcher_review: allowReview,
+        });
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "Erro ao salvar as regras");
+        return;
+      }
       setSaved(true);
       refresh();
       setTimeout(() => setSaved(false), 2000);

--- a/frontend/src/components/config/RoundsConfig.tsx
+++ b/frontend/src/components/config/RoundsConfig.tsx
@@ -66,8 +66,15 @@ export function RoundsConfig({
     if (!label) return;
     startTransition(async () => {
       const r = await createRound(projectId, label, rounds.length === 0);
-      if (r.error) toast.error(r.error);
-      else {
+      if (r.error) {
+        toast.error(r.error);
+        // Estado parcial: a rodada existe mas não virou a atual — atualiza a
+        // lista para o coordenador poder marcá-la manualmente.
+        if (r.id) {
+          setNewLabel("");
+          refresh();
+        }
+      } else {
         toast.success("Rodada criada");
         setNewLabel("");
         refresh();

--- a/frontend/src/components/llm/LlmConfigurePane.tsx
+++ b/frontend/src/components/llm/LlmConfigurePane.tsx
@@ -375,8 +375,9 @@ export function LlmConfigurePane({
   const handleSavePrompt = async () => {
     setSavingPrompt(true);
     try {
-      await savePrompt(projectId, prompt);
-      toast.success("Prompt salvo!");
+      const r = await savePrompt(projectId, prompt);
+      if (r?.error) toast.error(r.error);
+      else toast.success("Prompt salvo!");
     } catch (e: any) {
       toast.error(e.message);
     }
@@ -385,8 +386,9 @@ export function LlmConfigurePane({
 
   const handleSaveConfig = async () => {
     try {
-      await saveLlmConfig(projectId, config);
-      toast.success("Configuração salva!");
+      const r = await saveLlmConfig(projectId, config);
+      if (r?.error) toast.error(r.error);
+      else toast.success("Configuração salva!");
     } catch (e: any) {
       toast.error(e.message);
     }
@@ -398,10 +400,15 @@ export function LlmConfigurePane({
     setErrorInfo(null);
     try {
       // Save config before running
-      await Promise.all([
+      const [cfgResult, promptResult] = await Promise.all([
         saveLlmConfig(projectId, config),
         savePrompt(projectId, prompt),
       ]);
+      const saveError = cfgResult?.error ?? promptResult?.error;
+      if (saveError) {
+        toast.error(saveError);
+        return;
+      }
 
       const body: Record<string, unknown> = {
         project_id: projectId,
@@ -448,13 +455,20 @@ export function LlmConfigurePane({
     setHasAmbiguities(checked);
     startTransition(async () => {
       try {
-        await toggleLlmField(projectId, LLM_AMBIGUITIES_FIELD, checked);
+        const r = await toggleLlmField(projectId, LLM_AMBIGUITIES_FIELD, checked);
+        if (r?.error) {
+          // Reverte o estado otimista: o schema não mudou.
+          setHasAmbiguities(!checked);
+          toast.error(r.error);
+          return;
+        }
         toast.success(
           checked
             ? "Campo de ambiguidades adicionado"
             : "Campo de ambiguidades removido"
         );
       } catch (e: any) {
+        setHasAmbiguities(!checked);
         toast.error(e.message);
       }
     });

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -83,8 +83,15 @@ export function SchemaEditor({
   const handlePublishMajor = () => {
     startTransition(async () => {
       try {
-        const bumped = await publishMajorVersion(projectId);
-        toast.success(`Nova versão MAJOR publicada: ${bumped.major}.${bumped.minor}.${bumped.patch}`);
+        const r = await publishMajorVersion(projectId);
+        if (r?.error) {
+          toast.error(r.error);
+          // Falha parcial: a MAJOR foi publicada (só o log falhou) — reflete.
+          if (!r.bumped) return;
+        } else if (r?.bumped) {
+          const b = r.bumped;
+          toast.success(`Nova versão MAJOR publicada: ${b.major}.${b.minor}.${b.patch}`);
+        }
         setMajorDialogOpen(false);
         refresh();
       } catch (e: unknown) {
@@ -97,11 +104,15 @@ export function SchemaEditor({
   const handleBackfill = () => {
     startTransition(async () => {
       try {
-        const result = await backfillSchemaVersionHistory(projectId);
-        const v = result.finalVersion;
-        const m = result.byMethod;
+        const r = await backfillSchemaVersionHistory(projectId);
+        if (r?.error || !r?.stats) {
+          toast.error(r?.error ?? "Erro ao reconstruir");
+          return;
+        }
+        const v = r.stats.finalVersion;
+        const m = r.stats.byMethod;
         toast.success(
-          `v${v.major}.${v.minor}.${v.patch} · ${result.logEntriesUpdated} entradas, ${result.responsesProcessed} respostas — hashes: ${m.hashes}, created_at: ${m.created_at}, fallback: ${m.fallback_created_at}, live_save: ${m.live_save}`,
+          `v${v.major}.${v.minor}.${v.patch} · ${r.stats.logEntriesUpdated} entradas, ${r.stats.responsesProcessed} respostas — hashes: ${m.hashes}, created_at: ${m.created_at}, fallback: ${m.fallback_created_at}, live_save: ${m.live_save}`,
           { duration: 10000 },
         );
         setBackfillDialogOpen(false);
@@ -184,14 +195,22 @@ export function SchemaEditor({
             return;
           }
           setGuiErrors([]);
-          await saveSchemaFromGUI(projectId, fields);
+          const r = await saveSchemaFromGUI(projectId, fields);
+          if (r?.error) {
+            toast.error(r.error);
+            return;
+          }
           toast.success("Schema salvo!");
         } else {
           if (validationStatus !== "valid") {
             toast.error("Valide o schema antes de salvar");
             return;
           }
-          await saveSchema(projectId, code, codeFields);
+          const r = await saveSchema(projectId, code, codeFields);
+          if (r?.error) {
+            toast.error(r.error);
+            return;
+          }
           toast.success("Schema salvo!");
         }
       } catch (e: any) {

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -169,7 +169,8 @@ export function EditFieldDialog({
           if (result.error) throw new Error(result.error);
           toast.success("Sugestão aprovada e campo atualizado");
         } else {
-          await saveSchemaFromGUI(projectId, updatedFields);
+          const result = await saveSchemaFromGUI(projectId, updatedFields);
+          if (result?.error) throw new Error(result.error);
           toast.success("Campo atualizado");
         }
         onOpenChange(false);

--- a/frontend/src/lib/__tests__/rls-guard.test.ts
+++ b/frontend/src/lib/__tests__/rls-guard.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { updateOrThrow, deleteOrThrow, ZeroRowsError } from "../supabase/rls-guard";
+
+// Client mínimo: registra a cadeia chamada e resolve com o resultado fixado.
+function makeClient(result: { data: unknown; error: { message: string } | null }) {
+  const calls: Record<string, unknown[]> = {};
+  const builder = {
+    update(payload: unknown) {
+      calls.update = [payload];
+      return builder;
+    },
+    delete() {
+      calls.delete = [];
+      return builder;
+    },
+    match(m: unknown) {
+      calls.match = [m];
+      return builder;
+    },
+    select(col: string) {
+      calls.select = [col];
+      return Promise.resolve(result);
+    },
+  };
+  const client = { from: (table: string) => ((calls.from = [table]), builder) };
+  return { client: client as unknown as SupabaseClient, calls };
+}
+
+describe("updateOrThrow", () => {
+  it("retorna as linhas afetadas no caminho feliz", async () => {
+    const { client, calls } = makeClient({ data: [{ id: "p1" }], error: null });
+    const rows = await updateOrThrow(client, "projects", { name: "X" }, { id: "p1" });
+    expect(rows).toEqual([{ id: "p1" }]);
+    expect(calls.from).toEqual(["projects"]);
+    expect(calls.match).toEqual([{ id: "p1" }]);
+    expect(calls.select).toEqual(["id"]);
+  });
+
+  it("lança Error com a mensagem do PostgREST em erro real", async () => {
+    const { client } = makeClient({ data: null, error: { message: "boom" } });
+    await expect(
+      updateOrThrow(client, "projects", { name: "X" }, { id: "p1" }),
+    ).rejects.toThrow("boom");
+  });
+
+  it("lança ZeroRowsError em 0 linhas (RLS filtrou ou registro inexistente)", async () => {
+    const { client } = makeClient({ data: [], error: null });
+    const promise = updateOrThrow(client, "projects", { name: "X" }, { id: "p1" });
+    await expect(promise).rejects.toBeInstanceOf(ZeroRowsError);
+    await expect(promise).rejects.toThrow(/sem permissão/i);
+  });
+
+  it("usa a copy custom de opts.message", async () => {
+    const { client } = makeClient({ data: [], error: null });
+    await expect(
+      updateOrThrow(client, "projects", { name: "X" }, { id: "p1" }, {
+        message: "Sem permissão para alterar este projeto.",
+      }),
+    ).rejects.toThrow("Sem permissão para alterar este projeto.");
+  });
+
+  it("respeita selectColumn custom para tabelas sem coluna id", async () => {
+    const { client, calls } = makeClient({ data: [{ review_id: "r1" }], error: null });
+    await updateOrThrow(client, "verdict_acknowledgments", { resolved_at: null }, { review_id: "r1" }, {
+      selectColumn: "review_id",
+    });
+    expect(calls.select).toEqual(["review_id"]);
+  });
+});
+
+describe("deleteOrThrow", () => {
+  it("retorna as linhas removidas no caminho feliz", async () => {
+    const { client, calls } = makeClient({ data: [{ id: "r1" }], error: null });
+    const rows = await deleteOrThrow(client, "rounds", { id: "r1" });
+    expect(rows).toEqual([{ id: "r1" }]);
+    expect(calls.delete).toEqual([]);
+  });
+
+  it("lança ZeroRowsError em 0 linhas", async () => {
+    const { client } = makeClient({ data: [], error: null });
+    await expect(deleteOrThrow(client, "rounds", { id: "r1" })).rejects.toBeInstanceOf(
+      ZeroRowsError,
+    );
+  });
+});

--- a/frontend/src/lib/supabase/rls-guard.ts
+++ b/frontend/src/lib/supabase/rls-guard.ts
@@ -1,0 +1,69 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// UPDATE/DELETE via client RLS que não casa nenhuma linha (porque a policy
+// filtrou, ou porque o registro não existe) retorna sucesso com 0 linhas e
+// error=null no PostgREST — sem este guard a falha é invisível e a UI mostra
+// sucesso falso (issue #178: coordenador não-criador "salvava" o schema sem
+// persistir nada). Todo UPDATE/DELETE de Server Action via createSupabaseServer
+// deve passar por aqui ou checar 0-rows manualmente.
+
+export class ZeroRowsError extends Error {
+  constructor(
+    public readonly table: string,
+    public readonly operation: "update" | "delete",
+    message?: string,
+  ) {
+    super(
+      message ??
+        `Nenhuma linha alterada em ${table}: sem permissão (RLS) ou registro inexistente.`,
+    );
+    this.name = "ZeroRowsError";
+  }
+}
+
+interface GuardOpts {
+  // Copy pt-BR específica do fluxo — vai para o toast do usuário.
+  message?: string;
+  // Para tabelas sem coluna `id`.
+  selectColumn?: string;
+}
+
+export async function updateOrThrow(
+  supabase: SupabaseClient,
+  table: string,
+  payload: Record<string, unknown>,
+  match: Record<string, unknown>,
+  opts?: GuardOpts,
+): Promise<Array<Record<string, unknown>>> {
+  const col = opts?.selectColumn ?? "id";
+  const { data, error } = await supabase
+    .from(table)
+    .update(payload)
+    .match(match)
+    .select(col);
+  if (error) throw new Error(error.message);
+  if (!data || data.length === 0) {
+    throw new ZeroRowsError(table, "update", opts?.message);
+  }
+  // `col` dinâmico faz o supabase-js tipar data como GenericStringError[].
+  return data as unknown as Array<Record<string, unknown>>;
+}
+
+export async function deleteOrThrow(
+  supabase: SupabaseClient,
+  table: string,
+  match: Record<string, unknown>,
+  opts?: GuardOpts,
+): Promise<Array<Record<string, unknown>>> {
+  const col = opts?.selectColumn ?? "id";
+  const { data, error } = await supabase
+    .from(table)
+    .delete()
+    .match(match)
+    .select(col);
+  if (error) throw new Error(error.message);
+  if (!data || data.length === 0) {
+    throw new ZeroRowsError(table, "delete", opts?.message);
+  }
+  return data as unknown as Array<Record<string, unknown>>;
+}

--- a/frontend/src/lib/supabase/rls-guard.ts
+++ b/frontend/src/lib/supabase/rls-guard.ts
@@ -6,6 +6,15 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 // sucesso falso (issue #178: coordenador não-criador "salvava" o schema sem
 // persistir nada). Todo UPDATE/DELETE de Server Action via createSupabaseServer
 // deve passar por aqui ou checar 0-rows manualmente.
+//
+// Pressuposto: o .select() pós-write usa RETURNING, que no Postgres exige que
+// a linha afetada seja visível pela policy de SELECT. Se uma tabela tiver
+// policy de UPDATE/DELETE mais permissiva que a de SELECT, o guard reporta
+// falha falsa após uma escrita bem-sucedida — alinhar as policies antes de
+// usar o guard nessa tabela.
+//
+// Os throws daqui não devem atravessar a fronteira de uma Server Action: o
+// Next mascara a message em produção. A action captura e retorna { error }.
 
 export class ZeroRowsError extends Error {
   constructor(


### PR DESCRIPTION
## Contexto

Complemento de aplicação do fix da #178 — o PR #188 corrige as policies RLS (causa raiz); este PR garante que **falha silenciosa nunca mais pareça sucesso**, para qualquer ator e qualquer tabela.

O PostgREST devolve sucesso com 0 linhas e `error=null` quando a RLS filtra um UPDATE/DELETE. Várias Server Actions checavam só `error`: o save mostrava toast de sucesso sem persistir nada, e em `saveSchemaFromGUI` o INSERT do histórico rodava mesmo com o UPDATE de projects filtrado — o mecanismo exato das 80 entradas fantasma encontradas em produção.

## Mudanças

- **`lib/supabase/rls-guard.ts` (novo):** `updateOrThrow`/`deleteOrThrow` — `.select()` pós-write, `Error` em erro PostgREST, `ZeroRowsError` (copy pt-BR mencionando permissão) em 0 linhas.
- **`schema.ts`:** `saveSchema`/`savePrompt`/`publishMajorVersion`/`saveLlmConfig` via helper; o insert em `schema_change_log` só roda após o update confirmado e com `{error}` checado; `backfillSchemaVersionHistory` valida 0-rows nos 3 passos (entradas do log, versão do projeto, versionamento de responses).
- **`projects.ts`:** `updateProject`/`deleteProject` via helper (regras de resolução salvas por coordenador não-criador eram no-op mudo).
- **`rounds.ts`:** `setCurrentRound`/`setRoundStrategy`/`renameRound`/`deleteRound` checam 0-rows; `createRound(setAsCurrent)` devolve `{id, error}` no estado parcial (rodada criada sem virar a atual).
- **`suggestions.ts`:** sugestão só é marcada "approved" se o `saveSchemaFromGUI` persistiu (antes aprovava com schema não aplicado); assert server-side de coordenador.
- **`stats.ts`/`members.ts`:** resolve/reopen de comentários de review e reopen de note/difficulty/error + `changeRole`/`setCanResolve` checam 0-rows (padrão já existente em `resolveDuvida`).
- **`reviews.ts`:** comentário automático de ambiguidade com `author_id = user.id` — a policy de INSERT exige `author_id = clerk_uid()`; com `effectiveId`, a primeira conta-alias da spec 002 tomaria 42501.
- **UI:** `RulesForm` ganha try/catch + toast (o throw morria mudo dentro da transition e o usuário não via nada); `RoundsConfig` trata o estado parcial.
- **Testes:** `rls-guard.test.ts`, `schema.test.ts` (o caso da #178: update de projects filtrado → rejeita **sem** gravar log fantasma; ordem update→log; erro do log reportado) e `rounds.test.ts`. Suite 374/374, `tsc` e `next build` limpos.

## Sequência de rollout

Mergear **depois** do #188 + `db push` (com a RLS antiga no ar, este PR transforma os no-ops mudos do coordenador em erro visível — honesto, mas a UX boa exige as policies novas; e o backfill passa a depender da policy de UPDATE em `schema_change_log` criada lá).

Ref #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)
