### PR TITLE
fix(auto-review): isCodingComplete staleness-aware no caminho retroativo

### DIFF
--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -955,7 +955,18 @@ export async function regenerateAutoReviewBacklog(
       // completa. Espelha o gate inline de saveResponse (allAnswered) via o
       // mesmo helper. Sem isto, codificações em andamento eram varridas para a
       // arbitragem e apareciam como "(vazio)" em diversos campos.
-      if (!isCodingComplete(fields, (human.answers as Record<string, unknown>) ?? {})) {
+      //
+      // Staleness-aware: passamos answer_field_hashes porque a avaliação é
+      // RETROATIVA (schema atual vs. codificações antigas). Sem isto, um campo
+      // obrigatório adicionado depois (ex.: `medicamento`) tornaria toda
+      // codificação anterior "incompleta", varrendo arbitragens legítimas.
+      if (
+        !isCodingComplete(
+          fields,
+          (human.answers as Record<string, unknown>) ?? {},
+          human.answer_field_hashes as AnswerFieldHashes,
+        )
+      ) {
         continue;
       }
 

--- a/frontend/src/lib/__tests__/coding-completeness.test.ts
+++ b/frontend/src/lib/__tests__/coding-completeness.test.ts
@@ -99,3 +99,45 @@ describe("isCodingComplete", () => {
     expect(isCodingComplete(fields, { q1: "a" })).toBe(false);
   });
 });
+
+// Staleness-awareness (#174 follow-up): quando answer_field_hashes é fornecido,
+// um campo obrigatório ausente do snapshot não existia quando a resposta foi
+// codificada e não deve reprovar a completude. Sem isto, um campo adicionado ao
+// schema depois (ex.: `medicamento`) tornaria toda codificação antiga
+// falsamente "incompleta" na avaliação retroativa do backlog.
+describe("isCodingComplete — staleness-aware", () => {
+  it("campo obrigatório ausente do schema da época (não está nos hashes) → não exigido → true", () => {
+    const fields = [field({ name: "q1" }), field({ name: "medicamento", type: "multi" })];
+    // hashes da época só tinha q1 → medicamento não existia → não exigir
+    const hashes = { q1: "h1" };
+    expect(isCodingComplete(fields, { q1: "a" }, hashes)).toBe(true);
+  });
+
+  it("campo obrigatório que existia (está nos hashes) mas não respondido → false", () => {
+    const fields = [field({ name: "q1" }), field({ name: "q2" })];
+    const hashes = { q1: "h1", q2: "h2" };
+    expect(isCodingComplete(fields, { q1: "a" }, hashes)).toBe(false);
+    expect(isCodingComplete(fields, { q1: "a", q2: "b" }, hashes)).toBe(true);
+  });
+
+  it("hashes vazios = legacy → exige todos (comportamento staleness-blind)", () => {
+    const fields = [field({ name: "q1" }), field({ name: "medicamento", type: "multi" })];
+    expect(isCodingComplete(fields, { q1: "a" }, {})).toBe(false);
+  });
+
+  it("sem hashes = legacy → exige todos (comportamento staleness-blind do save-time)", () => {
+    const fields = [field({ name: "q1" }), field({ name: "medicamento", type: "multi" })];
+    expect(isCodingComplete(fields, { q1: "a" })).toBe(false);
+  });
+
+  it("campo da época respondido + campo novo (fora dos hashes) ausente → true", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2" }),
+      field({ name: "medicamento", type: "multi" }),
+    ];
+    const hashes = { q1: "h1", q2: "h2" };
+    // q1/q2 respondidos, medicamento (novo) ausente → completo
+    expect(isCodingComplete(fields, { q1: "a", q2: "b" }, hashes)).toBe(true);
+  });
+});

--- a/frontend/src/lib/auto-review.ts
+++ b/frontend/src/lib/auto-review.ts
@@ -88,11 +88,14 @@ export async function createAutoReviewIfDiverges(
   // #174: nunca arbitrar codificacao incompleta. O caminho inline (saveResponse)
   // ja so chama esta funcao apos allAnswered, mas a guarda evita regressao se a
   // funcao for chamada de outro ponto — e usa a mesma definicao de completude
-  // (isCodingComplete) do gate inline e do backlog.
+  // (isCodingComplete) do gate inline e do backlog. Staleness-aware: passa
+  // answer_field_hashes para nao reprovar codificacao completa a epoca por causa
+  // de campo obrigatorio adicionado depois (mesmo motivo do backlog).
   if (
     !isCodingComplete(
       fields,
       (humanResponse.answers as Record<string, unknown>) ?? {},
+      humanResponse.answer_field_hashes as AnswerFieldHashes,
     )
   ) {
     log("skip_incomplete_coding", {

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -1,21 +1,38 @@
 import { isFieldVisible } from "@/lib/conditional";
 import { isIncompleteOther } from "@/lib/other-option";
-import type { PydanticField } from "@/lib/types";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
+
+// Espelha `responseHadField` de compare-divergence: um campo só "existia" quando
+// a codificação foi feita se `answer_field_hashes` estiver presente, não-vazio e
+// contiver a chave do campo. Ausente/{} = legacy (não dá para inferir staleness)
+// → assume que o campo existia. Sem isto, um campo obrigatório adicionado ao
+// schema DEPOIS da codificação faria toda codificação antiga parecer incompleta.
+function fieldExistedWhenCoded(
+  answerFieldHashes: AnswerFieldHashes | undefined,
+  fieldName: string,
+): boolean {
+  if (!answerFieldHashes) return true;
+  if (Object.keys(answerFieldHashes).length === 0) return true;
+  return Object.prototype.hasOwnProperty.call(answerFieldHashes, fieldName);
+}
 
 // Campos que o humano precisa responder para a codificação contar como
 // completa: visíveis para humano (target != "llm_only"/"none"), obrigatórios
-// (required !== false) e cuja condição de visibilidade está satisfeita pelas
-// respostas atuais.
+// (required !== false), com a condição de visibilidade satisfeita pelas
+// respostas atuais e — quando `answerFieldHashes` é fornecido — que já existiam
+// no schema contra o qual a resposta foi codificada (staleness-aware).
 export function requiredHumanFields(
   fields: PydanticField[],
   answers: Record<string, unknown>,
+  answerFieldHashes?: AnswerFieldHashes,
 ): PydanticField[] {
   return fields.filter(
     (f) =>
       (f.target || "all") !== "llm_only" &&
       f.target !== "none" &&
       f.required !== false &&
-      isFieldVisible(f, answers),
+      isFieldVisible(f, answers) &&
+      fieldExistedWhenCoded(answerFieldHashes, f.name),
   );
 }
 
@@ -26,11 +43,19 @@ export function requiredHumanFields(
 // backlog varria codificações em andamento (parciais) para a arbitragem, onde
 // apareciam como "(vazio)" em diversos campos. Puro/client-safe — usado tanto
 // em server actions quanto em testes Vitest.
+//
+// `answerFieldHashes` (opcional): quando avaliado RETROATIVAMENTE (backlog,
+// createAutoReviewIfDiverges) contra o schema atual, passar o snapshot per-campo
+// da resposta evita que um campo obrigatório recém-adicionado torne codificações
+// antigas — completas à época — falsamente "incompletas". O gate inline de
+// saveResponse roda em save-time (schema = schema da codificação), então não
+// precisa passar e mantém o comportamento staleness-blind.
 export function isCodingComplete(
   fields: PydanticField[],
   answers: Record<string, unknown>,
+  answerFieldHashes?: AnswerFieldHashes,
 ): boolean {
-  const required = requiredHumanFields(fields, answers);
+  const required = requiredHumanFields(fields, answers, answerFieldHashes);
   return required.every((f) => {
     const v = answers[f.name];
     if (v === undefined || v === null || v === "") return false;


### PR DESCRIPTION
## Problema (follow-up do #196 / issue #174)

O gate `isCodingComplete` introduzido no #196 é **cego a staleness de schema**. Avaliado RETROATIVAMENTE (backlog de auto-revisão e `createAutoReviewIfDiverges`) contra o **schema atual**, um campo obrigatório adicionado **depois** de uma codificação faz toda codificação anterior — completa à época — parecer "incompleta".

**Caso real (Zolgensma).** O campo `medicamento` foi adicionado em **2026-06-11** como obrigatório. Das 102 codificações com review tocada, **82 são anteriores a ele** e nunca puderam respondê-lo. Investiguei a produção (somente leitura):

- Com o gate staleness-blind, re-rodar **"Regenerar backlog"** consideraria **as 394 reviews pendentes** como de codificações "incompletas" e **apagaria todas as 394** — não as ~191 espúrias previstas no #196.
- **194 dessas 394 são legítimas** (codificações completas que só não têm o `medicamento`): perda indevida de arbitragens reais.

Em outras palavras, o botão "Regenerar backlog" está **perigoso** no estado atual.

## Correção

- `isCodingComplete` e `requiredHumanFields` ganham um parâmetro opcional `answerFieldHashes` e **ignoram campos ausentes do snapshot** da resposta — espelhando exatamente `responseHadField` de `compare-divergence.ts` (mesma semântica de staleness já usada na divergência).
- Os dois chamadores **retroativos** passam `human.answer_field_hashes`:
  - `regenerateAutoReviewBacklog` (`actions/field-reviews.ts`)
  - `createAutoReviewIfDiverges` (`lib/auto-review.ts`)
- O gate inline de `saveResponse` permanece **staleness-blind de propósito**: roda em save-time, quando o schema da codificação É o schema atual (sem staleness possível). Comportamento inalterado.

Sem mudança de comportamento quando `answerFieldHashes` é ausente/`{}` (legacy) — mantém o gate original.

## Testes

- +5 casos em `coding-completeness.test.ts`: campo fora dos hashes não é exigido; campo nos hashes é exigido; hashes vazios/ausentes = legacy (staleness-blind).
- Suíte completa: **401 testes passando**, lint limpo.

Refs #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)