### PR TITLE
feat(sorteio): peso e limite de carga por participante

### DIFF
--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -2,7 +2,7 @@
 
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import {
   createRng,
   distributeDocs,
@@ -14,6 +14,10 @@ import {
   type LotteryMode,
   type LotteryParticipant,
 } from "@/lib/lottery-utils";
+
+// Perfil de cache do revalidateTag (Next 16) — espelha o revalidate: 300 do
+// getCachedMembers na página de atribuições. Mesmo padrão de members.ts.
+const TAG_PROFILE = Object.freeze({ expire: 300 });
 
 /**
  * Cicla a atribuição de um par (documento, pesquisador) por três estados:
@@ -112,6 +116,13 @@ export interface LotteryParams {
   label?: string;
   filters?: LotteryFilters;
   participantIds: string[];
+  /**
+   * Peso e limite por participante (spec: carga desigual). weight escala a
+   * carga na distribuição (default 1); cap é o teto absoluto de docs novos do
+   * participante (null/ausente = sem limite individual). Persistido em
+   * project_members ao sortear para pré-preencher o próximo sorteio.
+   */
+  participantSettings?: Record<string, { weight?: number; cap?: number | null }>;
 }
 
 interface LotteryAssignment {
@@ -342,16 +353,21 @@ async function computeLottery(params: LotteryParams): Promise<{
     }
   }
 
-  // Carga acumulada (conjunto preservado do modo) + capacidade
+  // Carga acumulada (conjunto preservado do modo) + capacidade + peso.
+  // O limite individual (cap) compõe com o global docsPerResearcher: vence
+  // o menor. O peso escala a chave de distribuição (load/weight).
+  const settings = params.participantSettings ?? {};
   const participants: LotteryParticipant[] = participantIds.map((pId) => {
     const accumulatedLoad = preservedByUser[pId] || 0;
-    return {
-      id: pId,
-      accumulatedLoad,
-      capacity: params.docsPerResearcher
-        ? Math.max(0, params.docsPerResearcher - accumulatedLoad)
-        : Infinity,
-    };
+    const cfg = settings[pId] ?? {};
+    const weight = cfg.weight && cfg.weight > 0 ? cfg.weight : 1;
+    const caps: number[] = [];
+    if (params.docsPerResearcher) caps.push(params.docsPerResearcher);
+    if (cfg.cap != null && cfg.cap > 0) caps.push(cfg.cap);
+    const capacity = caps.length
+      ? Math.max(0, Math.min(...caps) - accumulatedLoad)
+      : Infinity;
+    return { id: pId, accumulatedLoad, capacity, weight };
   });
 
   const newAssignments: LotteryAssignment[] = distributeDocs(
@@ -384,6 +400,7 @@ async function computeLottery(params: LotteryParams): Promise<{
     filters: {
       ...filters,
       participantIds,
+      participantSettings: settings,
       docSubsetSize: params.docSubsetSize ?? null,
       seed,
     },
@@ -478,6 +495,32 @@ export async function smartRandomize(params: LotteryParams) {
         `Erro ao gravar as atribuições (${i} de ${newAssignments.length} inseridas): ${insertError.message}`
       );
     }
+  }
+
+  // Persiste o peso/limite usado por participante (decisão: editar no diálogo,
+  // mas assumir continuidade no próximo sorteio). As atribuições já foram
+  // gravadas — uma falha aqui só afeta o default da próxima vez, não bloqueia.
+  const settingsEntries = Object.entries(params.participantSettings ?? {});
+  if (settingsEntries.length > 0) {
+    const results = await Promise.all(
+      settingsEntries.map(([userId, cfg]) =>
+        supabase
+          .from("project_members")
+          .update({
+            assignment_weight: cfg.weight && cfg.weight > 0 ? cfg.weight : 1,
+            assignment_cap: cfg.cap != null && cfg.cap > 0 ? cfg.cap : null,
+          })
+          .eq("project_id", params.projectId)
+          .eq("user_id", userId),
+      ),
+    );
+    const failed = results.find((r) => r.error);
+    if (failed?.error) {
+      console.error(
+        `[lottery] falha ao persistir peso/limite por membro: ${failed.error.message}`,
+      );
+    }
+    revalidateTag(`project-${params.projectId}-members`, TAG_PROFILE);
   }
 
   revalidatePath(`/projects/${params.projectId}/analyze/assignments`);

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -8,16 +8,16 @@ import {
   distributeDocs,
   filterEligibleDocs,
   shuffleWithRng,
+  computeCapacity,
+  resolveWeight,
+  resolveCap,
   type LotteryBalancing,
   type LotteryDocStats,
   type LotteryFilters,
   type LotteryMode,
   type LotteryParticipant,
 } from "@/lib/lottery-utils";
-
-// Perfil de cache do revalidateTag (Next 16) — espelha o revalidate: 300 do
-// getCachedMembers na página de atribuições. Mesmo padrão de members.ts.
-const TAG_PROFILE = Object.freeze({ expire: 300 });
+import { MEMBERS_TAG_PROFILE, membersTag } from "@/lib/cache";
 
 /**
  * Cicla a atribuição de um par (documento, pesquisador) por três estados:
@@ -354,20 +354,23 @@ async function computeLottery(params: LotteryParams): Promise<{
   }
 
   // Carga acumulada (conjunto preservado do modo) + capacidade + peso.
-  // O limite individual (cap) compõe com o global docsPerResearcher: vence
-  // o menor. O peso escala a chave de distribuição (load/weight).
+  // capacity é o teto de docs NOVOS: o limite individual (cap, teto direto de
+  // novos) compõe com o global docsPerResearcher (teto total) — vence o menor
+  // (ver computeCapacity). O peso escala a chave de distribuição (load/weight).
   const settings = params.participantSettings ?? {};
   const participants: LotteryParticipant[] = participantIds.map((pId) => {
     const accumulatedLoad = preservedByUser[pId] || 0;
     const cfg = settings[pId] ?? {};
-    const weight = cfg.weight && cfg.weight > 0 ? cfg.weight : 1;
-    const caps: number[] = [];
-    if (params.docsPerResearcher) caps.push(params.docsPerResearcher);
-    if (cfg.cap != null && cfg.cap > 0) caps.push(cfg.cap);
-    const capacity = caps.length
-      ? Math.max(0, Math.min(...caps) - accumulatedLoad)
-      : Infinity;
-    return { id: pId, accumulatedLoad, capacity, weight };
+    return {
+      id: pId,
+      accumulatedLoad,
+      capacity: computeCapacity({
+        accumulatedLoad,
+        docsPerResearcher: params.docsPerResearcher,
+        cap: cfg.cap,
+      }),
+      weight: resolveWeight(cfg.weight),
+    };
   });
 
   const newAssignments: LotteryAssignment[] = distributeDocs(
@@ -507,8 +510,8 @@ export async function smartRandomize(params: LotteryParams) {
         supabase
           .from("project_members")
           .update({
-            assignment_weight: cfg.weight && cfg.weight > 0 ? cfg.weight : 1,
-            assignment_cap: cfg.cap != null && cfg.cap > 0 ? cfg.cap : null,
+            assignment_weight: resolveWeight(cfg.weight),
+            assignment_cap: resolveCap(cfg.cap),
           })
           .eq("project_id", params.projectId)
           .eq("user_id", userId),
@@ -520,7 +523,7 @@ export async function smartRandomize(params: LotteryParams) {
         `[lottery] falha ao persistir peso/limite por membro: ${failed.error.message}`,
       );
     }
-    revalidateTag(`project-${params.projectId}-members`, TAG_PROFILE);
+    revalidateTag(membersTag(params.projectId), MEMBERS_TAG_PROFILE);
   }
 
   revalidatePath(`/projects/${params.projectId}/analyze/assignments`);

--- a/frontend/src/actions/members.ts
+++ b/frontend/src/actions/members.ts
@@ -10,8 +10,7 @@ import {
   releaseArbitrationsFromUser,
 } from "@/actions/field-reviews";
 import { revalidatePath, revalidateTag } from "next/cache";
-
-const TAG_PROFILE = Object.freeze({ expire: 300 });
+import { MEMBERS_TAG_PROFILE as TAG_PROFILE } from "@/lib/cache";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
@@ -4,18 +4,24 @@ import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { AssignmentTable } from "@/components/assignments/AssignmentTable";
 import { LotteryDialog } from "@/components/assignments/LotteryDialog";
 import { ClearPendingButton } from "@/components/assignments/ClearPendingButton";
+import { membersTag } from "@/lib/cache";
 import type { ProjectMember } from "@/lib/types";
 
 function getCachedDocuments(projectId: string) {
   return unstable_cache(
     async () => {
       const supabase = createSupabaseAdmin();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("documents")
         .select("id, external_id, title")
         .eq("project_id", projectId)
         .is("excluded_at", null)
         .order("created_at", { ascending: true });
+      if (error) {
+        console.error(
+          `[assignments] getCachedDocuments falhou (projeto ${projectId}): ${error.message}`,
+        );
+      }
       return data || [];
     },
     [`assignments-docs-${projectId}`],
@@ -27,17 +33,22 @@ function getCachedMembers(projectId: string, role: string) {
   return unstable_cache(
     async () => {
       const supabase = createSupabaseAdmin();
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from("project_members")
         .select(
           "user_id, role, project_id, assignment_weight, assignment_cap, profiles(first_name, email, activated_at)",
         )
         .eq("project_id", projectId)
         .eq("role", role);
+      if (error) {
+        console.error(
+          `[assignments] getCachedMembers falhou (projeto ${projectId}, role ${role}): ${error.message}`,
+        );
+      }
       return data || [];
     },
     [`assignments-members-${projectId}-${role}`],
-    { tags: [`project-${projectId}-members`], revalidate: 300 },
+    { tags: [membersTag(projectId)], revalidate: 300 },
   )();
 }
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
@@ -29,7 +29,9 @@ function getCachedMembers(projectId: string, role: string) {
       const supabase = createSupabaseAdmin();
       const { data } = await supabase
         .from("project_members")
-        .select("user_id, role, project_id, profiles(first_name, email, activated_at)")
+        .select(
+          "user_id, role, project_id, assignment_weight, assignment_cap, profiles(first_name, email, activated_at)",
+        )
         .eq("project_id", projectId)
         .eq("role", role);
       return data || [];
@@ -76,6 +78,8 @@ export default async function AssignmentsPage({
       m.profiles?.first_name || m.profiles?.email || m.user_id.slice(0, 8),
     role: m.role as "pesquisador" | "coordenador",
     pending: m.profiles?.activated_at === null,
+    weight: m.assignment_weight ?? 1,
+    cap: m.assignment_cap ?? null,
   }));
 
   const assignedDocIds = new Set(

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -48,6 +48,10 @@ export interface LotteryMember {
   role: "pesquisador" | "coordenador";
   // Pré-registrado (spec 002): ainda não criou conta.
   pending?: boolean;
+  // Defaults de carga persistidos (último sorteio): peso relativo e limite
+  // individual de docs. Pré-preenchem os campos por participante.
+  weight?: number;
+  cap?: number | null;
 }
 
 interface LotteryDialogProps {
@@ -127,8 +131,19 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     Record<string, boolean>
   >({});
 
+  // Peso/limite por participante, editados como string (inputs controlados).
+  // Ausência da chave = usar o default persistido do membro (m.weight/m.cap).
+  const [weightInputs, setWeightInputs] = useState<Record<string, string>>({});
+  const [capInputs, setCapInputs] = useState<Record<string, string>>({});
+
   const isParticipant = (m: LotteryMember) =>
     participantOverrides[m.userId] ?? m.role === "pesquisador";
+
+  // String exibida nos inputs: override local, senão default persistido.
+  const weightValue = (m: LotteryMember) =>
+    weightInputs[m.userId] ?? String(m.weight ?? 1);
+  const capValue = (m: LotteryMember) =>
+    capInputs[m.userId] ?? (m.cap != null ? String(m.cap) : "");
 
   const participantIds = useMemo(
     () =>
@@ -139,6 +154,25 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
         .map((m) => m.userId),
     [members, participantOverrides]
   );
+
+  // Peso/limite resolvido por participante ativo. Inclui TODOS os participantes
+  // (peso 1 / sem limite explícito) para que o server persista o reset de quem
+  // voltou ao default — não só quem está fora do padrão.
+  const participantSettings = useMemo(() => {
+    const out: Record<string, { weight: number; cap: number | null }> = {};
+    for (const m of members) {
+      if (!(participantOverrides[m.userId] ?? m.role === "pesquisador")) continue;
+      const wStr = weightInputs[m.userId] ?? String(m.weight ?? 1);
+      const cStr = capInputs[m.userId] ?? (m.cap != null ? String(m.cap) : "");
+      const w = parseFloat(wStr);
+      const c = cStr.trim() === "" ? null : parseInt(cStr, 10);
+      out[m.userId] = {
+        weight: Number.isFinite(w) && w > 0 ? w : 1,
+        cap: c != null && Number.isFinite(c) && c > 0 ? c : null,
+      };
+    }
+    return out;
+  }, [members, participantOverrides, weightInputs, capInputs]);
 
   // Label
   const [label, setLabel] = useState("");
@@ -184,6 +218,7 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     balancing,
     filters,
     participantIds,
+    participantSettings,
   });
   const [previewState, setPreviewState] = useState<{
     key: string;
@@ -227,6 +262,7 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     label: label || undefined,
     filters,
     participantIds,
+    participantSettings,
   });
 
   const handlePreview = async () => {
@@ -651,37 +687,91 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
                 <h4 className="text-sm font-semibold">Participantes</h4>
                 <p className="text-xs text-muted-foreground">
                   Quem está ligado entra no sorteio. Pesquisadores começam
-                  ligados; coordenadores, desligados.
+                  ligados; coordenadores, desligados. O <strong>peso</strong>{" "}
+                  ajusta a carga relativa (0,5 = metade dos demais); o{" "}
+                  <strong>limite</strong> (opcional) é o teto de docs novos da
+                  pessoa neste sorteio. Os valores ficam salvos para o próximo.
                 </p>
                 {members.map((m) => (
-                  <div key={m.userId} className="flex items-center justify-between">
-                    <Label htmlFor={`member-${m.userId}`} className="font-normal">
-                      {m.name}
-                      {m.role === "coordenador" && (
-                        <span className="ml-1.5 text-xs text-muted-foreground">
-                          coordenador
-                        </span>
-                      )}
-                      {m.pending && (
-                        <Badge
-                          variant="secondary"
-                          className="ml-1.5"
-                          title="Pré-registrado: ainda não criou conta."
+                  <div key={m.userId} className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <Label
+                        htmlFor={`member-${m.userId}`}
+                        className="font-normal"
+                      >
+                        {m.name}
+                        {m.role === "coordenador" && (
+                          <span className="ml-1.5 text-xs text-muted-foreground">
+                            coordenador
+                          </span>
+                        )}
+                        {m.pending && (
+                          <Badge
+                            variant="secondary"
+                            className="ml-1.5"
+                            title="Pré-registrado: ainda não criou conta."
+                          >
+                            Pendente
+                          </Badge>
+                        )}
+                      </Label>
+                      <Switch
+                        id={`member-${m.userId}`}
+                        checked={isParticipant(m)}
+                        onCheckedChange={(checked) =>
+                          setParticipantOverrides((prev) => ({
+                            ...prev,
+                            [m.userId]: checked,
+                          }))
+                        }
+                      />
+                    </div>
+                    {isParticipant(m) && (
+                      <div className="flex items-center gap-4 pl-1 text-xs text-muted-foreground">
+                        <label
+                          htmlFor={`weight-${m.userId}`}
+                          className="flex items-center gap-1.5"
                         >
-                          Pendente
-                        </Badge>
-                      )}
-                    </Label>
-                    <Switch
-                      id={`member-${m.userId}`}
-                      checked={isParticipant(m)}
-                      onCheckedChange={(checked) =>
-                        setParticipantOverrides((prev) => ({
-                          ...prev,
-                          [m.userId]: checked,
-                        }))
-                      }
-                    />
+                          peso
+                          <Input
+                            id={`weight-${m.userId}`}
+                            type="number"
+                            min={0}
+                            step={0.5}
+                            value={weightValue(m)}
+                            onChange={(e) =>
+                              setWeightInputs((prev) => ({
+                                ...prev,
+                                [m.userId]: e.target.value,
+                              }))
+                            }
+                            className="h-7 w-16"
+                            aria-label={`Peso de ${m.name}`}
+                          />
+                        </label>
+                        <label
+                          htmlFor={`cap-${m.userId}`}
+                          className="flex items-center gap-1.5"
+                        >
+                          limite
+                          <Input
+                            id={`cap-${m.userId}`}
+                            type="number"
+                            min={1}
+                            placeholder="—"
+                            value={capValue(m)}
+                            onChange={(e) =>
+                              setCapInputs((prev) => ({
+                                ...prev,
+                                [m.userId]: e.target.value,
+                              }))
+                            }
+                            className="h-7 w-16"
+                            aria-label={`Limite de docs de ${m.name}`}
+                          />
+                        </label>
+                      </div>
+                    )}
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -32,6 +32,8 @@ import {
 import type { LotteryParams, LotteryPreview } from "@/actions/assignments";
 import {
   filterEligibleDocs,
+  resolveWeight,
+  resolveCap,
   type AssignmentFilter,
   type LotteryBalancing,
   type LotteryDocStats,
@@ -140,10 +142,15 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     participantOverrides[m.userId] ?? m.role === "pesquisador";
 
   // String exibida nos inputs: override local, senão default persistido.
-  const weightValue = (m: LotteryMember) =>
-    weightInputs[m.userId] ?? String(m.weight ?? 1);
-  const capValue = (m: LotteryMember) =>
-    capInputs[m.userId] ?? (m.cap != null ? String(m.cap) : "");
+  const weightValue = useCallback(
+    (m: LotteryMember) => weightInputs[m.userId] ?? String(m.weight ?? 1),
+    [weightInputs],
+  );
+  const capValue = useCallback(
+    (m: LotteryMember) =>
+      capInputs[m.userId] ?? (m.cap != null ? String(m.cap) : ""),
+    [capInputs],
+  );
 
   const participantIds = useMemo(
     () =>
@@ -162,17 +169,15 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     const out: Record<string, { weight: number; cap: number | null }> = {};
     for (const m of members) {
       if (!(participantOverrides[m.userId] ?? m.role === "pesquisador")) continue;
-      const wStr = weightInputs[m.userId] ?? String(m.weight ?? 1);
-      const cStr = capInputs[m.userId] ?? (m.cap != null ? String(m.cap) : "");
-      const w = parseFloat(wStr);
-      const c = cStr.trim() === "" ? null : parseInt(cStr, 10);
+      const cStr = capValue(m);
       out[m.userId] = {
-        weight: Number.isFinite(w) && w > 0 ? w : 1,
-        cap: c != null && Number.isFinite(c) && c > 0 ? c : null,
+        // Mesma coerção do server (resolveWeight/resolveCap) — fonte única.
+        weight: resolveWeight(parseFloat(weightValue(m))),
+        cap: resolveCap(cStr.trim() === "" ? null : parseInt(cStr, 10)),
       };
     }
     return out;
-  }, [members, participantOverrides, weightInputs, capInputs]);
+  }, [members, participantOverrides, weightValue, capValue]);
 
   // Label
   const [label, setLabel] = useState("");
@@ -736,7 +741,7 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
                           <Input
                             id={`weight-${m.userId}`}
                             type="number"
-                            min={0}
+                            min={0.5}
                             step={0.5}
                             value={weightValue(m)}
                             onChange={(e) =>

--- a/frontend/src/lib/__tests__/lottery-utils.test.ts
+++ b/frontend/src/lib/__tests__/lottery-utils.test.ts
@@ -342,6 +342,64 @@ describe("distributeDocs", () => {
     for (const c of Object.values(counts)) expect(c).toBeLessThanOrEqual(2);
   });
 
+  describe("peso por participante", () => {
+    it("weight 0.5 recebe ~metade dos pares de peso 1 (round)", () => {
+      // pesos 1, 1, 0.5 → soma 2.5; 50 docs × 1 vaga → p2 ≈ 50·(0.5/2.5) = 10
+      const participants: LotteryParticipant[] = [
+        { id: "p0", accumulatedLoad: 0, capacity: Infinity, weight: 1 },
+        { id: "p1", accumulatedLoad: 0, capacity: Infinity, weight: 1 },
+        { id: "p2", accumulatedLoad: 0, capacity: Infinity, weight: 0.5 },
+      ];
+      const counts = countByUser(run(docIds(50), participants));
+      expect(counts.p0 + counts.p1 + counts.p2).toBe(50);
+      expect(counts.p2).toBeLessThan(counts.p0);
+      expect(counts.p2).toBeLessThan(counts.p1);
+      expect(counts.p2).toBeGreaterThanOrEqual(8);
+      expect(counts.p2).toBeLessThanOrEqual(12);
+    });
+
+    it("weight escala também no modo history", () => {
+      // todos partem de 0; alvo do history é nivelar load/weight, então
+      // p2 (peso 0.5) termina com ~metade da carga dos demais
+      const participants: LotteryParticipant[] = [
+        { id: "p0", accumulatedLoad: 0, capacity: Infinity, weight: 1 },
+        { id: "p1", accumulatedLoad: 0, capacity: Infinity, weight: 1 },
+        { id: "p2", accumulatedLoad: 0, capacity: Infinity, weight: 0.5 },
+      ];
+      const counts = countByUser(
+        run(docIds(50), participants, { balancing: "history" }),
+      );
+      expect(counts.p2).toBeLessThan(counts.p0);
+      expect(counts.p2).toBeLessThan(counts.p1);
+      expect(counts.p2).toBeGreaterThanOrEqual(8);
+      expect(counts.p2).toBeLessThanOrEqual(12);
+    });
+
+    it("weight ausente equivale a peso 1 (regressão)", () => {
+      // mesma entrada, com e sem weight=1 explícito → mesmo resultado
+      const semWeight = makeParticipants([0, 0, 0]);
+      const comWeight: LotteryParticipant[] = semWeight.map((p) => ({
+        ...p,
+        weight: 1,
+      }));
+      const a = run(docIds(12), semWeight, { seed: 7 });
+      const b = run(docIds(12), comWeight, { seed: 7 });
+      expect(a).toEqual(b);
+    });
+  });
+
+  it("limite individual corta a carga do participante; o resto vai aos demais", () => {
+    // p0 com capacity 3 (limite individual); p1 e p2 sem limite absorvem o resto
+    const participants: LotteryParticipant[] = [
+      { id: "p0", accumulatedLoad: 0, capacity: 3, weight: 1 },
+      { id: "p1", accumulatedLoad: 0, capacity: Infinity, weight: 1 },
+      { id: "p2", accumulatedLoad: 0, capacity: Infinity, weight: 1 },
+    ];
+    const counts = countByUser(run(docIds(30), participants));
+    expect(counts.p0).toBe(3);
+    expect((counts.p1 ?? 0) + (counts.p2 ?? 0)).toBe(27);
+  });
+
   it("nunca duplica par doc+pessoa preservado (preservedPairs)", () => {
     const participants = makeParticipants([0, 0]);
     for (let seed = 0; seed < 20; seed++) {

--- a/frontend/src/lib/__tests__/lottery-utils.test.ts
+++ b/frontend/src/lib/__tests__/lottery-utils.test.ts
@@ -3,6 +3,9 @@ import {
   createRng,
   distributeDocs,
   filterEligibleDocs,
+  computeCapacity,
+  resolveWeight,
+  resolveCap,
   type LotteryBalancing,
   type LotteryDocStats,
   type LotteryParticipant,
@@ -442,5 +445,72 @@ describe("distributeDocs", () => {
     expect(coOccurrence).toEqual(snapshot);
     expect(docs).toEqual(docIds(5));
     expect(participants[0].accumulatedLoad).toBe(1);
+  });
+});
+
+describe("resolveWeight", () => {
+  it("ausente, zero, negativo ou NaN caem para 1 (neutro)", () => {
+    expect(resolveWeight(undefined)).toBe(1);
+    expect(resolveWeight(null)).toBe(1);
+    expect(resolveWeight(0)).toBe(1);
+    expect(resolveWeight(-2)).toBe(1);
+    expect(resolveWeight(NaN)).toBe(1);
+    expect(resolveWeight(Infinity)).toBe(1);
+  });
+
+  it("preserva pesos positivos finitos, inclusive fracionários", () => {
+    expect(resolveWeight(0.5)).toBe(0.5);
+    expect(resolveWeight(2)).toBe(2);
+  });
+});
+
+describe("resolveCap", () => {
+  it("ausente, zero, negativo ou NaN → null (sem limite)", () => {
+    expect(resolveCap(undefined)).toBeNull();
+    expect(resolveCap(null)).toBeNull();
+    expect(resolveCap(0)).toBeNull();
+    expect(resolveCap(-3)).toBeNull();
+    expect(resolveCap(NaN)).toBeNull();
+  });
+
+  it("trunca para inteiro (coluna INTEGER)", () => {
+    expect(resolveCap(3)).toBe(3);
+    expect(resolveCap(2.9)).toBe(2);
+  });
+});
+
+describe("computeCapacity", () => {
+  it("sem docsPerResearcher e sem cap → Infinity", () => {
+    expect(computeCapacity({ accumulatedLoad: 0 })).toBe(Infinity);
+    expect(computeCapacity({ accumulatedLoad: 4 })).toBe(Infinity);
+  });
+
+  it("docsPerResearcher é teto TOTAL: converte em slots novos restantes", () => {
+    expect(computeCapacity({ accumulatedLoad: 0, docsPerResearcher: 10 })).toBe(10);
+    expect(computeCapacity({ accumulatedLoad: 4, docsPerResearcher: 10 })).toBe(6);
+    // carga acumulada já estourou o total → 0 slots novos (sem negativo)
+    expect(computeCapacity({ accumulatedLoad: 12, docsPerResearcher: 10 })).toBe(0);
+  });
+
+  it("cap é teto direto de docs NOVOS, independente da carga acumulada", () => {
+    // o ponto central do fix: cap=3 com 4 já atribuídos ainda dá 3 NOVOS,
+    // não max(0, 3 - 4) = 0 (semântica antiga, de teto total)
+    expect(computeCapacity({ accumulatedLoad: 4, cap: 3 })).toBe(3);
+    expect(computeCapacity({ accumulatedLoad: 0, cap: 3 })).toBe(3);
+  });
+
+  it("compõe os dois limites — vence o menor", () => {
+    // total restante = 10 - 4 = 6; cap de novos = 3 → 3
+    expect(
+      computeCapacity({ accumulatedLoad: 4, docsPerResearcher: 10, cap: 3 }),
+    ).toBe(3);
+    // total restante = 10 - 8 = 2; cap de novos = 5 → 2
+    expect(
+      computeCapacity({ accumulatedLoad: 8, docsPerResearcher: 10, cap: 5 }),
+    ).toBe(2);
+  });
+
+  it("cap fracionário é truncado antes de compor", () => {
+    expect(computeCapacity({ accumulatedLoad: 0, cap: 3.9 })).toBe(3);
   });
 });

--- a/frontend/src/lib/cache.ts
+++ b/frontend/src/lib/cache.ts
@@ -1,0 +1,14 @@
+// Tags e perfis de cache compartilhados entre Server Actions e RSC.
+// Fonte única para evitar drift entre quem invalida (revalidateTag) e quem
+// define o cache (unstable_cache na página).
+
+/**
+ * Perfil do revalidateTag (Next 16) para o cache de membros — espelha o
+ * `revalidate: 300` do getCachedMembers na página de atribuições.
+ */
+export const MEMBERS_TAG_PROFILE = Object.freeze({ expire: 300 });
+
+/** Tag de cache da lista de membros de um projeto. */
+export function membersTag(projectId: string): string {
+  return `project-${projectId}-members`;
+}

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -32,13 +32,54 @@ export interface LotteryParticipant {
   id: string;
   /** atribuições do tipo no conjunto preservado do modo */
   accumulatedLoad: number;
-  /** docsPerResearcher - accumulatedLoad, ou Infinity */
+  /** teto de docs NOVOS neste sorteio (ver computeCapacity), ou Infinity */
   capacity: number;
   /**
    * Peso relativo de carga (default 1). A chave de distribuição é load/weight,
    * então peso 0.5 recebe ~metade dos docs de um peso 1. Ausente/≤0 → 1.
    */
   weight?: number;
+}
+
+/**
+ * Peso efetivo de carga: ausente, NaN, zero ou negativo caem para 1 (neutro).
+ * Centraliza a regra usada no cliente (LotteryDialog), no server
+ * (computeLottery e persistência) e em distributeDocs — evita drift (#63).
+ */
+export function resolveWeight(weight?: number | null): number {
+  return weight != null && Number.isFinite(weight) && weight > 0 ? weight : 1;
+}
+
+/**
+ * Limite efetivo de docs NOVOS por participante: ausente, NaN, zero ou
+ * negativo → null (sem limite individual). Caso contrário, truncado para
+ * inteiro — a coluna assignment_cap é INTEGER.
+ */
+export function resolveCap(cap?: number | null): number | null {
+  return cap != null && Number.isFinite(cap) && cap > 0 ? Math.floor(cap) : null;
+}
+
+/**
+ * Capacidade de docs NOVOS de um participante neste sorteio (o teto duro de
+ * distributeDocs). Compõe dois limites e vence o menor:
+ *  - docsPerResearcher é teto TOTAL (acumulado + novos) — convertido aqui em
+ *    slots novos restantes (`docsPerResearcher - accumulatedLoad`);
+ *  - cap é teto direto de docs NOVOS, independente da carga acumulada.
+ * Ausência de ambos → Infinity (sem limite). Pura.
+ */
+export function computeCapacity(opts: {
+  accumulatedLoad: number;
+  docsPerResearcher?: number | null;
+  cap?: number | null;
+}): number {
+  const { accumulatedLoad, docsPerResearcher, cap } = opts;
+  const limits: number[] = [];
+  if (docsPerResearcher) {
+    limits.push(Math.max(0, docsPerResearcher - accumulatedLoad));
+  }
+  const resolvedCap = resolveCap(cap);
+  if (resolvedCap != null) limits.push(resolvedCap);
+  return limits.length ? Math.min(...limits) : Infinity;
 }
 
 /**
@@ -145,7 +186,7 @@ export function distributeDocs(
     remaining[p.id] = p.capacity;
     // Peso ausente, zero ou negativo cai para 1 (neutro) — a UI valida > 0;
     // deselecionar o participante é o caminho para "peso zero".
-    weight[p.id] = p.weight && p.weight > 0 ? p.weight : 1;
+    weight[p.id] = resolveWeight(p.weight);
   }
 
   // Cópia local da matriz para preservar a pureza da função

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -34,6 +34,11 @@ export interface LotteryParticipant {
   accumulatedLoad: number;
   /** docsPerResearcher - accumulatedLoad, ou Infinity */
   capacity: number;
+  /**
+   * Peso relativo de carga (default 1). A chave de distribuição é load/weight,
+   * então peso 0.5 recebe ~metade dos docs de um peso 1. Ausente/≤0 → 1.
+   */
+  weight?: number;
 }
 
 /**
@@ -105,12 +110,14 @@ export function shuffleWithRng<T>(arr: T[], rng: () => number): T[] {
 /**
  * Núcleo da distribuição do sorteio (research D12). Para cada documento
  * (em ordem embaralhada), cada vaga é dada ao candidato de menor chave
- * composta: carga corrente do modo de equilíbrio (`round`: só as novas
- * deste sorteio; `history`: acumulada + novas) → co-ocorrência com quem
- * já está no documento (variação de duplas, FR-014) → aleatório
- * (candidatos embaralhados antes do sort estável — a ordem do array de
- * participantes nunca decide, FR-019). Carga e co-ocorrência são
- * atualizadas a cada atribuição. Pura: não muta os inputs.
+ * composta: carga corrente do modo de equilíbrio dividida pelo peso do
+ * participante (`round`: só as novas deste sorteio; `history`: acumulada +
+ * novas) → co-ocorrência com quem já está no documento (variação de duplas,
+ * FR-014) → aleatório (candidatos embaralhados antes do sort estável — a
+ * ordem do array de participantes nunca decide, FR-019). O peso (default 1)
+ * escala a carga: quem tem peso 0.5 atinge a mesma chave com metade dos docs,
+ * recebendo ~metade; o teto duro continua sendo `capacity`. Carga e
+ * co-ocorrência são atualizadas a cada atribuição. Pura: não muta os inputs.
  */
 export function distributeDocs(
   eligibleDocIds: string[],
@@ -131,10 +138,14 @@ export function distributeDocs(
   const accumulated: Record<string, number> = {};
   const newLoad: Record<string, number> = {};
   const remaining: Record<string, number> = {};
+  const weight: Record<string, number> = {};
   for (const p of participants) {
     accumulated[p.id] = p.accumulatedLoad;
     newLoad[p.id] = 0;
     remaining[p.id] = p.capacity;
+    // Peso ausente, zero ou negativo cai para 1 (neutro) — a UI valida > 0;
+    // deselecionar o participante é o caminho para "peso zero".
+    weight[p.id] = p.weight && p.weight > 0 ? p.weight : 1;
   }
 
   // Cópia local da matriz para preservar a pureza da função
@@ -164,9 +175,9 @@ export function distributeDocs(
       const scored = shuffleWithRng(candidates, rng).map((p) => ({
         id: p.id,
         load:
-          balancing === "round"
+          (balancing === "round"
             ? newLoad[p.id]
-            : accumulated[p.id] + newLoad[p.id],
+            : accumulated[p.id] + newLoad[p.id]) / weight[p.id],
         coScore: alreadyOnDoc.reduce(
           (sum, uid) => sum + (coOccurrence[p.id]?.[uid] || 0),
           0,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -80,9 +80,10 @@ export interface ProjectMember {
   can_arbitrate: boolean;
   can_resolve: boolean;
   // Carga relativa no sorteio (1 = normal, 0.5 = metade). Ver distributeDocs.
-  assignment_weight: number;
+  // Opcional: nem toda query de project_members seleciona estas colunas.
+  assignment_weight?: number;
   // Teto absoluto de docs novos por sorteio; null = sem limite individual.
-  assignment_cap: number | null;
+  assignment_cap?: number | null;
   profiles?: Profile;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -79,6 +79,10 @@ export interface ProjectMember {
   role: "coordenador" | "pesquisador";
   can_arbitrate: boolean;
   can_resolve: boolean;
+  // Carga relativa no sorteio (1 = normal, 0.5 = metade). Ver distributeDocs.
+  assignment_weight: number;
+  // Teto absoluto de docs novos por sorteio; null = sem limite individual.
+  assignment_cap: number | null;
   profiles?: Profile;
 }
 

--- a/frontend/supabase/migrations/20260618120000_project_members_assignment_weight_cap.sql
+++ b/frontend/supabase/migrations/20260618120000_project_members_assignment_weight_cap.sql
@@ -1,0 +1,15 @@
+-- Peso e limite de carga por membro no sorteio de atribuicoes.
+--
+-- assignment_weight: proporcao relativa de carga no sorteio (1 = normal,
+--   0.5 = recebe metade do que um membro de peso 1). Entra na chave de
+--   distribuicao como load/weight (ver distributeDocs em lottery-utils.ts).
+-- assignment_cap: teto absoluto de docs novos por sorteio (NULL = sem limite
+--   individual; compoe com o limite global docsPerResearcher, vence o menor).
+--
+-- Editados no LotteryDialog e persistidos aqui ao sortear, para pre-preencher
+-- o proximo sorteio com o ultimo valor usado por membro.
+ALTER TABLE project_members
+  ADD COLUMN assignment_weight NUMERIC NOT NULL DEFAULT 1
+    CHECK (assignment_weight > 0),
+  ADD COLUMN assignment_cap INTEGER
+    CHECK (assignment_cap IS NULL OR assignment_cap > 0);


### PR DESCRIPTION
## Contexto

A Jacque combinou com o Daniel de pegar **metade dos casos**, porque não estava recebendo carga. Hoje o sorteio distribui de forma **igualitária** entre os participantes selecionados — há `researchersPerDoc` (global) e `docsPerResearcher` (limite global, igual para todos), mas **nenhum controle por pessoa**. O único caminho era gambiarra (deselecionar a pessoa e rodar sorteios separados).

Este PR adiciona controle de carga **por participante** no diálogo de sorteio.

## O que muda

Na seção **Participantes** do `LotteryDialog`, cada participante ativo ganha dois campos opcionais:

- **Peso** (default `1`): proporção relativa de carga. `0,5` → recebe ~metade dos docs de quem tem peso `1`. Entra na chave de distribuição como `load / weight` em `distributeDocs` (vale para `round` e `history`).
- **Limite** (opcional): teto absoluto de docs **novos** da pessoa naquele sorteio. Compõe com o `docsPerResearcher` global — vence o menor.

Os valores são **pré-preenchidos** pelo último salvo e **persistidos** ao sortear, então o próximo sorteio já assume a mesma configuração (decisão: editar no diálogo, mas manter continuidade). A prévia por participante (`Novos`) já reflete o efeito do peso na hora.

## Implementação

- **Migration** `20260618120000_project_members_assignment_weight_cap.sql`: colunas `assignment_weight NUMERIC DEFAULT 1 CHECK (> 0)` e `assignment_cap INTEGER CHECK (> 0 OR NULL)`. Default `1`/`null` = comportamento atual, sem backfill.
- **`distributeDocs`** (`lottery-utils.ts`): chave de carga vira `load / weight`; peso ausente/≤0 → 1 (neutro). `capacity` segue como teto duro do limite individual.
- **`computeLottery` / `smartRandomize`** (`assignments.ts`): monta participantes com peso + limite individual; persiste os valores em `project_members` ao sortear (via client autenticado, mesmo caminho do `setCanArbitrate`) e revalida o cache de membros.
- **Página de atribuições**: lê as colunas e propaga como defaults ao diálogo.

## Como testar

```bash
cd frontend && npm test && npm run lint   # 405 testes, lint sem erros
```

Manual: `Projetos > [projeto] > Atribuições > Sortear` (Codificação) → ligar um pesquisador, peso `0.5` → **Visualizar prévia**: a coluna "Novos" dele fica ~metade dos demais. Sortear e reabrir → o peso `0.5` vem pré-preenchido.

> ⚠️ **Migration não aplicada no banco.** Falta rodar `npx supabase db push` (remoto) ou `db reset` (local) — deixei como passo manual para você confirmar antes do merge.

Relacionado a #208 (comparação automática quando há 2 codificações divergentes — feature separada, virá em PR próprio).