### PR TITLE
refactor: remove gating de papel vestigial do Revisar

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/reviews/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/layout.tsx
@@ -1,4 +1,3 @@
-import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser } from "@/lib/auth";
 import { ReviewsNav } from "@/components/reviews/ReviewsNav";
 import { redirect } from "next/navigation";
@@ -10,33 +9,12 @@ export default async function ReviewsLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const [{ id }, user, supabase] = await Promise.all([
-    params,
-    getAuthUser(),
-    createSupabaseServer(),
-  ]);
+  const [{ id }, user] = await Promise.all([params, getAuthUser()]);
   if (!user) redirect("/auth/login");
-
-  const [{ data: project }, { data: membership }] = await Promise.all([
-    supabase
-      .from("projects")
-      .select("created_by")
-      .eq("id", id)
-      .single(),
-    supabase
-      .from("project_members")
-      .select("role")
-      .eq("project_id", id)
-      .eq("user_id", user.id)
-      .single(),
-  ]);
-
-  const isCoordinator =
-    membership?.role === "coordenador" || project?.created_by === user.id;
 
   return (
     <div className="flex flex-col">
-      <ReviewsNav projectId={id} isCoordinator={isCoordinator} />
+      <ReviewsNav projectId={id} />
       <div className="flex-1">{children}</div>
     </div>
   );

--- a/frontend/src/components/reviews/ReviewsNav.tsx
+++ b/frontend/src/components/reviews/ReviewsNav.tsx
@@ -7,8 +7,6 @@ import { cn } from "@/lib/utils";
 const reviewsTabs: Array<{
   label: string;
   href: string;
-  coordinatorOnly?: boolean;
-  researcherOnly?: boolean;
 }> = [
   { label: "Gabarito", href: "gabarito" },
   { label: "Meu Gabarito", href: "my-verdicts" },
@@ -19,21 +17,14 @@ const reviewsTabs: Array<{
 
 interface ReviewsNavProps {
   projectId: string;
-  isCoordinator: boolean;
 }
 
-export function ReviewsNav({ projectId, isCoordinator }: ReviewsNavProps) {
+export function ReviewsNav({ projectId }: ReviewsNavProps) {
   const pathname = usePathname();
-
-  const visibleTabs = reviewsTabs.filter(
-    (tab) =>
-      (!tab.coordinatorOnly || isCoordinator) &&
-      (!tab.researcherOnly || !isCoordinator),
-  );
 
   return (
     <nav className="flex items-center gap-1 border-b px-4 py-1">
-      {visibleTabs.map((tab) => {
+      {reviewsTabs.map((tab) => {
         const href = `/projects/${projectId}/reviews/${tab.href}`;
         const isActive = pathname.startsWith(href);
         return (


### PR DESCRIPTION
## Contexto

O #222 removeu as únicas duas abas `coordinatorOnly` da navegação de **Revisar** (Respondentes, Docs Difíceis). Com isso, toda a lógica de gating de papel daquela seção virou **dívida técnica vestigial** — esta PR (chore de simplificação) a remove.

## O que muda (2 arquivos, −35/+4)

- **`ReviewsNav.tsx`**: o filtro `(!tab.coordinatorOnly || isCoordinator) && (!tab.researcherOnly || !isCoordinator)` era sempre `true` (nenhuma aba restante define as flags). Removidas as flags `coordinatorOnly`/`researcherOnly`, a prop `isCoordinator` e o `.filter()` — mapeia `reviewsTabs` direto.
- **`reviews/layout.tsx`**: as duas queries Supabase (`projects.created_by` + `project_members.role`) existiam só para computar `isCoordinator`, que só alimentava aquele filtro morto. Removidas, junto com o import órfão de `createSupabaseServer` — corta **uma ida ao banco por request** sem efeito na saída.

## Segurança / comportamento

- **Sem regressão de acesso**: a query `project_members` removida **não** era guard (não havia `redirect` baseado em membership); as páginas filhas seguem protegidas por RLS.
- **`ProjectTabs.tsx` intocado** — ali o gating `coordinatorOnly` é ativo e legítimo (abas LLM e Configurações).
- As 5 abas restantes (Gabarito, Meu Gabarito, Erros LLM, Comentários, Exportar) já apareciam igualmente para coordenador e pesquisador após o #222.

## Verificação

- `tsc --noEmit`: limpo
- `vitest run`: 488 testes passando
- `eslint`: 0 errors (3 warnings pré-existentes, grandfathered)
- `react-doctor:diff`: 100/100, sem issues

## Sequência

Empilha sobre o #222 (já mergeado). Independente dos demais.