### PR TITLE
fix(auto-review): não arbitrar codificações incompletas no backlog (#174)

### DIFF
--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -8,6 +8,7 @@ import {
   isProjectCoordinator,
 } from "@/lib/auth";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
+import { isCodingComplete } from "@/lib/coding-completeness";
 import { canonicalPair, type EquivalencePair } from "@/lib/equivalence";
 import { resolveBlindVerdict } from "@/lib/arbitration-order";
 import { verdictRequiresJustification } from "@/lib/auto-review-decided";
@@ -947,6 +948,16 @@ export async function regenerateAutoReviewBacklog(
     for (const human of queue) {
       const llm = llmByDocId.get(human.document_id);
       if (!llm) continue;
+
+      // #174: só arbitrar codificações completas. is_partial é sinal inútil de
+      // completude para o humano (quase sempre false), então o filtro de query
+      // não basta: aqui pulamos respostas humanas cuja codificação não está
+      // completa. Espelha o gate inline de saveResponse (allAnswered) via o
+      // mesmo helper. Sem isto, codificações em andamento eram varridas para a
+      // arbitragem e apareciam como "(vazio)" em diversos campos.
+      if (!isCodingComplete(fields, (human.answers as Record<string, unknown>) ?? {})) {
+        continue;
+      }
 
       const divergent = computeDivergentFieldNames(
         fields,

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -4,6 +4,7 @@ import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getEffectiveMemberId } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { isFieldVisible } from "@/lib/conditional";
+import { isCodingComplete } from "@/lib/coding-completeness";
 import { createAutoReviewIfDiverges } from "@/lib/auto-review";
 import type { PydanticField } from "@/lib/types";
 
@@ -135,26 +136,9 @@ export async function saveResponse(
     }
 
     if (fields.length > 0) {
-      const humanFields = fields.filter(
-        (f) =>
-          (f.target || "all") !== "llm_only" &&
-          f.target !== "none" &&
-          f.required !== false &&
-          isFieldVisible(f, sanitizedAnswers),
-      );
-      const OTHER_PREFIX = "Outro: ";
-      const isIncompleteOther = (v: unknown) =>
-        typeof v === "string" && v === OTHER_PREFIX;
-      const allAnswered = humanFields.every((f) => {
-        const v = sanitizedAnswers[f.name];
-        if (v === undefined || v === null || v === "") return false;
-        if (f.type === "single" && isIncompleteOther(v)) return false;
-        if (f.type === "multi" && Array.isArray(v)) {
-          if (v.length === 0) return false;
-          if (v.some(isIncompleteOther)) return false;
-        }
-        return true;
-      });
+      // Definição única de "codificação completa" — ver lib/coding-completeness.
+      // O mesmo helper gateia o backlog de auto-revisão (issue #174).
+      const allAnswered = isCodingComplete(fields, sanitizedAnswers);
 
       // Auto-save nunca promove para "concluido" — mesmo que todos os campos
       // estejam preenchidos, o pesquisador ainda nao clicou em Enviar. Sem essa

--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { Check, Info, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { OTHER_PREFIX } from "@/lib/other-option";
 import {
   arePartsValid,
   buildDateValue,
@@ -30,7 +31,6 @@ interface FieldRendererProps {
 }
 
 const NOT_INFORMED = "Não informada";
-export const OTHER_PREFIX = "Outro: ";
 const isOtherValue = (v: unknown): v is string =>
   typeof v === "string" && v.startsWith(OTHER_PREFIX);
 const otherText = (v: string) => v.slice(OTHER_PREFIX.length);

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -9,6 +9,7 @@ import { Check, GripVertical, Loader2, MessageSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { isFieldVisible } from "@/lib/conditional";
+import { isIncompleteOther } from "@/lib/other-option";
 import { reorderFullList } from "@/lib/field-order";
 import { getScrollBehavior } from "@/lib/scroll";
 import type { PydanticField } from "@/lib/types";
@@ -29,9 +30,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-const OTHER_PREFIX = "Outro: ";
-const isIncompleteOther = (v: unknown) =>
-  typeof v === "string" && v === OTHER_PREFIX;
 const isAnsweredValue = (field: PydanticField, val: unknown): boolean => {
   if (val === undefined || val === null || val === "") return false;
   if (field.type === "single" && isIncompleteOther(val)) return false;

--- a/frontend/src/lib/__tests__/auto-review.test.ts
+++ b/frontend/src/lib/__tests__/auto-review.test.ts
@@ -151,6 +151,24 @@ describe("createAutoReviewIfDiverges", () => {
     });
   });
 
+  it("codificacao humana incompleta → divergentCount=0 e nenhum upsert (#174)", async () => {
+    const { createAutoReviewIfDiverges } = await import("@/lib/auto-review");
+    state.project = {
+      pydantic_fields: [
+        { name: "q1", type: "single", options: ["a", "b"], target: "all" },
+        { name: "q2", type: "single", options: ["x", "y"], target: "all" },
+      ],
+    };
+    // Humano so respondeu q1 (q2 ausente) → codificacao incompleta. Mesmo
+    // divergindo em q1, nao deve gerar arbitragem.
+    state.humanResponse = { id: "h1", answers: { q1: "a" } };
+    state.llmResponse = { id: "l1", answers: { q1: "b", q2: "x" } };
+
+    const r = await createAutoReviewIfDiverges("p1", "doc1", "user1");
+    expect(r.divergentCount).toBe(0);
+    expect(state.upserts).toHaveLength(0);
+  });
+
   it("equivalencia marcada → campo nao conta como divergente", async () => {
     const { createAutoReviewIfDiverges } = await import("@/lib/auto-review");
     state.project = {

--- a/frontend/src/lib/__tests__/coding-completeness.test.ts
+++ b/frontend/src/lib/__tests__/coding-completeness.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { isCodingComplete } from "@/lib/coding-completeness";
+import type { PydanticField } from "@/lib/types";
+
+// Helper: monta um PydanticField com defaults mínimos.
+function field(partial: Partial<PydanticField> & { name: string }): PydanticField {
+  return {
+    type: "single",
+    options: ["a", "b"],
+    description: "",
+    ...partial,
+  } as PydanticField;
+}
+
+describe("isCodingComplete", () => {
+  it("todos os campos obrigatórios respondidos → true", () => {
+    const fields = [field({ name: "q1" }), field({ name: "q2" })];
+    expect(isCodingComplete(fields, { q1: "a", q2: "b" })).toBe(true);
+  });
+
+  it("campo obrigatório ausente → false", () => {
+    const fields = [field({ name: "q1" }), field({ name: "q2" })];
+    expect(isCodingComplete(fields, { q1: "a" })).toBe(false);
+  });
+
+  it("campo obrigatório com string vazia → false", () => {
+    const fields = [field({ name: "q1" })];
+    expect(isCodingComplete(fields, { q1: "" })).toBe(false);
+  });
+
+  it("sem campos → true (nada exigido)", () => {
+    expect(isCodingComplete([], {})).toBe(true);
+  });
+
+  it("campo required:false ausente → true (não exigido)", () => {
+    const fields = [field({ name: "q1", required: false })];
+    expect(isCodingComplete(fields, {})).toBe(true);
+  });
+
+  it("campo target=llm_only ausente → true (não é do humano)", () => {
+    const fields = [field({ name: "q1", target: "llm_only" })];
+    expect(isCodingComplete(fields, {})).toBe(true);
+  });
+
+  it("campo target=none ausente → true (oculto)", () => {
+    const fields = [field({ name: "q1", target: "none" })];
+    expect(isCodingComplete(fields, {})).toBe(true);
+  });
+
+  it("condicional não-visível ausente → true (não exigido)", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    // q1='nao' → q2 invisível → não exigido, mesmo ausente
+    expect(isCodingComplete(fields, { q1: "nao" })).toBe(true);
+  });
+
+  it("condicional visível não respondido → false", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    // q1='sim' → q2 visível e exigido, mas ausente
+    expect(isCodingComplete(fields, { q1: "sim" })).toBe(false);
+    // q2 preenchido → completo
+    expect(isCodingComplete(fields, { q1: "sim", q2: "a" })).toBe(true);
+  });
+
+  it("multi com array vazio → false", () => {
+    const fields = [field({ name: "q1", type: "multi" })];
+    expect(isCodingComplete(fields, { q1: [] })).toBe(false);
+  });
+
+  it("multi preenchido → true", () => {
+    const fields = [field({ name: "q1", type: "multi" })];
+    expect(isCodingComplete(fields, { q1: ["a"] })).toBe(true);
+  });
+
+  it("single com 'Outro: ' incompleto → false", () => {
+    const fields = [field({ name: "q1", allow_other: true })];
+    expect(isCodingComplete(fields, { q1: "Outro: " })).toBe(false);
+    expect(isCodingComplete(fields, { q1: "Outro: cibavax" })).toBe(true);
+  });
+
+  it("multi com 'Outro: ' incompleto na lista → false", () => {
+    const fields = [field({ name: "q1", type: "multi", allow_other: true })];
+    expect(isCodingComplete(fields, { q1: ["a", "Outro: "] })).toBe(false);
+    expect(isCodingComplete(fields, { q1: ["a", "Outro: x"] })).toBe(true);
+  });
+
+  it("codificação quase vazia (1 de vários) → false", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2" }),
+      field({ name: "q3", type: "text", options: null }),
+      field({ name: "q4" }),
+    ];
+    expect(isCodingComplete(fields, { q1: "a" })).toBe(false);
+  });
+});

--- a/frontend/src/lib/auto-review.ts
+++ b/frontend/src/lib/auto-review.ts
@@ -1,5 +1,6 @@
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
+import { isCodingComplete } from "@/lib/coding-completeness";
 import type { EquivalencePair } from "@/lib/equivalence";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
@@ -83,6 +84,24 @@ export async function createAutoReviewIfDiverges(
   }
 
   const fields = project.pydantic_fields as PydanticField[];
+
+  // #174: nunca arbitrar codificacao incompleta. O caminho inline (saveResponse)
+  // ja so chama esta funcao apos allAnswered, mas a guarda evita regressao se a
+  // funcao for chamada de outro ponto — e usa a mesma definicao de completude
+  // (isCodingComplete) do gate inline e do backlog.
+  if (
+    !isCodingComplete(
+      fields,
+      (humanResponse.answers as Record<string, unknown>) ?? {},
+    )
+  ) {
+    log("skip_incomplete_coding", {
+      projectId,
+      documentId,
+      userId: humanUserId,
+    });
+    return { divergentCount: 0 };
+  }
 
   // Respeita equivalencias ja marcadas (aba Comparar ou veredito "equivalente"
   // da propria auto-revisao) — sem isto, um par marcado como equivalente

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -1,15 +1,6 @@
 import { isFieldVisible } from "@/lib/conditional";
+import { isIncompleteOther } from "@/lib/other-option";
 import type { PydanticField } from "@/lib/types";
-
-// Prefixo gravado quando o pesquisador escolhe a opção "Outro" mas ainda não
-// digitou o complemento de texto livre. Um valor exatamente igual ao prefixo
-// (sem complemento) conta como resposta incompleta. Mantido em sincronia com o
-// gate inline de saveResponse (actions/responses.ts).
-const OTHER_PREFIX = "Outro: ";
-
-function isIncompleteOther(v: unknown): boolean {
-  return typeof v === "string" && v === OTHER_PREFIX;
-}
 
 // Campos que o humano precisa responder para a codificação contar como
 // completa: visíveis para humano (target != "llm_only"/"none"), obrigatórios

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -1,0 +1,53 @@
+import { isFieldVisible } from "@/lib/conditional";
+import type { PydanticField } from "@/lib/types";
+
+// Prefixo gravado quando o pesquisador escolhe a opção "Outro" mas ainda não
+// digitou o complemento de texto livre. Um valor exatamente igual ao prefixo
+// (sem complemento) conta como resposta incompleta. Mantido em sincronia com o
+// gate inline de saveResponse (actions/responses.ts).
+const OTHER_PREFIX = "Outro: ";
+
+function isIncompleteOther(v: unknown): boolean {
+  return typeof v === "string" && v === OTHER_PREFIX;
+}
+
+// Campos que o humano precisa responder para a codificação contar como
+// completa: visíveis para humano (target != "llm_only"/"none"), obrigatórios
+// (required !== false) e cuja condição de visibilidade está satisfeita pelas
+// respostas atuais.
+export function requiredHumanFields(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+): PydanticField[] {
+  return fields.filter(
+    (f) =>
+      (f.target || "all") !== "llm_only" &&
+      f.target !== "none" &&
+      f.required !== false &&
+      isFieldVisible(f, answers),
+  );
+}
+
+// True quando todos os campos obrigatórios e visíveis para o humano estão
+// respondidos. Fonte única da regra de "codificação completa", espelhada pelo
+// gate inline de saveResponse (promoção a "concluido") e pelo backlog de
+// auto-revisão (regenerateAutoReviewBacklog). Ver issue #174: sem esse gate, o
+// backlog varria codificações em andamento (parciais) para a arbitragem, onde
+// apareciam como "(vazio)" em diversos campos. Puro/client-safe — usado tanto
+// em server actions quanto em testes Vitest.
+export function isCodingComplete(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+): boolean {
+  const required = requiredHumanFields(fields, answers);
+  return required.every((f) => {
+    const v = answers[f.name];
+    if (v === undefined || v === null || v === "") return false;
+    if (f.type === "single" && isIncompleteOther(v)) return false;
+    if (f.type === "multi" && Array.isArray(v)) {
+      if (v.length === 0) return false;
+      if (v.some(isIncompleteOther)) return false;
+    }
+    return true;
+  });
+}

--- a/frontend/src/lib/other-option.ts
+++ b/frontend/src/lib/other-option.ts
@@ -1,0 +1,14 @@
+// Prefixo gravado quando o pesquisador escolhe a opção "Outro" mas ainda não
+// digitou o complemento de texto livre. Fonte única do prefixo, compartilhada
+// entre o renderer de codificação (FieldRenderer), o cálculo de "respondido"
+// (QuestionsPanel) e o gate de codificação completa (coding-completeness).
+// Módulo puro/client-safe — sem React — para poder ser importado tanto em
+// componentes 'use client' quanto em server actions e testes Vitest.
+export const OTHER_PREFIX = "Outro: ";
+
+// True quando o valor é exatamente o prefixo "Outro" sem complemento — ou seja,
+// o pesquisador marcou "Outro" mas não digitou o texto livre. Conta como
+// resposta incompleta.
+export function isIncompleteOther(v: unknown): boolean {
+  return typeof v === "string" && v === OTHER_PREFIX;
+}


### PR DESCRIPTION
## Problema (issue #174)

Na arbitragem do projeto **Zolgensma**, o LLM aparecia dando "respostas vazias" em diversas perguntas. Investiguei os dados de produção (somente leitura) e a conclusão inverteu a hipótese inicial: o lado vazio é o **humano**, não o LLM.

Dos 1000 FieldReviews do projeto: 756 são divergência real de conteúdo, **232 são "humano vazio / LLM preencheu"** (espalhados por 19 campos), 11 são "LLM vazio" e 1 ambos vazios. Na fase cega (A vs B, sem rótulo), a célula vazia do humano é lida como "o LLM deu vazio". As 153 respostas do LLM em uso estão todas saudáveis (`llm_error = null`), descartando o "LLM bugado".

## Causa-raiz

Os 232 vazios-humanos vêm de **codificações incompletas** (1–6 de 28 campos) que entraram na arbitragem. `regenerateAutoReviewBacklog` selecionava as respostas humanas filtrando apenas por `is_partial=false` — sinal inútil de completude para humano (180 de 182 respostas têm `is_partial=false`) — **sem exigir codificação concluída**. Assim, 16 codificações `em_andamento` foram varridas e geraram **234 FieldReviews espúrios (23% do total)**. O caminho inline (`saveResponse`) está correto: só dispara a auto-revisão após `allAnswered`; o bug estava só no caminho de regeneração de backlog, que não replicava esse gate.

## Correção

- Extraio a regra de completude do gate inline de `saveResponse` para um helper puro **`isCodingComplete(fields, answers)`** (`frontend/src/lib/coding-completeness.ts`), client-safe e testável.
- **`saveResponse`** passa a consumir o helper (refator sem mudança de comportamento — definição única de "codificação completa").
- **`regenerateAutoReviewBacklog`** pula respostas humanas cuja codificação não está completa.
- **`createAutoReviewIfDiverges`** ganha a mesma guarda, para nenhum dos dois caminhos arbitrar codificação incompleta.

O gate é por **completude calculada das respostas**, não por status de assignment: verifiquei que 1 codificação `em_andamento` e 4 `sem assignment` estão completas — gatear por `status='concluido'` excluiria essas arbitragens legítimas.

## Testes

- Novo `coding-completeness.test.ts` (14 casos: completa/incompleta, condicional visível/oculta, `multi` vazio, `"Outro: "` incompleto, `required:false`, `target` llm_only/none).
- Novo caso em `auto-review.test.ts`: codificação incompleta → `divergentCount=0`, nenhum upsert.
- Suíte completa do frontend: 396 testes passando; lint limpo.

## Follow-ups (fora deste PR — operacional/config, não código)

- **Limpeza de dados no Zolgensma**: re-rodar "Regenerar backlog" após o merge remove os ~191 FieldReviews espúrios **pendentes** (o reconcile apaga pendentes fora do conjunto). Sobram ~43 já-tocados (22 `ambiguo`) + 28 comentários "(vazio)" que o reconcile preserva por design — decidir entre purgar (recomendado) ou resolver manualmente.
- **Schema**: marcar `q18_qual_outro_natjus` como condicional de `q17` (elimina os ~12 "LLM vazio" remanescentes, que são de configuração, não de código).
- **Workflow**: avisar os pesquisadores das 16 codificações `em_andamento` para concluí-las.

Refs #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)