### PR TITLE
fix(compare): aba Comparar respeita automation_mode (libera 1 humano + 1 LLM)

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 import { ComparePage } from "@/components/compare/ComparePage";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import type { EquivalencePair } from "@/lib/equivalence";
-import { readCompareFilters } from "@/lib/compare-filters";
+import { readCompareFilters, compareDefaultsForMode } from "@/lib/compare-filters";
 import {
   resolveMinVersion,
   responseQualifiesForVersion,
@@ -63,7 +63,6 @@ export default async function ComparePageRoute({
     getAuthUser(),
     createSupabaseServer(),
   ]);
-  const filters = readCompareFilters(sp);
   if (!user) redirect("/auth/login");
 
   const [
@@ -77,7 +76,7 @@ export default async function ComparePageRoute({
     supabase
       .from("projects")
       .select(
-        "pydantic_hash, pydantic_fields, min_responses_for_comparison, created_by, schema_version_major, schema_version_minor, schema_version_patch",
+        "pydantic_hash, pydantic_fields, min_responses_for_comparison, created_by, schema_version_major, schema_version_minor, schema_version_patch, automation_mode",
       )
       .eq("id", id)
       .single(),
@@ -150,6 +149,16 @@ export default async function ComparePageRoute({
       </div>
     );
   }
+
+  // Defaults da fila derivados do modo de automação do projeto. Em compare_llm
+  // o piso de humanos cai para 1 (a 2ª resposta exigida por minTotal é o LLM) —
+  // sem isso a aba ficaria vazia para documentos de 1 codificador + LLM. A
+  // revisora ainda pode estreitar a lente via o filtro `min_humans` na URL.
+  const compareDefaults = compareDefaultsForMode(
+    project?.automation_mode,
+    project?.min_responses_for_comparison ?? 2,
+  );
+  const filters = readCompareFilters(sp, compareDefaults);
 
   const projectVersion = {
     major: project?.schema_version_major ?? 0,
@@ -305,7 +314,16 @@ export default async function ComparePageRoute({
     // Apply coverage filters
     if (humanCount < filters.minHumans) continue;
     if (totalCount < filters.minTotal) continue;
-    if (assignedCodingCount > 0 && pct < filters.minAssignedPct) continue;
+    // O gate de "% atribuídos que responderam" só faz sentido quando se espera
+    // ≥ 2 humanos. Em compare_llm (piso de 1 humano + LLM) ele esconderia docs
+    // de 1 codificador onde há mais de um atribuído — fora do que o gatilho de
+    // comparação exige. Aplica-se só quando o piso de humanos é ≥ 2.
+    if (
+      filters.minHumans >= 2 &&
+      assignedCodingCount > 0 &&
+      pct < filters.minAssignedPct
+    )
+      continue;
 
     // Equivalence-aware divergence detection (free-text fields can have
     // responses fused via the reviewer's "marcar como equivalentes" action).
@@ -457,6 +475,7 @@ export default async function ComparePageRoute({
         existingReviews={existingReviews}
         projectPydanticHash={project?.pydantic_hash ?? null}
         respondentNames={respondentNames}
+        defaultMinHumans={compareDefaults.minHumans}
         coverageByDoc={coverageByDoc}
         commentCountsByKey={commentCountsByKey}
         suggestionCountsByField={suggestionCountsByField}

--- a/frontend/src/components/compare/CompareFilters.tsx
+++ b/frontend/src/components/compare/CompareFilters.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
-import { Suspense, useCallback, useTransition } from "react";
+import { Suspense, useCallback, useMemo, useTransition } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -27,6 +27,10 @@ import {
 
 interface CompareFiltersProps {
   respondentNames: string[];
+  // Piso default de "mín. humanos" derivado do automation_mode do projeto
+  // (compareDefaultsForMode). Mantém o controle coerente com o filtro aplicado
+  // no servidor — em compare_llm o default é 1, não o global 2.
+  defaultMinHumans: number;
   availableVersions: string[]; // ["X.Y.Z", ...] ordered desc
   latestMajorLabel: string | null; // "1.0.0" ou null
 }
@@ -43,6 +47,7 @@ export function CompareFilters(props: CompareFiltersProps) {
 
 function CompareFiltersInner({
   respondentNames,
+  defaultMinHumans,
   availableVersions,
   latestMajorLabel,
 }: CompareFiltersProps) {
@@ -51,12 +56,20 @@ function CompareFiltersInner({
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
 
-  const current = readCompareFilters(searchParams);
+  // Defaults coerentes com o modo de automação (o servidor deriva o piso de
+  // humanos de compareDefaultsForMode). Sem isto o filtro exibiria "2" enquanto
+  // a página lista docs de 1 humano em compare_llm, e marcar "2" pareceria o
+  // default mas esconderia esses docs.
+  const effectiveDefaults = useMemo(
+    () => ({ ...DEFAULT_COMPARE_FILTERS, minHumans: defaultMinHumans }),
+    [defaultMinHumans],
+  );
+  const current = readCompareFilters(searchParams, effectiveDefaults);
 
   const update = useCallback(
     (patch: Partial<CompareFiltersValue>) => {
       const sp = new URLSearchParams(searchParams.toString());
-      const apply = { ...readCompareFilters(searchParams), ...patch };
+      const apply = { ...readCompareFilters(searchParams, effectiveDefaults), ...patch };
       const map: Record<keyof CompareFiltersValue, string> = {
         version: "version",
         minHumans: "min_humans",
@@ -68,7 +81,7 @@ function CompareFiltersInner({
       for (const key of Object.keys(map) as (keyof CompareFiltersValue)[]) {
         const urlKey = map[key];
         const value = apply[key];
-        const def = DEFAULT_COMPARE_FILTERS[key];
+        const def = effectiveDefaults[key];
         if (value === def || value === "" || value === null) {
           sp.delete(urlKey);
         } else {
@@ -79,7 +92,7 @@ function CompareFiltersInner({
         push(`${pathname}?${sp.toString()}`);
       });
     },
-    [pathname, push, searchParams],
+    [pathname, push, searchParams, effectiveDefaults],
   );
 
   const reset = useCallback(() => {
@@ -89,12 +102,12 @@ function CompareFiltersInner({
   }, [pathname, push]);
 
   const activeCount = [
-    current.version !== DEFAULT_COMPARE_FILTERS.version,
-    current.minHumans !== DEFAULT_COMPARE_FILTERS.minHumans,
-    current.minTotal !== DEFAULT_COMPARE_FILTERS.minTotal,
-    current.minAssignedPct !== DEFAULT_COMPARE_FILTERS.minAssignedPct,
-    current.since !== DEFAULT_COMPARE_FILTERS.since,
-    current.respondent !== DEFAULT_COMPARE_FILTERS.respondent,
+    current.version !== effectiveDefaults.version,
+    current.minHumans !== effectiveDefaults.minHumans,
+    current.minTotal !== effectiveDefaults.minTotal,
+    current.minAssignedPct !== effectiveDefaults.minAssignedPct,
+    current.since !== effectiveDefaults.since,
+    current.respondent !== effectiveDefaults.respondent,
   ].filter(Boolean).length;
 
   return (

--- a/frontend/src/components/compare/CompareNav.tsx
+++ b/frontend/src/components/compare/CompareNav.tsx
@@ -21,6 +21,7 @@ interface CompareNavProps {
   onToggleFullscreen: () => void;
   parecerUrl?: string;
   respondentNames: string[];
+  defaultMinHumans: number;
   availableVersions: string[];
   latestMajorLabel: string | null;
   currentProjectVersion: string;
@@ -40,6 +41,7 @@ export function CompareNav({
   onToggleFullscreen,
   parecerUrl,
   respondentNames,
+  defaultMinHumans,
   availableVersions,
   latestMajorLabel,
   currentProjectVersion,
@@ -65,6 +67,7 @@ export function CompareNav({
         </Badge>
         <CompareFilters
           respondentNames={respondentNames}
+          defaultMinHumans={defaultMinHumans}
           availableVersions={availableVersions}
           latestMajorLabel={latestMajorLabel}
         />

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -71,6 +71,9 @@ interface ComparePageProps {
   existingReviews: Record<string, Record<string, ExistingVerdictInfo>>;
   projectPydanticHash: string | null;
   respondentNames: string[];
+  // Default de "mín. humanos" derivado do automation_mode (compareDefaultsForMode):
+  // mantém o filtro da UI coerente com o piso aplicado no servidor.
+  defaultMinHumans: number;
   coverageByDoc: Record<string, DocCoverage>;
   commentCountsByKey: Record<string, number>;
   suggestionCountsByField: Record<string, number>;
@@ -94,6 +97,7 @@ export function ComparePage({
   existingReviews,
   projectPydanticHash,
   respondentNames,
+  defaultMinHumans,
   coverageByDoc,
   commentCountsByKey,
   suggestionCountsByField,
@@ -557,6 +561,7 @@ export function ComparePage({
           onToggleFullscreen={toggleFullscreen}
           parecerUrl={parecerUrl}
           respondentNames={respondentNames}
+          defaultMinHumans={defaultMinHumans}
           availableVersions={availableVersions}
           latestMajorLabel={latestMajorLabel}
           currentProjectVersion={currentProjectVersion}

--- a/frontend/src/lib/__tests__/compare-filters.test.ts
+++ b/frontend/src/lib/__tests__/compare-filters.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_COMPARE_FILTERS,
+  readCompareFilters,
+  compareDefaultsForMode,
+} from "@/lib/compare-filters";
+
+// Estes testes cobrem a peça que liga a Comparação de "1 humano + 1 LLM": o
+// piso de "mín. humanos" passa a ser derivado do automation_mode do projeto
+// (compareDefaultsForMode), espelhando o gatilho createAutoComparisonIfDiverges
+// (lib/auto-comparison.ts). Sem isto, compare_llm (1 codificador) nunca
+// alcançaria o piso fixo de 2 e a aba ficaria vazia.
+
+describe("compareDefaultsForMode", () => {
+  it("compare_llm baixa o piso de humanos para 1 (a 2ª resposta é o LLM)", () => {
+    expect(compareDefaultsForMode("compare_llm", 2).minHumans).toBe(1);
+    // independe de min_responses_for_comparison
+    expect(compareDefaultsForMode("compare_llm", 5).minHumans).toBe(1);
+  });
+
+  it("compare_humans usa min_responses_for_comparison", () => {
+    expect(compareDefaultsForMode("compare_humans", 2).minHumans).toBe(2);
+    expect(compareDefaultsForMode("compare_humans", 3).minHumans).toBe(3);
+    // nunca abaixo de 1, mesmo com config inválida
+    expect(compareDefaultsForMode("compare_humans", 0).minHumans).toBe(1);
+  });
+
+  it("auto_review_llm / none / null / undefined / desconhecido mantêm o piso base (2)", () => {
+    expect(compareDefaultsForMode("auto_review_llm", 2).minHumans).toBe(
+      DEFAULT_COMPARE_FILTERS.minHumans,
+    );
+    expect(compareDefaultsForMode("none", 2).minHumans).toBe(2);
+    expect(compareDefaultsForMode(null, 2).minHumans).toBe(2);
+    expect(compareDefaultsForMode(undefined, 2).minHumans).toBe(2);
+    expect(compareDefaultsForMode("valor_legado", 2).minHumans).toBe(2);
+  });
+
+  it("preserva os demais defaults globais (só mexe em minHumans)", () => {
+    const d = compareDefaultsForMode("compare_llm", 2);
+    expect(d.version).toBe(DEFAULT_COMPARE_FILTERS.version);
+    expect(d.minTotal).toBe(DEFAULT_COMPARE_FILTERS.minTotal);
+    expect(d.minAssignedPct).toBe(DEFAULT_COMPARE_FILTERS.minAssignedPct);
+    expect(d.since).toBe(DEFAULT_COMPARE_FILTERS.since);
+    expect(d.respondent).toBe(DEFAULT_COMPARE_FILTERS.respondent);
+  });
+});
+
+describe("readCompareFilters com defaults por modo", () => {
+  it("sem param na URL, usa o piso do modo (compare_llm => 1)", () => {
+    const defaults = compareDefaultsForMode("compare_llm", 2);
+    expect(readCompareFilters({}, defaults).minHumans).toBe(1);
+  });
+
+  it("param min_humans na URL sobrepõe o default do modo (a revisora pode estreitar)", () => {
+    const defaults = compareDefaultsForMode("compare_llm", 2);
+    expect(readCompareFilters({ min_humans: "3" }, defaults).minHumans).toBe(3);
+  });
+
+  it("sem defaults explícitos, mantém o comportamento legado (piso 2)", () => {
+    expect(readCompareFilters({}).minHumans).toBe(2);
+  });
+
+  it("aceita URLSearchParams além de Record, misturando default-de-modo com URL", () => {
+    const defaults = compareDefaultsForMode("compare_llm", 2);
+    const sp = new URLSearchParams("min_total=3");
+    const f = readCompareFilters(sp, defaults);
+    expect(f.minHumans).toBe(1); // veio do modo
+    expect(f.minTotal).toBe(3); // veio da URL
+  });
+});

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -24,6 +24,12 @@ export const DEFAULT_COMPARE_FILTERS: CompareFiltersValue = {
 
 export function readCompareFilters(
   params: URLSearchParams | Record<string, string | undefined>,
+  // Defaults aplicados quando o param não vem na URL. Por padrão são os globais
+  // (DEFAULT_COMPARE_FILTERS); a página e o filtro passam os defaults derivados
+  // do modo de automação (ver `compareDefaultsForMode`) para que o piso de
+  // "mín. humanos" reflita o modo — sem isso, compare_llm (1 humano) nunca
+  // alcançaria o piso fixo de 2 e a fila ficaria vazia.
+  defaults: CompareFiltersValue = DEFAULT_COMPARE_FILTERS,
 ): CompareFiltersValue {
   const get = (k: string): string | undefined => {
     if (params instanceof URLSearchParams) return params.get(k) ?? undefined;
@@ -35,14 +41,37 @@ export function readCompareFilters(
     return Number.isFinite(n) ? n : fallback;
   };
   return {
-    version: get("version") ?? DEFAULT_COMPARE_FILTERS.version,
-    minHumans: toInt(get("min_humans"), DEFAULT_COMPARE_FILTERS.minHumans),
-    minTotal: toInt(get("min_total"), DEFAULT_COMPARE_FILTERS.minTotal),
-    minAssignedPct: toInt(
-      get("min_assigned_pct"),
-      DEFAULT_COMPARE_FILTERS.minAssignedPct,
-    ),
-    since: get("since") ?? DEFAULT_COMPARE_FILTERS.since,
-    respondent: get("respondent") ?? DEFAULT_COMPARE_FILTERS.respondent,
+    version: get("version") ?? defaults.version,
+    minHumans: toInt(get("min_humans"), defaults.minHumans),
+    minTotal: toInt(get("min_total"), defaults.minTotal),
+    minAssignedPct: toInt(get("min_assigned_pct"), defaults.minAssignedPct),
+    since: get("since") ?? defaults.since,
+    respondent: get("respondent") ?? defaults.respondent,
   };
+}
+
+// Defaults da aba Comparar derivados do modo de automação do projeto
+// (projects.automation_mode). O piso de "mín. humanos" espelha o gatilho que
+// cria o assignment de comparação (createAutoComparisonIfDiverges em
+// lib/auto-comparison.ts), para a lista da página não divergir de quando uma
+// comparação é de fato materializada (mesmo princípio anti-drift de
+// compare-version.ts / #217–#218):
+//   - compare_llm    → 1 humano completo (a 2ª resposta exigida por minTotal=2
+//                      é, na prática, o LLM)
+//   - compare_humans → min_responses_for_comparison humanos
+//   - auto_review_llm / none / desconhecido / null → default base (2)
+// `mode` é string solta (não o tipo AutomationMode) de propósito: mantém este
+// módulo de baixo nível sem depender de types.ts e tolera o valor null/legado
+// de projetos antes da migration do automation_mode.
+export function compareDefaultsForMode(
+  mode: string | null | undefined,
+  minResponsesForComparison: number,
+): CompareFiltersValue {
+  let minHumans = DEFAULT_COMPARE_FILTERS.minHumans;
+  if (mode === "compare_llm") {
+    minHumans = 1;
+  } else if (mode === "compare_humans") {
+    minHumans = Math.max(1, minResponsesForComparison);
+  }
+  return { ...DEFAULT_COMPARE_FILTERS, minHumans };
 }


### PR DESCRIPTION
## Contexto

Uma pesquisadora reportou que os pareceres de **Nusinersena** do projeto Zolgensma não apareciam na aba **Comparação**. Diagnóstico (dados do banco):

- Os 76 pareceres de Nusinersena ativos foram sorteados para **1 codificador cada** (1 resposta humana por doc).
- A aba Comparar exige **≥ 2 humanos** (`minHumans=2`, default de `compare-filters.ts`). O LLM conta em `totalCount`, não em `humanCount`.
- Resultado: **0 de 76** docs de Nusinersena passavam no gate (e só 8 de 89 de Zolgensma).

## O que faltava

O #211 (modo `compare_llm`) materializa um assignment de comparação quando **1 humano diverge do LLM** e mostra a aba — mas **não toca `compare/page.tsx`**. O gate `humanCount < filters.minHumans` (piso 2) barrava o doc antes de renderizar, então o revisor designado abriria a aba e não veria nada.

## Mudança

O piso de "mín. humanos" passa a ser derivado do `automation_mode`, espelhando o gatilho `createAutoComparisonIfDiverges` (`lib/auto-comparison.ts`) — mesmo princípio anti-drift de `compare-version.ts`:

| modo | piso de humanos |
|------|-----------------|
| `compare_llm` | 1 (a 2ª resposta exigida por `minTotal=2` é o LLM) |
| `compare_humans` | `min_responses_for_comparison` |
| `auto_review_llm` / `none` / legado (`null`) | 2 (sem mudança) |

- `readCompareFilters` passa a aceitar `defaults`, e o default por modo flui até o filtro da UI — o controle "mín. humanos" não exibe mais "2" enquanto a lista mostra docs de 1 humano.
- O gate de "% atribuídos que responderam" só se aplica quando o piso é ≥ 2.
- `compare-sync.ts` já era compatível (não usa piso de humanos; computa divergência sobre as respostas qualificadas, incluindo o LLM).

## ⚠️ Dependência

Depende de **#211** (coluna `projects.automation_mode` + migrations) estar **mergeado e aplicado** (`npx supabase db push`). Sem a coluna, os projetos seguem no piso base 2. Mergear este PR **depois** do #211 (por isso está como draft).

Para liberar de fato a Comparação de Nusinersena: setar `automation_mode = 'compare_llm'` no projeto Zolgensma e marcar `can_compare` nos revisores (isso também drena o backlog dos 76 docs já existentes).

## Verificação

- `npx tsc --noEmit`: 0 erros nos arquivos alterados
- `npx vitest run`: 452/452 (8 novos em `compare-filters.test.ts`)
- `npm run lint`: 0 errors
- `npm run react-doctor:diff`: 0 errors

Relacionado a #211 / #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)