### PR TITLE
fix(compare): só respostas is_latest entram na fila de comparação

### DIFF
--- a/frontend/src/actions/stats.ts
+++ b/frontend/src/actions/stats.ts
@@ -264,7 +264,9 @@ export async function fetchGabaritoForComment(
       .select("id, respondent_name, respondent_type, answers")
       .eq("project_id", projectId)
       .eq("document_id", documentId)
-      .or("is_latest.eq.true,respondent_type.eq.humano");
+      // Só respostas ativas: humanas rebaixadas (is_latest=false) ou LLM antigo
+      // não devem aparecer no gabarito do comentário.
+      .eq("is_latest", true);
 
     if (!responses) return { answers: [] };
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -279,8 +279,12 @@ export default async function ComparePageRoute({
 
     // Apply version + since + respondent filters per response
     const qualifiedResponses = docResponses.filter((r) => {
-      // Keep only active (is_latest) OR human responses — antigos (is_latest=false) do LLM ficam fora
-      if (!r.is_latest && r.respondent_type !== "humano") return false;
+      // Só respostas ativas (is_latest). Antigas (is_latest=false) — do LLM
+      // (re-runs) ou humanas (codificação rebaixada ao promover uma versão mais
+      // recente, ou após unificação de membros/documentos) — ficam de fora.
+      // Mantê-las faria o mesmo respondente aparecer como dois cards. A contagem
+      // abaixo ainda agrega por respondente distinto como defesa adicional.
+      if (!r.is_latest) return false;
 
       // Respostas pré-versionamento (pydantic_hash NULL) foram gravadas antes
       // da migration 20260420 que introduziu schema_version_*. Elas têm
@@ -306,15 +310,29 @@ export default async function ComparePageRoute({
       return true;
     });
 
-    const humanCount = qualifiedResponses.filter((r) => r.respondent_type === "humano").length;
+    // Conta respondentes humanos DISTINTOS (não linhas). Fallback para r.id
+    // quando respondent_id é null (dados legados) para não fundir respostas
+    // anônimas distintas numa só.
+    const humanCount = new Set(
+      qualifiedResponses
+        .filter((r) => r.respondent_type === "humano")
+        .map((r) => r.respondent_id ?? r.id),
+    ).size;
     const totalCount = qualifiedResponses.length;
 
     const assignedUsers = codingAssignedByDoc.get(docId) ?? new Set<string>();
     const assignedCodingCount = assignedUsers.size;
 
-    const humansFromAssigned = qualifiedResponses.filter(
-      (r) => r.respondent_type === "humano" && r.respondent_id && assignedUsers.has(r.respondent_id),
-    ).length;
+    const humansFromAssigned = new Set(
+      qualifiedResponses
+        .filter(
+          (r) =>
+            r.respondent_type === "humano" &&
+            r.respondent_id &&
+            assignedUsers.has(r.respondent_id),
+        )
+        .map((r) => r.respondent_id),
+    ).size;
 
     const pct = assignedCodingCount === 0 ? 100 : Math.round((humansFromAssigned / assignedCodingCount) * 100);
 


### PR DESCRIPTION
## Problema

Na aba de Comparação, um documento podia aparecer com o **mesmo respondente em dois cards**, como se duas pessoas tivessem codificado.

## Causa raiz

O filtro `qualifiedResponses` em `compare/page.tsx` mantinha **qualquer resposta humana mesmo com `is_latest=false`** (`if (!r.is_latest && r.respondent_type !== "humano") return false;`) e contava **linhas, não respondentes distintos** (`humanCount`/`humansFromAssigned` via `.length`). Quando um respondente tem uma codificação rebaixada para `is_latest=false` — ao promover uma versão mais recente (dedup de documento) ou após unificação de membros — ele reaparecia como dois cards, inflando `humanCount` e disparando a fila de comparação.

A condição `|| humano` nasceu quando `saveResponse` sempre atualizava a resposta humana in-place (humano era sempre `is_latest=true`), então era inofensiva. Deixou de ser quando passou a existir resposta humana `is_latest=false`.

## Mudança

- `compare/page.tsx`: descarta **toda** resposta `is_latest=false` (humana ou LLM), preservando a última de cada respondente (último humano + último LLM). `humanCount` e `humansFromAssigned` passam a contar `respondent_id` **distinto** (fallback para `id` quando `respondent_id` é null em dados legados).
- `stats.ts` (`fetchGabaritoForComment`): troca `.or("is_latest.eq.true,respondent_type.eq.humano")` por `.eq("is_latest", true)`.

## Impacto

**No-op no estado atual** — hoje não há nenhuma resposta humana `is_latest=false` no banco, então o display não muda. É pré-requisito para promover/rebaixar codificações ao deduplicar documentos (limpeza em andamento dos pareceres 0647/1663) e torna a aba robusta à unificação de membros.

## Verificação

- `npm run lint`: 0 erros. `tsc --noEmit`: limpo. `vitest`: 414 testes passando. `react-doctor --diff`: sem problemas.

Relacionado a #212.