### PR TITLE
feat(lottery): sorteio de comparação aceita docs pessoa-vs-LLM

### DIFF
--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -6,6 +6,7 @@ import { revalidatePath, revalidateTag } from "next/cache";
 import {
   createRng,
   distributeDocs,
+  filterComparisonEligible,
   filterEligibleDocs,
   shuffleWithRng,
   computeCapacity,
@@ -144,6 +145,8 @@ interface LotteryData {
   docs: LotteryDocStats[];
   batches: { id: string; label: string | null; createdAt: string }[];
   minResponsesForComparison: number;
+  /** modo de automação do projeto — governa o gate de comparação */
+  automationMode: string | null;
   assignmentRows: {
     document_id: string;
     user_id: string;
@@ -155,8 +158,14 @@ interface LotteryData {
 async function fetchLotteryData(projectId: string): Promise<LotteryData> {
   const supabase = await createSupabaseServer();
 
-  const [{ data: docs }, { data: responses }, { data: assignments }, { data: batches }, { data: project }] =
-    await Promise.all([
+  const [
+    { data: docs },
+    { data: responses },
+    { data: llmResponses },
+    { data: assignments },
+    { data: batches },
+    { data: project },
+  ] = await Promise.all([
       supabase
         .from("documents")
         .select("id, external_id, title")
@@ -169,6 +178,12 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
         .eq("is_latest", true)
         .eq("respondent_type", "humano"),
       supabase
+        .from("responses")
+        .select("document_id")
+        .eq("project_id", projectId)
+        .eq("is_latest", true)
+        .eq("respondent_type", "llm"),
+      supabase
         .from("assignments")
         .select("document_id, user_id, status, type, batch_id")
         .eq("project_id", projectId),
@@ -179,7 +194,7 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
         .order("created_at", { ascending: false }),
       supabase
         .from("projects")
-        .select("min_responses_for_comparison")
+        .select("min_responses_for_comparison, automation_mode")
         .eq("id", projectId)
         .single(),
     ]);
@@ -188,6 +203,9 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
   for (const r of responses || []) {
     (respondentsByDoc[r.document_id] ??= new Set()).add(r.respondent_id);
   }
+
+  const docsWithLlm = new Set<string>();
+  for (const r of llmResponses || []) docsWithLlm.add(r.document_id);
 
   const activeByDoc: Record<string, { codificacao: number; comparacao: number }> = {};
   const everAssigned = new Set<string>();
@@ -210,6 +228,7 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
       externalId: d.external_id,
       title: d.title,
       humanCodingCount: respondentsByDoc[d.id]?.size || 0,
+      hasLlmResponse: docsWithLlm.has(d.id),
       activeAssignments: activeByDoc[d.id] || { codificacao: 0, comparacao: 0 },
       hasAnyAssignmentEver: everAssigned.has(d.id),
       batchIds: Array.from(batchIdsByDoc[d.id] || []),
@@ -220,6 +239,7 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
       createdAt: b.created_at,
     })),
     minResponsesForComparison: project?.min_responses_for_comparison || 2,
+    automationMode: project?.automation_mode ?? null,
     assignmentRows: (assignments || []).map((a) => ({
       document_id: a.document_id,
       user_id: a.user_id,
@@ -237,12 +257,14 @@ export async function getLotteryDocStats(projectId: string): Promise<{
   docs: LotteryDocStats[];
   batches: { id: string; label: string | null; createdAt: string }[];
   minResponsesForComparison: number;
+  automationMode: string | null;
 }> {
   const user = await getAuthUser();
   if (!user) throw new Error("Não autenticado");
 
-  const { docs, batches, minResponsesForComparison } = await fetchLotteryData(projectId);
-  return { docs, batches, minResponsesForComparison };
+  const { docs, batches, minResponsesForComparison, automationMode } =
+    await fetchLotteryData(projectId);
+  return { docs, batches, minResponsesForComparison, automationMode };
 }
 
 async function computeLottery(params: LotteryParams): Promise<{
@@ -282,14 +304,21 @@ async function computeLottery(params: LotteryParams): Promise<{
     throw new Error("Necessário ter documentos.");
   }
 
-  // Exigência mínima de respostas para comparação — compõe com os filtros
+  // Gate de comparação derivado do modo de automação — compõe com os filtros.
+  // compare_llm exige 1 humano + LLM; demais modos exigem N humanos.
   let candidateDocs = data.docs;
   if (assignmentType === "comparacao") {
-    candidateDocs = candidateDocs.filter(
-      (d) => d.humanCodingCount >= data.minResponsesForComparison
+    candidateDocs = filterComparisonEligible(
+      candidateDocs,
+      data.automationMode,
+      data.minResponsesForComparison,
     );
     if (!candidateDocs.length) {
-      throw new Error("Nenhum documento tem respostas suficientes para comparação.");
+      throw new Error(
+        data.automationMode === "compare_llm"
+          ? "Nenhum documento tem resposta humana e do LLM para comparação."
+          : "Nenhum documento tem respostas humanas suficientes para comparação.",
+      );
     }
   }
 

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/actions/assignments";
 import type { LotteryParams, LotteryPreview } from "@/actions/assignments";
 import {
+  filterComparisonEligible,
   filterEligibleDocs,
   resolveWeight,
   resolveCap,
@@ -65,6 +66,7 @@ interface LotteryStats {
   docs: LotteryDocStats[];
   batches: { id: string; label: string | null; createdAt: string }[];
   minResponsesForComparison: number;
+  automationMode: string | null;
 }
 
 type CodingsFilterMode = "all" | "none" | "atMost";
@@ -237,8 +239,10 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     if (!stats) return null;
     let candidates = stats.docs;
     if (isComparacao) {
-      candidates = candidates.filter(
-        (d) => d.humanCodingCount >= stats.minResponsesForComparison
+      candidates = filterComparisonEligible(
+        candidates,
+        stats.automationMode,
+        stats.minResponsesForComparison,
       );
     }
     return filterEligibleDocs(candidates, type, filters).length;
@@ -353,6 +357,13 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
                 </Label>
               </div>
             </RadioGroup>
+            {isComparacao && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                {stats?.automationMode === "compare_llm"
+                  ? "Elegíveis: documentos com ao menos 1 codificação humana e 1 resposta do LLM."
+                  : `Elegíveis: documentos com ao menos ${stats?.minResponsesForComparison ?? 2} codificações humanas.`}
+              </p>
+            )}
           </div>
 
           <Separator />

--- a/frontend/src/lib/__tests__/lottery-utils.test.ts
+++ b/frontend/src/lib/__tests__/lottery-utils.test.ts
@@ -275,6 +275,23 @@ describe("filterComparisonEligible", () => {
         "h2llm",
       ]);
     });
+
+    it("auto_review_llm (default do DB) cai no gate por humanos, ignorando o LLM", () => {
+      expect(ids(filterComparisonEligible(docs, "auto_review_llm", 2))).toEqual([
+        "h2",
+        "h2llm",
+      ]);
+    });
+
+    it("min_responses 0/inválido cai no piso de 1 humano (Math.max)", () => {
+      // sem o piso, min=0 deixaria passar docs com 0 humanos (h0)
+      expect(ids(filterComparisonEligible(docs, "compare_humans", 0))).toEqual([
+        "h1",
+        "h1llm",
+        "h2",
+        "h2llm",
+      ]);
+    });
   });
 });
 

--- a/frontend/src/lib/__tests__/lottery-utils.test.ts
+++ b/frontend/src/lib/__tests__/lottery-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   createRng,
   distributeDocs,
+  filterComparisonEligible,
   filterEligibleDocs,
   computeCapacity,
   resolveWeight,
@@ -16,6 +17,7 @@ function doc(overrides: Partial<LotteryDocStats> & { id: string }): LotteryDocSt
     externalId: null,
     title: null,
     humanCodingCount: 0,
+    hasLlmResponse: false,
     activeAssignments: { codificacao: 0, comparacao: 0 },
     hasAnyAssignmentEver: false,
     batchIds: [],
@@ -216,6 +218,63 @@ describe("filterEligibleDocs", () => {
     expect(
       filterEligibleDocs(docs, "codificacao", { maxHumanCodings: 0 }),
     ).toEqual([]);
+  });
+});
+
+describe("filterComparisonEligible", () => {
+  const docs = [
+    doc({ id: "h0", humanCodingCount: 0, hasLlmResponse: true }),
+    doc({ id: "h1", humanCodingCount: 1, hasLlmResponse: false }),
+    doc({ id: "h1llm", humanCodingCount: 1, hasLlmResponse: true }),
+    doc({ id: "h2", humanCodingCount: 2, hasLlmResponse: false }),
+    doc({ id: "h2llm", humanCodingCount: 2, hasLlmResponse: true }),
+  ];
+
+  describe("modo compare_llm", () => {
+    it("exige >= 1 humano E resposta do LLM", () => {
+      expect(ids(filterComparisonEligible(docs, "compare_llm", 2))).toEqual([
+        "h1llm",
+        "h2llm",
+      ]);
+    });
+
+    it("doc de 1 humano + LLM passa (independente de min_responses)", () => {
+      const d = [doc({ id: "x", humanCodingCount: 1, hasLlmResponse: true })];
+      expect(ids(filterComparisonEligible(d, "compare_llm", 2))).toEqual(["x"]);
+    });
+
+    it("doc com 2 humanos mas sem LLM é excluído", () => {
+      const d = [doc({ id: "x", humanCodingCount: 2, hasLlmResponse: false })];
+      expect(filterComparisonEligible(d, "compare_llm", 2)).toEqual([]);
+    });
+
+    it("doc com 0 humanos + LLM é excluído", () => {
+      const d = [doc({ id: "x", humanCodingCount: 0, hasLlmResponse: true })];
+      expect(filterComparisonEligible(d, "compare_llm", 2)).toEqual([]);
+    });
+  });
+
+  describe("modo compare_humans / none / null", () => {
+    it("respeita min_responses, ignorando o LLM", () => {
+      expect(ids(filterComparisonEligible(docs, "compare_humans", 2))).toEqual([
+        "h2",
+        "h2llm",
+      ]);
+    });
+
+    it("doc de 1 humano + LLM falha quando min=2", () => {
+      const d = [doc({ id: "x", humanCodingCount: 1, hasLlmResponse: true })];
+      expect(filterComparisonEligible(d, "compare_humans", 2)).toEqual([]);
+    });
+
+    it("null (projeto legado) cai no gate por humanos", () => {
+      expect(ids(filterComparisonEligible(docs, null, 1))).toEqual([
+        "h1",
+        "h1llm",
+        "h2",
+        "h2llm",
+      ]);
+    });
   });
 });
 

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -86,12 +86,14 @@ export function computeCapacity(opts: {
 
 /**
  * Gate de elegibilidade do sorteio de COMPARAÇÃO, derivado do modo de
- * automação do projeto (projects.automation_mode) — espelha o gatilho que
- * cria a comparação automática (createAutoComparisonIfDiverges em
- * lib/auto-comparison.ts) para o sorteio manual não divergir de quando uma
- * comparação é de fato materializada:
+ * automação do projeto (projects.automation_mode). Espelha o *critério de
+ * elegibilidade* do gatilho que cria a comparação automática
+ * (createAutoComparisonIfDiverges em lib/auto-comparison.ts) — quem é candidato
+ * a virar comparação — mas NÃO a condição de divergência: o sorteio manual
+ * libera por presença de respostas, de propósito, justamente para distribuir a
+ * revisão que a automação não cobriu (não exige que os codificadores divirjam).
  *   - compare_llm    → 1 humano + resposta do LLM (a 2ª resposta é o LLM)
- *   - demais modos   → min_responses_for_comparison humanos
+ *   - demais modos   → min_responses_for_comparison humanos (piso de 1)
  * Compõe ANTES de filterEligibleDocs (que não recebe esse limiar). `mode` é
  * string solta de propósito: tolera o valor null/legado de projetos antes da
  * migration do automation_mode, sem depender de types.ts.
@@ -104,7 +106,11 @@ export function filterComparisonEligible(
   if (mode === "compare_llm") {
     return docs.filter((d) => d.humanCodingCount >= 1 && d.hasLlmResponse);
   }
-  return docs.filter((d) => d.humanCodingCount >= minResponsesForComparison);
+  // Piso de 1 humano mesmo se min_responses for 0/inválido — simetria com
+  // compareDefaultsForMode (compare-filters.ts, #219): comparação sem nenhum
+  // humano não faz sentido.
+  const minHumans = Math.max(1, minResponsesForComparison);
+  return docs.filter((d) => d.humanCodingCount >= minHumans);
 }
 
 /**

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -22,6 +22,8 @@ export interface LotteryDocStats {
   title: string | null;
   /** respondentes humanos distintos com resposta is_latest */
   humanCodingCount: number;
+  /** existe ao menos uma resposta LLM is_latest para o doc */
+  hasLlmResponse: boolean;
   /** pendente + em_andamento, por tipo */
   activeAssignments: { codificacao: number; comparacao: number };
   hasAnyAssignmentEver: boolean;
@@ -80,6 +82,29 @@ export function computeCapacity(opts: {
   const resolvedCap = resolveCap(cap);
   if (resolvedCap != null) limits.push(resolvedCap);
   return limits.length ? Math.min(...limits) : Infinity;
+}
+
+/**
+ * Gate de elegibilidade do sorteio de COMPARAÇÃO, derivado do modo de
+ * automação do projeto (projects.automation_mode) — espelha o gatilho que
+ * cria a comparação automática (createAutoComparisonIfDiverges em
+ * lib/auto-comparison.ts) para o sorteio manual não divergir de quando uma
+ * comparação é de fato materializada:
+ *   - compare_llm    → 1 humano + resposta do LLM (a 2ª resposta é o LLM)
+ *   - demais modos   → min_responses_for_comparison humanos
+ * Compõe ANTES de filterEligibleDocs (que não recebe esse limiar). `mode` é
+ * string solta de propósito: tolera o valor null/legado de projetos antes da
+ * migration do automation_mode, sem depender de types.ts.
+ */
+export function filterComparisonEligible(
+  docs: LotteryDocStats[],
+  mode: string | null | undefined,
+  minResponsesForComparison: number,
+): LotteryDocStats[] {
+  if (mode === "compare_llm") {
+    return docs.filter((d) => d.humanCodingCount >= 1 && d.hasLlmResponse);
+  }
+  return docs.filter((d) => d.humanCodingCount >= minResponsesForComparison);
 }
 
 /**


### PR DESCRIPTION
## Problema

O sorteio manual (`LotteryDialog`) de assignments tipo `comparacao` exigia `humanCodingCount >= min_responses_for_comparison` (default 2), tanto no server (`computeLottery`) quanto no espelho do client. Como `fetchLotteryData` só conta respostas humanas, num projeto **compare_llm** — cada doc com 1 humano + 1 LLM — `humanCodingCount = 1 < 2` e o sorteio recusava todos os docs ("Nenhum documento tem respostas suficientes para comparação"). O coordenador não conseguia **distribuir manualmente** a revisão pessoa-vs-LLM (útil quando a distribuição automática via `can_compare` não cobre todo mundo de forma equilibrada).

## Solução

O gate de comparação passa a **derivar do `automation_mode`** do projeto, espelhando o gatilho da comparação automática (`createAutoComparisonIfDiverges`) e o `compareDefaultsForMode` da aba Comparar (#219) — mesmo princípio anti-drift:

- `compare_llm`  → elegível com ≥1 humano + 1 resposta do LLM
- demais modos (`compare_humans` / `none` / legado `null`) → mantém ≥`min_responses_for_comparison` humanos (comportamento atual **intacto**)

Em vez de um toggle manual no dialog, a base é derivada do modo do projeto — consistente com a arquitetura de `automation_mode` introduzida no #219 e impedindo que um projeto `compare_humans` escolha "com LLM" arbitrariamente.

## Mudanças

- **`lib/lottery-utils.ts`** — campo `hasLlmResponse` em `LotteryDocStats` + função pura `filterComparisonEligible(docs, mode, minResponses)` (fonte única server↔client).
- **`actions/assignments.ts`** — `fetchLotteryData` busca presença de resposta LLM por doc e o `automation_mode`; gate de `computeLottery` usa a função pura, com mensagem de erro por modo.
- **`components/assignments/LotteryDialog.tsx`** — espelho do `eligibleCount` usa a função pura; nota explicando a regra de elegibilidade vigente.
- **`lib/__tests__/lottery-utils.test.ts`** — 7 casos novos cobrindo ambos os modos e edges (2 humanos sem LLM excluído no modo LLM; 0 humanos + LLM excluído; 1 humano + LLM passa só no modo LLM; legado `null`).

## Verificação

- ✅ 488 testes passando (`npm test`)
- ✅ `tsc --noEmit` limpo
- ✅ `npm run lint` — 0 errors
- ✅ `react-doctor --diff` — sem novos errors

## Notas

- A "peça companheira" de visibilidade na aba Comparar para docs 1-humano+1-LLM **já foi resolvida pelo #219** (merged) — não foi necessário tocar `compare/page.tsx`.
- O basis não é gravado por assignment (comparações humano-vs-humano e humano-vs-LLM coexistem como `type="comparacao"`); é registrado no batch via `filters`. A aba Comparar renderiza divergências humano-vs-LLM automaticamente, sem precisar do basis por linha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)