### PR TITLE
chore(lint): classifica os 6 errors de Security do react-doctor como FP (#203)

### DIFF
--- a/docs/LINT_CONFIG.md
+++ b/docs/LINT_CONFIG.md
@@ -39,16 +39,17 @@ pre-commit install              # da raiz do repo: grava o hook em .git/hooks
 
 Scan completo (`npm run react-doctor`) após o bump 0.2.11 → 0.5.6, já com os overrides aplicados:
 
-- **Score: 39 / 100** (o algoritmo de score mudou entre 0.2 e 0.5 — não é comparável ao "75" da versão anterior).
-- **17 errors / 148 warnings** (165 issues), distribuídos em: Security (6 errors), Bugs (11 errors + 90 warnings), Performance (19 warnings), Accessibility (5 warnings), Maintainability (34 warnings).
+- **Score: 39 / 100** na medição do bump (o algoritmo de score mudou entre 0.2 e 0.5 — não é comparável ao "75" da versão anterior).
+- **Baseline do bump (2026-06-15): 17 errors** contabilizados — Security (6 errors), Bugs (11 errors), além de ~148 warnings (Bugs 90, Performance 19, Accessibility 5, Maintainability 34).
+- **Após a auditoria de #203: os 6 errors de Security saem da contagem** (Security 6 → 0 errors). Foram classificados como falso positivo e silenciados via override escopado por arquivo (ver as duas subseções abaixo). Restam os errors da categoria Bugs.
 
-Os 17 errors vêm de **três regras novas** da 0.5.x, todas legítimas (não são FP) e por isso **não silenciadas** — ficam grandfathered pelo `--diff` hunk-scoped até que as linhas em questão sejam editadas:
+Os errors do bump vinham de **três regras novas** da 0.5.x. Após #203, o débito de errors **legítimo e não silenciado** é o da categoria Bugs — sobretudo o cluster `no-adjust-state-on-prop-change` —, grandfathered pelo `--diff` hunk-scoped até que as linhas em questão sejam editadas:
 
-- `react-doctor/no-adjust-state-on-prop-change` (11) — Bugs; ajustar state em effect/render conforme prop muda. Ex.: `DocumentPreview.tsx`, `CodingPage.tsx`, `MyVerdictsView.tsx`.
-- `react-doctor/supabase-client-owned-authz-field` (4) — Security; campo de autorização escrito via client. Ex.: `lib/auto-review.ts`, `actions/{assignments,members,projects}.ts`.
-- `react-doctor/supabase-table-missing-rls` (2) — Security; `CREATE TABLE` sem RLS em `migrations/{clerk_user_mapping,master_users}.sql`.
+- `react-doctor/no-adjust-state-on-prop-change` (11) — Bugs; ajustar state em effect/render conforme prop muda. Ex.: `DocumentPreview.tsx`, `CodingPage.tsx`, `MyVerdictsView.tsx`. **Legítimo, não silenciado.** (Um scan posterior pode listar também `server-no-mutable-module-state` em `projects.ts` conforme o código evolui; contar via `npm run react-doctor`, não fixar o total aqui.)
 
-Pagar esse débito (corrigir os errors de verdade) é trabalho de PR(s) à parte, fora do escopo do bump. O gate de pre-commit não obriga a corrigi-los para commitar — só barra se a *linha* alterada produzir um error.
+Os 6 errors de Security (4 `supabase-client-owned-authz-field` + 2 `supabase-table-missing-rls`) foram auditados em #203, confirmados como FP heurístico e silenciados por arquivo — detalhes nas subseções "Por que `supabase-client-owned-authz-field`…" e "Por que `supabase-table-missing-rls`…" abaixo.
+
+Pagar o débito de Bugs restante é trabalho de PR(s) à parte (cluster State & Effects #149/#152), fora do escopo de #203. O gate de pre-commit não obriga a corrigi-los para commitar — só barra se a *linha* alterada produzir um error.
 
 ## Por que `server-auth-actions` está silenciada em `src/actions/**`
 
@@ -61,6 +62,23 @@ Se o react-doctor passar a aceitar custom auth helpers (ou se o projeto adotar `
 ## `only-export-components` ignorada em `src/components/ui/**`
 
 Os componentes shadcn/ui (`ui/button`, `ui/badge`, `ui/tabs`) exportam, além do componente, suas variantes CVA (`buttonVariants`, `badgeVariants` etc.) — convenção intencional do shadcn. A regra `react-doctor/only-export-components` (orientada a Fast Refresh) acusa isso como error. O override silencia a regra **apenas em `src/components/ui/**`** (onde o padrão é da própria biblioteca), mantendo-a ativa no resto do app. Na 0.2.x estes eram os únicos errors do codebase, junto com `server-auth-actions`; com os overrides, a baseline daquela versão era 0 errors. Na 0.5.6 o ruleset expandido introduziu novos errors (ver baseline abaixo), mas estes dois overrides continuam necessários e ativos.
+
+## Por que `supabase-client-owned-authz-field` está silenciada nos 4 arquivos auditados
+
+A regra `react-doctor/supabase-client-owned-authz-field` acusa código client Supabase que escreve campos de `user`/`tenant`/`owner`/`role` que deveriam ser enforçados pela RLS. Os 4 disparos da baseline foram auditados em #203 e confirmados como FP heurístico — silenciados **por arquivo** (não pela regra inteira, nem por `src/actions/**`), para que a regra continue pegando actions novas:
+
+- `src/lib/auto-review.ts` — a escrita (`assignments.status`, `field_reviews`) passa pelo **admin client** (service-role), que ignora a RLS por design; `status` é estado de workflow, não autz. O uso do admin é deliberado e comentado no arquivo (a policy de `assignments` restringe INSERT a coordenadores; o pesquisador precisa criar a própria fila de revisão).
+- `src/actions/assignments.ts` — a regra aponta o parâmetro `userId`; as escritas gravam `type`/`assignment_weight`/`assignment_cap` (operacionais) e são barradas pela policy `Coordinators manage assignments`.
+- `src/actions/members.ts` — escreve `role`/`can_resolve`/`can_arbitrate`/`can_compare` via client autenticado, mas a policy `Coordinators manage members` (`USING project_id IN auth_user_coordinator_or_creator_project_ids() OR is_master()`) barra qualquer não-coordenador: o UPDATE afeta 0 linhas e o código retorna "Sem permissão". Não há auto-escalação explorável. A ausência de um *column-level guard* em `project_members` (defesa em profundidade, presente em `projects`/`project_comments`/`schema_change_log`) é a única lacuna real, rastreada em issue-filha de #203 — não é vulnerabilidade, e fechá-la embute decisão de produto (se um coordenador pode alternar as próprias flags).
+- `src/actions/projects.ts` — `role: "coordenador"` inserido no bootstrap criador→coordenador, gated pela policy `Creator inserts members` (só permite inserir em projeto cujo `created_by = clerk_uid()`). Intencional; ninguém entra em projeto alheio.
+
+Se algum desses fluxos migrar para depender de coluna client-fornecida sem RLS, **remover o override do arquivo afetado** e corrigir.
+
+## Por que `supabase-table-missing-rls` está silenciada nas 2 migrations auditadas
+
+A regra `react-doctor/supabase-table-missing-rls` acusa `CREATE TABLE` que não habilita RLS **na mesma migration**. Os 2 disparos (`migrations/20260401000000_clerk_user_mapping.sql` e `migrations/20260402000000_master_users.sql`) foram auditados em #203 e são FP: ambas as tabelas têm RLS habilitada numa migration posterior (`20260407000000_enable_rls_system_tables.sql`) somada a `REVOKE ALL ... FROM anon, authenticated`, e são acessadas só via service-role (`lib/clerk-sync.ts` e `lib/auth.ts`). A proteção existe — só está distribuída entre arquivos, padrão que a heurística não reconhece. Editar migrations já aplicadas em produção para re-habilitar RLS seria no-op.
+
+O override é escopado **às duas migrations específicas**, de propósito: uma `CREATE TABLE` nova sem RLS deve continuar falhando.
 
 ## `js-combine-iterations` desligada globalmente
 

--- a/frontend/doctor.config.json
+++ b/frontend/doctor.config.json
@@ -13,6 +13,26 @@
         "rules": [
           "react-doctor/only-export-components"
         ]
+      },
+      {
+        "files": [
+          "src/lib/auto-review.ts",
+          "src/actions/assignments.ts",
+          "src/actions/members.ts",
+          "src/actions/projects.ts"
+        ],
+        "rules": [
+          "react-doctor/supabase-client-owned-authz-field"
+        ]
+      },
+      {
+        "files": [
+          "supabase/migrations/20260401000000_clerk_user_mapping.sql",
+          "supabase/migrations/20260402000000_master_users.sql"
+        ],
+        "rules": [
+          "react-doctor/supabase-table-missing-rls"
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Resumo

Auditoria de #203: os **6 errors de Security** da baseline do react-doctor 0.5.6 (4 `supabase-client-owned-authz-field` + 2 `supabase-table-missing-rls`) foram auditados e confirmados como **falso positivo heurístico** — nenhum é vulnerabilidade explorável. Este PR os classifica como FP, silencia via override **escopado por arquivo** em `doctor.config.json` e documenta a justificativa por caso em `docs/LINT_CONFIG.md`.

**Sem mudança de comportamento, sem migration, sem código de aplicação alterado.**

## Auditoria (verdade de campo, via `react-doctor --verbose` + leitura de código/policies)

| Error | Por que é FP |
|---|---|
| `lib/auto-review.ts:1` | Escrita via **admin client** (service-role), que ignora a RLS por design; `status` é estado de workflow, não autz. Uso comentado no arquivo. |
| `actions/assignments.ts:33` | Regra aponta o param `userId`; escritas gravam `type`/`assignment_weight`/`assignment_cap` (operacionais), barradas pela policy `Coordinators manage assignments`. |
| `actions/members.ts:4` | `role`/`can_*` via client autenticado, mas `Coordinators manage members` (`USING project_id IN auth_user_coordinator_or_creator_project_ids() OR is_master()`) barra não-coordenador: UPDATE afeta 0 linhas. Sem auto-escalação. |
| `actions/projects.ts:46` | `role: "coordenador"` no bootstrap criador→coordenador, gated por `Creator inserts members` (só insere em projeto cujo `created_by = clerk_uid()`). |
| `migrations/…clerk_user_mapping.sql:4` | RLS habilitada em `20260407000000_enable_rls_system_tables.sql` + `REVOKE ALL FROM anon, authenticated`; acesso só via service-role. |
| `migrations/…master_users.sql:6` | Idem: RLS habilitada em `20260407…` + `REVOKE ALL` na própria migration; acesso só via service-role. |

## Por que override por arquivo (não por diretório nem pela regra)

Escopar aos 4 arquivos / 2 migrations específicos preserva o enforcement para o futuro: uma `CREATE TABLE` nova sem RLS, ou uma action nova que escreva campo de autz, **ainda deve falhar**. Espelha o padrão restrito dos overrides já existentes.

## Verificação

- `npm run react-doctor`: Security passa de **6 errors → 0**. As demais categorias (Bugs 12e/91w, Performance 19w, Accessibility 4w, Maintainability 32w) ficam **idênticas** — o override removeu exatamente os 6 alvos e nada mais.
- Nenhum dos 6 `file:line` auditados aparece mais no `--verbose`; as regras seguem ativas para outros caminhos.
- `doctor.config.json` parseia como JSON válido.

## Follow-up (defesa em profundidade — NÃO neste PR)

A única lacuna real: `project_members` não tem *column-level guard* (presente em `projects`/`project_comments`/`schema_change_log` via `enforce_*_column_guard`, ver `20260612100000_rls_guard_hardening.sql`). Não é vulnerabilidade (a RLS row-level já barra não-coordenadores), mas fechar a superfície teórica embute **decisão de produto**: um coordenador pode alternar as próprias flags `can_resolve`/`can_arbitrate`/`can_compare`? Sugeri abrir issue-filha para rastrear — a criação automática foi bloqueada pelo classificador, então fica para o @bdcdo decidir se quer que eu a crie.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)