### PR TITLE
fix(compare): conclusão do parecer usa o conjunto da rodada corrente (#217)

### DIFF
--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -4,6 +4,7 @@ import {
   isFreeTextField,
   isDocComplete,
   findNextPendingDocIndex,
+  resolveCompareStatus,
 } from "@/lib/compare-divergence";
 import type { EquivalencePair } from "@/lib/equivalence";
 import type { PydanticField } from "@/lib/types";
@@ -267,5 +268,31 @@ describe("findNextPendingDocIndex", () => {
     expect(
       findNextPendingDocIndex(["d2", "d3", "d1"], divergentFields, reviews, "d1"),
     ).toBe(-1);
+  });
+});
+
+describe("resolveCompareStatus", () => {
+  it("concluido quando todos os campos divergentes foram revisados", () => {
+    expect(resolveCompareStatus(["a", "b"], new Set(["a", "b"]))).toBe(
+      "concluido",
+    );
+  });
+
+  // #217: edge `divergentFields.length === 0` — antes ficava preso em
+  // em_andamento; um doc sem divergências (ex.: todas fundidas por equivalência)
+  // agora fecha, mesmo sem reviews (`every` é vácuo-verdadeiro).
+  it("concluido quando não há campos divergentes (lista vazia)", () => {
+    expect(resolveCompareStatus([], new Set())).toBe("concluido");
+    expect(resolveCompareStatus([], new Set(["a"]))).toBe("concluido");
+  });
+
+  it("pendente quando há divergências e nenhuma review", () => {
+    expect(resolveCompareStatus(["a", "b"], new Set())).toBe("pendente");
+  });
+
+  it("em_andamento quando há divergências não revisadas mas alguma review", () => {
+    expect(resolveCompareStatus(["a", "b"], new Set(["a"]))).toBe(
+      "em_andamento",
+    );
   });
 });

--- a/frontend/src/lib/__tests__/compare-version.test.ts
+++ b/frontend/src/lib/__tests__/compare-version.test.ts
@@ -9,6 +9,12 @@ import {
   type SchemaVersion,
   type VersionedResponse,
 } from "@/lib/compare-version";
+import { DEFAULT_COMPARE_FILTERS } from "@/lib/compare-filters";
+import {
+  computeDivergentFieldNames,
+  resolveCompareStatus,
+} from "@/lib/compare-divergence";
+import type { PydanticField } from "@/lib/types";
 
 const v = (major: number, minor: number, patch: number): SchemaVersion => ({
   major,
@@ -152,6 +158,118 @@ describe("responseQualifiesForVersion", () => {
   it("schema_version NULL + hash antigo reprova (schema anterior)", () => {
     expect(responseQualifiesForVersion(nullVer("hash-antigo"), floor, proj)).toBe(
       false,
+    );
+  });
+});
+
+// O fecho do parecer (compare-sync.ts) deriva seu piso de versão do MESMO
+// default da UI que compare/page.tsx usa, via
+// resolveMinVersion(DEFAULT_COMPARE_FILTERS.version, ...). Estes testes travam
+// esse contrato e reproduzem o incidente #217/#218 no pipeline puro do sync,
+// sem Supabase.
+describe("fecho espelha o filtro default da UI (#217/#218)", () => {
+  it("resolveMinVersion com o default da UI não impõe piso (default = 'all')", () => {
+    // Se alguém mudar DEFAULT_COMPARE_FILTERS.version sem revisar o sync, este
+    // teste quebra — a intenção é manter sync e visão default acoplados.
+    expect(DEFAULT_COMPARE_FILTERS.version).toBe("all");
+    expect(
+      resolveMinVersion(DEFAULT_COMPARE_FILTERS.version, v(0, 20, 0)),
+    ).toBeNull();
+  });
+
+  // Incidente Zolgensma: doc com várias codificações humanas — uma SUPERSEDED
+  // (is_latest=false), uma pré-versionamento (pydantic_hash NULL), uma de minor
+  // antiga (0.18.0) e duas da corrente (0.20.0). O sync antigo
+  // (`is_latest || respondent_type === "humano"`) contava a superseded, que a
+  // tela não mostra, criando divergência invisível → trava. Sob o default 'all'
+  // (minVersion null), o fecho descarta SÓ a superseded e mantém o resto,
+  // espelhando o que a revisora vê "sem filtro".
+  type Row = VersionedResponse & {
+    id: string;
+    answers: Record<string, unknown>;
+  };
+  const proj = { pydanticHash: "hash-atual", version: v(0, 20, 0) };
+  const minVersion = resolveMinVersion(
+    DEFAULT_COMPARE_FILTERS.version,
+    v(0, 20, 0),
+  );
+
+  const human = (
+    id: string,
+    answers: Record<string, unknown>,
+    over: Partial<VersionedResponse>,
+  ): Row => ({
+    id,
+    answers,
+    respondent_type: "humano",
+    is_latest: true,
+    pydantic_hash: "hash-atual",
+    schema_version_major: 0,
+    schema_version_minor: 20,
+    schema_version_patch: 0,
+    ...over,
+  });
+
+  // "decisao" diverge entre os ativos (improc vs proc); "obs" só diverge se a
+  // superseded entrar (ativos concordam em "irrelevante").
+  const rows: Row[] = [
+    human(
+      "sup",
+      { decisao: "improc", obs: "diferente" },
+      { is_latest: false, pydantic_hash: "hash-antigo", schema_version_minor: 18 },
+    ),
+    human(
+      "pre",
+      { decisao: "improc", obs: "irrelevante" },
+      {
+        pydantic_hash: null,
+        schema_version_major: null,
+        schema_version_minor: null,
+        schema_version_patch: null,
+      },
+    ),
+    human(
+      "v18",
+      { decisao: "proc", obs: "irrelevante" },
+      { pydantic_hash: "hash-018", schema_version_minor: 18 },
+    ),
+    human("v20a", { decisao: "proc", obs: "irrelevante" }, {}),
+    human("v20b", { decisao: "proc", obs: "irrelevante" }, {}),
+  ];
+
+  const fields: PydanticField[] = [
+    {
+      name: "decisao",
+      type: "single",
+      options: ["proc", "improc"],
+      description: "",
+      target: "all",
+    },
+    { name: "obs", type: "text", options: null, description: "", target: "all" },
+  ];
+
+  const active = rows.filter((r) =>
+    responseQualifiesForVersion(r, minVersion, proj),
+  );
+
+  it("o fecho descarta só a superseded, mantendo pré-versionamento e minor antiga", () => {
+    expect(active.map((r) => r.id)).toEqual(["pre", "v18", "v20a", "v20b"]);
+  });
+
+  it("incluir a superseded (bug antigo) inflaria 'obs' como divergência invisível", () => {
+    const withSuperseded = computeDivergentFieldNames(fields, rows);
+    expect(withSuperseded).toContain("obs");
+  });
+
+  it("sem a superseded, 'obs' não diverge — só 'decisao' exige veredito", () => {
+    const divergent = computeDivergentFieldNames(fields, active);
+    expect(divergent).toEqual(["decisao"]);
+  });
+
+  it("resolvido o campo divergente visível, o parecer fecha (concluido)", () => {
+    const divergent = computeDivergentFieldNames(fields, active);
+    expect(resolveCompareStatus(divergent, new Set(["decisao"]))).toBe(
+      "concluido",
     );
   });
 });

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -119,6 +119,22 @@ export function computeDivergentFieldNames(
   return divergent;
 }
 
+export type CompareAssignmentStatus = "pendente" | "em_andamento" | "concluido";
+
+// Pure decision for the reviewer's "comparacao" assignment status, given the
+// canonical divergent fields of the document and the set of fields the reviewer
+// already has a verdict for. `every` is vacuously true for an empty divergent
+// list, so a document with no divergences (e.g. all fused via equivalence)
+// resolves to "concluido" instead of being stuck forever (#217).
+export function resolveCompareStatus(
+  divergentFields: string[],
+  reviewedFields: Set<string>,
+): CompareAssignmentStatus {
+  if (divergentFields.every((fn) => reviewedFields.has(fn))) return "concluido";
+  if (reviewedFields.size === 0) return "pendente";
+  return "em_andamento";
+}
+
 // A document is "complete" in the Compare queue when it has at least one
 // divergent field and every divergent field already has a verdict.
 export function isDocComplete(

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -5,7 +5,14 @@ import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import {
   computeDivergentFieldNames,
   isFreeTextField,
+  resolveCompareStatus,
 } from "@/lib/compare-divergence";
+import {
+  latestMajorAnchor,
+  responseQualifiesForVersion,
+  type SchemaVersion,
+  type VersionedResponse,
+} from "@/lib/compare-version";
 import type { EquivalencePair } from "@/lib/equivalence";
 
 // Recomputes assignment status (pendente / em_andamento / concluido) for the
@@ -36,12 +43,16 @@ export async function syncCompareAssignment(
   ] = await Promise.all([
     supabase
       .from("projects")
-      .select("pydantic_fields")
+      .select(
+        "pydantic_fields, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch",
+      )
       .eq("id", projectId)
       .single(),
     supabase
       .from("responses")
-      .select("id, respondent_type, is_latest, answers, answer_field_hashes")
+      .select(
+        "id, respondent_type, is_latest, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch, answers, answer_field_hashes",
+      )
       .eq("project_id", projectId)
       .eq("document_id", documentId),
     supabase
@@ -59,24 +70,41 @@ export async function syncCompareAssignment(
 
   const reviewedFields = new Set((reviews ?? []).map((r) => r.field_name));
 
-  if (reviewedFields.size === 0) {
-    if (assignment.status !== "pendente") {
-      await supabase
-        .from("assignments")
-        .update({ status: "pendente", completed_at: null })
-        .eq("id", assignment.id);
-    }
-    return;
-  }
-
   const fields = (project?.pydantic_fields as PydanticField[]) || [];
+
+  // Conclusão usa o MESMO predicado da página (`responseQualifiesForVersion`,
+  // anti-drift #217) com o piso da RODADA CORRENTE — `latestMajorAnchor` da
+  // versão atual do projeto, que é exatamente o filtro default `latest_major`
+  // da UI. Esse é o conjunto canônico de "concluído": independe do filtro de
+  // versão efêmero que a revisora escolha, e por ser a visão mais estreita
+  // selecionável é sempre subconjunto do que ela vê em qualquer filtro — então
+  // resolver tudo que aparece na tela sempre fecha o parecer. Isso descarta
+  // tanto o pré-versionamento (pydantic_hash NULL) quanto rodadas antigas
+  // (is_latest superseded ou versão < corrente), espelhando o que a tela mostra.
+  const projectVersion: SchemaVersion = {
+    major: project?.schema_version_major ?? 0,
+    minor: project?.schema_version_minor ?? 1,
+    patch: project?.schema_version_patch ?? 0,
+  };
+  const minVersion = latestMajorAnchor(projectVersion);
+  const projectVersionCtx = {
+    pydanticHash: project?.pydantic_hash ?? null,
+    version: projectVersion,
+  };
+
   type ActiveResponse = {
     id: string;
     answers: Record<string, unknown>;
     answerFieldHashes: AnswerFieldHashes;
   };
   const activeResponses: ActiveResponse[] = (responses ?? [])
-    .filter((r) => r.is_latest || r.respondent_type === "humano")
+    .filter((r) =>
+      responseQualifiesForVersion(
+        r as unknown as VersionedResponse,
+        minVersion,
+        projectVersionCtx,
+      ),
+    )
     .map((r) => ({
       id: r.id,
       answers: (r.answers ?? {}) as Record<string, unknown>,
@@ -100,21 +128,18 @@ export async function syncCompareAssignment(
     equivalencesByField,
   );
 
-  const allReviewed =
-    divergentFields.length > 0 &&
-    divergentFields.every((fn) => reviewedFields.has(fn));
-
-  if (allReviewed) {
-    if (assignment.status !== "concluido") {
-      await supabase
-        .from("assignments")
-        .update({ status: "concluido", completed_at: new Date().toISOString() })
-        .eq("id", assignment.id);
-    }
-  } else if (assignment.status === "pendente") {
+  // `resolveCompareStatus` trata o caso `divergentFields.length === 0` (ex.:
+  // todas as divergências fundidas por equivalência): vira `concluido` em vez de
+  // ficar preso. Atualiza só quando o status muda, limpando `completed_at` em
+  // qualquer regressão (ex.: desmarcar uma equivalência reabre a divergência).
+  const next = resolveCompareStatus(divergentFields, reviewedFields);
+  if (assignment.status !== next) {
     await supabase
       .from("assignments")
-      .update({ status: "em_andamento" })
+      .update({
+        status: next,
+        completed_at: next === "concluido" ? new Date().toISOString() : null,
+      })
       .eq("id", assignment.id);
   }
 }

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -8,11 +8,12 @@ import {
   resolveCompareStatus,
 } from "@/lib/compare-divergence";
 import {
-  latestMajorAnchor,
+  resolveMinVersion,
   responseQualifiesForVersion,
   type SchemaVersion,
   type VersionedResponse,
 } from "@/lib/compare-version";
+import { DEFAULT_COMPARE_FILTERS } from "@/lib/compare-filters";
 import type { EquivalencePair } from "@/lib/equivalence";
 
 // Recomputes assignment status (pendente / em_andamento / concluido) for the
@@ -72,21 +73,34 @@ export async function syncCompareAssignment(
 
   const fields = (project?.pydantic_fields as PydanticField[]) || [];
 
-  // Conclusão usa o MESMO predicado da página (`responseQualifiesForVersion`,
-  // anti-drift #217) com o piso da RODADA CORRENTE — `latestMajorAnchor` da
-  // versão atual do projeto, que é exatamente o filtro default `latest_major`
-  // da UI. Esse é o conjunto canônico de "concluído": independe do filtro de
-  // versão efêmero que a revisora escolha, e por ser a visão mais estreita
-  // selecionável é sempre subconjunto do que ela vê em qualquer filtro — então
-  // resolver tudo que aparece na tela sempre fecha o parecer. Isso descarta
-  // tanto o pré-versionamento (pydantic_hash NULL) quanto rodadas antigas
-  // (is_latest superseded ou versão < corrente), espelhando o que a tela mostra.
+  // Conclusão usa o MESMO predicado (`responseQualifiesForVersion`, anti-drift
+  // #217) e o MESMO piso de versão que a página aplica no estado DEFAULT da UI
+  // — derivado de `DEFAULT_COMPARE_FILTERS.version` via `resolveMinVersion`, a
+  // mesma função que `compare/page.tsx` chama. Hoje o default é "all"
+  // (compare-filters.ts), então `minVersion` é null (sem piso) e o fecho
+  // considera toda resposta `is_latest`, de qualquer versão — exatamente o que
+  // a revisora vê "sem filtro". Por construção, no estado default a visão e o
+  // fecho coincidem: resolver as divergências visíveis sempre fecha o parecer.
+  //
+  // O que muda em relação ao sync antigo (`is_latest || respondent_type ===
+  // "humano"`) é só a exclusão de codificações SUPERSEDED (`is_latest=false`,
+  // humanas inclusive) — que o antigo contava e a tela não mostrava, a causa
+  // real da trava do #217. Pré-versionamento (`pydantic_hash` NULL) e rodadas
+  // antigas permanecem no fecho, espelhando o default `all`.
+  //
+  // Filtros efêmeros (versão manual, `since`, `respondent`) são lentes de
+  // inspeção: NÃO redefinem "concluído". Se a revisora escolher uma lente mais
+  // estreita que o default, a tela pode mostrar menos do que o fecho exige —
+  // comportamento esperado de uma lente, fora do fluxo "sem filtro".
   const projectVersion: SchemaVersion = {
     major: project?.schema_version_major ?? 0,
     minor: project?.schema_version_minor ?? 1,
     patch: project?.schema_version_patch ?? 0,
   };
-  const minVersion = latestMajorAnchor(projectVersion);
+  const minVersion = resolveMinVersion(
+    DEFAULT_COMPARE_FILTERS.version,
+    projectVersion,
+  );
   const projectVersionCtx = {
     pydanticHash: project?.pydantic_hash ?? null,
     version: projectVersion,


### PR DESCRIPTION
## Problema

Na aba **Comparação**, a revisora resolvia todas as divergências que via na tela, mas o parecer não fechava — ficava em `em_andamento`. A causa é um *drift* entre **display** e **conclusão**: cada lado computava divergência sobre um **conjunto de respostas diferente**.

- A tela (`compare/page.tsx`) qualifica respostas via `responseQualifiesForVersion` aplicado ao **filtro default da UI**, que é **`all`** (`compare-filters.ts`) — todas as respostas `is_latest`, de qualquer versão.
- A conclusão (`syncCompareAssignment` em `lib/compare-sync.ts`) usava `is_latest || respondent_type === "humano"` — **sem** o predicado de versão, e em particular **mantendo codificações superseded** (`is_latest=false`). Era o drift que o cabeçalho de `lib/compare-version.ts` já antecipava, mas que o sync nunca tinha plugado.

### Incidente (Zolgensma, dados reais)

Cada um dos 4 docs afetados tem 6–7 codificações humanas; uma é pré-versionamento (`pydantic_hash` NULL) e há codificações de minor anterior (`0.18.0`) além das da corrente (`0.20.0`). O sync antigo contava inclusive uma codificação humana **rebaixada** (`is_latest=false`) que a tela não exibe → divergência invisível → trava.

## Fix (revisado)

> **Correção de rumo em relação à primeira versão deste PR.** A v1 ancorava o fecho em `latestMajorAnchor(projectVersion)` ("rodada corrente"), partindo da premissa de que o filtro default da UI é `latest_major`. **O default real é `all`** (ver `compare-filters.ts`). Sob `latest_major` fixo, no fluxo "sem filtro" a tela mostrava *mais* (todas as versões) do que o fecho considerava (só a minor corrente) — o drift reaparecia no sentido inverso.

- **Pluga o sync no MESMO predicado e no MESMO piso que a página usa no estado default**: `responseQualifiesForVersion` + `resolveMinVersion(DEFAULT_COMPARE_FILTERS.version, projectVersion)`. Como o default é `all`, isso é `minVersion = null` (sem piso) e o fecho passa a considerar toda resposta `is_latest`, de qualquer versão — **exatamente o que a revisora vê "sem filtro"**. Por construção, no estado default a visão e o fecho coincidem: resolver as divergências visíveis sempre fecha o parecer. Anti-drift estrutural — se o default da UI mudar, o sync acompanha.
- **Efeito líquido sobre o sync antigo**: passa a **excluir codificações superseded** (`is_latest=false`, humanas inclusive) — a causa real da trava. Pré-versionamento (`pydantic_hash` NULL) e minors antigas **permanecem** no fecho, coerentes com `all`.
- **Edge `divergentFields.length === 0`**: `resolveCompareStatus` (pura, testável) fecha um doc sem divergências (ex.: tudo fundido por equivalência) em vez de prendê-lo.
- Limpa `completed_at` em regressões de status (ex.: desmarcar uma equivalência reabre a divergência).

### Decisão de design

"Concluído" é definido pelo **filtro default da UI**, não pela escolha efêmera da revisora. Filtros efêmeros (versão manual, `since`, `respondent`) são **lentes de inspeção** e não redefinem o fecho — `page.tsx` não muda. Limite conhecido e aceito: se a revisora aplicar uma lente **mais estreita** que o default, a tela pode mostrar menos do que o fecho exige — comportamento esperado de uma lente, fora do fluxo "sem filtro / só filtro temporal" que é o uso real.

## Nota sobre `isDocComplete` vs `resolveCompareStatus`

Há uma diferença semântica no caso de zero divergências (`isDocComplete` → false; `resolveCompareStatus` → `concluido`), mas ela **não** afeta a navegação: docs sem divergências nunca entram na fila (`page.tsx`: `if (divergent.length === 0) continue;`). Um assignment `concluido` sem divergências aparece corretamente como concluído na tabela de assignments. Sem mudança de código.

## Fora de escopo

- **Backfill** de respostas legadas: desnecessário para o fix.
- **Onde aparecem os casos de Nusinersena**: questão operacional para a revisora, não código.

## Rollout

Os ~5 assignments já presos em `em_andamento` **não** recomputam sozinhos (o sync só roda em ações da revisora). Basta re-tocar cada doc (re-salvar um veredito) para disparar o re-sync e fechar.

## Verificação

- `tsc --noEmit`: limpo.
- `vitest run`: **444** testes passam (inclui trava de `resolveMinVersion(default) === null` e reprodução do incidente Zolgensma no pipeline puro).
- `react-doctor --scope changed`: sem issues (87/100).
- `eslint`: 0 errors.

Closes #217
