### PR TITLE
refactor(reviews): centraliza isCoordinator em getProjectAccessContext

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from "next/navigation";
 import { ComparePage } from "@/components/compare/ComparePage";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import type { EquivalencePair } from "@/lib/equivalence";
+import { coordinatorGate } from "@/lib/project-access";
 import {
   readCompareFilters,
   compareDefaultsForMode,
@@ -140,7 +141,7 @@ export default async function ComparePageRoute({
   // si (compareAssignedDocIds). A policy RLS deixa qualquer membro ler todas as
   // responses, entao esse recorte e so aplicacional; fail-open exporia
   // documentos/respostas de terceiros em erro transitorio.
-  const isCoordinator = access.isCoordinator;
+  const isCoordinator = coordinatorGate(access, { failOpen: false });
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { ComparePage } from "@/components/compare/ComparePage";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
@@ -67,24 +67,18 @@ export default async function ComparePageRoute({
 
   const [
     { data: project },
-    { data: membership },
     { data: allResponses, error: responsesError },
     { data: versionLog },
     { data: allAssignments },
     { data: allEquivalences },
+    access,
   ] = await Promise.all([
     supabase
       .from("projects")
       .select(
-        "pydantic_hash, pydantic_fields, min_responses_for_comparison, created_by, schema_version_major, schema_version_minor, schema_version_patch, automation_mode",
+        "pydantic_hash, pydantic_fields, min_responses_for_comparison, schema_version_major, schema_version_minor, schema_version_patch, automation_mode",
       )
       .eq("id", id)
-      .single(),
-    supabase
-      .from("project_members")
-      .select("role")
-      .eq("project_id", id)
-      .eq("user_id", user.id)
       .single(),
     supabase
       .from("responses")
@@ -114,6 +108,7 @@ export default async function ComparePageRoute({
       // divergences. Revisit if it becomes a bottleneck.
       .select("id, document_id, field_name, response_a_id, response_b_id, reviewer_id")
       .eq("project_id", id),
+    getProjectAccessContext(id, user.id, user.isMaster),
   ]);
 
   // Build (docId, fieldName) -> EquivalencePair[] map. Used both for divergence
@@ -136,8 +131,12 @@ export default async function ComparePageRoute({
     });
   }
 
-  const isCoordinator =
-    membership?.role === "coordenador" || project?.created_by === user.id || user.isMaster;
+  // Fail-CLOSED (ao contrario de comments/llm-insights): isCoordinator decide
+  // quais documentos aparecem na fila — um nao-coordenador ve so os atribuidos a
+  // si (compareAssignedDocIds). A policy RLS deixa qualquer membro ler todas as
+  // responses, entao esse recorte e so aplicacional; fail-open exporia
+  // documentos/respostas de terceiros em erro transitorio.
+  const isCoordinator = access.isCoordinator;
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -5,7 +5,11 @@ import { redirect } from "next/navigation";
 import { ComparePage } from "@/components/compare/ComparePage";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import type { EquivalencePair } from "@/lib/equivalence";
-import { readCompareFilters, compareDefaultsForMode } from "@/lib/compare-filters";
+import {
+  readCompareFilters,
+  compareDefaultsForMode,
+  assignedCompareDocIds,
+} from "@/lib/compare-filters";
 import {
   resolveMinVersion,
   responseQualifiesForVersion,
@@ -200,15 +204,12 @@ export default async function ComparePageRoute({
   });
   const latestMajorLabel = formatVersion(latestMajorAnchor(projectVersion));
 
-  // Compare-type assignments filter for researchers
-  let compareAssignedDocIds: Set<string> | null = null;
-  if (!isCoordinator) {
-    compareAssignedDocIds = new Set(
-      (allAssignments ?? [])
-        .filter((a) => a.type === "comparacao" && a.user_id === user.id)
-        .map((a) => a.document_id),
-    );
-  }
+  // Compare-type assignments filter for researchers (ver assignedCompareDocIds).
+  const compareAssignedDocIds = assignedCompareDocIds(
+    isCoordinator,
+    allAssignments,
+    user.id,
+  );
 
   // Coding-type assignments map per doc (denominator for % atribuídos)
   const codingAssignedByDoc = new Map<string, Set<string>>();

--- a/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
@@ -1,5 +1,5 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { RoundsConfig } from "@/components/config/RoundsConfig";
 import type { Round, RoundStrategy } from "@/lib/types";
@@ -17,32 +17,27 @@ export default async function RoundsConfigPage({
   ]);
   if (!user) redirect("/auth/login");
 
-  const [{ data: project }, { data: rounds }, { data: membership }] =
-    await Promise.all([
-      supabase
-        .from("projects")
-        .select(
-          "round_strategy, current_round_id, schema_version_major, schema_version_minor, schema_version_patch, created_by",
-        )
-        .eq("id", id)
-        .single(),
-      supabase
-        .from("rounds")
-        .select("id, project_id, label, created_at")
-        .eq("project_id", id)
-        .order("created_at", { ascending: true }),
-      supabase
-        .from("project_members")
-        .select("role")
-        .eq("project_id", id)
-        .eq("user_id", user.id)
-        .maybeSingle(),
-    ]);
+  const [{ data: project }, { data: rounds }, access] = await Promise.all([
+    supabase
+      .from("projects")
+      .select(
+        "round_strategy, current_round_id, schema_version_major, schema_version_minor, schema_version_patch",
+      )
+      .eq("id", id)
+      .single(),
+    supabase
+      .from("rounds")
+      .select("id, project_id, label, created_at")
+      .eq("project_id", id)
+      .order("created_at", { ascending: true }),
+    getProjectAccessContext(id, user.id, user.isMaster),
+  ]);
 
-  const isCoordinator =
-    user.isMaster ||
-    project?.created_by === user.id ||
-    membership?.role === "coordenador";
+  // Fail-open em erro transitorio, alinhado ao gate fail-open de config/layout:
+  // isCoordinator aqui so liga affordances de config (mutacoes de rodada
+  // re-checam coordenador em actions/rounds.ts). getProjectAccessContext cobre
+  // isMaster e e cache-hit da leitura ja feita pelo config/layout.
+  const isCoordinator = access.isCoordinator || access.queryFailed;
 
   const currentVersion = versionLabel({
     major: project?.schema_version_major ?? 0,

--- a/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
@@ -2,6 +2,7 @@ import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { RoundsConfig } from "@/components/config/RoundsConfig";
+import { coordinatorGate } from "@/lib/project-access";
 import type { Round, RoundStrategy } from "@/lib/types";
 import { versionLabel } from "@/lib/rounds";
 
@@ -37,7 +38,7 @@ export default async function RoundsConfigPage({
   // isCoordinator aqui so liga affordances de config (mutacoes de rodada
   // re-checam coordenador em actions/rounds.ts). getProjectAccessContext cobre
   // isMaster e e cache-hit da leitura ja feita pelo config/layout.
-  const isCoordinator = access.isCoordinator || access.queryFailed;
+  const isCoordinator = coordinatorGate(access, { failOpen: true });
 
   const currentVersion = versionLabel({
     major: project?.schema_version_major ?? 0,

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -114,7 +114,12 @@ export default async function CommentsPage({
     ]),
   ];
 
-  const isCoordinator = accessContext?.isCoordinator ?? false;
+  // Fail-open em erro transitorio de query (ver config/layout.tsx): nao rebaixa
+  // um coordenador legitimo a nao-coordenador por falha transiente. As mutacoes
+  // por tras das affordances re-checam via isProjectCoordinator (fail-closed).
+  const isCoordinator = accessContext
+    ? accessContext.isCoordinator || accessContext.queryFailed
+    : false;
 
   let reviewerMap = new Map<string, string>();
   if (reviewerIds.length > 0) {

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -1,5 +1,5 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { ReviewCommentsView } from "@/components/stats/ReviewCommentsView";
 import type { ReviewComment } from "@/components/stats/CommentCard";
 import type { PydanticField } from "@/lib/types";
@@ -19,7 +19,6 @@ export default async function CommentsPage({
     { data: project },
     { data: reviews },
     { data: documents },
-    { data: membership },
     { data: responsesWithNotes },
     { data: suggestions },
     { data: llmResponses },
@@ -27,10 +26,11 @@ export default async function CommentsPage({
     { data: projectComments },
     { data: verdictQuestions },
     { data: noteResolutions },
+    accessContext,
   ] = await Promise.all([
     supabase
       .from("projects")
-      .select("pydantic_fields, created_by")
+      .select("pydantic_fields")
       .eq("id", id)
       .single(),
     supabase
@@ -46,14 +46,6 @@ export default async function CommentsPage({
       .select("id, title, external_id")
       .eq("project_id", id)
       .is("excluded_at", null),
-    user
-      ? supabase
-          .from("project_members")
-          .select("role")
-          .eq("project_id", id)
-          .eq("user_id", user.id)
-          .maybeSingle()
-      : Promise.resolve({ data: null }),
     supabase
       .from("responses")
       .select("id, document_id, respondent_name, justifications, created_at")
@@ -94,6 +86,9 @@ export default async function CommentsPage({
       .from("note_resolutions")
       .select("response_id, resolved_at")
       .eq("project_id", id),
+    user
+      ? getProjectAccessContext(id, user.id, user.isMaster)
+      : Promise.resolve(null),
   ]);
 
   const noteResolvedMap = new Map(
@@ -119,8 +114,7 @@ export default async function CommentsPage({
     ]),
   ];
 
-  const isCoordinator =
-    project?.created_by === user?.id || membership?.role === "coordenador";
+  const isCoordinator = accessContext?.isCoordinator ?? false;
 
   let reviewerMap = new Map<string, string>();
   if (reviewerIds.length > 0) {

--- a/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
@@ -1,5 +1,6 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
+import { coordinatorGate } from "@/lib/project-access";
 import { ReviewCommentsView } from "@/components/stats/ReviewCommentsView";
 import type { ReviewComment } from "@/components/stats/CommentCard";
 import type { PydanticField } from "@/lib/types";
@@ -114,12 +115,14 @@ export default async function CommentsPage({
     ]),
   ];
 
-  // Fail-open em erro transitorio de query (ver config/layout.tsx): nao rebaixa
-  // um coordenador legitimo a nao-coordenador por falha transiente. As mutacoes
-  // por tras das affordances re-checam via isProjectCoordinator (fail-closed).
-  const isCoordinator = accessContext
-    ? accessContext.isCoordinator || accessContext.queryFailed
-    : false;
+  // Fail-open em erro transitorio de query: nao rebaixa um coordenador legitimo
+  // a nao-coordenador por falha transiente. Seguro aqui porque isCoordinator so
+  // liga affordances no ReviewCommentsView (a view nao recorta dados por papel)
+  // e as mutacoes por tras delas re-checam via isProjectCoordinator (fail-closed).
+  // NB: ao contrario de config/rounds, o layout-pai reviews/layout.tsx NAO
+  // gateia coordenador (so faz `if (!user) redirect`) — a seguranca do fail-open
+  // aqui depende inteiramente do affordance-only acima, nao de um backstop no layout.
+  const isCoordinator = coordinatorGate(accessContext, { failOpen: true });
 
   let reviewerMap = new Map<string, string>();
   if (reviewerIds.length > 0) {

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -1,5 +1,6 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
+import { coordinatorGate } from "@/lib/project-access";
 import { normalizeForComparison } from "@/lib/utils";
 import { LlmInsightsView } from "@/components/stats/LlmInsightsView";
 import { formatAnswer } from "@/lib/reviews/queries";
@@ -92,12 +93,14 @@ export default async function LlmInsightsPage({
       : Promise.resolve(null),
   ]);
 
-  // Fail-open em erro transitorio de query (ver config/layout.tsx): nao rebaixa
-  // um coordenador legitimo a nao-coordenador por falha transiente. As mutacoes
-  // por tras das affordances re-checam via isProjectCoordinator (fail-closed).
-  const isCoordinator = accessContext
-    ? accessContext.isCoordinator || accessContext.queryFailed
-    : false;
+  // Fail-open em erro transitorio de query: nao rebaixa um coordenador legitimo
+  // a nao-coordenador por falha transiente. Seguro aqui porque isCoordinator so
+  // liga affordances no LlmInsightsView (a view nao recorta dados por papel) e as
+  // mutacoes por tras delas re-checam via isProjectCoordinator (fail-closed).
+  // NB: ao contrario de config/rounds, o layout-pai reviews/layout.tsx NAO
+  // gateia coordenador (so faz `if (!user) redirect`) — a seguranca do fail-open
+  // aqui depende inteiramente do affordance-only acima, nao de um backstop no layout.
+  const isCoordinator = coordinatorGate(accessContext, { failOpen: true });
 
   const allFields = (project?.pydantic_fields || []) as PydanticField[];
 

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -1,5 +1,5 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { normalizeForComparison } from "@/lib/utils";
 import { LlmInsightsView } from "@/components/stats/LlmInsightsView";
 import { formatAnswer } from "@/lib/reviews/queries";
@@ -52,11 +52,11 @@ export default async function LlmInsightsPage({
     { data: documents },
     { data: errorResolutions },
     { data: equivalencePairs },
-    { data: membership },
+    accessContext,
   ] = await Promise.all([
     supabase
       .from("projects")
-      .select("pydantic_fields, created_by")
+      .select("pydantic_fields")
       .eq("id", id)
       .single(),
     supabase
@@ -88,17 +88,11 @@ export default async function LlmInsightsPage({
       .select("document_id, field_name, response_a_id, response_b_id")
       .eq("project_id", id),
     user
-      ? supabase
-          .from("project_members")
-          .select("role")
-          .eq("project_id", id)
-          .eq("user_id", user.id)
-          .maybeSingle()
-      : Promise.resolve({ data: null }),
+      ? getProjectAccessContext(id, user.id, user.isMaster)
+      : Promise.resolve(null),
   ]);
 
-  const isCoordinator =
-    project?.created_by === user?.id || membership?.role === "coordenador";
+  const isCoordinator = accessContext?.isCoordinator ?? false;
 
   const allFields = (project?.pydantic_fields || []) as PydanticField[];
 

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -92,7 +92,12 @@ export default async function LlmInsightsPage({
       : Promise.resolve(null),
   ]);
 
-  const isCoordinator = accessContext?.isCoordinator ?? false;
+  // Fail-open em erro transitorio de query (ver config/layout.tsx): nao rebaixa
+  // um coordenador legitimo a nao-coordenador por falha transiente. As mutacoes
+  // por tras das affordances re-checam via isProjectCoordinator (fail-closed).
+  const isCoordinator = accessContext
+    ? accessContext.isCoordinator || accessContext.queryFailed
+    : false;
 
   const allFields = (project?.pydantic_fields || []) as PydanticField[];
 

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -46,8 +46,11 @@ export default async function MyVerdictsPage({
   // Project fields + papel do usuario. isCoordinator vem de
   // getProjectAccessContext (request-scoped via cache()) — reaproveita a
   // leitura project+membership ja feita pelo layout pai e cobre isMaster.
-  // Fail-open em erro transitorio (ver config/layout.tsx): coordenador legitimo
-  // nao perde affordances; mutacoes re-checam via isProjectCoordinator.
+  // Fail-CLOSED aqui (ao contrario de comments/llm-insights): isCoordinator
+  // gateia viewAsUser, que le o gabarito de OUTRO respondente. A policy RLS
+  // "Members view responses" deixa qualquer membro ler todas as responses (nao
+  // filtra por respondent_id), entao o recorte por effectiveUserId e so
+  // aplicacional — fail-open exporia gabarito de terceiros em erro transitorio.
   const [{ data: project }, access] = await Promise.all([
     supabase
       .from("projects")
@@ -56,7 +59,7 @@ export default async function MyVerdictsPage({
       .single(),
     getProjectAccessContext(id, user.id, user.isMaster),
   ]);
-  const isCoordinator = access.isCoordinator || access.queryFailed;
+  const isCoordinator = access.isCoordinator;
 
   const effectiveUserId =
     (user.isMaster || isCoordinator) && sp.viewAsUser ? sp.viewAsUser : user.id;

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -3,6 +3,7 @@ import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { MyVerdictsView } from "@/components/reviews/MyVerdictsView";
 import { isAnswerCorrect, resolveEffectiveUserId } from "@/lib/reviews/queries";
+import { coordinatorGate } from "@/lib/project-access";
 import type { PydanticField } from "@/lib/types";
 
 export interface VerdictItem {
@@ -59,7 +60,7 @@ export default async function MyVerdictsPage({
       .single(),
     getProjectAccessContext(id, user.id, user.isMaster),
   ]);
-  const isCoordinator = access.isCoordinator;
+  const isCoordinator = coordinatorGate(access, { failOpen: false });
 
   const effectiveUserId = resolveEffectiveUserId({
     selfId: user.id,

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { MyVerdictsView } from "@/components/reviews/MyVerdictsView";
-import { isAnswerCorrect } from "@/lib/reviews/queries";
+import { isAnswerCorrect, resolveEffectiveUserId } from "@/lib/reviews/queries";
 import type { PydanticField } from "@/lib/types";
 
 export interface VerdictItem {
@@ -61,8 +61,12 @@ export default async function MyVerdictsPage({
   ]);
   const isCoordinator = access.isCoordinator;
 
-  const effectiveUserId =
-    (user.isMaster || isCoordinator) && sp.viewAsUser ? sp.viewAsUser : user.id;
+  const effectiveUserId = resolveEffectiveUserId({
+    selfId: user.id,
+    isMaster: user.isMaster,
+    isCoordinator,
+    viewAsUser: sp.viewAsUser,
+  });
 
   // Fetch responses for the effective user
   const { data: myResponses } = await supabase

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
 import { MyVerdictsView } from "@/components/reviews/MyVerdictsView";
 import { isAnswerCorrect } from "@/lib/reviews/queries";
 import type { PydanticField } from "@/lib/types";
@@ -43,23 +43,17 @@ export default async function MyVerdictsPage({
 
   const supabase = await createSupabaseServer();
 
-  // First fetch project + membership to determine role
-  const [{ data: project }, { data: membership }] = await Promise.all([
+  // Project fields + papel do usuario. isCoordinator vem de
+  // getProjectAccessContext (request-scoped via cache()) — reaproveita a
+  // leitura project+membership ja feita pelo layout pai e cobre isMaster.
+  const [{ data: project }, { isCoordinator }] = await Promise.all([
     supabase
       .from("projects")
-      .select("pydantic_fields, created_by")
+      .select("pydantic_fields")
       .eq("id", id)
       .single(),
-    supabase
-      .from("project_members")
-      .select("role")
-      .eq("project_id", id)
-      .eq("user_id", user.id)
-      .maybeSingle(),
+    getProjectAccessContext(id, user.id, user.isMaster),
   ]);
-
-  const isCoordinator =
-    project?.created_by === user.id || membership?.role === "coordenador";
 
   const effectiveUserId =
     (user.isMaster || isCoordinator) && sp.viewAsUser ? sp.viewAsUser : user.id;

--- a/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/my-verdicts/page.tsx
@@ -46,7 +46,9 @@ export default async function MyVerdictsPage({
   // Project fields + papel do usuario. isCoordinator vem de
   // getProjectAccessContext (request-scoped via cache()) — reaproveita a
   // leitura project+membership ja feita pelo layout pai e cobre isMaster.
-  const [{ data: project }, { isCoordinator }] = await Promise.all([
+  // Fail-open em erro transitorio (ver config/layout.tsx): coordenador legitimo
+  // nao perde affordances; mutacoes re-checam via isProjectCoordinator.
+  const [{ data: project }, access] = await Promise.all([
     supabase
       .from("projects")
       .select("pydantic_fields")
@@ -54,6 +56,7 @@ export default async function MyVerdictsPage({
       .single(),
     getProjectAccessContext(id, user.id, user.isMaster),
   ]);
+  const isCoordinator = access.isCoordinator || access.queryFailed;
 
   const effectiveUserId =
     (user.isMaster || isCoordinator) && sp.viewAsUser ? sp.viewAsUser : user.id;

--- a/frontend/src/lib/__tests__/compare-filters.test.ts
+++ b/frontend/src/lib/__tests__/compare-filters.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_COMPARE_FILTERS,
   readCompareFilters,
   compareDefaultsForMode,
+  assignedCompareDocIds,
 } from "@/lib/compare-filters";
 
 // Estes testes cobrem a peça que liga a Comparação de "1 humano + 1 LLM": o
@@ -66,5 +67,36 @@ describe("readCompareFilters com defaults por modo", () => {
     const f = readCompareFilters(sp, defaults);
     expect(f.minHumans).toBe(1); // veio do modo
     expect(f.minTotal).toBe(3); // veio da URL
+  });
+});
+
+// Invariante de segurança: na fila de Comparação, um não-coordenador só pode
+// ver os documentos atribuídos a ele. A policy RLS "Members view responses" não
+// restringe por linha, então este recorte é a única barreira — por isso o
+// `isCoordinator` que o alimenta é fail-closed.
+describe("assignedCompareDocIds — não-coordenador vê só os docs atribuídos", () => {
+  const userId = "user-self";
+  const assignments = [
+    { document_id: "doc-meu", user_id: userId, type: "comparacao" },
+    { document_id: "doc-de-outro", user_id: "user-other", type: "comparacao" },
+    { document_id: "doc-codificacao", user_id: userId, type: "codificacao" },
+  ];
+
+  it("coordenador → null (sem restrição: vê todos os documentos)", () => {
+    expect(assignedCompareDocIds(true, assignments, userId)).toBeNull();
+  });
+
+  it("não-coordenador → só os docs de comparação atribuídos a ele", () => {
+    const visible = assignedCompareDocIds(false, assignments, userId);
+    expect(visible).toEqual(new Set(["doc-meu"]));
+    // não vaza o doc de comparação atribuído a outro respondente...
+    expect(visible!.has("doc-de-outro")).toBe(false);
+    // ...nem um assignment de outro tipo (codificação) do próprio usuário
+    expect(visible!.has("doc-codificacao")).toBe(false);
+  });
+
+  it("não-coordenador sem assignments → conjunto vazio (não vê nada)", () => {
+    expect(assignedCompareDocIds(false, [], userId)).toEqual(new Set());
+    expect(assignedCompareDocIds(false, null, userId)).toEqual(new Set());
   });
 });

--- a/frontend/src/lib/__tests__/project-access.test.ts
+++ b/frontend/src/lib/__tests__/project-access.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { coordinatorGate } from "@/lib/project-access";
+
+// A escolha fail-open vs fail-closed é a decisão de segurança central da
+// centralização de `isCoordinator`: páginas que recortam DADOS por papel
+// (compare, my-verdicts) precisam ser fail-CLOSED, enquanto páginas onde
+// `isCoordinator` só liga affordances re-checadas na mutation (rounds,
+// comments, llm-insights) podem ser fail-OPEN. Estes testes travam essa
+// fronteira para que uma edição futura não a inverta silenciosamente.
+describe("coordinatorGate — fronteira fail-open vs fail-closed", () => {
+  const coordinator = { isCoordinator: true, queryFailed: false };
+  const naoCoordenador = { isCoordinator: false, queryFailed: false };
+  const erroTransitorio = { isCoordinator: false, queryFailed: true };
+
+  it("access null → sempre false (independente do flag)", () => {
+    expect(coordinatorGate(null, { failOpen: true })).toBe(false);
+    expect(coordinatorGate(null, { failOpen: false })).toBe(false);
+  });
+
+  it("coordenador → true nos dois modos", () => {
+    expect(coordinatorGate(coordinator, { failOpen: true })).toBe(true);
+    expect(coordinatorGate(coordinator, { failOpen: false })).toBe(true);
+  });
+
+  it("não-coordenador sem erro → false nos dois modos", () => {
+    expect(coordinatorGate(naoCoordenador, { failOpen: true })).toBe(false);
+    expect(coordinatorGate(naoCoordenador, { failOpen: false })).toBe(false);
+  });
+
+  // O par decisivo: o MESMO estado (erro transitório de query) resolve
+  // diferente conforme o flag.
+  it("erro transitório + fail-open → true (não rebaixa coordenador legítimo)", () => {
+    expect(coordinatorGate(erroTransitorio, { failOpen: true })).toBe(true);
+  });
+
+  it("erro transitório + fail-closed → false (NÃO expõe dados de terceiros)", () => {
+    // Invariante de segurança: fail-closed jamais incorpora queryFailed.
+    expect(coordinatorGate(erroTransitorio, { failOpen: false })).toBe(false);
+  });
+});

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -75,3 +75,25 @@ export function compareDefaultsForMode(
   }
   return { ...DEFAULT_COMPARE_FILTERS, minHumans };
 }
+
+// Conjunto de document_ids que um usuário pode VER na fila de comparação.
+// Coordenador → null (sem restrição: vê todos os documentos). Não-coordenador
+// → apenas os docs com assignment de comparação atribuído a ele.
+// SEGURANÇA: a policy RLS "Members view responses" deixa qualquer membro ler
+// todas as responses do projeto, então este recorte é a única barreira de
+// visibilidade — por isso o `isCoordinator` que o alimenta é fail-closed (não
+// incorpora queryFailed). Ver analyze/compare/page.tsx.
+export function assignedCompareDocIds(
+  isCoordinator: boolean,
+  assignments:
+    | ReadonlyArray<{ document_id: string; user_id: string; type: string }>
+    | null,
+  userId: string,
+): Set<string> | null {
+  if (isCoordinator) return null;
+  return new Set(
+    (assignments ?? [])
+      .filter((a) => a.type === "comparacao" && a.user_id === userId)
+      .map((a) => a.document_id),
+  );
+}

--- a/frontend/src/lib/project-access.ts
+++ b/frontend/src/lib/project-access.ts
@@ -1,0 +1,19 @@
+// Decisão única fail-open vs fail-closed sobre o resultado de
+// `getProjectAccessContext`. Pura (sem import de server) para ser testável em
+// isolamento — a fronteira de confiança não deve viver implícita numa expressão
+// booleana espalhada por cada page.
+//
+// SEGURANÇA: `failOpen` só pode ser `true` onde `isCoordinator` liga apenas
+// affordances que são re-checadas na mutation (`isProjectCoordinator`,
+// fail-closed). Onde `isCoordinator` recorta DADOS por papel (fila de
+// comparação, gabarito de terceiros), use `failOpen: false` — incorporar
+// `queryFailed` ali exporia dados de terceiros num erro transitório.
+export function coordinatorGate(
+  access: { isCoordinator: boolean; queryFailed: boolean } | null,
+  opts: { failOpen: boolean },
+): boolean {
+  if (!access) return false;
+  return opts.failOpen
+    ? access.isCoordinator || access.queryFailed
+    : access.isCoordinator;
+}

--- a/frontend/src/lib/reviews/__tests__/queries.test.ts
+++ b/frontend/src/lib/reviews/__tests__/queries.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   computeTruncation,
   REVIEW_BASE_DATA_LIMIT,
+  resolveEffectiveUserId,
 } from "@/lib/reviews/queries";
 
 // Array esparso: `.length` e o teto sem alocar 50k elementos.
@@ -57,5 +58,69 @@ describe("computeTruncation — flags do TruncationBanner (issue #105)", () => {
       reviews: false,
       documents: false,
     });
+  });
+});
+
+// Invariante de segurança: em "Meu Gabarito", `viewAsUser` (ver o gabarito de
+// outro respondente) só vale para coordenador/criador/master. A policy RLS
+// "Members view responses" não filtra por respondent_id, então esta função é a
+// única barreira — por isso `isCoordinator` aqui é fail-closed.
+describe("resolveEffectiveUserId — viewAsUser só para coordenador/criador/master", () => {
+  const selfId = "user-self";
+  const other = "user-other";
+
+  it("não-coordenador/não-master NÃO impersona, mesmo passando viewAsUser", () => {
+    expect(
+      resolveEffectiveUserId({
+        selfId,
+        isMaster: false,
+        isCoordinator: false,
+        viewAsUser: other,
+      }),
+    ).toBe(selfId);
+  });
+
+  it("coordenador pode ver as respostas de outro via viewAsUser", () => {
+    expect(
+      resolveEffectiveUserId({
+        selfId,
+        isMaster: false,
+        isCoordinator: true,
+        viewAsUser: other,
+      }),
+    ).toBe(other);
+  });
+
+  it("master pode ver as respostas de outro mesmo sem ser coordenador", () => {
+    expect(
+      resolveEffectiveUserId({
+        selfId,
+        isMaster: true,
+        isCoordinator: false,
+        viewAsUser: other,
+      }),
+    ).toBe(other);
+  });
+
+  it("sem viewAsUser, sempre o próprio usuário (mesmo coordenador)", () => {
+    expect(
+      resolveEffectiveUserId({
+        selfId,
+        isMaster: false,
+        isCoordinator: true,
+        viewAsUser: undefined,
+      }),
+    ).toBe(selfId);
+  });
+
+  it("viewAsUser vazio é tratado como ausente (não impersona)", () => {
+    expect(
+      resolveEffectiveUserId({
+        selfId,
+        isMaster: true,
+        isCoordinator: true,
+        viewAsUser: "",
+      }),
+    ).toBe(selfId);
   });
 });

--- a/frontend/src/lib/reviews/queries.ts
+++ b/frontend/src/lib/reviews/queries.ts
@@ -119,6 +119,23 @@ export function formatAnswer(val: unknown): string {
   return String(val);
 }
 
+// Resolve o respondente efetivo cujas respostas a aba "Meu Gabarito" exibe.
+// Só coordenador, criador ou master podem inspecionar as respostas de OUTRO
+// respondente (via ?viewAsUser=...); qualquer outro vê apenas as próprias.
+// SEGURANÇA: a policy RLS "Members view responses" deixa qualquer membro ler
+// todas as responses do projeto (não filtra por respondent_id), então esta
+// checagem é a única barreira — por isso o `isCoordinator` que a alimenta é
+// fail-closed (não incorpora queryFailed). Ver reviews/my-verdicts/page.tsx.
+export function resolveEffectiveUserId(opts: {
+  selfId: string;
+  isMaster: boolean;
+  isCoordinator: boolean;
+  viewAsUser: string | undefined;
+}): string {
+  const { selfId, isMaster, isCoordinator, viewAsUser } = opts;
+  return (isMaster || isCoordinator) && viewAsUser ? viewAsUser : selfId;
+}
+
 function getRespondentKey(r: {
   respondent_id: string | null;
   respondent_name: string | null;


### PR DESCRIPTION
## Contexto

No review do #224, identifiquei uma dívida pré-existente: várias pages recomputavam `isCoordinator` **inline** — refazendo as queries `projects` + `project_members` e calculando `created_by === user.id || role === "coordenador"` — em vez de reusar o helper canônico `getProjectAccessContext()` (`frontend/src/lib/auth.ts`). O #224 já havia removido a cópia do `reviews/layout.tsx`; esta PR fecha as restantes e, na sequência da review, centraliza também a decisão fail-open/fail-closed que vivia implícita em cada page.

## O que muda

**5 pages deixam de recalcular `isCoordinator`** e passam a obtê-lo de `getProjectAccessContext(id, user.id, user.isMaster)`; o `select` de `projects` perde o `created_by` (virou responsabilidade do helper):

- `reviews/comments/page.tsx`, `reviews/my-verdicts/page.tsx`, `reviews/llm-insights/page.tsx` — as três abas de Revisar.
- `analyze/compare/page.tsx` — fila de Comparação (decisão **fail-closed**, recorta documentos por papel).
- `config/rounds/page.tsx` — config de rodadas (decisão **fail-open**, só liga affordances).

**Novo helper puro `coordinatorGate(access, { failOpen })`** (`frontend/src/lib/project-access.ts`): centraliza a decisão fail-open vs fail-closed que antes era uma expressão booleana repetida e implícita em cada page. Tornar a fronteira de confiança uma função pura permite testá-la diretamente.

**Helpers de filtro extraídos e testados**: `assignedCompareDocIds()` (`compare-filters.ts`) e `resolveEffectiveUserId()` (`reviews/queries.ts`) — recortes de visibilidade que eram filtros inline.

A divergência fechada tinha três faces:

1. **`isMaster` ignorado** — nas três abas de Revisar, um usuário master **não** era tratado como coordenador, ao contrário do layout-pai e do `ProjectTabs`. Agora `isCoordinator` inclui `isMaster`, unificando o conceito com o resto de `/projects/[id]`.
2. **`queryFailed` não tratado** — fail-closed silencioso: timeout/RLS rebaixava um coordenador legítimo a "não-coordenador". O helper loga e sinaliza a falha.
3. **Query redundante** — `getProjectAccessContext` é `cache()`-wrapped e o layout raiz já o chama com os mesmos args na mesma request, então a chamada nas pages é cache hit (0 queries extras). A cópia inline ainda batia no `project_members` de novo.

## Fail-open vs fail-closed (decisão de segurança)

A escolha por página é deliberada e agora explícita via o flag de `coordinatorGate`:

- **fail-closed** (`{ failOpen: false }`) onde `isCoordinator` **recorta dados** por papel: `analyze/compare` (um não-coordenador vê só os documentos atribuídos a si) e `reviews/my-verdicts` (`viewAsUser` lê o gabarito de outro respondente). A policy RLS `Members view responses` deixa qualquer membro ler todas as responses, então esse recorte é a única barreira aplicacional — incorporar `queryFailed` exporia dados de terceiros num erro transitório.
- **fail-open** (`{ failOpen: true }`) onde `isCoordinator` **só liga affordances** re-checadas na mutation (`isProjectCoordinator`, fail-closed): `config/rounds`, `reviews/comments`, `reviews/llm-insights`. Em erro transitório não rebaixa um coordenador legítimo; o pior caso é mostrar um botão cuja mutation será rejeitada server-side.

## Mudança de comportamento (intencional)

`isCoordinator` agora inclui `user.isMaster` nas três abas de Revisar, unificando o conceito de coordenador com o resto da árvore de `/projects/[id]`. Masters já são privilegiados por design (impersonation no layout-pai, `ProjectTabs` como coordenador), então tratá-los como coordenador nas abas de review é o comportamento consistente — sem exposição nova de dado a quem já não fosse privilegiado.

## Verificação

- `tsc --noEmit`: limpo
- `vitest run`: **501 testes** passando (inclui os novos de `coordinatorGate`, `assignedCompareDocIds` e `resolveEffectiveUserId`)
- `eslint`: 0 errors (3 warnings pré-existentes, grandfathered)
- `react-doctor --scope changed`: 97/100, sem issues

## Sequência

Empilha sobre o #224 (já mergeado). Independente dos demais.
