### PR TITLE
chore: remove tipo órfão AssignmentBatch (#227)

### DIFF
--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -178,17 +178,6 @@ export interface Assignment {
   completed_at: string | null;
 }
 
-export interface AssignmentBatch {
-  id: string;
-  project_id: string;
-  created_by: string;
-  created_at: string;
-  researchers_per_doc: number;
-  docs_per_researcher: number | null;
-  doc_subset_size: number | null;
-  label: string | null;
-}
-
 // Snapshot por-campo do schema contra o qual a response foi codificada
 // (1 chave por campo existente na época, valor = field.hash). Gravado em
 // saveResponse iterando o schema completo (não os campos respondidos), então


### PR DESCRIPTION
## Contexto

O tipo `AssignmentBatch` em `frontend/src/lib/types.ts` era um tipo **órfão**: `git grep AssignmentBatch -- frontend/src` retornava apenas a própria declaração — nenhum leitor.

Ao investigar, encontrei um agravante: além de órfão, o tipo estava **defasado**. A tabela `assignment_batches` ganhou as colunas `mode`, `balancing` e `filters` na migration `20260611125000`, mas o tipo nunca foi atualizado. Ou seja, era código morto que ainda por cima descrevia a tabela errada.

## Decisão

A issue oferecia (a) remover ou (b) cabear o tipo como fonte de verdade do schema. Optei por **(a) remover**, alinhado ao objetivo de simplificar e reduzir dívida técnica:

- O projeto **não tem codegen de tipos do Supabase** — toda tabela é acessada sem tipo no `.from()`. Manter um tipo de linha à mão só para `assignment_batches` seria uma exceção ao padrão, exceção que já falhou na prática (o tipo desatualizou silenciosamente).
- Os dados gravados passam por um object literal inferido (`batchData` em `assignments.ts`), sem relação com o tipo. A remoção não tem impacto de runtime nem leitores a ajustar.

## Verificação

- `git grep AssignmentBatch -- frontend/src` → vazio (sem leitores).
- `tsc --noEmit`: nenhum erro novo (diff contra baseline = subconjunto estrito; só erros pré-existentes de cache `.next/` no lado do baseline).
- `npm test`: 488 testes passando (39 arquivos).
- `npm run lint`: 0 errors.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)