### PR TITLE
refactor(reviews): zera react-doctor em MyVerdictsView (#232)

### DIFF
--- a/frontend/src/components/reviews/MyVerdictsView.tsx
+++ b/frontend/src/components/reviews/MyVerdictsView.tsx
@@ -1,72 +1,28 @@
 "use client";
 
-import { Suspense, useState, useEffect, useMemo, useTransition, useRef } from "react";
-import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { Suspense, useState, useMemo, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import {
   ResizablePanelGroup,
   ResizablePanel,
   ResizableHandle,
 } from "@/components/ui/resizable";
 import { DocumentReader } from "@/components/coding/DocumentReader";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  ChevronLeft,
-  ChevronRight,
-  ChevronDown,
-  Check,
-  X,
-  Loader2,
-  MessageSquare,
-  Bot,
-} from "lucide-react";
-import { cn } from "@/lib/utils";
-import { isAnswerCorrect } from "@/lib/reviews/queries";
-import { getDocumentText } from "@/actions/documents";
+import { Loader2 } from "lucide-react";
 import { acknowledgeVerdict } from "@/actions/verdicts";
 import { toast } from "sonner";
+import { useDocumentText } from "@/hooks/useDocumentText";
+import { useUrlState } from "@/hooks/useUrlState";
+import {
+  VerdictsHeader,
+  type FilterValue,
+  type RespondentOption,
+} from "@/components/reviews/VerdictsHeader";
+import { VerdictsList } from "@/components/reviews/VerdictsList";
 import type { VerdictItem } from "@/app/(app)/projects/[id]/reviews/my-verdicts/page";
 import type { PydanticField } from "@/lib/types";
-import { AddNoteButton } from "@/components/shared/AddNoteButton";
 
-function formatAnswer(answer: unknown): string {
-  if (answer == null) return "(sem resposta)";
-  if (typeof answer === "string") return answer;
-  if (Array.isArray(answer)) return answer.join(", ");
-  if (typeof answer === "object") {
-    return Object.entries(answer as Record<string, unknown>)
-      .flatMap(([k, v]) =>
-        v != null && String(v).trim() !== "" ? [`${k}: ${v}`] : [],
-      )
-      .join(", ");
-  }
-  return String(answer);
-}
-
-function formatVerdictDisplay(verdict: string, fieldType?: string): string {
-  if (verdict === "ambiguo") return "Ambíguo";
-  if (verdict === "pular") return "Pular";
-  if (fieldType === "multi" || verdict.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(verdict) as Record<string, boolean>;
-      const selected = Object.entries(parsed).flatMap(([k, v]) =>
-        v ? [k] : [],
-      );
-      return selected.length > 0 ? selected.join("; ") : "(nenhuma)";
-    } catch {
-      // fallback
-    }
-  }
-  return verdict;
-}
+export type { RespondentOption };
 
 /** Sort priority: incorrect+pending first, then incorrect+questioned, then incorrect+accepted, then correct */
 function verdictSortKey(item: VerdictItem): number {
@@ -76,11 +32,6 @@ function verdictSortKey(item: VerdictItem): number {
     return 2; // accepted
   }
   return 3; // correct
-}
-
-export interface RespondentOption {
-  id: string;
-  name: string;
 }
 
 const EMPTY_RESPONDENTS: RespondentOption[] = [];
@@ -94,8 +45,6 @@ interface MyVerdictsViewProps {
   respondents?: RespondentOption[];
   currentViewUserId?: string;
 }
-
-type FilterValue = "pending" | "incorrect" | "questioned" | "all";
 
 export function MyVerdictsView(props: MyVerdictsViewProps) {
   // useSearchParams precisa de boundary de Suspense (react-doctor
@@ -116,12 +65,9 @@ function MyVerdictsViewInner({
   respondents = EMPTY_RESPONDENTS,
   currentViewUserId,
 }: MyVerdictsViewProps) {
-  const { push, refresh } = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
+  const { refresh } = useRouter();
+  const { set: setUrlState } = useUrlState();
   const [isPending, startTransition] = useTransition();
-  const [commentingReviewId, setCommentingReviewId] = useState<string | null>(null);
-  const [questionComment, setQuestionComment] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [fieldFilter, setFieldFilter] = useState("all");
 
@@ -194,70 +140,56 @@ function MyVerdictsViewInner({
     return groups;
   }, [items, effectiveFilter, fieldFilter, searchQuery]);
 
-  const [docIndex, setDocIndex] = useState(0);
-  const [docTextCache, setDocTextCache] = useState<Record<string, string>>({});
-  const [loadingText, setLoadingText] = useState(false);
-  const scrollRef = useRef<HTMLDivElement>(null);
+  // Selected document tracked by identity; index is derived (molde:
+  // AutoReviewPage). Quando o filtro tira o doc do grupo, findIndex → -1 e o
+  // índice cai para 0 naturalmente — sem effect de reset.
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
+  const docIndex = useMemo(() => {
+    if (docGroups.length === 0) return 0;
+    if (selectedDocId) {
+      const i = docGroups.findIndex((g) => g.docId === selectedDocId);
+      if (i >= 0) return i;
+    }
+    return 0;
+  }, [docGroups, selectedDocId]);
 
   const currentGroup = docGroups[docIndex];
   const currentDocId = currentGroup?.docId;
-  const currentText = currentDocId ? docTextCache[currentDocId] : undefined;
+  const { text: currentText, loading: loadingText } = useDocumentText(
+    projectId,
+    currentDocId,
+  );
 
-  // Reset doc index when filters change
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- reseta o índice ao mudar os filtros
-    setDocIndex(0);
-  }, [filter, fieldFilter, searchQuery]);
-
-  // Scroll to top when document changes
-  useEffect(() => {
-    scrollRef.current?.scrollTo(0, 0);
-  }, [docIndex]);
-
-  // Lazy-load document text
-  useEffect(() => {
-    if (!currentDocId || docTextCache[currentDocId]) return;
-    let cancelled = false;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- inicia o lazy-load do texto do doc (sincronização com backend)
-    setLoadingText(true);
-    getDocumentText(projectId, currentDocId).then((result) => {
-      if (cancelled) return;
-      setDocTextCache((prev) => ({
-        ...prev,
-        [currentDocId]: result?.text ?? "(Documento não encontrado)",
-      }));
-      setLoadingText(false);
-    });
-    return () => { cancelled = true; };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentDocId, projectId]);
-
-  const handleAcknowledge = (reviewId: string, status: "accepted" | "questioned", comment?: string) => {
-    startTransition(async () => {
-      const result = await acknowledgeVerdict(reviewId, projectId, status, comment);
-      if (result.error) {
-        toast.error(result.error);
-      } else {
-        toast.success(status === "accepted" ? "Correção aceita" : "Dúvida enviada");
-        setCommentingReviewId(null);
-        setQuestionComment("");
-        refresh();
-      }
-    });
+  const goToIndex = (i: number) => {
+    const g = docGroups[i];
+    if (g) setSelectedDocId(g.docId);
   };
 
-  const selectRespondent = (userId: string | null) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (userId) {
-      params.set("viewAsUser", userId);
-    } else {
-      params.delete("viewAsUser");
-    }
-    const qs = params.toString();
+  // Resolve true on success so the caller (VerdictsList) can clear its local
+  // comment input only when the acknowledgment actually went through.
+  const handleAcknowledge = (
+    reviewId: string,
+    status: "accepted" | "questioned",
+    comment?: string,
+  ): Promise<boolean> =>
+    new Promise((resolve) => {
+      startTransition(async () => {
+        const result = await acknowledgeVerdict(reviewId, projectId, status, comment);
+        if (result.error) {
+          toast.error(result.error);
+          resolve(false);
+        } else {
+          toast.success(status === "accepted" ? "Correção aceita" : "Dúvida enviada");
+          refresh();
+          resolve(true);
+        }
+      });
+    });
+
+  const selectRespondent = (userId: string | null) =>
     startTransition(() => {
-      push(`${pathname}${qs ? `?${qs}` : ""}`);
+      setUrlState({ viewAsUser: userId }, { method: "push" });
     });
-  };
 
   if (totalItems === 0) {
     return (
@@ -269,80 +201,29 @@ function MyVerdictsViewInner({
 
   return (
     <div className="flex h-[calc(100vh-12rem)] flex-col">
-      {/* Header */}
-      <div className="border-b px-4 py-2 space-y-1.5">
-        {/* Row 1: main filters + navigation */}
-        <div className="flex items-center gap-2">
-          <Input
-            placeholder="Buscar documento..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-44 h-8 text-xs"
-          />
-          <Select value={filter} onValueChange={(v) => setFilter(v as FilterValue)}>
-            <SelectTrigger className="w-48 h-8 text-xs">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todos ({totalItems})</SelectItem>
-              <SelectItem value="incorrect">Incorretos ({totalIncorrect})</SelectItem>
-              <SelectItem value="pending">Aguardando feedback ({totalPending})</SelectItem>
-              <SelectItem value="questioned">Com dúvida ({totalQuestioned})</SelectItem>
-            </SelectContent>
-          </Select>
-          <span className="text-xs text-muted-foreground">
-            {totalItems - totalIncorrect}/{totalItems} corretos
-          </span>
-          <div className="ml-auto flex items-center gap-1">
-            {isCoordinator && respondents.length > 0 && (
-              <Select
-                value={currentViewUserId || "_self"}
-                onValueChange={(v) => selectRespondent(v === "_self" ? null : v)}
-                disabled={isPending}
-              >
-                <SelectTrigger className="w-40 h-8 text-xs">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_self">Minhas respostas</SelectItem>
-                  {respondents.map((r) => (
-                    <SelectItem key={r.id} value={r.id}>
-                      {r.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            {docGroups.length > 0 && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-7"
-                  disabled={docIndex === 0}
-                  onClick={() => setDocIndex((i) => i - 1)}
-                >
-                  <ChevronLeft className="size-4" />
-                </Button>
-                <span className="text-xs tabular-nums text-muted-foreground">
-                  {docIndex + 1}/{docGroups.length}
-                </span>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="size-7"
-                  disabled={docIndex === docGroups.length - 1}
-                  onClick={() => setDocIndex((i) => i + 1)}
-                >
-                  <ChevronRight className="size-4" />
-                </Button>
-              </>
-            )}
-          </div>
-        </div>
-      </div>
+      <VerdictsHeader
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
+        filter={filter}
+        onFilterChange={setFilter}
+        totals={{
+          items: totalItems,
+          incorrect: totalIncorrect,
+          pending: totalPending,
+          questioned: totalQuestioned,
+        }}
+        isCoordinator={isCoordinator}
+        respondents={respondents}
+        currentViewUserId={currentViewUserId}
+        onSelectRespondent={selectRespondent}
+        isPending={isPending}
+        docCount={docGroups.length}
+        docIndex={docIndex}
+        onPrev={() => goToIndex(docIndex - 1)}
+        onNext={() => goToIndex(docIndex + 1)}
+      />
 
-      {docGroups.length === 0 ? (
+      {docGroups.length === 0 || !currentGroup ? (
         <p className="py-12 text-center text-sm text-muted-foreground">
           Nenhum resultado para este filtro.
         </p>
@@ -359,326 +240,18 @@ function MyVerdictsViewInner({
           </ResizablePanel>
           <ResizableHandle withHandle />
           <ResizablePanel defaultSize={45} minSize={25}>
-            <div ref={scrollRef} className="h-full overflow-y-auto p-4 space-y-4">
-              <div className="flex items-center justify-between gap-2">
-                <p className="min-w-0 truncate text-xs font-medium text-muted-foreground">
-                  {currentGroup.title}
-                </p>
-                <div className="flex items-center gap-1.5 shrink-0">
-                  <Select value={fieldFilter} onValueChange={setFieldFilter}>
-                    <SelectTrigger className="w-36 h-7 text-xs">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent className="max-w-[min(24rem,calc(100vw-3rem))]">
-                      <SelectItem value="all">Todos os campos</SelectItem>
-                      {fields.map((f) => (
-                        <SelectItem key={f.name} value={f.name}>
-                          <div className="flex flex-col items-start gap-0.5">
-                            <code className="text-xs font-mono">{f.name}</code>
-                            {f.description && f.description !== f.name && (
-                              <span className="text-[11px] text-muted-foreground line-clamp-2">
-                                {f.description}
-                              </span>
-                            )}
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <AddNoteButton
-                    projectId={projectId}
-                    documentId={currentGroup.docId}
-                    documentTitle={currentGroup.title}
-                    fields={fields}
-                  />
-                </div>
-              </div>
-              {currentGroup.items.map((item) => (
-                <VerdictCard
-                  key={item.reviewId}
-                  item={item}
-                  userName={userName}
-                  isPending={isPending}
-                  commentingReviewId={commentingReviewId}
-                  questionComment={questionComment}
-                  onSetCommentingReviewId={setCommentingReviewId}
-                  onSetQuestionComment={setQuestionComment}
-                  onAcknowledge={handleAcknowledge}
-                />
-              ))}
-            </div>
+            <VerdictsList
+              group={currentGroup}
+              fields={fields}
+              fieldFilter={fieldFilter}
+              onFieldFilterChange={setFieldFilter}
+              projectId={projectId}
+              userName={userName}
+              isPending={isPending}
+              onAcknowledge={handleAcknowledge}
+            />
           </ResizablePanel>
         </ResizablePanelGroup>
-      )}
-    </div>
-  );
-}
-
-/* ── Verdict Card ── */
-
-function VerdictCard({
-  item,
-  userName,
-  isPending,
-  commentingReviewId,
-  questionComment,
-  onSetCommentingReviewId,
-  onSetQuestionComment,
-  onAcknowledge,
-}: {
-  item: VerdictItem;
-  userName: string;
-  isPending: boolean;
-  commentingReviewId: string | null;
-  questionComment: string;
-  onSetCommentingReviewId: (id: string | null) => void;
-  onSetQuestionComment: (v: string) => void;
-  onAcknowledge: (reviewId: string, status: "accepted" | "questioned", comment?: string) => void;
-}) {
-  const isSpecialVerdict = item.verdict === "ambiguo" || item.verdict === "pular";
-  const otherResponses = item.responseSnapshot?.filter(
-    (r) => r.respondent_name !== userName,
-  );
-
-  return (
-    <div
-      className={cn(
-        "space-y-2.5 rounded-lg border p-4",
-        item.isCorrect
-          ? "border-green-200 bg-green-50/50 dark:border-green-900 dark:bg-green-950/20"
-          : "border-red-200 bg-red-50/50 dark:border-red-900 dark:bg-red-950/20",
-      )}
-    >
-      {/* 1. Field question — prominent */}
-      <div className="flex items-start justify-between gap-2">
-        <p className="min-w-0 text-sm leading-snug">
-          {item.fieldDescription}
-        </p>
-        {item.isCorrect ? (
-          <Badge className="shrink-0 bg-green-500/10 text-green-700 text-xs">
-            <Check className="mr-1 size-3" /> Correta
-          </Badge>
-        ) : (
-          <Badge className="shrink-0 bg-red-500/10 text-red-700 text-xs">
-            <X className="mr-1 size-3" /> Incorreta
-          </Badge>
-        )}
-      </div>
-
-      {/* 2. Your answer vs Verdict — side by side comparison */}
-      <div className="grid grid-cols-2 gap-2">
-        <div className="rounded px-2.5 py-1.5 bg-muted/60">
-          <span className="text-[11px] text-muted-foreground">Sua resposta</span>
-          <p className={cn(
-            "text-sm font-medium mt-0.5",
-            !item.isCorrect && !isSpecialVerdict && "text-red-600 dark:text-red-400",
-          )}>
-            {formatAnswer(item.myAnswer)}
-          </p>
-        </div>
-        <div
-          className={cn(
-            "rounded px-2.5 py-1.5",
-            isSpecialVerdict
-              ? "bg-amber-50 dark:bg-amber-950/30"
-              : "bg-emerald-50 dark:bg-emerald-950/30",
-          )}
-        >
-          <span className={cn(
-            "text-[11px]",
-            isSpecialVerdict
-              ? "text-amber-600 dark:text-amber-400"
-              : "text-emerald-600 dark:text-emerald-400",
-          )}>
-            Gabarito
-          </span>
-          <p className={cn(
-            "text-sm font-medium mt-0.5",
-            isSpecialVerdict
-              ? "text-amber-700 dark:text-amber-400"
-              : "text-emerald-700 dark:text-emerald-400",
-          )}>
-            {formatVerdictDisplay(item.verdict, item.fieldType)}
-          </p>
-        </div>
-      </div>
-
-      {/* 3. Coordinator comment — why the verdict */}
-      {item.coordinatorComment && (
-        <blockquote className="border-l-2 pl-3 text-xs text-muted-foreground italic">
-          {item.coordinatorComment}
-        </blockquote>
-      )}
-
-      {/* 4. Other responses */}
-      {otherResponses && otherResponses.length > 0 && (
-        <div>
-          <p className="text-[11px] text-muted-foreground mb-1">Outras respostas</p>
-          <div className="space-y-0.5 rounded-md bg-background/80 p-2">
-            {otherResponses.map((r) => (
-              <RespondentRow
-                key={r.id}
-                respondent={r}
-                isMe={false}
-                isSpecialVerdict={isSpecialVerdict}
-                verdict={item.verdict}
-                fieldType={item.fieldType}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {/* 5. Acknowledgment actions */}
-      {(!item.isCorrect || isSpecialVerdict) && (
-        <div className="flex items-center gap-2 pt-0.5">
-          {(!item.acknowledgmentStatus || item.acknowledgmentStatus === "pending") && (
-            <>
-              {!item.isCorrect && (
-                <Button
-                  variant="default"
-                  size="sm"
-                  className="h-6 text-xs"
-                  disabled={isPending}
-                  onClick={() => onAcknowledge(item.reviewId, "accepted")}
-                >
-                  <Check className="mr-1 size-3" />
-                  Aceitar correção
-                </Button>
-              )}
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-6 text-xs"
-                disabled={isPending}
-                onClick={() =>
-                  onSetCommentingReviewId(
-                    commentingReviewId === item.reviewId ? null : item.reviewId,
-                  )
-                }
-              >
-                <MessageSquare className="mr-1 size-3" />
-                Comentar dúvida
-              </Button>
-            </>
-          )}
-          {item.acknowledgmentStatus === "accepted" && (
-            <Badge className="text-xs bg-green-500/10 text-green-700">Aceita</Badge>
-          )}
-          {item.acknowledgmentStatus === "questioned" && (
-            <Badge className="text-xs bg-amber-500/10 text-amber-700">Dúvida enviada</Badge>
-          )}
-        </div>
-      )}
-
-      {/* Comment input */}
-      {commentingReviewId === item.reviewId && (
-        <div className="flex gap-2">
-          <Input
-            value={questionComment}
-            onChange={(e) => onSetQuestionComment(e.target.value)}
-            placeholder="Qual a sua dúvida?"
-            className="text-xs h-7"
-          />
-          <Button
-            size="sm"
-            className="h-7 text-xs shrink-0"
-            disabled={isPending || !questionComment.trim()}
-            onClick={() =>
-              onAcknowledge(item.reviewId, "questioned", questionComment)
-            }
-          >
-            Enviar
-          </Button>
-        </div>
-      )}
-    </div>
-  );
-}
-
-/* ── Respondent Row ── */
-
-function RespondentRow({
-  respondent,
-  isMe,
-  isSpecialVerdict,
-  verdict,
-  fieldType,
-}: {
-  respondent: NonNullable<VerdictItem["responseSnapshot"]>[number];
-  isMe: boolean;
-  isSpecialVerdict: boolean;
-  verdict: string;
-  fieldType: VerdictItem["fieldType"];
-}) {
-  const [showJustification, setShowJustification] = useState(false);
-  const correct = isSpecialVerdict || isAnswerCorrect(respondent.answer, verdict, fieldType);
-
-  return (
-    <div className="space-y-0.5">
-      <div
-        className={cn(
-          "flex items-center gap-2 rounded px-2 py-1 text-xs",
-          isMe && "bg-brand/5 font-medium",
-        )}
-      >
-        {/* Correctness icon */}
-        {!isSpecialVerdict && (
-          correct ? (
-            <Check className="size-3.5 shrink-0 text-emerald-600" />
-          ) : (
-            <X className="size-3.5 shrink-0 text-red-500" />
-          )
-        )}
-
-        {/* Answer */}
-        <span
-          className={cn(
-            "min-w-0 truncate",
-            !isSpecialVerdict && !correct && "text-red-600 dark:text-red-400",
-          )}
-        >
-          {formatAnswer(respondent.answer) || (
-            <span className="italic text-muted-foreground">sem resposta</span>
-          )}
-        </span>
-
-        {/* Respondent info */}
-        <span className="ml-auto flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-          {respondent.respondent_type === "llm" && (
-            <Bot className="size-3" />
-          )}
-          {isMe ? (
-            <>
-              <span className="text-brand">★</span>
-              <span className="font-medium">Você</span>
-            </>
-          ) : (
-            respondent.respondent_name
-          )}
-        </span>
-
-        {/* Justification toggle */}
-        {respondent.justification && (
-          <button
-            type="button"
-            onClick={() => setShowJustification(!showJustification)}
-            className="shrink-0 text-muted-foreground hover:text-foreground"
-          >
-            {showJustification ? (
-              <ChevronDown className="size-3.5" />
-            ) : (
-              <ChevronRight className="size-3.5" />
-            )}
-          </button>
-        )}
-      </div>
-
-      {/* Expandable justification */}
-      {showJustification && respondent.justification && (
-        <blockquote className="ml-6 border-l-2 pl-2 text-xs text-muted-foreground whitespace-pre-wrap">
-          {respondent.justification}
-        </blockquote>
       )}
     </div>
   );

--- a/frontend/src/components/reviews/MyVerdictsView.tsx
+++ b/frontend/src/components/reviews/MyVerdictsView.tsx
@@ -22,8 +22,6 @@ import { VerdictsList } from "@/components/reviews/VerdictsList";
 import type { VerdictItem } from "@/app/(app)/projects/[id]/reviews/my-verdicts/page";
 import type { PydanticField } from "@/lib/types";
 
-export type { RespondentOption };
-
 /** Sort priority: incorrect+pending first, then incorrect+questioned, then incorrect+accepted, then correct */
 function verdictSortKey(item: VerdictItem): number {
   if (!item.isCorrect) {
@@ -174,14 +172,21 @@ function MyVerdictsViewInner({
   ): Promise<boolean> =>
     new Promise((resolve) => {
       startTransition(async () => {
-        const result = await acknowledgeVerdict(reviewId, projectId, status, comment);
-        if (result.error) {
-          toast.error(result.error);
+        try {
+          const result = await acknowledgeVerdict(reviewId, projectId, status, comment);
+          if (result.error) {
+            toast.error(result.error);
+            resolve(false);
+          } else {
+            toast.success(status === "accepted" ? "Correção aceita" : "Dúvida enviada");
+            refresh();
+            resolve(true);
+          }
+        } catch {
+          // Server action rejeitou (rede/auth) — sem catch, a Promise nunca
+          // resolveria e o input de dúvida ficaria pendente para sempre.
+          toast.error("Não foi possível registrar. Tente novamente.");
           resolve(false);
-        } else {
-          toast.success(status === "accepted" ? "Correção aceita" : "Dúvida enviada");
-          refresh();
-          resolve(true);
         }
       });
     });

--- a/frontend/src/components/reviews/VerdictsHeader.tsx
+++ b/frontend/src/components/reviews/VerdictsHeader.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export interface RespondentOption {
+  id: string;
+  name: string;
+}
+
+export type FilterValue = "pending" | "incorrect" | "questioned" | "all";
+
+interface VerdictsHeaderProps {
+  searchQuery: string;
+  onSearchChange: (v: string) => void;
+  filter: FilterValue;
+  onFilterChange: (v: FilterValue) => void;
+  totals: {
+    items: number;
+    incorrect: number;
+    pending: number;
+    questioned: number;
+  };
+  isCoordinator?: boolean;
+  respondents: RespondentOption[];
+  currentViewUserId?: string;
+  onSelectRespondent: (userId: string | null) => void;
+  isPending: boolean;
+  docCount: number;
+  docIndex: number;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export function VerdictsHeader({
+  searchQuery,
+  onSearchChange,
+  filter,
+  onFilterChange,
+  totals,
+  isCoordinator,
+  respondents,
+  currentViewUserId,
+  onSelectRespondent,
+  isPending,
+  docCount,
+  docIndex,
+  onPrev,
+  onNext,
+}: VerdictsHeaderProps) {
+  return (
+    <div className="border-b px-4 py-2 space-y-1.5">
+      {/* Row 1: main filters + navigation */}
+      <div className="flex items-center gap-2">
+        <Input
+          placeholder="Buscar documento..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-44 h-8 text-xs"
+        />
+        <Select value={filter} onValueChange={(v) => onFilterChange(v as FilterValue)}>
+          <SelectTrigger className="w-48 h-8 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Todos ({totals.items})</SelectItem>
+            <SelectItem value="incorrect">Incorretos ({totals.incorrect})</SelectItem>
+            <SelectItem value="pending">Aguardando feedback ({totals.pending})</SelectItem>
+            <SelectItem value="questioned">Com dúvida ({totals.questioned})</SelectItem>
+          </SelectContent>
+        </Select>
+        <span className="text-xs text-muted-foreground">
+          {totals.items - totals.incorrect}/{totals.items} corretos
+        </span>
+        <div className="ml-auto flex items-center gap-1">
+          {isCoordinator && respondents.length > 0 && (
+            <Select
+              value={currentViewUserId || "_self"}
+              onValueChange={(v) => onSelectRespondent(v === "_self" ? null : v)}
+              disabled={isPending}
+            >
+              <SelectTrigger className="w-40 h-8 text-xs">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="_self">Minhas respostas</SelectItem>
+                {respondents.map((r) => (
+                  <SelectItem key={r.id} value={r.id}>
+                    {r.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {docCount > 0 && (
+            <>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                disabled={docIndex === 0}
+                onClick={onPrev}
+              >
+                <ChevronLeft className="size-4" />
+              </Button>
+              <span className="text-xs tabular-nums text-muted-foreground">
+                {docIndex + 1}/{docCount}
+              </span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="size-7"
+                disabled={docIndex === docCount - 1}
+                onClick={onNext}
+              >
+                <ChevronRight className="size-4" />
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/reviews/VerdictsHeader.tsx
+++ b/frontend/src/components/reviews/VerdictsHeader.tsx
@@ -108,6 +108,7 @@ export function VerdictsHeader({
                 className="size-7"
                 disabled={docIndex === 0}
                 onClick={onPrev}
+                aria-label="Documento anterior"
               >
                 <ChevronLeft className="size-4" />
               </Button>
@@ -120,6 +121,7 @@ export function VerdictsHeader({
                 className="size-7"
                 disabled={docIndex === docCount - 1}
                 onClick={onNext}
+                aria-label="Próximo documento"
               >
                 <ChevronRight className="size-4" />
               </Button>

--- a/frontend/src/components/reviews/VerdictsList.tsx
+++ b/frontend/src/components/reviews/VerdictsList.tsx
@@ -1,0 +1,439 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  ChevronDown,
+  ChevronRight,
+  Check,
+  X,
+  MessageSquare,
+  Bot,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { isAnswerCorrect } from "@/lib/reviews/queries";
+import { AddNoteButton } from "@/components/shared/AddNoteButton";
+import type { VerdictItem } from "@/app/(app)/projects/[id]/reviews/my-verdicts/page";
+import type { PydanticField } from "@/lib/types";
+
+function formatAnswer(answer: unknown): string {
+  if (answer == null) return "(sem resposta)";
+  if (typeof answer === "string") return answer;
+  if (Array.isArray(answer)) return answer.join(", ");
+  if (typeof answer === "object") {
+    return Object.entries(answer as Record<string, unknown>)
+      .flatMap(([k, v]) =>
+        v != null && String(v).trim() !== "" ? [`${k}: ${v}`] : [],
+      )
+      .join(", ");
+  }
+  return String(answer);
+}
+
+function formatVerdictDisplay(verdict: string, fieldType?: string): string {
+  if (verdict === "ambiguo") return "Ambíguo";
+  if (verdict === "pular") return "Pular";
+  if (fieldType === "multi" || verdict.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(verdict) as Record<string, boolean>;
+      const selected = Object.entries(parsed).flatMap(([k, v]) =>
+        v ? [k] : [],
+      );
+      return selected.length > 0 ? selected.join("; ") : "(nenhuma)";
+    } catch {
+      // fallback
+    }
+  }
+  return verdict;
+}
+
+export interface DocGroup {
+  docId: string;
+  title: string;
+  items: VerdictItem[];
+}
+
+interface VerdictsListProps {
+  group: DocGroup;
+  fields: PydanticField[];
+  fieldFilter: string;
+  onFieldFilterChange: (v: string) => void;
+  projectId: string;
+  userName: string;
+  isPending: boolean;
+  onAcknowledge: (
+    reviewId: string,
+    status: "accepted" | "questioned",
+    comment?: string,
+  ) => Promise<boolean>;
+}
+
+export function VerdictsList({
+  group,
+  fields,
+  fieldFilter,
+  onFieldFilterChange,
+  projectId,
+  userName,
+  isPending,
+  onAcknowledge,
+}: VerdictsListProps) {
+  const [commentingReviewId, setCommentingReviewId] = useState<string | null>(
+    null,
+  );
+  const [questionComment, setQuestionComment] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Scroll back to top when the displayed document changes.
+  useEffect(() => {
+    scrollRef.current?.scrollTo(0, 0);
+  }, [group.docId]);
+
+  // Clear the comment input on any successful acknowledgment (mirrors the
+  // previous top-level handler), so the open input never lingers after refresh.
+  const handleAck = async (
+    reviewId: string,
+    status: "accepted" | "questioned",
+    comment?: string,
+  ) => {
+    const ok = await onAcknowledge(reviewId, status, comment);
+    if (ok) {
+      setCommentingReviewId(null);
+      setQuestionComment("");
+    }
+  };
+
+  return (
+    <div ref={scrollRef} className="h-full overflow-y-auto p-4 space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <p className="min-w-0 truncate text-xs font-medium text-muted-foreground">
+          {group.title}
+        </p>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <Select value={fieldFilter} onValueChange={onFieldFilterChange}>
+            <SelectTrigger className="w-36 h-7 text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="max-w-[min(24rem,calc(100vw-3rem))]">
+              <SelectItem value="all">Todos os campos</SelectItem>
+              {fields.map((f) => (
+                <SelectItem key={f.name} value={f.name}>
+                  <div className="flex flex-col items-start gap-0.5">
+                    <code className="text-xs font-mono">{f.name}</code>
+                    {f.description && f.description !== f.name && (
+                      <span className="text-[11px] text-muted-foreground line-clamp-2">
+                        {f.description}
+                      </span>
+                    )}
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <AddNoteButton
+            projectId={projectId}
+            documentId={group.docId}
+            documentTitle={group.title}
+            fields={fields}
+          />
+        </div>
+      </div>
+      {group.items.map((item) => (
+        <VerdictCard
+          key={item.reviewId}
+          item={item}
+          userName={userName}
+          isPending={isPending}
+          commentingReviewId={commentingReviewId}
+          questionComment={questionComment}
+          onSetCommentingReviewId={setCommentingReviewId}
+          onSetQuestionComment={setQuestionComment}
+          onAcknowledge={handleAck}
+        />
+      ))}
+    </div>
+  );
+}
+
+/* ── Verdict Card ── */
+
+function VerdictCard({
+  item,
+  userName,
+  isPending,
+  commentingReviewId,
+  questionComment,
+  onSetCommentingReviewId,
+  onSetQuestionComment,
+  onAcknowledge,
+}: {
+  item: VerdictItem;
+  userName: string;
+  isPending: boolean;
+  commentingReviewId: string | null;
+  questionComment: string;
+  onSetCommentingReviewId: (id: string | null) => void;
+  onSetQuestionComment: (v: string) => void;
+  onAcknowledge: (
+    reviewId: string,
+    status: "accepted" | "questioned",
+    comment?: string,
+  ) => void;
+}) {
+  const isSpecialVerdict = item.verdict === "ambiguo" || item.verdict === "pular";
+  const otherResponses = item.responseSnapshot?.filter(
+    (r) => r.respondent_name !== userName,
+  );
+
+  return (
+    <div
+      className={cn(
+        "space-y-2.5 rounded-lg border p-4",
+        item.isCorrect
+          ? "border-green-200 bg-green-50/50 dark:border-green-900 dark:bg-green-950/20"
+          : "border-red-200 bg-red-50/50 dark:border-red-900 dark:bg-red-950/20",
+      )}
+    >
+      {/* 1. Field question — prominent */}
+      <div className="flex items-start justify-between gap-2">
+        <p className="min-w-0 text-sm leading-snug">
+          {item.fieldDescription}
+        </p>
+        {item.isCorrect ? (
+          <Badge className="shrink-0 bg-green-500/10 text-green-700 text-xs">
+            <Check className="mr-1 size-3" /> Correta
+          </Badge>
+        ) : (
+          <Badge className="shrink-0 bg-red-500/10 text-red-700 text-xs">
+            <X className="mr-1 size-3" /> Incorreta
+          </Badge>
+        )}
+      </div>
+
+      {/* 2. Your answer vs Verdict — side by side comparison */}
+      <div className="grid grid-cols-2 gap-2">
+        <div className="rounded px-2.5 py-1.5 bg-muted/60">
+          <span className="text-[11px] text-muted-foreground">Sua resposta</span>
+          <p className={cn(
+            "text-sm font-medium mt-0.5",
+            !item.isCorrect && !isSpecialVerdict && "text-red-600 dark:text-red-400",
+          )}>
+            {formatAnswer(item.myAnswer)}
+          </p>
+        </div>
+        <div
+          className={cn(
+            "rounded px-2.5 py-1.5",
+            isSpecialVerdict
+              ? "bg-amber-50 dark:bg-amber-950/30"
+              : "bg-emerald-50 dark:bg-emerald-950/30",
+          )}
+        >
+          <span className={cn(
+            "text-[11px]",
+            isSpecialVerdict
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-emerald-600 dark:text-emerald-400",
+          )}>
+            Gabarito
+          </span>
+          <p className={cn(
+            "text-sm font-medium mt-0.5",
+            isSpecialVerdict
+              ? "text-amber-700 dark:text-amber-400"
+              : "text-emerald-700 dark:text-emerald-400",
+          )}>
+            {formatVerdictDisplay(item.verdict, item.fieldType)}
+          </p>
+        </div>
+      </div>
+
+      {/* 3. Coordinator comment — why the verdict */}
+      {item.coordinatorComment && (
+        <blockquote className="border-l-2 pl-3 text-xs text-muted-foreground italic">
+          {item.coordinatorComment}
+        </blockquote>
+      )}
+
+      {/* 4. Other responses */}
+      {otherResponses && otherResponses.length > 0 && (
+        <div>
+          <p className="text-[11px] text-muted-foreground mb-1">Outras respostas</p>
+          <div className="space-y-0.5 rounded-md bg-background/80 p-2">
+            {otherResponses.map((r) => (
+              <RespondentRow
+                key={r.id}
+                respondent={r}
+                isMe={false}
+                isSpecialVerdict={isSpecialVerdict}
+                verdict={item.verdict}
+                fieldType={item.fieldType}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 5. Acknowledgment actions */}
+      {(!item.isCorrect || isSpecialVerdict) && (
+        <div className="flex items-center gap-2 pt-0.5">
+          {(!item.acknowledgmentStatus || item.acknowledgmentStatus === "pending") && (
+            <>
+              {!item.isCorrect && (
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="h-6 text-xs"
+                  disabled={isPending}
+                  onClick={() => onAcknowledge(item.reviewId, "accepted")}
+                >
+                  <Check className="mr-1 size-3" />
+                  Aceitar correção
+                </Button>
+              )}
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 text-xs"
+                disabled={isPending}
+                onClick={() =>
+                  onSetCommentingReviewId(
+                    commentingReviewId === item.reviewId ? null : item.reviewId,
+                  )
+                }
+              >
+                <MessageSquare className="mr-1 size-3" />
+                Comentar dúvida
+              </Button>
+            </>
+          )}
+          {item.acknowledgmentStatus === "accepted" && (
+            <Badge className="text-xs bg-green-500/10 text-green-700">Aceita</Badge>
+          )}
+          {item.acknowledgmentStatus === "questioned" && (
+            <Badge className="text-xs bg-amber-500/10 text-amber-700">Dúvida enviada</Badge>
+          )}
+        </div>
+      )}
+
+      {/* Comment input */}
+      {commentingReviewId === item.reviewId && (
+        <div className="flex gap-2">
+          <Input
+            value={questionComment}
+            onChange={(e) => onSetQuestionComment(e.target.value)}
+            placeholder="Qual a sua dúvida?"
+            className="text-xs h-7"
+          />
+          <Button
+            size="sm"
+            className="h-7 text-xs shrink-0"
+            disabled={isPending || !questionComment.trim()}
+            onClick={() =>
+              onAcknowledge(item.reviewId, "questioned", questionComment)
+            }
+          >
+            Enviar
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Respondent Row ── */
+
+function RespondentRow({
+  respondent,
+  isMe,
+  isSpecialVerdict,
+  verdict,
+  fieldType,
+}: {
+  respondent: NonNullable<VerdictItem["responseSnapshot"]>[number];
+  isMe: boolean;
+  isSpecialVerdict: boolean;
+  verdict: string;
+  fieldType: VerdictItem["fieldType"];
+}) {
+  const [showJustification, setShowJustification] = useState(false);
+  const correct = isSpecialVerdict || isAnswerCorrect(respondent.answer, verdict, fieldType);
+
+  return (
+    <div className="space-y-0.5">
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded px-2 py-1 text-xs",
+          isMe && "bg-brand/5 font-medium",
+        )}
+      >
+        {/* Correctness icon */}
+        {!isSpecialVerdict && (
+          correct ? (
+            <Check className="size-3.5 shrink-0 text-emerald-600" />
+          ) : (
+            <X className="size-3.5 shrink-0 text-red-500" />
+          )
+        )}
+
+        {/* Answer */}
+        <span
+          className={cn(
+            "min-w-0 truncate",
+            !isSpecialVerdict && !correct && "text-red-600 dark:text-red-400",
+          )}
+        >
+          {formatAnswer(respondent.answer) || (
+            <span className="italic text-muted-foreground">sem resposta</span>
+          )}
+        </span>
+
+        {/* Respondent info */}
+        <span className="ml-auto flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+          {respondent.respondent_type === "llm" && (
+            <Bot className="size-3" />
+          )}
+          {isMe ? (
+            <>
+              <span className="text-brand">★</span>
+              <span className="font-medium">Você</span>
+            </>
+          ) : (
+            respondent.respondent_name
+          )}
+        </span>
+
+        {/* Justification toggle */}
+        {respondent.justification && (
+          <button
+            type="button"
+            onClick={() => setShowJustification(!showJustification)}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            {showJustification ? (
+              <ChevronDown className="size-3.5" />
+            ) : (
+              <ChevronRight className="size-3.5" />
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Expandable justification */}
+      {showJustification && respondent.justification && (
+        <blockquote className="ml-6 border-l-2 pl-2 text-xs text-muted-foreground whitespace-pre-wrap">
+          {respondent.justification}
+        </blockquote>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/reviews/VerdictsList.tsx
+++ b/frontend/src/components/reviews/VerdictsList.tsx
@@ -21,40 +21,10 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { isAnswerCorrect } from "@/lib/reviews/queries";
+import { formatAnswer, formatVerdictDisplay } from "@/lib/reviews/verdict-format";
 import { AddNoteButton } from "@/components/shared/AddNoteButton";
 import type { VerdictItem } from "@/app/(app)/projects/[id]/reviews/my-verdicts/page";
 import type { PydanticField } from "@/lib/types";
-
-function formatAnswer(answer: unknown): string {
-  if (answer == null) return "(sem resposta)";
-  if (typeof answer === "string") return answer;
-  if (Array.isArray(answer)) return answer.join(", ");
-  if (typeof answer === "object") {
-    return Object.entries(answer as Record<string, unknown>)
-      .flatMap(([k, v]) =>
-        v != null && String(v).trim() !== "" ? [`${k}: ${v}`] : [],
-      )
-      .join(", ");
-  }
-  return String(answer);
-}
-
-function formatVerdictDisplay(verdict: string, fieldType?: string): string {
-  if (verdict === "ambiguo") return "Ambíguo";
-  if (verdict === "pular") return "Pular";
-  if (fieldType === "multi" || verdict.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(verdict) as Record<string, boolean>;
-      const selected = Object.entries(parsed).flatMap(([k, v]) =>
-        v ? [k] : [],
-      );
-      return selected.length > 0 ? selected.join("; ") : "(nenhuma)";
-    } catch {
-      // fallback
-    }
-  }
-  return verdict;
-}
 
 export interface DocGroup {
   docId: string;

--- a/frontend/src/components/reviews/__tests__/MyVerdictsView.test.tsx
+++ b/frontend/src/components/reviews/__tests__/MyVerdictsView.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+
+const { push, refresh, getDocumentText, acknowledgeVerdict } = vi.hoisted(
+  () => ({
+    push: vi.fn(),
+    refresh: vi.fn(),
+    getDocumentText: vi.fn(),
+    acknowledgeVerdict: vi.fn(),
+  }),
+);
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, refresh }),
+  usePathname: () => "/projects/p1/reviews/my-verdicts",
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/actions/documents", () => ({ getDocumentText }));
+vi.mock("@/actions/verdicts", () => ({ acknowledgeVerdict }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// Painéis resizable usam ResizeObserver (ausente em jsdom) — passthrough.
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+vi.mock("@/components/coding/DocumentReader", () => ({
+  DocumentReader: ({ text }: { text: string }) => (
+    <div data-testid="doc-reader">{text}</div>
+  ),
+}));
+vi.mock("@/components/shared/AddNoteButton", () => ({
+  AddNoteButton: () => <div data-testid="add-note" />,
+}));
+
+import { MyVerdictsView } from "@/components/reviews/MyVerdictsView";
+import type { VerdictItem } from "@/app/(app)/projects/[id]/reviews/my-verdicts/page";
+
+function makeItem(overrides?: Partial<VerdictItem>): VerdictItem {
+  return {
+    reviewId: "r-" + (overrides?.documentId ?? "d1"),
+    documentId: "d1",
+    documentTitle: "Documento Um",
+    fieldName: "campo",
+    fieldDescription: "Descrição do campo",
+    fieldType: "text",
+    verdict: "sim",
+    coordinatorComment: null,
+    myAnswer: "sim",
+    isCorrect: true,
+    responseSnapshot: null,
+    acknowledgmentStatus: null,
+    acknowledgmentComment: null,
+    ...overrides,
+  };
+}
+
+// Três documentos corretos → filtro default "all" (sem itens pendentes).
+const THREE_DOCS: VerdictItem[] = [
+  makeItem({ documentId: "d1", documentTitle: "Documento Um" }),
+  makeItem({ documentId: "d2", documentTitle: "Documento Dois" }),
+  makeItem({ documentId: "d3", documentTitle: "Documento Tres" }),
+];
+
+function renderView(items: VerdictItem[]) {
+  return render(
+    <MyVerdictsView projectId="p1" items={items} fields={[]} userName="João" />,
+  );
+}
+
+afterEach(cleanup);
+beforeEach(() => {
+  Element.prototype.scrollTo = vi.fn();
+  push.mockReset();
+  refresh.mockReset();
+  getDocumentText.mockReset();
+  getDocumentText.mockResolvedValue({ text: "conteúdo do documento" });
+  acknowledgeVerdict.mockReset();
+  acknowledgeVerdict.mockResolvedValue({ error: null });
+});
+
+describe("MyVerdictsView — navegação e filtro", () => {
+  it("mostra estado vazio quando não há itens", () => {
+    renderView([]);
+    expect(
+      screen.getByText(/nenhum veredito encontrado/i),
+    ).toBeTruthy();
+  });
+
+  it("navega entre documentos com os botões ◂ ▸", async () => {
+    const user = userEvent.setup();
+    renderView(THREE_DOCS);
+
+    expect(screen.getByText("1/3")).toBeTruthy();
+    expect(screen.getByText("Documento Um")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /próximo documento/i }));
+    expect(screen.getByText("2/3")).toBeTruthy();
+    expect(screen.getByText("Documento Dois")).toBeTruthy();
+
+    await user.click(
+      screen.getByRole("button", { name: /documento anterior/i }),
+    );
+    expect(screen.getByText("1/3")).toBeTruthy();
+    expect(screen.getByText("Documento Um")).toBeTruthy();
+  });
+
+  it("preserva o documento selecionado quando ele sobrevive ao filtro de busca", async () => {
+    const user = userEvent.setup();
+    renderView(THREE_DOCS);
+
+    await user.click(screen.getByRole("button", { name: /próximo documento/i })); // → Documento Dois
+    expect(screen.getByText("Documento Dois")).toBeTruthy();
+
+    await user.type(
+      screen.getByPlaceholderText(/buscar documento/i),
+      "Documento",
+    );
+
+    // "Documento" casa os três; Dois é mantido (não reseta para o 1º).
+    expect(screen.getByText("2/3")).toBeTruthy();
+    expect(screen.getByText("Documento Dois")).toBeTruthy();
+  });
+
+  it("cai para o primeiro resultado quando o documento selecionado sai do filtro", async () => {
+    const user = userEvent.setup();
+    renderView(THREE_DOCS);
+
+    await user.click(screen.getByRole("button", { name: /próximo documento/i })); // → Documento Dois
+    expect(screen.getByText("Documento Dois")).toBeTruthy();
+
+    await user.type(screen.getByPlaceholderText(/buscar documento/i), "Tres");
+
+    expect(screen.getByText("1/1")).toBeTruthy();
+    expect(screen.getByText("Documento Tres")).toBeTruthy();
+  });
+
+  it("aplica o filtro default 'pending' quando há itens pendentes", () => {
+    renderView([
+      makeItem({
+        documentId: "dp",
+        documentTitle: "Doc Pendente",
+        isCorrect: false,
+        acknowledgmentStatus: "pending",
+        verdict: "nao",
+      }),
+      makeItem({
+        documentId: "dok",
+        documentTitle: "Doc Correto",
+        isCorrect: true,
+      }),
+    ]);
+
+    // Só o doc com item pendente aparece; o correto fica fora.
+    expect(screen.getByText("1/1")).toBeTruthy();
+    expect(screen.getByText("Doc Pendente")).toBeTruthy();
+    expect(screen.queryByText("Doc Correto")).toBeNull();
+  });
+});

--- a/frontend/src/components/reviews/__tests__/VerdictsList.test.tsx
+++ b/frontend/src/components/reviews/__tests__/VerdictsList.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// AddNoteButton arrasta next/navigation + server actions; como aqui só
+// importa renderizar um placeholder, mockamos o componente inteiro.
+vi.mock("@/components/shared/AddNoteButton", () => ({
+  AddNoteButton: () => <div data-testid="add-note" />,
+}));
+
+import { VerdictsList, type DocGroup } from "@/components/reviews/VerdictsList";
+import type { VerdictItem } from "@/app/(app)/projects/[id]/reviews/my-verdicts/page";
+
+function makeItem(overrides?: Partial<VerdictItem>): VerdictItem {
+  return {
+    reviewId: "r1",
+    documentId: "d1",
+    documentTitle: "Doc 1",
+    fieldName: "campo",
+    fieldDescription: "Descrição do campo",
+    fieldType: "text",
+    verdict: "nao",
+    coordinatorComment: null,
+    myAnswer: "sim",
+    isCorrect: false,
+    responseSnapshot: null,
+    acknowledgmentStatus: "pending",
+    acknowledgmentComment: null,
+    ...overrides,
+  };
+}
+
+function renderList(
+  onAcknowledge: (
+    reviewId: string,
+    status: "accepted" | "questioned",
+    comment?: string,
+  ) => Promise<boolean>,
+  item: VerdictItem = makeItem(),
+) {
+  const group: DocGroup = { docId: "d1", title: "Doc 1", items: [item] };
+  return render(
+    <VerdictsList
+      group={group}
+      fields={[]}
+      fieldFilter="all"
+      onFieldFilterChange={vi.fn()}
+      projectId="p1"
+      userName="João"
+      isPending={false}
+      onAcknowledge={onAcknowledge}
+    />,
+  );
+}
+
+const QUESTION_PLACEHOLDER = /qual a sua dúvida/i;
+
+afterEach(cleanup);
+beforeEach(() => {
+  // jsdom não implementa scrollTo; o effect de scroll do VerdictsList o chama.
+  Element.prototype.scrollTo = vi.fn();
+});
+
+describe("VerdictsList — input de dúvida", () => {
+  it("envia a dúvida e limpa o input ao concluir com sucesso", async () => {
+    const user = userEvent.setup();
+    const onAcknowledge = vi.fn().mockResolvedValue(true);
+    renderList(onAcknowledge);
+
+    await user.click(screen.getByRole("button", { name: /comentar dúvida/i }));
+    await user.type(
+      screen.getByPlaceholderText(QUESTION_PLACEHOLDER),
+      "minha dúvida",
+    );
+    await user.click(screen.getByRole("button", { name: /^enviar$/i }));
+
+    expect(onAcknowledge).toHaveBeenCalledWith("r1", "questioned", "minha dúvida");
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText(QUESTION_PLACEHOLDER)).toBeNull(),
+    );
+  });
+
+  it("fecha o input de dúvida aberto ao aceitar a correção (handleAck limpa em qualquer sucesso)", async () => {
+    const user = userEvent.setup();
+    const onAcknowledge = vi.fn().mockResolvedValue(true);
+    renderList(onAcknowledge);
+
+    await user.click(screen.getByRole("button", { name: /comentar dúvida/i }));
+    expect(screen.getByPlaceholderText(QUESTION_PLACEHOLDER)).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /aceitar correção/i }));
+
+    expect(onAcknowledge).toHaveBeenCalledWith("r1", "accepted", undefined);
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText(QUESTION_PLACEHOLDER)).toBeNull(),
+    );
+  });
+
+  it("mantém o input e o texto quando o acknowledge falha", async () => {
+    const user = userEvent.setup();
+    const onAcknowledge = vi.fn().mockResolvedValue(false);
+    renderList(onAcknowledge);
+
+    await user.click(screen.getByRole("button", { name: /comentar dúvida/i }));
+    await user.type(screen.getByPlaceholderText(QUESTION_PLACEHOLDER), "texto");
+    await user.click(screen.getByRole("button", { name: /^enviar$/i }));
+
+    await waitFor(() => expect(onAcknowledge).toHaveBeenCalled());
+    const input = screen.getByPlaceholderText(
+      QUESTION_PLACEHOLDER,
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.value).toBe("texto");
+  });
+});

--- a/frontend/src/lib/reviews/__tests__/verdict-format.test.ts
+++ b/frontend/src/lib/reviews/__tests__/verdict-format.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { formatAnswer, formatVerdictDisplay } from "@/lib/reviews/verdict-format";
+
+describe("formatAnswer", () => {
+  it("trata null/undefined como '(sem resposta)'", () => {
+    expect(formatAnswer(null)).toBe("(sem resposta)");
+    expect(formatAnswer(undefined)).toBe("(sem resposta)");
+  });
+
+  it("retorna strings cruas e converte primitivos", () => {
+    expect(formatAnswer("sim")).toBe("sim");
+    expect(formatAnswer(42)).toBe("42");
+    expect(formatAnswer(true)).toBe("true");
+  });
+
+  it("junta arrays com ', '", () => {
+    expect(formatAnswer(["a", "b", "c"])).toBe("a, b, c");
+  });
+
+  it("serializa objeto como 'k: v' separado por ', ', omitindo vazios", () => {
+    expect(formatAnswer({ a: "1", b: "", c: "3" })).toBe("a: 1, c: 3");
+  });
+});
+
+describe("formatVerdictDisplay", () => {
+  it("rotula vereditos especiais", () => {
+    expect(formatVerdictDisplay("ambiguo")).toBe("Ambíguo");
+    expect(formatVerdictDisplay("pular")).toBe("Pular");
+  });
+
+  it("expande seleções multi a partir de JSON", () => {
+    expect(formatVerdictDisplay('{"x":true,"y":false,"z":true}', "multi")).toBe(
+      "x; z",
+    );
+  });
+
+  it("retorna '(nenhuma)' quando nenhuma opção multi está marcada", () => {
+    expect(formatVerdictDisplay('{"x":false}', "multi")).toBe("(nenhuma)");
+  });
+
+  it("faz fallback para o texto cru quando o JSON é inválido", () => {
+    expect(formatVerdictDisplay("sim", "text")).toBe("sim");
+    expect(formatVerdictDisplay("{quebrado", "multi")).toBe("{quebrado");
+  });
+});

--- a/frontend/src/lib/reviews/verdict-format.ts
+++ b/frontend/src/lib/reviews/verdict-format.ts
@@ -1,0 +1,40 @@
+// Formatação de respostas e vereditos no fluxo "Meus Vereditos" / gabarito.
+//
+// Semântica própria deste fluxo, intencionalmente distinta das outras variantes
+// do codebase — por isso NÃO são intercambiáveis:
+//   - `formatAnswer` (@/lib/reviews/queries): null → "", objeto separado por
+//     "; ", recursivo.
+//   - `formatAnswerDisplay` (@/lib/format-answer): null/vazio → "(vazio)",
+//     objeto via JSON.stringify.
+// Aqui: null → "(sem resposta)", objeto "k: v" separado por ", ".
+
+export function formatAnswer(answer: unknown): string {
+  if (answer == null) return "(sem resposta)";
+  if (typeof answer === "string") return answer;
+  if (Array.isArray(answer)) return answer.join(", ");
+  if (typeof answer === "object") {
+    return Object.entries(answer as Record<string, unknown>)
+      .flatMap(([k, v]) =>
+        v != null && String(v).trim() !== "" ? [`${k}: ${v}`] : [],
+      )
+      .join(", ");
+  }
+  return String(answer);
+}
+
+export function formatVerdictDisplay(verdict: string, fieldType?: string): string {
+  if (verdict === "ambiguo") return "Ambíguo";
+  if (verdict === "pular") return "Pular";
+  if (fieldType === "multi" || verdict.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(verdict) as Record<string, boolean>;
+      const selected = Object.entries(parsed).flatMap(([k, v]) =>
+        v ? [k] : [],
+      );
+      return selected.length > 0 ? selected.join("; ") : "(nenhuma)";
+    } catch {
+      // fallback
+    }
+  }
+  return verdict;
+}


### PR DESCRIPTION
**Onda 4 — Hotspot (PILOTO)** da campanha *Zerar react-doctor* (épico #239). Elimina os **9 diagnósticos** de `MyVerdictsView.tsx` (2 `error` + 7 `warning`) refatorando o débito real — sem supressões — e valida em uso real os hooks compartilhados da Onda 3 (#231).

## Diagnósticos eliminados

Confirmado via `react-doctor . --json` na branch: **0 diagnósticos** nos 3 arquivos (antes: 9 em `MyVerdictsView.tsx`).

| Regra | Como foi resolvido |
|---|---|
| `no-adjust-state-on-prop-change` (error ×2) | derivação de `docIndex` + `useDocumentText` |
| `no-derived-state-effect`, `no-chain-state-updates`, `no-effect-chain` | derivação de `docIndex` (sem effect de reset) |
| `no-cascading-set-state`, `exhaustive-deps` | hook `useDocumentText` |
| `no-giant-component`, `prefer-useReducer` | extração de `VerdictsHeader`/`VerdictsList` |

## O que mudou

1. **`docIndex` derivado de `selectedDocId`** via `useMemo` (molde de `AutoReviewPage.tsx:112-119`). Some o effect que resetava o índice ao mudar filtro — quando o filtro tira o doc do grupo, `findIndex` → −1 e o índice cai para 0 naturalmente.
2. **`useDocumentText(projectId, currentDocId)`** no lugar do lazy-load manual com cache (precedente: `CommentsSplitView`). O `loading` é derivado no render, sem `setState` em effect.
3. **`selectRespondent` via `useUrlState`** (`set({ viewAsUser }, { method: "push" })` dentro do `startTransition`).
4. **Extração de `VerdictsHeader` e `VerdictsList`** (arquivos-irmãos, convenção do projeto). `MyVerdictsViewInner` cai de 306 → ~150 linhas; `useState` de 8 → 4. O state de comentário e o effect de scroll migram para `VerdictsList`, co-localizados com o DOM/UI que controlam (`VerdictCard`/`RespondentRow` acompanham). `MyVerdictsViewInner` fica **sem nenhum `useEffect`**.

## Mudança de comportamento intencional

Ao trocar filtro/campo/busca, o documento selecionado é **preservado** se sobrevive ao filtro (antes resetava sempre para o 1º). Sancionado pela issue. Item de verify manual.

## Validação

- `react-doctor` — 0 diagnósticos nos 3 arquivos; `--diff` vs `main` **"No issues found!"** (score 100/100). Total do projeto: 160 → 130, score 39 → 53.
- `tsc --noEmit` — 0 erros.
- `eslint` — limpo nos 3 arquivos.
- ⚠️ **Verify manual pendente** (precisa de auth + dados): navegação ◂ ▸, troca de filtro/campo/busca, scroll ao topo ao trocar de doc, aceitar correção / enviar dúvida, e "ver como" (coordenador).

Closes #232