### PR TITLE
fix(a11y): role manual → elemento nativo (MobileWarning, AnswerCard) [RD-A11Y]

### DIFF
--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -82,18 +82,9 @@ export function AnswerCard({
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onVote}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" || e.key === " ") {
-          e.preventDefault();
-          onVote();
-        }
-      }}
       className={cn(
-        "w-full cursor-pointer rounded-lg border p-2.5 text-left transition-colors hover:bg-accent/50",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        "relative isolate w-full rounded-lg border p-2.5 text-left transition-colors hover:bg-accent/50",
+        "has-[[data-vote-target]:focus-visible]:outline-none has-[[data-vote-target]:focus-visible]:ring-2 has-[[data-vote-target]:focus-visible]:ring-ring has-[[data-vote-target]:focus-visible]:ring-offset-2",
         isChosen
           ? "border-green-500/50 bg-green-500/5"
           : selected
@@ -101,13 +92,29 @@ export function AnswerCard({
             : "border-muted",
       )}
     >
+      {/*
+        Vote target: a transparent <button> overlaying the whole card. The card
+        itself is a plain <div> so the interactive controls below (checkbox,
+        popover, gabarito radio) can be siblings of this button instead of
+        nested inside it (nested interactive = invalid HTML, plus the manual
+        role="button" that prefer-tag-over-role flagged). Any new interactive or
+        hover child must be lifted above this overlay with `relative z-[2]`;
+        non-interactive content stays below and clicking it votes
+        (stretched-link pattern). The native <button> handles Enter/Space.
+      */}
+      <button
+        type="button"
+        data-vote-target
+        onClick={onVote}
+        aria-label={`Escolher esta resposta: ${displayAnswer || "(vazia)"}`}
+        className="absolute inset-0 z-[1] cursor-pointer rounded-lg focus:outline-none"
+      />
       <div className="flex items-start gap-2">
         {selectable && (
-          <div className="flex h-5 shrink-0 items-center">
+          <div className="relative z-[2] flex h-5 shrink-0 items-center">
             <Checkbox
               checked={selected}
               onCheckedChange={() => onSelectionToggle?.()}
-              onClick={(e) => e.stopPropagation()}
               aria-label="Selecionar para marcar como equivalente"
               title="Selecionar como equivalente"
             />
@@ -122,7 +129,7 @@ export function AnswerCard({
           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="cursor-default underline decoration-dotted underline-offset-2">
+                <span className="relative z-[2] cursor-default underline decoration-dotted underline-offset-2">
                   {respondentCount}{" "}
                   {respondentCount === 1 ? "respondente" : "respondentes"}
                 </span>
@@ -155,19 +162,14 @@ export function AnswerCard({
                 <PopoverTrigger asChild>
                   <button
                     type="button"
-                    onClick={(e) => e.stopPropagation()}
-                    className="inline-flex items-center gap-1 rounded bg-brand/10 px-1.5 py-0.5 text-[10px] text-brand hover:bg-brand/15"
+                    className="relative z-[2] inline-flex items-center gap-1 rounded bg-brand/10 px-1.5 py-0.5 text-[10px] text-brand hover:bg-brand/15"
                     title="Variantes marcadas como equivalentes"
                   >
                     <Link2 className="size-3" />
                     {fusedCount} variante{fusedCount === 1 ? "" : "s"}
                   </button>
                 </PopoverTrigger>
-                <PopoverContent
-                  align="start"
-                  className="w-72 p-2"
-                  onClick={(e) => e.stopPropagation()}
-                >
+                <PopoverContent align="start" className="w-72 p-2">
                   <p className="px-1 pb-1.5 text-xs font-medium">
                     Respostas equivalentes
                   </p>
@@ -189,10 +191,7 @@ export function AnswerCard({
                           {showUnmark && (
                             <button
                               type="button"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                onUnmarkPair!(v.pairId);
-                              }}
+                              onClick={() => onUnmarkPair!(v.pairId)}
                               className="rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
                               title="Desfazer equivalência"
                               aria-label="Desfazer equivalência"
@@ -219,7 +218,7 @@ export function AnswerCard({
             {versions.length > 1 && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="cursor-default font-mono text-[10px] text-muted-foreground underline decoration-dotted underline-offset-2">
+                  <span className="relative z-[2] cursor-default font-mono text-[10px] text-muted-foreground underline decoration-dotted underline-offset-2">
                     {versions.length} versões
                   </span>
                 </TooltipTrigger>
@@ -236,11 +235,8 @@ export function AnswerCard({
             <div className="mt-1.5">
               <button
                 type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowJustification(!showJustification);
-                }}
-                className="text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => setShowJustification(!showJustification)}
+                className="relative z-[2] text-xs text-muted-foreground hover:text-foreground"
               >
                 {showJustification ? <ChevronDown className="inline size-3" /> : <ChevronRight className="inline size-3" />}{" "}Justificativa
               </button>
@@ -255,16 +251,13 @@ export function AnswerCard({
 
         {showGabarito && (
           <label
-            className="flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"
+            className="relative z-[2] flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"
             title="Esta é a resposta que será registrada como gabarito"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
           >
             <input
               type="radio"
               checked={isGabarito}
               onChange={() => onSetGabarito?.()}
-              onClick={(e) => e.stopPropagation()}
               className="size-3 accent-brand"
             />
             <span className={cn(isGabarito && "font-medium text-brand")}>

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -209,7 +209,7 @@ export function AnswerCard({
 
             {versions.length === 1 && (
               <span
-                className="font-mono text-[10px] text-muted-foreground"
+                className="relative z-[2] font-mono text-[10px] text-muted-foreground"
                 title="Versão do schema em que esta resposta foi salva"
               >
                 v{versions[0]}

--- a/frontend/src/components/compare/__tests__/AnswerCard.test.tsx
+++ b/frontend/src/components/compare/__tests__/AnswerCard.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AnswerCard } from "@/components/compare/AnswerCard";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+afterEach(cleanup);
+
+function renderCard(props: Partial<Parameters<typeof AnswerCard>[0]> = {}) {
+  const onVote = vi.fn();
+  const onSetGabarito = vi.fn();
+  render(
+    <TooltipProvider>
+      <AnswerCard
+        index={0}
+        displayAnswer="Deferido"
+        respondentNames={["Ana"]}
+        respondentCount={1}
+        hasLlm={false}
+        staleCount={0}
+        isChosen={false}
+        versions={["1.0.0"]}
+        onVote={onVote}
+        onSetGabarito={onSetGabarito}
+        {...props}
+      />
+    </TooltipProvider>,
+  );
+  return { onVote, onSetGabarito };
+}
+
+describe("AnswerCard — overlay de voto", () => {
+  it("vota ao clicar no card (overlay button) e ao acionar pelo teclado", async () => {
+    const user = userEvent.setup();
+    const { onVote } = renderCard();
+
+    const voteButton = screen.getByRole("button", {
+      name: /escolher esta resposta/i,
+    });
+    await user.click(voteButton);
+    expect(onVote).toHaveBeenCalledTimes(1);
+
+    voteButton.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard(" ");
+    expect(onVote).toHaveBeenCalledTimes(3);
+  });
+
+  it("seleciona o gabarito sem disparar o voto (não há mais aninhamento)", async () => {
+    const user = userEvent.setup();
+    const { onVote, onSetGabarito } = renderCard({
+      showGabarito: true,
+      isGabarito: false,
+    });
+
+    await user.click(screen.getByRole("radio"));
+    expect(onSetGabarito).toHaveBeenCalledTimes(1);
+    expect(onVote).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/shell/MobileWarning.tsx
+++ b/frontend/src/components/shell/MobileWarning.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function MobileWarning() {
   const [dismissed, setDismissed] = useState(false);
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768);
@@ -15,21 +16,41 @@ export function MobileWarning() {
     return () => window.removeEventListener("resize", check);
   }, []);
 
-  if (isMobile === null || !isMobile || dismissed) return null;
+  // The dialog stays mounted (closed => display:none) so we can drive it via
+  // showModal()/close(); showModal() gives us the top layer, focus trap, and
+  // initial focus for free.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const shouldShow = isMobile === true && !dismissed;
+    if (shouldShow && !dialog.open) dialog.showModal();
+    else if (!shouldShow && dialog.open) dialog.close();
+  }, [isMobile, dismissed]);
 
   return (
-    <div role="dialog" aria-modal="true" aria-labelledby="mobile-warning-title" className="fixed inset-0 z-[100] flex items-center justify-center bg-background/95 p-6">
-      <div className="max-w-sm text-center space-y-4">
-        <Monitor className="size-12 mx-auto text-brand" />
-        <h2 id="mobile-warning-title" className="text-lg font-semibold">Use um computador</h2>
-        <p className="text-sm text-muted-foreground">
-          Esta plataforma foi projetada para telas maiores. Para a melhor
-          experiência, acesse pelo computador.
-        </p>
-        <Button variant="outline" onClick={() => setDismissed(true)}>
-          Continuar mesmo assim
-        </Button>
+    <dialog
+      ref={dialogRef}
+      aria-labelledby="mobile-warning-title"
+      // `cancel` fires only on Escape (not on the programmatic close above), so
+      // resizing desktop -> mobile re-shows the warning instead of staying hidden.
+      onCancel={() => setDismissed(true)}
+      className="fixed inset-0 m-0 h-full max-h-none w-full max-w-none bg-background/95 p-6 text-foreground backdrop:bg-transparent"
+    >
+      <div className="flex h-full items-center justify-center">
+        <div className="max-w-sm space-y-4 text-center">
+          <Monitor className="mx-auto size-12 text-brand" />
+          <h2 id="mobile-warning-title" className="text-lg font-semibold">
+            Use um computador
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Esta plataforma foi projetada para telas maiores. Para a melhor
+            experiência, acesse pelo computador.
+          </p>
+          <Button variant="outline" onClick={() => setDismissed(true)}>
+            Continuar mesmo assim
+          </Button>
+        </div>
       </div>
-    </div>
+    </dialog>
   );
 }

--- a/frontend/src/components/shell/MobileWarning.tsx
+++ b/frontend/src/components/shell/MobileWarning.tsx
@@ -1,39 +1,45 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 export function MobileWarning() {
-  const [dismissed, setDismissed] = useState(false);
-  const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const dialogRef = useRef<HTMLDialogElement>(null);
+  // `<dialog>`/showModal() is an imperative DOM API, so we drive it directly
+  // from the resize subscription and the dismiss handlers instead of bridging
+  // state -> effect. `dismissed` never affects render (the dialog is controlled
+  // imperatively), so a ref is the right tool — no re-renders, no state/effect
+  // sync to flag.
+  const dismissedRef = useRef(false);
 
-  useEffect(() => {
-    const check = () => setIsMobile(window.innerWidth < 768);
-    check();
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
-  }, []);
-
-  // The dialog stays mounted (closed => display:none) so we can drive it via
-  // showModal()/close(); showModal() gives us the top layer, focus trap, and
-  // initial focus for free.
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
-    const shouldShow = isMobile === true && !dismissed;
-    if (shouldShow && !dialog.open) dialog.showModal();
-    else if (!shouldShow && dialog.open) dialog.close();
-  }, [isMobile, dismissed]);
+    const sync = () => {
+      const shouldShow = window.innerWidth < 768 && !dismissedRef.current;
+      if (shouldShow && !dialog.open) dialog.showModal();
+      else if (!shouldShow && dialog.open) dialog.close();
+    };
+    sync();
+    window.addEventListener("resize", sync);
+    return () => window.removeEventListener("resize", sync);
+  }, []);
+
+  function dismiss() {
+    dismissedRef.current = true;
+    dialogRef.current?.close();
+  }
 
   return (
     <dialog
       ref={dialogRef}
       aria-labelledby="mobile-warning-title"
-      // `cancel` fires only on Escape (not on the programmatic close above), so
-      // resizing desktop -> mobile re-shows the warning instead of staying hidden.
-      onCancel={() => setDismissed(true)}
+      // Escape closes a modal <dialog> natively; just record the dismissal so a
+      // later resize back to mobile doesn't re-open it.
+      onCancel={() => {
+        dismissedRef.current = true;
+      }}
       className="fixed inset-0 m-0 h-full max-h-none w-full max-w-none bg-background/95 p-6 text-foreground backdrop:bg-transparent"
     >
       <div className="flex h-full items-center justify-center">
@@ -46,7 +52,7 @@ export function MobileWarning() {
             Esta plataforma foi projetada para telas maiores. Para a melhor
             experiência, acesse pelo computador.
           </p>
-          <Button variant="outline" onClick={() => setDismissed(true)}>
+          <Button variant="outline" onClick={dismiss}>
             Continuar mesmo assim
           </Button>
         </div>

--- a/frontend/src/components/shell/__tests__/MobileWarning.test.tsx
+++ b/frontend/src/components/shell/__tests__/MobileWarning.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { MobileWarning } from "@/components/shell/MobileWarning";
+
+// jsdom não implementa a API de <dialog> (showModal/close); browsers reais sim
+// (suporte universal desde ~2022). Polyfill mínimo que apenas reflete o atributo
+// `open` para o ambiente de teste — não roda em browser real (feature-detect).
+if (typeof HTMLDialogElement !== "undefined" && !HTMLDialogElement.prototype.showModal) {
+  HTMLDialogElement.prototype.showModal = function () {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function () {
+    this.open = false;
+    this.dispatchEvent(new Event("close"));
+  };
+}
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  setViewportWidth(1024);
+});
+
+describe("MobileWarning", () => {
+  it("não abre o dialog em telas largas", () => {
+    setViewportWidth(1280);
+    render(<MobileWarning />);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("abre o dialog (showModal) em telas estreitas e o botão dispensa", async () => {
+    const user = userEvent.setup();
+    setViewportWidth(500);
+    render(<MobileWarning />);
+
+    const dialog = screen.getByRole("dialog", { name: "Use um computador" });
+    expect((dialog as HTMLDialogElement).open).toBe(true);
+
+    await user.click(
+      screen.getByRole("button", { name: /continuar mesmo assim/i }),
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});


### PR DESCRIPTION
Parte da campanha **Zerar react-doctor** (épico #239). Corrige os três diagnósticos de a11y triados na #230 como **corrigir, não suprimir** — HTML cru de app simulando elementos interativos com `role` manual.

## O que muda

### `MobileWarning.tsx` — `<div role="dialog">` → `<dialog>` nativo
- Elemento `<dialog>` nativo aberto via `showModal()` (top layer, trap de foco e foco inicial vêm de graça). Mantém só `aria-labelledby`; remove `role="dialog"` e `aria-modal` (implícitos).
- Como `<dialog>`/`showModal()` é API **imperativa**, o componente é controlado imperativamente: **sem state**, drivando o dialog direto da subscription de `resize` e dos handlers de clique/Escape, com `dismissed` num `ref` (nunca afeta render). Escape dispensa via `onCancel`.
- Resolve `prefer-tag-over-role` + `prefer-html-dialog`, e a abordagem imperativa zera os warnings de `react-doctor` que a versão state+effect introduzia ("State only used in handlers" / "Event logic handled in an effect").

### `AnswerCard.tsx` — `<div role="button">` → overlay `<button>` (stretched-link)
O card era um `<div role="button">` (vota ao clicar) contendo, **aninhados**, controles interativos (checkbox, popover, e o `<input radio>` do gabarito) que usavam `stopPropagation` para o clique neles não votar. Trocar por `<button>` direto produziria *nested interactive* (HTML inválido).

Adotado o **padrão overlay** (issue, opção 2):
- Card vira `<div relative isolate>`; um `<button absolute inset-0>` transparente cobre o card e dispara o voto (Enter/Espaço tratados nativamente — handler de teclado manual removido).
- Os controles interativos/hover sobem com `relative z-[2]`, virando **irmãos** do botão em vez de aninhados. Isso permitiu **remover todos os `stopPropagation`** e os handlers do `<label>`.
- Conteúdo não-interativo fica abaixo do overlay ⇒ clicar nele vota, como hoje. Anel de foco redirecionado para o card via `:has`.
- Resolve `prefer-tag-over-role` (linha 85) + `no-noninteractive-element-interactions` (linha 257).

Decisão registrada: o `AnswerCard` é exclusivo da tela de **Comparação** e exibe a resposta codificada (`displayAnswer`), não o documento — o overlay bloqueia seleção de texto desse card, sem impacto no fluxo (confirmado com o autor).

## Verificação
- `react-doctor`: as 3 regras-alvo sumiram dos dois arquivos; `react-doctor . --diff main` ⇒ **"No issues found!"** (97/100), `--blocking error` exit 0.
- `eslint`, `next build` (typecheck) e `vitest` (505 testes) passam.
- **4 testes novos** de regressão: voto por clique + teclado, gabarito sem disparar voto, e abertura/dispensa do MobileWarning.

Closes #241