### PR TITLE
feat: modo de automação por projeto (comparação automática + auto-revisão gated)

### DIFF
--- a/frontend/src/actions/__tests__/comparisons-retry.test.ts
+++ b/frontend/src/actions/__tests__/comparisons-retry.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PydanticField } from "@/lib/types";
+
+// Mock supabase filter-aware (mesmo padrão de lib/__tests__/auto-comparison.test.ts).
+type WriteCall = { table: string; op: string; payload: unknown };
+let writeCalls: WriteCall[];
+let tableData: Record<string, unknown[]>;
+
+const upsertCallsOf = (table?: string) =>
+  writeCalls.filter((c) => c.op === "upsert" && (!table || c.table === table));
+
+function makeClient() {
+  return {
+    from: (table: string) => {
+      const eqs: Array<[string, unknown]> = [];
+      const neqs: Array<[string, unknown]> = [];
+      const ins: Array<[string, unknown[]]> = [];
+      let op = "select";
+      let limitN: number | null = null;
+      const builder: Record<string, unknown> = {};
+      builder.select = () => builder;
+      builder.eq = (c: string, v: unknown) => (eqs.push([c, v]), builder);
+      builder.neq = (c: string, v: unknown) => (neqs.push([c, v]), builder);
+      builder.is = (c: string, v: unknown) => (eqs.push([c, v]), builder);
+      builder.in = (c: string, v: unknown[]) => (ins.push([c, v]), builder);
+      builder.limit = (n: number) => ((limitN = n), builder);
+      builder.upsert = (payload: unknown) => {
+        writeCalls.push({ table, op: "upsert", payload });
+        op = "upsert";
+        return builder;
+      };
+      builder.update = (payload: unknown) => {
+        writeCalls.push({ table, op: "update", payload });
+        op = "update";
+        return builder;
+      };
+      builder.delete = () => {
+        writeCalls.push({ table, op: "delete", payload: null });
+        op = "delete";
+        return builder;
+      };
+      const rows = () => {
+        const data = (tableData[table] ?? []) as Array<Record<string, unknown>>;
+        const filtered = data.filter((r) => {
+          for (const [c, v] of eqs) if (r[c] !== v) return false;
+          for (const [c, v] of neqs) if (r[c] === v) return false;
+          for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
+          return true;
+        });
+        return limitN != null ? filtered.slice(0, limitN) : filtered;
+      };
+      const err = () => tableData[`__error:${table}:${op}`] ?? null;
+      builder.single = () => Promise.resolve({ data: rows()[0] ?? null, error: err() });
+      builder.maybeSingle = () => Promise.resolve({ data: rows()[0] ?? null, error: err() });
+      builder.then = (resolve: (v: unknown) => unknown) => resolve({ data: rows(), error: err() });
+      return builder;
+    },
+  };
+}
+
+const hoisted = vi.hoisted(() => ({
+  isCoord: vi.fn<() => Promise<boolean>>(async () => true),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "userCoord" }),
+  isProjectCoordinator: () => hoisted.isCoord(),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createSupabaseAdmin: () => makeClient(),
+}));
+
+const FIELDS: PydanticField[] = [
+  { name: "q1", type: "text", options: null, description: "", required: true },
+];
+const human = (respondent_id: string, q1: string, document_id = "doc1") => ({
+  id: `r-${respondent_id}-${document_id}`,
+  project_id: "p1",
+  document_id,
+  respondent_id,
+  respondent_type: "humano",
+  is_latest: true,
+  answers: { q1 },
+  answer_field_hashes: null,
+});
+const projectRow = (over: Record<string, unknown> = {}) => ({
+  id: "p1",
+  pydantic_fields: FIELDS,
+  min_responses_for_comparison: 2,
+  comparison_includes_llm: true,
+  automation_mode: "compare_humans",
+  ...over,
+});
+
+beforeEach(() => {
+  writeCalls = [];
+  tableData = {
+    projects: [projectRow()],
+    project_members: [],
+    assignments: [],
+    responses: [],
+    response_equivalences: [],
+  };
+  hoisted.isCoord.mockResolvedValue(true);
+});
+
+async function loadRetry() {
+  return (await import("@/actions/comparisons")).retryPendingComparisons;
+}
+
+describe("retryPendingComparisons — guards", () => {
+  it("não-coordenador → erro, sem efeito", async () => {
+    hoisted.isCoord.mockResolvedValueOnce(false);
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(false);
+    expect(r.error).toContain("coordenadores");
+    expect(writeCalls).toHaveLength(0);
+  });
+
+  it("modo não-comparação → no-op", async () => {
+    tableData.projects = [projectRow({ automation_mode: "auto_review_llm" })];
+    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    tableData.project_members = [{ user_id: "userC", project_id: "p1", can_compare: true }];
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    expect(r.assigned).toBe(0);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+});
+
+describe("retryPendingComparisons — atribui backlog divergente", () => {
+  it("doc divergente sem comparacao ativa → atribui 1", async () => {
+    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    tableData.project_members = [{ user_id: "userC", project_id: "p1", can_compare: true }];
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    expect(r.assigned).toBe(1);
+    expect(r.stillNoPool).toBe(0);
+    expect(upsertCallsOf("assignments")[0].payload).toMatchObject({
+      document_id: "doc1",
+      user_id: "userC",
+      type: "comparacao",
+    });
+  });
+
+  it("doc divergente sem revisor elegível → stillNoPool", async () => {
+    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    tableData.project_members = []; // ninguém can_compare
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    expect(r.assigned).toBe(0);
+    expect(r.stillNoPool).toBe(1);
+  });
+
+  it("doc em consenso → nada a atribuir", async () => {
+    tableData.responses = [human("userA", "A"), human("userB", "A")];
+    tableData.project_members = [{ user_id: "userC", project_id: "p1", can_compare: true }];
+    const retry = await loadRetry();
+    const r = await retry("p1");
+    expect(r.success).toBe(true);
+    expect(r.assigned).toBe(0);
+  });
+});

--- a/frontend/src/actions/comparisons.ts
+++ b/frontend/src/actions/comparisons.ts
@@ -1,0 +1,94 @@
+"use server";
+
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
+import { revalidatePath } from "next/cache";
+import {
+  scanComparisonBacklog,
+  assignComparisonReviewer,
+  type ComparisonMode,
+} from "@/lib/auto-comparison";
+
+// Re-sorteia revisores para todo documento divergente sem comparação ativa
+// (o "backlog" sem revisor). Disparada por setCanCompare ao habilitar/desabilitar
+// um membro, para drenar o backlog acumulado enquanto não havia ninguém elegível.
+// Espelha retryPendingArbitrations (actions/field-reviews.ts:1118).
+//
+// Diferença estrutural: a comparação não materializa divergência (não há stub
+// como field_reviews), então o backlog é recomputado por varredura — ver
+// scanComparisonBacklog (varredura em 2 fases).
+export async function retryPendingComparisons(projectId: string): Promise<{
+  success: boolean;
+  error?: string;
+  assigned: number;
+  stillNoPool: number;
+}> {
+  try {
+    const user = await getAuthUser();
+    if (!user)
+      return { success: false, error: "Não autenticado", assigned: 0, stillNoPool: 0 };
+    const isCoord = await isProjectCoordinator(projectId, user);
+    if (!isCoord)
+      return {
+        success: false,
+        error: "Apenas coordenadores podem reprocessar comparações.",
+        assigned: 0,
+        stillNoPool: 0,
+      };
+
+    const admin = createSupabaseAdmin();
+
+    // Só compare_humans/compare_llm têm backlog de comparação a drenar.
+    const { data: project } = await admin
+      .from("projects")
+      .select("automation_mode")
+      .eq("id", projectId)
+      .single();
+    const mode = project?.automation_mode;
+    if (mode !== "compare_humans" && mode !== "compare_llm") {
+      return { success: true, assigned: 0, stillNoPool: 0 };
+    }
+
+    const backlog = await scanComparisonBacklog(admin, projectId, mode as ComparisonMode);
+    if (backlog.length === 0) return { success: true, assigned: 0, stillNoPool: 0 };
+
+    // Carga aberta pré-computada uma vez; assignComparisonReviewer a incrementa
+    // entre docs para preservar o balanceamento sem N queries (sequencial: cada
+    // atribuição enxerga a carga atualizada da anterior).
+    const { data: openCounts } = await admin
+      .from("assignments")
+      .select("user_id")
+      .eq("project_id", projectId)
+      .eq("type", "comparacao")
+      .neq("status", "concluido");
+    const loadByUser = new Map<string, number>();
+    for (const r of openCounts ?? []) {
+      loadByUser.set(r.user_id, (loadByUser.get(r.user_id) ?? 0) + 1);
+    }
+
+    let assigned = 0;
+    let stillNoPool = 0;
+    for (const { documentId, coderIds } of backlog) {
+      const result = await assignComparisonReviewer(
+        admin,
+        projectId,
+        documentId,
+        coderIds,
+        loadByUser,
+      );
+      if (result.assigned) assigned++;
+      if (result.noPool) stillNoPool++;
+    }
+
+    revalidatePath(`/projects/${projectId}/analyze/compare`);
+    revalidatePath(`/projects/${projectId}/config/members`);
+    return { success: true, assigned, stillNoPool };
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "Erro",
+      assigned: 0,
+      stillNoPool: 0,
+    };
+  }
+}

--- a/frontend/src/actions/members.ts
+++ b/frontend/src/actions/members.ts
@@ -9,6 +9,8 @@ import {
   retryPendingArbitrations,
   releaseArbitrationsFromUser,
 } from "@/actions/field-reviews";
+import { retryPendingComparisons } from "@/actions/comparisons";
+import { releaseComparisonsFromUser } from "@/lib/auto-comparison";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { MEMBERS_TAG_PROFILE as TAG_PROFILE } from "@/lib/cache";
 
@@ -345,6 +347,55 @@ export async function setCanArbitrate(
 
   let retried: { assigned: number; stillNoPool: number } | undefined;
   const result = await retryPendingArbitrations(projectId);
+  if (result.success) {
+    retried = { assigned: result.assigned, stillNoPool: result.stillNoPool };
+  }
+
+  revalidatePath(`/projects/${projectId}`);
+  revalidatePath(`/projects/${projectId}/config/members`);
+  revalidateTag(`project-${projectId}-members`, TAG_PROFILE);
+  return { retried };
+}
+
+// Define se um membro entra no sorteio de revisores de comparação
+// (assignComparisonReviewer). Espelha setCanArbitrate: em ambos os sentidos
+// dispara retryPendingComparisons para realocar o backlog — a contagem volta em
+// `retried` para a UI informar o coordenador.
+//
+// Habilita: drena os documentos divergentes que estavam sem revisor elegível.
+// Desabilita: solta as comparações PENDENTES atribuídas a esse membro
+// (releaseComparisonsFromUser) — senão ficariam presas com quem não pode mais
+// comparar — e em seguida re-sorteia os casos liberados.
+export async function setCanCompare(
+  memberId: string,
+  canCompare: boolean,
+  projectId: string,
+): Promise<{ error?: string; retried?: { assigned: number; stillNoPool: number } }> {
+  const supabase = await createSupabaseServer();
+  const { data: member, error } = await supabase
+    .from("project_members")
+    .update({ can_compare: canCompare })
+    .eq("id", memberId)
+    .select("user_id")
+    .single();
+
+  if (error) return { error: error.message };
+
+  if (!canCompare) {
+    const admin = createSupabaseAdmin();
+    const releaseResult = await releaseComparisonsFromUser(
+      admin,
+      projectId,
+      member.user_id,
+    );
+    // Falha no release deixa comparações atribuídas a quem não pode mais
+    // comparar — devolve error sem chamar retry (o retry só recomputa o backlog
+    // sem comparação ativa e não tocaria nesses casos travados).
+    if (releaseResult.error) return { error: releaseResult.error };
+  }
+
+  let retried: { assigned: number; stillNoPool: number } | undefined;
+  const result = await retryPendingComparisons(projectId);
   if (result.success) {
     retried = { assigned: result.assigned, stillNoPool: result.stillNoPool };
   }

--- a/frontend/src/actions/projects.ts
+++ b/frontend/src/actions/projects.ts
@@ -5,6 +5,14 @@ import { getAuthUser } from "@/lib/auth";
 import { updateOrThrow, deleteOrThrow } from "@/lib/supabase/rls-guard";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
+import type { AutomationMode } from "@/lib/types";
+
+const AUTOMATION_MODE_VALUES: ReadonlyArray<AutomationMode> = [
+  "none",
+  "auto_review_llm",
+  "compare_humans",
+  "compare_llm",
+];
 
 export async function createProject(_prev: unknown, formData: FormData) {
   const user = await getAuthUser();
@@ -14,10 +22,16 @@ export async function createProject(_prev: unknown, formData: FormData) {
 
   const name = formData.get("name") as string;
   const description = formData.get("description") as string;
+  const rawMode = formData.get("automation_mode") as string | null;
+  const automation_mode: AutomationMode = AUTOMATION_MODE_VALUES.includes(
+    rawMode as AutomationMode,
+  )
+    ? (rawMode as AutomationMode)
+    : "auto_review_llm";
 
   const { data: project, error } = await supabase
     .from("projects")
-    .insert({ name, description, created_by: user.id })
+    .insert({ name, description, created_by: user.id, automation_mode })
     .select()
     .single();
 
@@ -50,6 +64,8 @@ export async function updateProject(
     min_responses_for_comparison?: number;
     allow_researcher_review?: boolean;
     arbitration_blind?: boolean;
+    automation_mode?: AutomationMode;
+    comparison_includes_llm?: boolean;
   }
 ): Promise<{ error?: string }> {
   const supabase = await createSupabaseServer();

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -6,6 +6,7 @@ import { revalidatePath, revalidateTag } from "next/cache";
 import { isFieldVisible } from "@/lib/conditional";
 import { isCodingComplete } from "@/lib/coding-completeness";
 import { createAutoReviewIfDiverges } from "@/lib/auto-review";
+import { createAutoComparisonIfDiverges } from "@/lib/auto-comparison";
 import type { PydanticField } from "@/lib/types";
 
 export interface SaveResponseOpts {
@@ -53,7 +54,7 @@ export async function saveResponse(
       supabase
         .from("projects")
         .select(
-          "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, round_strategy, current_round_id",
+          "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, round_strategy, current_round_id, automation_mode",
         )
         .eq("id", projectId)
         .single(),
@@ -154,17 +155,27 @@ export async function saveResponse(
           .eq("type", "codificacao");
         if (assignErr) return { success: false, error: assignErr.message };
 
-        // Dispara auto-revisao humano vs LLM ao submeter. Falhas nao bloqueiam
-        // o submit do pesquisador — coordenador pode regenerar o backlog
-        // manualmente via regenerateAutoReviewBacklog().
+        // Dispara a automacao do projeto ao submeter, conforme automation_mode.
+        // Falhas nao bloqueiam o submit do pesquisador — o coordenador pode
+        // regenerar o backlog manualmente (regenerateAutoReviewBacklog /
+        // retryPendingComparisons). "none" nao dispara nada.
+        const mode = project?.automation_mode;
         try {
-          await createAutoReviewIfDiverges(projectId, documentId, effectiveId);
+          if (mode === "auto_review_llm") {
+            await createAutoReviewIfDiverges(projectId, documentId, effectiveId);
+          } else if (mode === "compare_humans") {
+            await createAutoComparisonIfDiverges(projectId, documentId, "compare_humans");
+          } else if (mode === "compare_llm") {
+            await createAutoComparisonIfDiverges(projectId, documentId, "compare_llm");
+          }
         } catch (err) {
-          // Log estruturado JSON — mesmo formato dos demais eventos em
-          // lib/auto-review.ts, facilita grep "[auto-review]" nos logs.
+          // Log estruturado JSON — mesmo formato dos demais eventos das libs de
+          // automacao, facilita grep "[auto-review]" / "[auto-compare]" nos logs.
+          const prefix = mode === "auto_review_llm" ? "[auto-review]" : "[auto-compare]";
           console.error(
-            `[auto-review] ${JSON.stringify({
+            `${prefix} ${JSON.stringify({
               event: "inline_call_failed",
+              mode,
               projectId,
               documentId,
               userId: effectiveId,

--- a/frontend/src/app/(app)/projects/[id]/analyze/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/layout.tsx
@@ -1,6 +1,8 @@
 import { AnalyzeNav } from "@/components/analyze/AnalyzeNav";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
+import { computeAnalyzeTabVisibility } from "@/lib/analyze-tabs";
+import type { AutomationMode } from "@/lib/types";
 
 export default async function AnalyzeLayout({
   children,
@@ -9,43 +11,68 @@ export default async function AnalyzeLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  // Esconde abas Auto-revisão / Arbitragem para quem nao tem assignments
-  // correspondentes. Coordenador sempre ve. Pesquisador ve enquanto tiver
-  // pelo menos um assignment do tipo (pendente, em_andamento OU concluido) —
-  // preserva acesso ao historico mesmo apos a fila zerar.
+  // Quais abas de revisão aparecem depende do modo de automação do projeto +
+  // dos assignments do usuário. O coordenador vê as abas do mecanismo ativo no
+  // modo; o pesquisador vê enquanto tiver assignment do tipo (pendente,
+  // em_andamento OU concluido) — preserva acesso ao histórico mesmo se o modo
+  // mudou depois. Ver computeAnalyzeTabVisibility.
   const [{ id }, user] = await Promise.all([params, getAuthUser()]);
   let showAutoReview = false;
   let showArbitragem = false;
+  let showCompare = false;
 
   if (user) {
     const supabase = await createSupabaseServer();
-    // Duas queries direcionadas com .limit(1) em vez de uma query genérica com
-    // .limit(50): se o usuario tiver muitos assignments de um tipo, o teto de
-    // 50 ainda poderia mascarar o outro tipo. .limit(1) é O(1) com o index
-    // (project_id, user_id, type).
-    const [{ data: autoReviewRow }, { data: arbitragemRow }, isCoord] =
-      await Promise.all([
-        supabase
-          .from("assignments")
-          .select("id")
-          .eq("project_id", id)
-          .eq("user_id", user.id)
-          .eq("type", "auto_revisao")
-          .limit(1)
-          .maybeSingle(),
-        supabase
-          .from("assignments")
-          .select("id")
-          .eq("project_id", id)
-          .eq("user_id", user.id)
-          .eq("type", "arbitragem")
-          .limit(1)
-          .maybeSingle(),
-        isProjectCoordinator(id, user),
-      ]);
+    // Queries direcionadas com .limit(1) (O(1) com o index (project_id, user_id,
+    // type)) em vez de uma genérica com .limit(50), que poderia mascarar um tipo
+    // se o usuário tiver muitos assignments de outro.
+    const [
+      { data: autoReviewRow },
+      { data: arbitragemRow },
+      { data: comparacaoRow },
+      { data: project },
+      isCoord,
+    ] = await Promise.all([
+      supabase
+        .from("assignments")
+        .select("id")
+        .eq("project_id", id)
+        .eq("user_id", user.id)
+        .eq("type", "auto_revisao")
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from("assignments")
+        .select("id")
+        .eq("project_id", id)
+        .eq("user_id", user.id)
+        .eq("type", "arbitragem")
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from("assignments")
+        .select("id")
+        .eq("project_id", id)
+        .eq("user_id", user.id)
+        .eq("type", "comparacao")
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from("projects")
+        .select("automation_mode")
+        .eq("id", id)
+        .single(),
+      isProjectCoordinator(id, user),
+    ]);
 
-    showAutoReview = isCoord || autoReviewRow !== null;
-    showArbitragem = isCoord || arbitragemRow !== null;
+    ({ showAutoReview, showArbitragem, showCompare } =
+      computeAnalyzeTabVisibility({
+        mode: project?.automation_mode as AutomationMode | undefined,
+        isCoordinator: isCoord,
+        hasAutoRevisaoAssignment: autoReviewRow !== null,
+        hasArbitragemAssignment: arbitragemRow !== null,
+        hasComparacaoAssignment: comparacaoRow !== null,
+      }));
   }
 
   return (
@@ -54,6 +81,7 @@ export default async function AnalyzeLayout({
         projectId={id}
         showAutoReview={showAutoReview}
         showArbitragem={showArbitragem}
+        showCompare={showCompare}
       />
       <div className="flex-1">{children}</div>
     </div>

--- a/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
@@ -1,5 +1,7 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { getAuthUser } from "@/lib/auth";
+import { scanComparisonBacklog } from "@/lib/auto-comparison";
 import { MemberList } from "@/components/members/MemberList";
 import { AddMemberDialog } from "@/components/members/AddMemberDialog";
 import type { MemberEmailLink, ProjectMember, Profile } from "@/lib/types";
@@ -15,23 +17,42 @@ export default async function MembersPage({
     createSupabaseServer(),
   ]);
 
-  const [{ data: members }, { count: orphanedReviews }, { data: emailLinks }] =
-    await Promise.all([
-      supabase
-        .from("project_members")
-        .select("id, project_id, user_id, role, can_arbitrate, can_resolve, profiles(id, email, first_name, last_name, activated_at)")
-        .eq("project_id", id),
-      supabase
-        .from("field_reviews")
-        .select("id", { count: "exact", head: true })
-        .eq("project_id", id)
-        .eq("self_verdict", "contesta_llm")
-        .is("arbitrator_id", null),
-      supabase
-        .from("member_email_links")
-        .select("id, project_id, member_user_id, email, linked_user_id, created_by, created_at")
-        .eq("project_id", id),
-    ]);
+  const [
+    { data: members },
+    { count: orphanedReviews },
+    { data: emailLinks },
+    { data: project },
+  ] = await Promise.all([
+    supabase
+      .from("project_members")
+      .select("id, project_id, user_id, role, can_arbitrate, can_resolve, can_compare, profiles(id, email, first_name, last_name, activated_at)")
+      .eq("project_id", id),
+    supabase
+      .from("field_reviews")
+      .select("id", { count: "exact", head: true })
+      .eq("project_id", id)
+      .eq("self_verdict", "contesta_llm")
+      .is("arbitrator_id", null),
+    supabase
+      .from("member_email_links")
+      .select("id, project_id, member_user_id, email, linked_user_id, created_by, created_at")
+      .eq("project_id", id),
+    supabase
+      .from("projects")
+      .select("automation_mode")
+      .eq("id", id)
+      .single(),
+  ]);
+
+  // Backlog de comparação sem revisor — só relevante nos modos de comparação.
+  // Recomputado por varredura (a comparação não materializa divergência). Página
+  // coordinator-only e de baixo tráfego, então a varredura aqui é aceitável.
+  const mode = project?.automation_mode;
+  let orphanedComparisons = 0;
+  if (mode === "compare_humans" || mode === "compare_llm") {
+    const admin = createSupabaseAdmin();
+    orphanedComparisons = (await scanComparisonBacklog(admin, id, mode)).length;
+  }
 
   const typedMembers = (members || []) as unknown as (ProjectMember & { profiles: Profile })[];
 
@@ -44,6 +65,11 @@ export default async function MembersPage({
       {orphanedReviews && orphanedReviews > 0 ? (
         <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
           {orphanedReviews} caso(s) aguardando arbitragem sem árbitro elegível. Marque ao menos um membro como <strong>Arbitra</strong> abaixo para alocá-los.
+        </div>
+      ) : null}
+      {orphanedComparisons > 0 ? (
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+          {orphanedComparisons} documento(s) divergente(s) sem revisor de comparação. Marque ao menos um membro como <strong>Compara</strong> abaixo para alocá-los.
         </div>
       ) : null}
       <MemberList

--- a/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
@@ -16,12 +16,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { AUTOMATION_MODES, type AutomationMode } from "@/lib/types";
 
 interface RulesFormProps {
   projectId: string;
   resolutionRule: string;
   minResponses: number;
   allowResearcherReview: boolean;
+  automationMode: AutomationMode;
+  comparisonIncludesLlm: boolean;
 }
 
 const RESOLUTION_OPTIONS = [
@@ -35,13 +39,19 @@ export function RulesForm({
   resolutionRule,
   minResponses,
   allowResearcherReview,
+  automationMode,
+  comparisonIncludesLlm,
 }: RulesFormProps) {
   const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [rule, setRule] = useState(resolutionRule);
   const [min, setMin] = useState(minResponses);
   const [allowReview, setAllowReview] = useState(allowResearcherReview);
+  const [mode, setMode] = useState<AutomationMode>(automationMode);
+  const [includesLlm, setIncludesLlm] = useState(comparisonIncludesLlm);
   const [saved, setSaved] = useState(false);
+
+  const modeMeta = AUTOMATION_MODES.find((m) => m.value === mode);
 
   function handleSave() {
     startTransition(async () => {
@@ -50,6 +60,8 @@ export function RulesForm({
           resolution_rule: rule,
           min_responses_for_comparison: min,
           allow_researcher_review: allowReview,
+          automation_mode: mode,
+          comparison_includes_llm: includesLlm,
         });
         if (r?.error) {
           toast.error(r.error);
@@ -68,9 +80,54 @@ export function RulesForm({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Regras de Resolução</CardTitle>
+        <CardTitle>Regras de Revisão</CardTitle>
       </CardHeader>
       <CardContent className="space-y-5">
+        <div className="space-y-2">
+          <Label className="text-sm">Modo de automação</Label>
+          <Select value={mode} onValueChange={(v) => setMode(v as AutomationMode)}>
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {AUTOMATION_MODES.map((m) => (
+                <SelectItem key={m.value} value={m.value}>
+                  {m.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {modeMeta && (
+            <p className="text-xs text-muted-foreground">{modeMeta.description}</p>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Mudar o modo só afeta novas codificações; o backlog existente é
+            preenchido conforme as pessoas codificam (ou via sorteio manual).
+            Determina também quais abas de revisão aparecem no projeto.
+          </p>
+        </div>
+
+        {mode === "compare_humans" && (
+          <div className="flex items-start gap-3">
+            <Switch
+              id="includesLlm"
+              checked={includesLlm}
+              onCheckedChange={setIncludesLlm}
+              aria-label="Incluir o LLM no disparo da comparação"
+            />
+            <div className="space-y-1">
+              <Label htmlFor="includesLlm" className="text-sm">
+                Incluir o LLM no disparo da comparação
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Quando ligado, a comparação é liberada também se os humanos
+                concordam mas o LLM diverge. Desligado, só dispara quando os
+                humanos divergem entre si (o LLM ainda aparece na comparação).
+              </p>
+            </div>
+          </div>
+        )}
+
         <div className="space-y-2">
           <Label className="text-sm">Regra de resolução</Label>
           <Select value={rule} onValueChange={setRule}>

--- a/frontend/src/app/(app)/projects/[id]/config/rules/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/page.tsx
@@ -10,7 +10,7 @@ export default async function RulesPage({
 
   const { data: project } = await supabase
     .from("projects")
-    .select("resolution_rule, min_responses_for_comparison, allow_researcher_review")
+    .select("resolution_rule, min_responses_for_comparison, allow_researcher_review, automation_mode, comparison_includes_llm")
     .eq("id", id)
     .single();
 
@@ -21,6 +21,8 @@ export default async function RulesPage({
         resolutionRule={project?.resolution_rule || "majority"}
         minResponses={project?.min_responses_for_comparison || 2}
         allowResearcherReview={project?.allow_researcher_review ?? false}
+        automationMode={project?.automation_mode ?? "auto_review_llm"}
+        comparisonIncludesLlm={project?.comparison_includes_llm ?? true}
       />
     </div>
   );

--- a/frontend/src/app/(app)/projects/new/page.tsx
+++ b/frontend/src/app/(app)/projects/new/page.tsx
@@ -1,14 +1,24 @@
 "use client";
 
-import { useActionState } from "react";
+import { useActionState, useState } from "react";
 import { createProject } from "@/actions/projects";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { AUTOMATION_MODES, type AutomationMode } from "@/lib/types";
 
 export default function NewProjectPage() {
   const [state, formAction, pending] = useActionState(createProject, null);
+  const [mode, setMode] = useState<AutomationMode>("auto_review_llm");
+  const modeMeta = AUTOMATION_MODES.find((m) => m.value === mode);
 
   return (
     <main className="mx-auto max-w-lg p-6">
@@ -42,6 +52,35 @@ export default function NewProjectPage() {
                 placeholder="Breve descrição do objetivo da revisão..."
                 rows={3}
               />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="automation_mode_trigger" className="text-sm font-medium">
+                Modo de automação
+              </label>
+              {/* Input hidden: o form é FormData-based; o Select (Radix) controla
+                  o estado e o hidden carrega o valor para a Server Action. */}
+              <input type="hidden" name="automation_mode" value={mode} />
+              <Select
+                value={mode}
+                onValueChange={(v) => setMode(v as AutomationMode)}
+              >
+                <SelectTrigger id="automation_mode_trigger" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {AUTOMATION_MODES.map((m) => (
+                    <SelectItem key={m.value} value={m.value}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {modeMeta && (
+                <p className="text-xs text-muted-foreground">
+                  {modeMeta.description} Você pode mudar isso depois em
+                  Configurações › Regras.
+                </p>
+              )}
             </div>
             <Button
               type="submit"

--- a/frontend/src/components/analyze/AnalyzeNav.tsx
+++ b/frontend/src/components/analyze/AnalyzeNav.tsx
@@ -7,24 +7,26 @@ import { cn } from "@/lib/utils";
 const baseTabs = [
   { label: "Atribuições", href: "assignments" },
   { label: "Codificar", href: "code" },
-  { label: "Comparar", href: "compare" },
 ];
 
 interface AnalyzeNavProps {
   projectId: string;
   showAutoReview?: boolean;
   showArbitragem?: boolean;
+  showCompare?: boolean;
 }
 
 export function AnalyzeNav({
   projectId,
   showAutoReview = false,
   showArbitragem = false,
+  showCompare = false,
 }: AnalyzeNavProps) {
   const pathname = usePathname();
 
   const tabs = [
     ...baseTabs,
+    ...(showCompare ? [{ label: "Comparar", href: "compare" }] : []),
     ...(showAutoReview
       ? [{ label: "Auto-revisão", href: "auto-revisao" }]
       : []),

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -6,6 +6,7 @@ import {
   changeRole,
   setCanArbitrate,
   setCanResolve,
+  setCanCompare,
   updatePendingMemberEmail,
   unlinkMemberEmail,
   type UnificationPreview,
@@ -121,6 +122,7 @@ export function MemberList({
   // sequência não precisa esperar serializar.
   const [pendingArbitrateId, setPendingArbitrateId] = useState<string | null>(null);
   const [pendingResolveId, setPendingResolveId] = useState<string | null>(null);
+  const [pendingCompareId, setPendingCompareId] = useState<string | null>(null);
   const [editingEmailMemberId, setEditingEmailMemberId] = useState<string | null>(null);
   // Vínculo de e-mails (US2): um único par de dialogs no root, dirigido pelo
   // membro selecionado / preview de unificação retornado pela action.
@@ -152,7 +154,7 @@ export function MemberList({
   // revalidatePath devolver — em conexão lenta parece que o clique não pegou.
   const [optimisticMembers, applyOptimistic] = useOptimistic<
     MemberRow[],
-    { memberId: string; patch: Partial<Pick<MemberRow, "can_arbitrate" | "can_resolve">> }
+    { memberId: string; patch: Partial<Pick<MemberRow, "can_arbitrate" | "can_resolve" | "can_compare">> }
   >(members, (current, update) =>
     current.map((m) =>
       m.id === update.memberId ? { ...m, ...update.patch } : m,
@@ -223,6 +225,35 @@ export function MemberList({
         );
       } finally {
         setPendingResolveId(null);
+      }
+    });
+  };
+
+  const handleToggleCompare = (memberId: string, value: boolean) => {
+    setPendingCompareId(memberId);
+    startTransition(async () => {
+      applyOptimistic({ memberId, patch: { can_compare: value } });
+      try {
+        const result = await setCanCompare(memberId, value, projectId);
+        if (result?.error) {
+          toast.error(result.error);
+          return;
+        }
+        const verb = value ? "habilitada" : "desabilitada";
+        const retried = result.retried;
+        if (retried && retried.assigned > 0 && retried.stillNoPool > 0) {
+          toast.success(
+            `Comparação ${verb}. ${retried.assigned} caso(s) realocado(s); ${retried.stillNoPool} ainda sem revisor elegível.`,
+          );
+        } else if (retried && retried.assigned > 0) {
+          toast.success(
+            `Comparação ${verb}. ${retried.assigned} caso(s) realocado(s).`,
+          );
+        } else {
+          toast.success(`Comparação ${verb}.`);
+        }
+      } finally {
+        setPendingCompareId(null);
       }
     });
   };
@@ -316,6 +347,18 @@ export function MemberList({
                 aria-label="Elegível para arbitrar"
               />
               Arbitra
+            </span>
+            <span
+              className="flex items-center gap-2 text-xs text-muted-foreground"
+              title="Recebe documentos divergentes para comparar"
+            >
+              <Switch
+                checked={m.can_compare}
+                onCheckedChange={(v) => handleToggleCompare(m.id, v)}
+                disabled={pendingCompareId === m.id}
+                aria-label="Elegível para comparar"
+              />
+              Compara
             </span>
             <Select
               value={m.role}

--- a/frontend/src/lib/__tests__/analyze-tabs.test.ts
+++ b/frontend/src/lib/__tests__/analyze-tabs.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { computeAnalyzeTabVisibility } from "@/lib/analyze-tabs";
+
+const base = {
+  isCoordinator: false,
+  hasAutoRevisaoAssignment: false,
+  hasArbitragemAssignment: false,
+  hasComparacaoAssignment: false,
+};
+
+describe("computeAnalyzeTabVisibility — coordenador segue o modo", () => {
+  it("auto_review_llm → Auto-revisão + Arbitragem; Comparar oculta", () => {
+    const v = computeAnalyzeTabVisibility({
+      ...base,
+      mode: "auto_review_llm",
+      isCoordinator: true,
+    });
+    expect(v).toEqual({
+      showAutoReview: true,
+      showArbitragem: true,
+      showCompare: false,
+    });
+  });
+
+  it("compare_humans → Comparar; Auto-revisão/Arbitragem ocultas", () => {
+    const v = computeAnalyzeTabVisibility({
+      ...base,
+      mode: "compare_humans",
+      isCoordinator: true,
+    });
+    expect(v).toEqual({
+      showAutoReview: false,
+      showArbitragem: false,
+      showCompare: true,
+    });
+  });
+
+  it("compare_llm → Comparar", () => {
+    const v = computeAnalyzeTabVisibility({
+      ...base,
+      mode: "compare_llm",
+      isCoordinator: true,
+    });
+    expect(v.showCompare).toBe(true);
+    expect(v.showAutoReview).toBe(false);
+  });
+
+  it("none → nenhuma aba de revisão", () => {
+    const v = computeAnalyzeTabVisibility({
+      ...base,
+      mode: "none",
+      isCoordinator: true,
+    });
+    expect(v).toEqual({
+      showAutoReview: false,
+      showArbitragem: false,
+      showCompare: false,
+    });
+  });
+});
+
+describe("computeAnalyzeTabVisibility — pesquisador vê o que tem assignment", () => {
+  it("sem assignments, qualquer modo → nada (não-coordenador)", () => {
+    const v = computeAnalyzeTabVisibility({ ...base, mode: "compare_humans" });
+    expect(v).toEqual({
+      showAutoReview: false,
+      showArbitragem: false,
+      showCompare: false,
+    });
+  });
+
+  it("tem comparacao → vê Comparar mesmo se o modo mudou para auto_review_llm", () => {
+    const v = computeAnalyzeTabVisibility({
+      ...base,
+      mode: "auto_review_llm",
+      hasComparacaoAssignment: true,
+    });
+    expect(v.showCompare).toBe(true);
+  });
+
+  it("tem auto_revisao → vê Auto-revisão mesmo em modo de comparação", () => {
+    const v = computeAnalyzeTabVisibility({
+      ...base,
+      mode: "compare_humans",
+      hasAutoRevisaoAssignment: true,
+    });
+    expect(v.showAutoReview).toBe(true);
+  });
+});

--- a/frontend/src/lib/__tests__/auto-comparison.test.ts
+++ b/frontend/src/lib/__tests__/auto-comparison.test.ts
@@ -1,0 +1,369 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PydanticField } from "@/lib/types";
+
+// Mock supabase chainable e FILTER-AWARE: diferente do mock de
+// arbitration-retry.test.ts, aplica os filtros .eq/.neq/.in às linhas, porque a
+// comparação consulta `responses` duas vezes na mesma chamada (humano vs LLM) —
+// um mock que ignora filtros devolveria o mesmo array para ambas.
+type WriteCall = { table: string; op: string; payload: unknown };
+let writeCalls: WriteCall[];
+let tableData: Record<string, unknown[]>;
+
+const upsertCallsOf = (table?: string) =>
+  writeCalls.filter((c) => c.op === "upsert" && (!table || c.table === table));
+const deleteCallsOf = (table?: string) =>
+  writeCalls.filter((c) => c.op === "delete" && (!table || c.table === table));
+
+function makeClient() {
+  return {
+    from: (table: string) => {
+      const eqs: Array<[string, unknown]> = [];
+      const neqs: Array<[string, unknown]> = [];
+      const ins: Array<[string, unknown[]]> = [];
+      let op = "select";
+      let limitN: number | null = null;
+
+      const builder: Record<string, unknown> = {};
+      builder.select = () => builder;
+      builder.eq = (c: string, v: unknown) => {
+        eqs.push([c, v]);
+        return builder;
+      };
+      builder.neq = (c: string, v: unknown) => {
+        neqs.push([c, v]);
+        return builder;
+      };
+      builder.is = (c: string, v: unknown) => {
+        eqs.push([c, v]);
+        return builder;
+      };
+      builder.in = (c: string, v: unknown[]) => {
+        ins.push([c, v]);
+        return builder;
+      };
+      builder.limit = (n: number) => {
+        limitN = n;
+        return builder;
+      };
+      builder.update = (payload: unknown) => {
+        writeCalls.push({ table, op: "update", payload });
+        op = "update";
+        return builder;
+      };
+      builder.upsert = (payload: unknown) => {
+        writeCalls.push({ table, op: "upsert", payload });
+        op = "upsert";
+        return builder;
+      };
+      builder.insert = (payload: unknown) => {
+        writeCalls.push({ table, op: "insert", payload });
+        op = "insert";
+        return builder;
+      };
+      builder.delete = () => {
+        writeCalls.push({ table, op: "delete", payload: null });
+        op = "delete";
+        return builder;
+      };
+
+      const rows = () => {
+        const data = (tableData[table] ?? []) as Array<Record<string, unknown>>;
+        const filtered = data.filter((r) => {
+          for (const [c, v] of eqs) if (r[c] !== v) return false;
+          for (const [c, v] of neqs) if (r[c] === v) return false;
+          for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
+          return true;
+        });
+        return limitN != null ? filtered.slice(0, limitN) : filtered;
+      };
+      const err = () => tableData[`__error:${table}:${op}`] ?? null;
+
+      builder.single = () =>
+        Promise.resolve({ data: rows()[0] ?? null, error: err() });
+      builder.maybeSingle = () =>
+        Promise.resolve({ data: rows()[0] ?? null, error: err() });
+      builder.then = (resolve: (v: unknown) => unknown) =>
+        resolve({ data: rows(), error: err() });
+      return builder;
+    },
+  };
+}
+
+const hoisted = vi.hoisted(() => ({
+  isCoord: vi.fn<() => Promise<boolean>>(async () => true),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "userCoord" }),
+  isProjectCoordinator: () => hoisted.isCoord(),
+}));
+vi.mock("@/lib/supabase/admin", () => ({
+  createSupabaseAdmin: () => makeClient(),
+}));
+
+const FIELDS: PydanticField[] = [
+  { name: "q1", type: "text", options: null, description: "", required: true },
+];
+
+// Helpers de fixture
+const human = (
+  respondent_id: string,
+  q1: string,
+  extra: Record<string, unknown> = {},
+) => ({
+  id: `r-${respondent_id}`,
+  project_id: "p1",
+  document_id: "doc1",
+  respondent_id,
+  respondent_type: "humano",
+  is_latest: true,
+  answers: { q1 },
+  answer_field_hashes: null,
+  ...extra,
+});
+const llm = (q1: string) => ({
+  id: "r-llm",
+  project_id: "p1",
+  document_id: "doc1",
+  respondent_type: "llm",
+  is_latest: true,
+  answers: { q1 },
+  answer_field_hashes: null,
+});
+const member = (user_id: string) => ({
+  user_id,
+  project_id: "p1",
+  can_compare: true,
+});
+const projectRow = (over: Record<string, unknown> = {}) => ({
+  id: "p1",
+  pydantic_fields: FIELDS,
+  min_responses_for_comparison: 2,
+  comparison_includes_llm: true,
+  automation_mode: "compare_humans",
+  ...over,
+});
+
+beforeEach(() => {
+  writeCalls = [];
+  tableData = {
+    projects: [projectRow()],
+    project_members: [],
+    assignments: [],
+    responses: [],
+    response_equivalences: [],
+  };
+  hoisted.isCoord.mockResolvedValue(true);
+});
+
+async function loadLib() {
+  return import("@/lib/auto-comparison");
+}
+
+describe("assignComparisonReviewer — pool e balanceamento", () => {
+  it("exclui TODOS os codificadores do pool", async () => {
+    const { assignComparisonReviewer } = await loadLib();
+    tableData.project_members = [member("userA"), member("userB"), member("userC")];
+    const r = await assignComparisonReviewer(
+      makeClient() as never,
+      "p1",
+      "doc1",
+      new Set(["userA", "userB"]), // codificadores
+    );
+    expect(r.assigned).toBe(true);
+    expect(r.noPool).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(1);
+    expect(upsertCallsOf("assignments")[0].payload).toMatchObject({
+      user_id: "userC",
+      type: "comparacao",
+      status: "pendente",
+    });
+  });
+
+  it("pool vazio (todos codificaram) → noPool, sem upsert", async () => {
+    const { assignComparisonReviewer } = await loadLib();
+    tableData.project_members = [member("userA"), member("userB")];
+    const r = await assignComparisonReviewer(
+      makeClient() as never,
+      "p1",
+      "doc1",
+      new Set(["userA", "userB"]),
+    );
+    expect(r.noPool).toBe(true);
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("ninguém can_compare → noPool", async () => {
+    const { assignComparisonReviewer } = await loadLib();
+    tableData.project_members = [];
+    const r = await assignComparisonReviewer(
+      makeClient() as never,
+      "p1",
+      "doc1",
+      new Set(),
+    );
+    expect(r.noPool).toBe(true);
+  });
+
+  it("escolhe o revisor de menor carga de comparações abertas", async () => {
+    const { assignComparisonReviewer } = await loadLib();
+    tableData.project_members = [member("userB"), member("userC")];
+    // userB já tem 2 comparações abertas; userC nenhuma → escolhe userC.
+    tableData.assignments = [
+      { user_id: "userB", project_id: "p1", type: "comparacao", status: "pendente" },
+      { user_id: "userB", project_id: "p1", type: "comparacao", status: "em_andamento" },
+    ];
+    const r = await assignComparisonReviewer(
+      makeClient() as never,
+      "p1",
+      "doc1",
+      new Set(["userA"]),
+    );
+    expect(r.assigned).toBe(true);
+    expect(upsertCallsOf("assignments")[0].payload).toMatchObject({
+      user_id: "userC",
+    });
+  });
+});
+
+describe("createAutoComparisonIfDiverges — compare_humans", () => {
+  it("2 humanos divergentes → atribui comparacao", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(true);
+    expect(upsertCallsOf("assignments")).toHaveLength(1);
+    expect(upsertCallsOf("assignments")[0].payload).toMatchObject({
+      user_id: "userC",
+      type: "comparacao",
+    });
+  });
+
+  it("2 humanos em consenso → não atribui", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.responses = [human("userA", "A"), human("userB", "A")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("abaixo do mínimo (1 humano) → não dispara", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.responses = [human("userA", "A")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("codificação incompleta não conta para o mínimo", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    // userB tem resposta vazia (incompleta) → só 1 humano completo.
+    tableData.responses = [
+      human("userA", "A"),
+      { ...human("userB", "B"), answers: {} },
+    ];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+  });
+
+  it("já existe comparacao ativa → idempotente, não re-sorteia", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    tableData.project_members = [member("userC")];
+    tableData.assignments = [
+      { document_id: "doc1", project_id: "p1", type: "comparacao", status: "pendente" },
+    ];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("comparison_includes_llm=true: humanos concordam mas LLM diverge → dispara", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [projectRow({ comparison_includes_llm: true })];
+    tableData.responses = [human("userA", "A"), human("userB", "A"), llm("Z")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(true);
+  });
+
+  it("comparison_includes_llm=false: humanos concordam e só LLM diverge → NÃO dispara", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [projectRow({ comparison_includes_llm: false })];
+    tableData.responses = [human("userA", "A"), human("userB", "A"), llm("Z")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+  });
+});
+
+describe("createAutoComparisonIfDiverges — compare_llm", () => {
+  it("1 humano + LLM divergentes → atribui comparacao", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [human("userA", "A"), llm("B")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
+    expect(r.assigned).toBe(true);
+    expect(upsertCallsOf("assignments")[0].payload).toMatchObject({
+      user_id: "userC",
+      type: "comparacao",
+    });
+  });
+
+  it("1 humano + LLM em consenso → não dispara", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [human("userA", "A"), llm("A")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
+    expect(r.assigned).toBe(false);
+  });
+
+  it("sem resposta do LLM → não dispara", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [human("userA", "A")];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
+    expect(r.assigned).toBe(false);
+  });
+
+  it("codificador do doc não entra no pool (LLM compara, mas humano que codificou não revisa)", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [human("userA", "A"), llm("B")];
+    // userA é o único can_compare, mas codificou o doc → noPool.
+    tableData.project_members = [member("userA")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
+    expect(r.assigned).toBe(false);
+    expect(r.noPool).toBe(true);
+  });
+});
+
+describe("releaseComparisonsFromUser", () => {
+  it("deleta comparacao pendente do usuário", async () => {
+    const { releaseComparisonsFromUser } = await loadLib();
+    tableData.assignments = [
+      { id: "a1", project_id: "p1", user_id: "userX", type: "comparacao", status: "pendente" },
+      { id: "a2", project_id: "p1", user_id: "userX", type: "comparacao", status: "em_andamento" },
+    ];
+    const r = await releaseComparisonsFromUser(makeClient() as never, "p1", "userX");
+    // só a pendente é contada (o filtro status=pendente exclui em_andamento)
+    expect(r.released).toBe(1);
+    expect(deleteCallsOf("assignments")).toHaveLength(1);
+  });
+
+  it("nada pendente → released 0", async () => {
+    const { releaseComparisonsFromUser } = await loadLib();
+    tableData.assignments = [];
+    const r = await releaseComparisonsFromUser(makeClient() as never, "p1", "userX");
+    expect(r.released).toBe(0);
+  });
+});

--- a/frontend/src/lib/analyze-tabs.ts
+++ b/frontend/src/lib/analyze-tabs.ts
@@ -1,0 +1,34 @@
+import type { AutomationMode } from "@/lib/types";
+
+// Decide quais abas de revisão aparecem em /analyze, a partir do modo de
+// automação do projeto e dos assignments do usuário. Pura — testável sem DB.
+//
+// Regra: o coordenador vê as abas do mecanismo ATIVO no projeto (modo); o
+// pesquisador vê uma aba enquanto tiver assignment do tipo (preserva acesso a
+// trabalho já atribuído mesmo se o modo mudou depois — não orfana). Atribuições
+// e Codificar são sempre visíveis (não passam por aqui).
+export function computeAnalyzeTabVisibility(opts: {
+  mode: AutomationMode | null | undefined;
+  isCoordinator: boolean;
+  hasAutoRevisaoAssignment: boolean;
+  hasArbitragemAssignment: boolean;
+  hasComparacaoAssignment: boolean;
+}): { showAutoReview: boolean; showArbitragem: boolean; showCompare: boolean } {
+  const {
+    mode,
+    isCoordinator,
+    hasAutoRevisaoAssignment,
+    hasArbitragemAssignment,
+    hasComparacaoAssignment,
+  } = opts;
+
+  const coordSeesAutoReview = isCoordinator && mode === "auto_review_llm";
+  const coordSeesCompare =
+    isCoordinator && (mode === "compare_humans" || mode === "compare_llm");
+
+  return {
+    showAutoReview: coordSeesAutoReview || hasAutoRevisaoAssignment,
+    showArbitragem: coordSeesAutoReview || hasArbitragemAssignment,
+    showCompare: coordSeesCompare || hasComparacaoAssignment,
+  };
+}

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -1,0 +1,428 @@
+import { createSupabaseAdmin } from "@/lib/supabase/admin";
+import { computeDivergentFieldNames } from "@/lib/compare-divergence";
+import { isCodingComplete } from "@/lib/coding-completeness";
+import type { EquivalencePair } from "@/lib/equivalence";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
+
+type Admin = ReturnType<typeof createSupabaseAdmin>;
+
+// Modos de automação que materializam uma comparação (assignment type=comparacao)
+// para um revisor terceiro. auto_review_llm e none não passam por aqui.
+export type ComparisonMode = "compare_humans" | "compare_llm";
+
+// Log estruturado JSON com prefixo "[auto-compare]" — pesquisavel em logs
+// Vercel/Fly via `grep '[auto-compare]'`. Espelha o logger de lib/auto-review.ts.
+function log(
+  event: string,
+  fields: Record<string, unknown>,
+  level: "info" | "warn" | "error" = "info",
+) {
+  const payload = JSON.stringify({ event, ...fields });
+  const line = `[auto-compare] ${payload}`;
+  if (level === "error") console.error(line);
+  else if (level === "warn") console.warn(line);
+  else console.log(line);
+}
+
+interface ResponseRow {
+  id: string;
+  respondent_id?: string | null;
+  answers: Record<string, unknown> | null;
+  answer_field_hashes: AnswerFieldHashes | null;
+}
+
+function toResponseLike(r: ResponseRow) {
+  return {
+    id: r.id,
+    answers: (r.answers as Record<string, unknown>) ?? {},
+    answerFieldHashes: r.answer_field_hashes as AnswerFieldHashes,
+  };
+}
+
+function buildEquivByField(
+  rows: Array<{ field_name: string; response_a_id: string; response_b_id: string }> | null,
+): Map<string, EquivalencePair[]> {
+  const map = new Map<string, EquivalencePair[]>();
+  for (const eq of rows ?? []) {
+    const list = map.get(eq.field_name) ?? [];
+    list.push({ response_a_id: eq.response_a_id, response_b_id: eq.response_b_id });
+    map.set(eq.field_name, list);
+  }
+  return map;
+}
+
+// Sorteia UM revisor de comparação para o documento e cria o assignment
+// (type=comparacao) idempotente. Espelha assignArbitrator (actions/field-reviews.ts):
+//   - Pool = membros can_compare=true MENOS todos os codificadores (coderIds) —
+//     sem fallback: um codificador comparando o próprio doc julgaria a própria
+//     codificação. Pool vazio → noPool=true (banner de pendência ao coordenador).
+//   - Balanceia por menor carga de comparações abertas; desempate aleatório.
+//   - precomputedOpenLoad: quando passado (batch do retry), evita N queries de
+//     carga e é incrementado a cada atribuição para balancear entre docs.
+export async function assignComparisonReviewer(
+  admin: Admin,
+  projectId: string,
+  documentId: string,
+  coderIds: Set<string>,
+  precomputedOpenLoad?: Map<string, number>,
+): Promise<{ assigned: boolean; noPool: boolean }> {
+  const { data: eligibleMembers } = await admin
+    .from("project_members")
+    .select("user_id")
+    .eq("project_id", projectId)
+    .eq("can_compare", true);
+
+  const eligible = (eligibleMembers ?? []).filter(
+    (m) => !coderIds.has(m.user_id as string),
+  );
+  if (eligible.length === 0) return { assigned: false, noPool: true };
+
+  let loadByUser: Map<string, number>;
+  if (precomputedOpenLoad) {
+    loadByUser = precomputedOpenLoad;
+  } else {
+    const { data: openCounts } = await admin
+      .from("assignments")
+      .select("user_id")
+      .eq("project_id", projectId)
+      .eq("type", "comparacao")
+      .neq("status", "concluido");
+    loadByUser = new Map<string, number>();
+    for (const r of openCounts ?? []) {
+      loadByUser.set(r.user_id, (loadByUser.get(r.user_id) ?? 0) + 1);
+    }
+  }
+
+  let minLoad = Infinity;
+  for (const m of eligible) {
+    const l = loadByUser.get(m.user_id) ?? 0;
+    if (l < minLoad) minLoad = l;
+  }
+  const candidatesAtMin = eligible.filter(
+    (m) => (loadByUser.get(m.user_id) ?? 0) === minLoad,
+  );
+
+  // Desempate aleatorio entre os de menor carga (sem preferencia de role).
+  const reviewerId = candidatesAtMin[
+    Math.floor(Math.random() * candidatesAtMin.length)
+  ].user_id as string;
+
+  const { error } = await admin.from("assignments").upsert(
+    {
+      project_id: projectId,
+      document_id: documentId,
+      user_id: reviewerId,
+      type: "comparacao",
+      status: "pendente",
+    },
+    { onConflict: "document_id,user_id,type", ignoreDuplicates: true },
+  );
+  if (error) throw new Error(error.message);
+
+  // Mantem a carga in-memory coerente para o proximo doc do batch (retry).
+  if (precomputedOpenLoad) {
+    precomputedOpenLoad.set(reviewerId, (precomputedOpenLoad.get(reviewerId) ?? 0) + 1);
+  }
+
+  return { assigned: true, noPool: false };
+}
+
+// Detecta divergencia segundo o modo e, se houver, materializa um assignment
+// comparacao para um revisor terceiro. Chamado de saveResponse() apos a
+// codificacao virar "concluido". Usa admin client porque a policy de assignments
+// restringe INSERT a coordenadores; aqui o pesquisador precisa criar a fila.
+//
+// "o minimo necessario para liberar a revisao":
+//   compare_humans → >= min_responses_for_comparison humanos completos
+//   compare_llm    → >= 1 humano completo + resposta LLM
+// comparison_includes_llm (so compare_humans) decide se o LLM entra no calculo
+// de divergencia que dispara.
+export async function createAutoComparisonIfDiverges(
+  projectId: string,
+  documentId: string,
+  mode: ComparisonMode,
+): Promise<{ assigned: boolean; noPool: boolean }> {
+  const admin = createSupabaseAdmin();
+
+  const [
+    { data: project },
+    { data: humanResponses },
+    { data: llmResponse },
+    { data: equivalences },
+    { data: activeAssignments },
+  ] = await Promise.all([
+    admin
+      .from("projects")
+      .select("pydantic_fields, min_responses_for_comparison, comparison_includes_llm")
+      .eq("id", projectId)
+      .single(),
+    admin
+      .from("responses")
+      .select("id, respondent_id, answers, answer_field_hashes")
+      .eq("project_id", projectId)
+      .eq("document_id", documentId)
+      .eq("respondent_type", "humano")
+      .eq("is_latest", true),
+    admin
+      .from("responses")
+      .select("id, answers, answer_field_hashes")
+      .eq("project_id", projectId)
+      .eq("document_id", documentId)
+      .eq("respondent_type", "llm")
+      .eq("is_latest", true)
+      .maybeSingle(),
+    admin
+      .from("response_equivalences")
+      .select("field_name, response_a_id, response_b_id")
+      .eq("project_id", projectId)
+      .eq("document_id", documentId),
+    admin
+      .from("assignments")
+      .select("id")
+      .eq("project_id", projectId)
+      .eq("document_id", documentId)
+      .eq("type", "comparacao")
+      .neq("status", "concluido")
+      .limit(1),
+  ]);
+
+  if (!project?.pydantic_fields) {
+    log("skip_no_data", { projectId, documentId, mode }, "warn");
+    return { assigned: false, noPool: false };
+  }
+  const fields = project.pydantic_fields as PydanticField[];
+
+  // Idempotencia: ja existe comparacao ativa para este doc → nao re-sorteia.
+  if (activeAssignments && activeAssignments.length > 0) {
+    log("skip_active_assignment", { projectId, documentId, mode });
+    return { assigned: false, noPool: false };
+  }
+
+  // So codificacoes humanas completas contam para o gatilho (#174).
+  const completeHumans = (humanResponses ?? []).filter((r) =>
+    isCodingComplete(fields, (r.answers as Record<string, unknown>) ?? {}),
+  );
+
+  const minHumans =
+    mode === "compare_humans" ? (project.min_responses_for_comparison ?? 2) : 1;
+  if (completeHumans.length < minHumans) {
+    log("skip_insufficient", {
+      projectId,
+      documentId,
+      mode,
+      completeHumans: completeHumans.length,
+      minHumans,
+    });
+    return { assigned: false, noPool: false };
+  }
+  if (mode === "compare_llm" && !llmResponse) {
+    log("skip_insufficient", { projectId, documentId, mode, reason: "no_llm" });
+    return { assigned: false, noPool: false };
+  }
+
+  const includeLlm =
+    mode === "compare_llm" ||
+    (mode === "compare_humans" && project.comparison_includes_llm === true);
+
+  const responsesForDivergence = completeHumans.map((r) =>
+    toResponseLike(r as ResponseRow),
+  );
+  if (includeLlm && llmResponse) {
+    responsesForDivergence.push(toResponseLike(llmResponse as ResponseRow));
+  }
+  if (responsesForDivergence.length < 2) {
+    log("skip_insufficient", {
+      projectId,
+      documentId,
+      mode,
+      reason: "needs_two_responses",
+    });
+    return { assigned: false, noPool: false };
+  }
+
+  const divergent = computeDivergentFieldNames(
+    fields,
+    responsesForDivergence,
+    buildEquivByField(equivalences),
+  );
+  if (divergent.length === 0) {
+    log("consensus", { projectId, documentId, mode, totalFields: fields.length });
+    return { assigned: false, noPool: false };
+  }
+
+  const coderIds = new Set<string>();
+  for (const r of completeHumans) {
+    if (r.respondent_id) coderIds.add(r.respondent_id as string);
+  }
+
+  const result = await assignComparisonReviewer(admin, projectId, documentId, coderIds);
+  log(result.assigned ? "created" : "no_pool", {
+    projectId,
+    documentId,
+    mode,
+    divergentCount: divergent.length,
+    divergentFields: divergent,
+  });
+  return result;
+}
+
+// Varre o projeto e devolve os documentos que DIVERGEM (segundo o modo) e ainda
+// nao tem comparacao ativa — o "backlog" sem revisor. Usado pelo retry
+// (atribui) e pelo banner de pendencia (conta). Varredura em 2 fases para nao
+// puxar `answers` de todo doc: fase 1 acha candidatos por metadado leve, fase 2
+// busca answers so deles e recomputa divergencia.
+export async function scanComparisonBacklog(
+  admin: Admin,
+  projectId: string,
+  mode: ComparisonMode,
+): Promise<Array<{ documentId: string; coderIds: Set<string> }>> {
+  // Fase 1: metadados leves (sem answers).
+  const [{ data: project }, { data: humanMeta }, { data: activeAsg }] =
+    await Promise.all([
+      admin
+        .from("projects")
+        .select("pydantic_fields, min_responses_for_comparison, comparison_includes_llm")
+        .eq("id", projectId)
+        .single(),
+      admin
+        .from("responses")
+        .select("document_id, respondent_id")
+        .eq("project_id", projectId)
+        .eq("respondent_type", "humano")
+        .eq("is_latest", true),
+      admin
+        .from("assignments")
+        .select("document_id")
+        .eq("project_id", projectId)
+        .eq("type", "comparacao")
+        .neq("status", "concluido"),
+    ]);
+
+  if (!project?.pydantic_fields) return [];
+  const fields = project.pydantic_fields as PydanticField[];
+  if (fields.length === 0) return [];
+
+  const docsWithActive = new Set(
+    (activeAsg ?? []).map((a) => a.document_id as string),
+  );
+
+  const humansByDoc = new Map<string, Set<string>>();
+  for (const r of humanMeta ?? []) {
+    const docId = r.document_id as string;
+    const respId = r.respondent_id as string | null;
+    if (!respId) continue;
+    const set = humansByDoc.get(docId) ?? new Set<string>();
+    set.add(respId);
+    humansByDoc.set(docId, set);
+  }
+
+  const minHumans =
+    mode === "compare_humans" ? (project.min_responses_for_comparison ?? 2) : 1;
+
+  // Candidatos: humanos suficientes (por respondente; completude conferida na
+  // fase 2) e sem comparacao ativa.
+  const candidates = [...humansByDoc.entries()]
+    .filter(([docId, humans]) => humans.size >= minHumans && !docsWithActive.has(docId))
+    .map(([docId]) => docId);
+  if (candidates.length === 0) return [];
+
+  // Fase 2: answers só dos candidatos.
+  const [{ data: humanFull }, { data: llmFull }, { data: equivs }] =
+    await Promise.all([
+      admin
+        .from("responses")
+        .select("id, document_id, respondent_id, answers, answer_field_hashes")
+        .eq("project_id", projectId)
+        .eq("respondent_type", "humano")
+        .eq("is_latest", true)
+        .in("document_id", candidates),
+      admin
+        .from("responses")
+        .select("id, document_id, answers, answer_field_hashes")
+        .eq("project_id", projectId)
+        .eq("respondent_type", "llm")
+        .eq("is_latest", true)
+        .in("document_id", candidates),
+      admin
+        .from("response_equivalences")
+        .select("document_id, field_name, response_a_id, response_b_id")
+        .eq("project_id", projectId)
+        .in("document_id", candidates),
+    ]);
+
+  const llmByDoc = new Map(
+    (llmFull ?? []).map((r) => [r.document_id as string, r as ResponseRow & { document_id: string }]),
+  );
+
+  const humansFullByDoc = new Map<string, Array<ResponseRow & { document_id: string }>>();
+  for (const r of humanFull ?? []) {
+    const docId = r.document_id as string;
+    const list = humansFullByDoc.get(docId) ?? [];
+    list.push(r as ResponseRow & { document_id: string });
+    humansFullByDoc.set(docId, list);
+  }
+
+  const equivByDoc = new Map<string, Map<string, EquivalencePair[]>>();
+  for (const eq of equivs ?? []) {
+    const docId = eq.document_id as string;
+    const byField = equivByDoc.get(docId) ?? new Map<string, EquivalencePair[]>();
+    const list = byField.get(eq.field_name) ?? [];
+    list.push({ response_a_id: eq.response_a_id, response_b_id: eq.response_b_id });
+    byField.set(eq.field_name, list);
+    equivByDoc.set(docId, byField);
+  }
+
+  const result: Array<{ documentId: string; coderIds: Set<string> }> = [];
+  for (const docId of candidates) {
+    const completeHumans = (humansFullByDoc.get(docId) ?? []).filter((r) =>
+      isCodingComplete(fields, (r.answers as Record<string, unknown>) ?? {}),
+    );
+    if (completeHumans.length < minHumans) continue;
+    const llm = llmByDoc.get(docId);
+    if (mode === "compare_llm" && !llm) continue;
+
+    const includeLlm =
+      mode === "compare_llm" ||
+      (mode === "compare_humans" && project.comparison_includes_llm === true);
+
+    const responses = completeHumans.map((r) => toResponseLike(r));
+    if (includeLlm && llm) responses.push(toResponseLike(llm));
+    if (responses.length < 2) continue;
+
+    const divergent = computeDivergentFieldNames(
+      fields,
+      responses,
+      equivByDoc.get(docId),
+    );
+    if (divergent.length === 0) continue;
+
+    const coderIds = new Set<string>();
+    for (const r of completeHumans) {
+      if (r.respondent_id) coderIds.add(r.respondent_id as string);
+    }
+    result.push({ documentId: docId, coderIds });
+  }
+
+  return result;
+}
+
+// Solta as comparações PENDENTES atribuídas a `userId` (em_andamento/concluido
+// ficam intactas). Disparada por setCanCompare ao desmarcar can_compare, antes
+// do retry re-sortear. Espelha releaseArbitrationsFromUser, porém mais simples
+// (não há field_reviews para limpar — a comparação é só o assignment).
+export async function releaseComparisonsFromUser(
+  admin: Admin,
+  projectId: string,
+  userId: string,
+): Promise<{ released: number; error?: string }> {
+  const { data: deleted, error } = await admin
+    .from("assignments")
+    .delete()
+    .eq("project_id", projectId)
+    .eq("user_id", userId)
+    .eq("type", "comparacao")
+    .eq("status", "pendente")
+    .select("id");
+  if (error) return { released: 0, error: error.message };
+  return { released: deleted?.length ?? 0 };
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -10,6 +10,49 @@ export interface Profile {
 
 export type RoundStrategy = "schema_version" | "manual";
 
+// Modo de automação de revisão do projeto (projects.automation_mode). Define o
+// "mínimo necessário para liberar a revisão" + quem revê, e governa quais abas
+// de revisão aparecem. Mutuamente exclusivo. Ver lib/auto-review.ts (auto_review_llm)
+// e lib/auto-comparison.ts (compare_*).
+export type AutomationMode =
+  | "none"
+  | "auto_review_llm"
+  | "compare_humans"
+  | "compare_llm";
+
+// Fonte única dos rótulos/descrições dos modos — reaproveitada pelos seletores
+// de criação (projects/new) e de Config › Regras (RulesForm), evitando drift.
+export const AUTOMATION_MODES: ReadonlyArray<{
+  value: AutomationMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    value: "none",
+    label: "Nenhuma automação",
+    description:
+      "Sem revisão automática. Qualquer comparação ou revisão é criada manualmente pelo coordenador.",
+  },
+  {
+    value: "auto_review_llm",
+    label: "Auto-revisão vs LLM",
+    description:
+      "Quando uma pessoa termina de codificar e diverge do LLM, ela mesma revisa os campos divergentes; contestados vão para arbitragem.",
+  },
+  {
+    value: "compare_humans",
+    label: "Comparação humano-vs-humano",
+    description:
+      "Quando duas pessoas codificam o mesmo documento e divergem, um revisor é sorteado para comparar as codificações.",
+  },
+  {
+    value: "compare_llm",
+    label: "Comparação pessoa-vs-LLM",
+    description:
+      "Quando uma pessoa codifica e diverge do LLM, um revisor é sorteado para comparar a codificação humana contra a do LLM.",
+  },
+];
+
 export interface Round {
   id: string;
   project_id: string;
@@ -36,6 +79,10 @@ export interface Project {
   round_strategy: RoundStrategy;
   current_round_id: string | null;
   arbitration_blind: boolean;
+  automation_mode: AutomationMode;
+  // Só relevante em automation_mode = "compare_humans": inclui a resposta do LLM
+  // (quando existe) no cálculo de divergência que dispara a comparação.
+  comparison_includes_llm: boolean;
 }
 
 export interface SubfieldDef {
@@ -79,6 +126,8 @@ export interface ProjectMember {
   role: "coordenador" | "pesquisador";
   can_arbitrate: boolean;
   can_resolve: boolean;
+  // Elegível para receber comparações automáticas (assignComparisonReviewer).
+  can_compare: boolean;
   // Carga relativa no sorteio (1 = normal, 0.5 = metade). Ver distributeDocs.
   // Opcional: nem toda query de project_members seleciona estas colunas.
   assignment_weight?: number;

--- a/frontend/supabase/migrations/20260618130000_projects_automation_mode.sql
+++ b/frontend/supabase/migrations/20260618130000_projects_automation_mode.sql
@@ -1,0 +1,31 @@
+-- projects.automation_mode: modo de automação de revisão do projeto, escolhido
+-- na criação e editável em Config › Regras. Mutuamente exclusivo — define qual
+-- mecanismo dispara automaticamente e quais abas de revisão aparecem.
+--
+--   none            → nenhuma automação (tudo manual via LotteryDialog)
+--   auto_review_llm → 1 codificador diverge do LLM → auto-revisão do próprio
+--                     codificador → contestados viram arbitragem (comportamento
+--                     EXISTENTE, antes incondicional em saveResponse)
+--   compare_humans  → 2+ codificadores (>= min_responses_for_comparison) divergem
+--                     → comparação por um revisor terceiro (can_compare)
+--   compare_llm     → 1 codificador diverge do LLM → comparação por um revisor
+--                     terceiro (can_compare), humano-vs-LLM
+--
+-- DEFAULT 'auto_review_llm' faz o backfill que preserva exatamente o
+-- comportamento atual: até esta migration, createAutoReviewIfDiverges rodava em
+-- todo projeto, sem config (actions/responses.ts). Sem esse default, os projetos
+-- em produção parariam de auto-revisar ao aplicar a migration.
+
+ALTER TABLE projects
+  ADD COLUMN automation_mode TEXT NOT NULL DEFAULT 'auto_review_llm'
+  CHECK (automation_mode IN ('none', 'auto_review_llm', 'compare_humans', 'compare_llm'));
+
+-- comparison_includes_llm: no modo compare_humans, controla se a resposta do LLM
+-- (quando existe) entra no cálculo de divergência que DISPARA a comparação.
+--   true  → dispara quando, entre todas as respostas presentes (humanos + LLM),
+--           houver divergência (humanos concordando mas LLM diferente já libera).
+--   false → dispara só quando os humanos divergem entre si; o LLM ainda aparece
+--           na tela de comparação, mas não decide o disparo.
+-- Só afeta compare_humans; em compare_llm/auto_review_llm o LLM é intrínseco.
+ALTER TABLE projects
+  ADD COLUMN comparison_includes_llm BOOLEAN NOT NULL DEFAULT true;

--- a/frontend/supabase/migrations/20260618130100_project_members_can_compare.sql
+++ b/frontend/supabase/migrations/20260618130100_project_members_can_compare.sql
@@ -1,0 +1,15 @@
+-- project_members.can_compare: flag por membro controlando se ele entra no
+-- sorteio de revisores de comparação em assignComparisonReviewer()
+-- (lib/auto-comparison.ts), análogo a can_arbitrate para a arbitragem.
+--
+-- Default false e SEM backfill (diferente de can_arbitrate): a comparação
+-- automática é feature nova e opt-in — nenhum projeto dependia desse
+-- comportamento antes. O coordenador marca explicitamente quem revisa.
+
+ALTER TABLE project_members
+  ADD COLUMN can_compare BOOLEAN NOT NULL DEFAULT false;
+
+-- Index parcial: assignComparisonReviewer() filtra por (project_id, can_compare=true).
+CREATE INDEX idx_project_members_comparers
+  ON project_members (project_id)
+  WHERE can_compare = true;


### PR DESCRIPTION
## Contexto

Expande a issue #208. Em vez de um toggle isolado para "comparação automática humano-vs-humano", o coordenador escolhe **um modo de automação por projeto** (mutuamente exclusivo) que define qual mecanismo de revisão roda automaticamente — e esse modo também governa **quais abas de revisão aparecem** no projeto.

A auto-revisão humano-vs-LLM **rodava em todo projeto, sem config** (`responses.ts` chamava `createAutoReviewIfDiverges` incondicionalmente). Ela vira o modo `auto_review_llm` e passa a ser o **default** da nova coluna — o backfill preserva exatamente o comportamento atual dos projetos existentes.

## Os quatro modos (`projects.automation_mode`)

| Valor | Mínimo para liberar | Quem revisa | Abas |
|-------|--------------------|-------------|------|
| `none` | — | — | nenhuma de revisão |
| `auto_review_llm` (default) | 1 humano diverge do LLM | o próprio codificador → arbitragem | Auto-revisão, Arbitragem |
| `compare_humans` | 2+ humanos (`min_responses_for_comparison`) divergem | revisor terceiro (`can_compare`) | Comparar |
| `compare_llm` | 1 humano diverge do LLM | revisor terceiro (`can_compare`) | Comparar |

O modo é **escolhido na criação** do projeto e editável em **Config › Regras**.

### Toggle `comparison_includes_llm` (só `compare_humans`)
Decide se o LLM, quando presente, entra no cálculo de divergência que **dispara** a comparação. `true` (default): dispara também se os humanos concordam mas o LLM diverge. `false`: só dispara com divergência entre humanos (o LLM ainda aparece na tela de comparação).

## Decisões de design
- **Sorteio** (`assignComparisonReviewer`) espelha `assignArbitrator`: pool = `can_compare` **menos todos os codificadores** (sem fallback — um codificador não compara o próprio doc); balanceio por menor carga; sorteio aleatório; upsert idempotente (`onConflict: document_id,user_id,type`).
- **Um único revisor** por documento.
- A comparação **não materializa divergência** (não há stub como `field_reviews`): backlog e banner são recomputados por **varredura em 2 fases** (`scanComparisonBacklog`), seguindo o precedente de `regenerateAutoReviewBacklog`.
- **Desmarcar `can_compare`** espelha a arbitragem: solta as comparações pendentes do membro e re-sorteia (`setCanCompare` → `releaseComparisonsFromUser` + `retryPendingComparisons`).
- Falha do gatilho **não bloqueia** o submit (try/catch + log `[auto-compare]`).

## Mudanças de comportamento (atenção na revisão)
- A aba **Comparar** deixa de ser sempre visível: agora aparece só nos modos de comparação (para o coordenador) ou para quem tem assignment `comparacao`. Em `auto_review_llm`, fica oculta. Trabalho já atribuído nunca é orfanado (a aba reaparece para quem tem assignment).
- Mudar o modo **não** faz backfill automático; o gatilho inline cobre novas codificações e o toggle `can_compare` drena o backlog.

## Migrations (aplicar antes/no merge)
Duas migrations aditivas (colunas com default seguro):
- `20260618130000_projects_automation_mode.sql`
- `20260618130100_project_members_can_compare.sql`

Aplicar com `cd frontend && npx supabase db push` (ver CLAUDE.md › Supabase CLI). **Ainda não apliquei no banco remoto** — aguardando sua revisão.

## Verificação
- `npx tsc --noEmit` limpo
- `npm run lint` → 0 errors (4 warnings pré-existentes, fora do meu diff)
- `npx vitest run` → 443 testes verdes (29 novos)
- `npm run react-doctor:diff` → sem novos errors

Cobertura nova: sorteio (pool/balanceio/noPool), gatilho por modo + toggle LLM, idempotência, retry/release, e visibilidade de abas.

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)