### PR TITLE
fix(ci): gitleaks precisa de pull-requests:read para escanear PRs

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -8,6 +8,11 @@ on:
 
 permissions:
   contents: read
+  # gitleaks-action chama GET /pulls/{n}/commits para descobrir o range a
+  # escanear no evento pull_request — sem este read leva 403 e o check falha
+  # antes de escanear (nao e vazamento). Mantemos write fora (so o comentario
+  # inline de PR precisaria dele, e esse segue desligado abaixo).
+  pull-requests: read
 
 concurrency:
   group: secret-scan-${{ github.ref }}


### PR DESCRIPTION
## Contexto

O check `gitleaks` (workflow `secret-scan.yml`) ficava **red em todo PR** — inclusive no #209 recém-mergeado — sem que isso significasse vazamento.

## Causa

A `gitleaks-action`, em evento `pull_request`, chama `GET /repos/.../pulls/{n}/commits` para descobrir o range de commits a escanear. Com `permissions: contents: read` apenas, a chamada toma **403 "Resource not accessible by integration"** (`x-accepted-github-permissions: pull_requests=read`) e a action **crasha antes de escanear**.

## Fix

Adiciona `pull-requests: read` ao bloco `permissions`. Mantém `write` de fora — só o comentário inline de PR precisaria dele, e segue desligado via `GITLEAKS_ENABLE_COMMENTS: false`. É o menor privilégio que faz o scan rodar de fato.

Sem isso, o secret-scan está efetivamente quebrado em PRs (falha sempre, dando falsa sensação de cobertura).