### PR TITLE
refactor: remover controle de prazo (deadline) por completo (#176)

### DIFF
--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -425,7 +425,6 @@ async function computeLottery(params: LotteryParams): Promise<{
     researchers_per_doc: params.researchersPerDoc,
     docs_per_researcher: params.docsPerResearcher || null,
     doc_subset_size: params.docSubsetSize || null,
-    deadline_mode: "none",
     label: params.label || null,
     mode: params.mode,
     balancing: params.balancing,

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
@@ -65,7 +65,7 @@ export default async function AssignmentsPage({
       getCachedMembers(id, "pesquisador"),
       supabase
         .from("assignments")
-        .select("id, project_id, document_id, user_id, status, type, batch_id, deadline, completed_at")
+        .select("id, project_id, document_id, user_id, status, type, batch_id, completed_at")
         .eq("project_id", id),
       getCachedMembers(id, "coordenador"),
     ]);

--- a/frontend/src/components/assignments/AssignmentTable.tsx
+++ b/frontend/src/components/assignments/AssignmentTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useOptimistic, useState, useTransition } from "react";
+import { useOptimistic, useTransition } from "react";
 import { cycleAssignment } from "@/actions/assignments";
 import { cn } from "@/lib/utils";
 import {
@@ -57,7 +57,6 @@ function cycleOptimistic(
     status: "pendente",
     type,
     batch_id: null,
-    deadline: null,
     completed_at: null,
   });
 
@@ -92,16 +91,6 @@ export function AssignmentTable({ projectId, documents, researchers, assignments
       await cycleAssignment(projectId, documentId, userId);
     });
   };
-
-  // Hidratado client-only para evitar mismatch entre server (timezone do server)
-  // e client (timezone do navegador) no cálculo de `isOverdue`.
-  const [today, setToday] = useState<Date | null>(null);
-  useEffect(() => {
-    const t = new Date();
-    t.setHours(0, 0, 0, 0);
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- valor client-only (hora local); ver comentário acima
-    setToday(t);
-  }, []);
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -140,16 +129,6 @@ export function AssignmentTable({ projectId, documents, researchers, assignments
                     );
                   const status = dominant?.status;
 
-                  const deadlines = [cod?.deadline, comp?.deadline].filter(Boolean) as string[];
-                  const nearestDeadline = deadlines.length
-                    ? deadlines.reduce((min, d) => (d < min ? d : min))
-                    : undefined;
-                  const isOverdue =
-                    today &&
-                    nearestDeadline &&
-                    status !== "concluido" &&
-                    new Date(nearestDeadline + "T00:00:00") < today;
-
                   const isNonRemovable = status === "concluido" || status === "em_andamento";
 
                   // Cor base pelo status
@@ -180,7 +159,6 @@ export function AssignmentTable({ projectId, documents, researchers, assignments
                       className={cn(
                         "relative size-6 rounded border transition-colors",
                         baseColor,
-                        isOverdue && "ring-2 ring-destructive ring-offset-1",
                         (isNonRemovable || isPending) && "cursor-default",
                       )}
                       aria-label={
@@ -212,13 +190,6 @@ export function AssignmentTable({ projectId, documents, researchers, assignments
                   const tooltipParts: string[] = [];
                   if (cod) tooltipParts.push(`Codificação (${cod.status})`);
                   if (comp) tooltipParts.push(`Comparação (${comp.status})`);
-                  if (nearestDeadline) {
-                    const label = `Prazo: ${new Date(nearestDeadline + "T00:00:00").toLocaleDateString(
-                      "pt-BR",
-                      { day: "numeric", month: "short" },
-                    )}${isOverdue ? " (atrasado)" : ""}`;
-                    tooltipParts.push(label);
-                  }
 
                   return (
                     <td key={r.user_id} className="px-3 py-1.5 text-center">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -175,7 +175,6 @@ export interface Assignment {
   status: "pendente" | "em_andamento" | "concluido";
   type: AssignmentType;
   batch_id: string | null;
-  deadline: string | null;
   completed_at: string | null;
 }
 
@@ -187,10 +186,6 @@ export interface AssignmentBatch {
   researchers_per_doc: number;
   docs_per_researcher: number | null;
   doc_subset_size: number | null;
-  deadline_mode: "none" | "batch" | "recurring";
-  deadline_date: string | null;
-  recurring_count: number | null;
-  recurring_start: string | null;
   label: string | null;
 }
 

--- a/frontend/supabase/migrations/20260623120000_remove_deadline_columns.sql
+++ b/frontend/supabase/migrations/20260623120000_remove_deadline_columns.sql
@@ -1,0 +1,10 @@
+-- Remove a infraestrutura de controle de prazo (issue #176).
+-- Descarta os prazos históricos: a plataforma deixou de gerenciar deadline.
+-- A CHECK constraint de deadline_mode cai junto com a coluna; não há índices nem FKs sobre estes campos.
+ALTER TABLE assignments DROP COLUMN IF EXISTS deadline;
+
+ALTER TABLE assignment_batches
+  DROP COLUMN IF EXISTS deadline_mode,
+  DROP COLUMN IF EXISTS deadline_date,
+  DROP COLUMN IF EXISTS recurring_count,
+  DROP COLUMN IF EXISTS recurring_start;


### PR DESCRIPTION
## Contexto

A issue #176 decidiu tirar o controle de prazo da plataforma. O commit #221 ("simplificação 1/3") já removeu a aba "Meu Progresso", `actions/progress.ts` e os componentes de progresso — mas a infraestrutura de `deadline` continuava viva em 4 arquivos de código e nas colunas do banco. Auditoria linha a linha confirmou as referências residuais; este PR fecha a issue zerando-as.

## Mudanças

- **`AssignmentTable.tsx`**: remove o indicador de atraso (anel `ring-destructive`, cálculo `isOverdue`/`nearestDeadline`, tooltip "Prazo: … (atrasado)") e o estado client-only `today` + `useEffect`; limpa os imports `useState`/`useEffect` que ficaram sem uso (e o `eslint-disable` órfão).
- **`lib/types.ts`**: remove `Assignment.deadline` e os campos `deadline_mode`, `deadline_date`, `recurring_count`, `recurring_start` de `AssignmentBatch`.
- **`actions/assignments.ts`**: remove `deadline_mode: "none"` do `batchData` do sorteio.
- **`analyze/assignments/page.tsx`**: remove `deadline` da lista de colunas do `.select()`.
- **Migration destrutiva** (`20260623120000_remove_deadline_columns.sql`): `DROP COLUMN` de `deadline` em `assignments` e dos 4 campos de prazo em `assignment_batches`. Descarta prazos históricos (autorizado na issue).

## Ordem de deploy ⚠️

A migration é destrutiva e deve ser aplicada **por último**, depois que o frontend novo já estiver no ar — senão o frontend antigo quebra o `SELECT` que ainda pede `deadline`. Fluxo: merge → frontend deploya → `npx supabase db push`.

## Verificação

- `grep` por `deadline`/`recurring_*`/`isOverdue`/`nearestDeadline` em `frontend/src` → zero ocorrências.
- `npx tsc --noEmit` → limpo.
- `npm run lint` → 0 errors (3 warnings pré-existentes em outros arquivos).
- Backend Python: nenhuma referência a `deadline`.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)