### PR TITLE
chore(security): secret scanning com gitleaks (CI + pre-commit) (#165)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -29,3 +29,8 @@ jobs:
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Comentario de PR desligado de proposito: ele exige `pull-requests:
+          # write`, e mantemos o token em `contents: read` (menor privilegio).
+          # O gate ja falha o check ao achar segredo e o log do gitleaks aponta
+          # arquivo/linha/regra — o comentario inline seria so redundante.
+          GITLEAKS_ENABLE_COMMENTS: "false"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,31 @@
+name: Secret scan (gitleaks)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Historico completo para o gitleaks computar o range de commits.
+          fetch-depth: 0
+      # Pin a SHA (v3.0.0) por supply-chain safety — tags sao refs mutaveis.
+      # Conta pessoal (bdcdo): nao requer GITLEAKS_LICENSE (so organizacoes).
+      # Escaneia o diff do PR e os commits do push, nunca a historia inteira,
+      # entao o vazamento pre-#157 (revogado no #165) nao dispara aqui.
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+# Hooks de pre-commit. Habilite uma vez por checkout com `pre-commit install`
+# (instale a ferramenta antes: `pipx install pre-commit` ou
+# `uv tool install pre-commit`). O CI roda o mesmo gitleaks em todo push/PR
+# via .github/workflows/secret-scan.yml — este hook é a primeira barreira,
+# antes do segredo entrar no histórico.
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # Hooks de pre-commit. Habilite uma vez por checkout com `pre-commit install`
 # (instale a ferramenta antes: `pipx install pre-commit` ou
-# `uv tool install pre-commit`). O CI roda o mesmo gitleaks em todo push/PR
-# via .github/workflows/secret-scan.yml — este hook é a primeira barreira,
-# antes do segredo entrar no histórico.
+# `uv tool install pre-commit`). O CI roda o mesmo gitleaks em todo PR e push
+# para `main` via .github/workflows/secret-scan.yml — este hook é a primeira
+# barreira, antes do segredo entrar no histórico.
 repos:
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ npx supabase db push
 
 ## Secret scanning
 
-O repositório roda [gitleaks](https://github.com/gitleaks/gitleaks) em dois pontos: no CI (`.github/workflows/secret-scan.yml`, em todo push e PR) e como hook de pre-commit local. Para habilitar o hook (uma vez por checkout):
+O repositório roda [gitleaks](https://github.com/gitleaks/gitleaks) em dois pontos: no CI (`.github/workflows/secret-scan.yml`, em todo PR e em push para `main`) e como hook de pre-commit local. Para habilitar o hook (uma vez por checkout):
 
 ```bash
 pipx install pre-commit   # ou: uv tool install pre-commit

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ npx supabase start
 npx supabase db push
 ```
 
+## Secret scanning
+
+O repositório roda [gitleaks](https://github.com/gitleaks/gitleaks) em dois pontos: no CI (`.github/workflows/secret-scan.yml`, em todo push e PR) e como hook de pre-commit local. Para habilitar o hook (uma vez por checkout):
+
+```bash
+pipx install pre-commit   # ou: uv tool install pre-commit
+pre-commit install
+```
+
+A partir daí, cada commit é varrido em busca de segredos antes de entrarem no histórico.
+
 ## Deploy (Produção)
 
 ### 1. Supabase Cloud


### PR DESCRIPTION
## Contexto

Implementa a **parte 3 (prevenção)** do #165: adiciona varredura de segredos para evitar que credenciais voltem a entrar no repositório (como o `keyless.json` do Clerk que motivou a issue).

## Mudanças

- **CI** — `.github/workflows/secret-scan.yml`: roda `gitleaks-action` (pin de SHA na **v3.0.0**, seguindo a convenção de pinar third-party actions já usada no `fly-deploy.yml`) em push para `main`, PR e `workflow_dispatch`.
- **Pre-commit** — `.pre-commit-config.yaml`: hook `gitleaks` (**v8.30.1**), primeira barreira local antes do segredo entrar no histórico.
- **README** — nota de como habilitar o hook (`pre-commit install`).

## Notas de design

- **Escaneamento por evento** (diff do PR + commits do push), nunca a história inteira. Logo o `keyless.json` vazado **antes do #157** (já fora do tree, e que será **rotacionado** nas partes 0/1 do #165) **não dispara** o CI. Um comentário no workflow documenta isso.
- **Conta pessoal** (`bdcdo`) não requer `GITLEAKS_LICENSE` — só organizações precisam (anotado em comentário, caso o repo migre para uma org).

## Escopo

Fecha apenas a **prevenção** do #165. As partes **0 (reivindicar a instância via `claimUrl`)** e **1 (rotação da `sk_test` + claim-token)** são ações no dashboard do Clerk e ficam para a **janela do cutover de domínio** — por isso `Refs` e não `Closes`.

Refs #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)