### PR TITLE
fix(documents): índice único parcial + filtro defensivo no import (causa raiz das duplicatas)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,12 @@ cd frontend && npm run react-doctor:diff   # só arquivos alterados vs main
 
 O **react-doctor** é um linter pinado (`react-doctor@0.5.8`, devDependency) com config em `frontend/doctor.config.json` (fonte única; na 0.5.x o nome do arquivo passou a ser `doctor.config.*`). Um hook **local de pre-commit** (`.pre-commit-config.yaml`) roda `react-doctor . --scope changed --base HEAD --blocking error` nos commits que tocam `frontend/**/*.{ts,tsx}`: **bloqueia só se a linha alterada produzir um error** (`--scope changed` é line-scoped; substituiu o `--diff` deprecado na 0.5.7); o débito legado de errors/warnings fica grandfathered. Setup (1x): `uv tool install pre-commit && pre-commit install` (requer `npm install` em `frontend/`). Por ser local e opt-in, é uma rede de proteção do dev — não um portão de merge no servidor. Detalhes, baseline 0.5.8 e regras silenciadas em `docs/LINT_CONFIG.md`.
 
+## Scripts one-off de dados / específicos de projeto
+
+Scripts pontuais que operam sobre os dados de **um projeto específico** (dedup, correção de import, migração de dados ad hoc, re-OCR) **não vão para o repositório geral**: vivem em `pipeline-processos/` (gitignored), junto dos outros utilitários locais do Zolgensma. Motivo: carregam IDs e suposições de um projeto/dataset, não são reutilizáveis nem revisáveis como código de produto, e versioná-los polui o repo e expõe dados do banco (backups). Quando precisar resolver o `.env.local`, use caminho canônico do `frontend/` ou a env var `SUPABASE_ENV_PATH` — nunca suba a árvore de diretórios.
+
+Vai para o repo (PR normal) só a **correção de causa raiz genérica** que decorre desse trabalho — migration, mudança de comportamento no app, teste. Exemplo concreto (2026-06-23): as duplicatas de `documents` por re-import (projetos Zolgensma `0c6394da` e Zolgensma-Judiciário `00779233`) foram resolvidas por scripts locais em `pipeline-processos/dedup/`; o que entrou no repo foi a **migration do índice único parcial** `documents_project_external_id_active_uniq` (`UNIQUE(project_id, external_id) WHERE external_id IS NOT NULL AND excluded_at IS NULL`) + o **filtro defensivo** `filterActiveExternalIdConflicts` em `uploadDocuments`, que pula external_ids já ativos ou repetidos no lote em vez de deixar o INSERT em lote falhar inteiro.
+
 ## Performance — Regras de Arquitetura
 
 Seguir estas regras para evitar regressoes de performance:

--- a/frontend/src/actions/__tests__/documents.test.ts
+++ b/frontend/src/actions/__tests__/documents.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Testa o filtro de conflito com o indice unico parcial
+// documents_project_external_id_active_uniq (migration 20260623130000):
+// uploadDocuments nao pode mais inserir external_id ja ATIVO no projeto nem
+// repetido no proprio lote, senao o INSERT em lote falharia inteiro. O mock de
+// documents e uma FILA: 1a query = SELECT dos external_ids ativos existentes,
+// 2a = o INSERT. Quando o lote nao tem external_id, o SELECT e pulado e o INSERT
+// consome o 1o item.
+import {
+  makeSupabaseMock,
+  type TableResults,
+  type WriteCall,
+} from "./supabase-mock";
+
+let writeCalls: WriteCall[];
+let serverTableResults: TableResults | undefined;
+
+vi.mock("next/cache", () => ({
+  revalidatePath: () => {},
+  revalidateTag: () => {},
+}));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "userCoord" }),
+  isProjectCoordinator: async () => true,
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () =>
+    makeSupabaseMock({ tableResults: serverTableResults, writeCalls }),
+}));
+
+beforeEach(() => {
+  writeCalls = [];
+  serverTableResults = undefined;
+});
+
+async function loadUpload() {
+  return (await import("@/actions/documents")).uploadDocuments;
+}
+
+function insertedExternalIds(): (string | null)[] {
+  const call = writeCalls.find(
+    (c) => c.table === "documents" && c.op === "insert",
+  );
+  return ((call?.payload as { external_id: string | null }[]) ?? []).map(
+    (r) => r.external_id,
+  );
+}
+
+describe("uploadDocuments — filtro do indice unico (add_all)", () => {
+  it("pula external_id ja ATIVO no projeto e insere os demais", async () => {
+    // SELECT devolve DOC-1 como ja existente ativo; depois o INSERT (sem erro).
+    serverTableResults = {
+      documents: [{ data: [{ external_id: "DOC-1" }] }, { error: null }],
+    };
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [
+        { external_id: "DOC-1", text: "ja existe" },
+        { external_id: "DOC-2", text: "novo a" },
+        { external_id: "DOC-3", text: "novo b" },
+      ],
+      false,
+    );
+
+    expect(r.error).toBeUndefined();
+    expect(r.count).toBe(2);
+    expect(r.skipped).toBe(1);
+    expect(insertedExternalIds()).toEqual(["DOC-2", "DOC-3"]);
+  });
+
+  it("pula repeticao do mesmo external_id dentro do lote (mantem a 1a)", async () => {
+    serverTableResults = {
+      documents: [{ data: [] }, { error: null }],
+    };
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [
+        { external_id: "DOC-A", text: "primeira" },
+        { external_id: "DOC-A", text: "duplicata no arquivo" },
+        { external_id: "DOC-B", text: "outra" },
+      ],
+      false,
+    );
+
+    expect(r.count).toBe(2);
+    expect(r.skipped).toBe(1);
+    expect(insertedExternalIds()).toEqual(["DOC-A", "DOC-B"]);
+  });
+
+  it("nunca filtra documentos sem external_id", async () => {
+    // Sem external_ids no lote -> SELECT e pulado; INSERT consome o 1o item.
+    serverTableResults = { documents: [{ error: null }] };
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [
+        { text: "sem id 1" },
+        { text: "sem id 2" },
+      ],
+      false,
+    );
+
+    expect(r.count).toBe(2);
+    expect(r.skipped).toBe(0);
+    expect(insertedExternalIds()).toEqual([null, null]);
+  });
+});

--- a/frontend/src/actions/__tests__/documents.test.ts
+++ b/frontend/src/actions/__tests__/documents.test.ts
@@ -111,3 +111,92 @@ describe("uploadDocuments — filtro do indice unico (add_all)", () => {
     expect(insertedExternalIds()).toEqual([null, null]);
   });
 });
+
+describe("uploadDocuments — contagem em add_new_only", () => {
+  it("conta os duplicados do duplicateMap em skipped (count + skipped == total)", async () => {
+    // SELECT do filtro nao acha nada ativo; INSERT do DOC-2 ok.
+    serverTableResults = {
+      documents: [{ data: [] }, { error: null }],
+    };
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [
+        { external_id: "DOC-1", text: "ja existe no projeto" },
+        { external_id: "DOC-2", text: "novo" },
+      ],
+      false,
+      {
+        mode: "add_new_only",
+        duplicateMap: [
+          { csvIndex: 0, existingDocId: "id-1", matchType: "external_id" },
+        ],
+      },
+    );
+
+    expect(r.error).toBeUndefined();
+    expect(r.count).toBe(1);
+    expect(r.skipped).toBe(1);
+    expect(insertedExternalIds()).toEqual(["DOC-2"]);
+  });
+
+  it("todos duplicados -> 0 importados e skipped == total", async () => {
+    // Early return: nenhuma query e disparada.
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [
+        { external_id: "DOC-1", text: "x" },
+        { external_id: "DOC-2", text: "y" },
+      ],
+      false,
+      {
+        mode: "add_new_only",
+        duplicateMap: [
+          { csvIndex: 0, existingDocId: "id-1", matchType: "external_id" },
+          { csvIndex: 1, existingDocId: "id-2", matchType: "external_id" },
+        ],
+      },
+    );
+
+    expect(r.count).toBe(0);
+    expect(r.skipped).toBe(2);
+  });
+});
+
+describe("uploadDocuments — replace_and_add propaga erro de UPDATE", () => {
+  it("retorna error quando o UPDATE viola o indice unico (23505)", async () => {
+    // 1a query em documents = o UPDATE do duplicado, que falha com 23505.
+    serverTableResults = {
+      documents: [
+        {
+          error: {
+            message: "duplicate key value violates unique constraint",
+            code: "23505",
+          },
+        },
+      ],
+    };
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [{ external_id: "DOC-1", text: "casa por hash com outro doc" }],
+      false,
+      {
+        mode: "replace_and_add",
+        duplicateMap: [
+          { csvIndex: 0, existingDocId: "id-1", matchType: "text_hash" },
+        ],
+      },
+    );
+
+    expect(r.error).toContain("duplicate key");
+    // O INSERT nao deve acontecer apos o erro do UPDATE.
+    expect(
+      writeCalls.some((c) => c.table === "documents" && c.op === "insert"),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -201,7 +201,11 @@ export async function uploadDocuments(
   if (mode === "add_new_only") {
     // Filter out duplicates, only insert new ones
     const newDocs = documents.filter((_, i) => !duplicateIndices.has(i));
-    if (newDocs.length === 0) return { count: 0, skipped: 0 };
+    // Duplicatas descartadas aqui (detectadas pelo duplicateMap) ja contam como
+    // ignoradas — mantem a invariante count + skipped == documents.length para
+    // o toast reportar o numero correto.
+    const skippedDuplicates = documents.length - newDocs.length;
+    if (newDocs.length === 0) return { count: 0, skipped: skippedDuplicates };
 
     const baseRows = newDocs.map((doc) => ({
       project_id: projectId,
@@ -225,7 +229,10 @@ export async function uploadDocuments(
       revalidatePath(`/projects/${projectId}/config/documents`);
       revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
     }
-    return { count: rows.length, skipped: skippedExisting + skippedInBatch };
+    return {
+      count: rows.length,
+      skipped: skippedDuplicates + skippedExisting + skippedInBatch,
+    };
   }
 
   if (mode === "replace_and_add") {
@@ -257,7 +264,11 @@ export async function uploadDocuments(
 
     // Batch update duplicate documents (avoid N+1)
     if (duplicateMap.length > 0) {
-      await Promise.all(
+      // Checa o erro de cada update: setar external_id num doc casado por
+      // text_hash pode colidir com outro doc ativo e violar o indice unico
+      // parcial (23505). Sem isso o erro seria resolvido e ignorado em silencio
+      // (o doc nao seria atualizado mas contaria como processado).
+      const updateResults = await Promise.all(
         duplicateMap.map((dup) => {
           const doc = documents[dup.csvIndex];
           return supabase
@@ -272,6 +283,8 @@ export async function uploadDocuments(
             .eq("id", dup.existingDocId);
         })
       );
+      const failedUpdate = updateResults.find((r) => r.error);
+      if (failedUpdate?.error) return { error: failedUpdate.error.message };
     }
 
     // Insert new (non-duplicate) documents

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -131,6 +131,61 @@ export interface UploadOptions {
   deleteResponses?: boolean;
 }
 
+/**
+ * Remove as linhas que violariam o indice unico parcial
+ * documents_project_external_id_active_uniq — UNIQUE(project_id, external_id)
+ * WHERE external_id IS NOT NULL AND excluded_at IS NULL (migration
+ * 20260623130000). Dois conflitos possiveis num INSERT em lote, ambos abortariam
+ * a operacao inteira (perdendo tambem as linhas novas validas):
+ *   1. external_id ja ATIVO no projeto (re-import — a causa raiz das duplicatas);
+ *   2. external_id repetido dentro do proprio lote (CSV com linhas duplicadas).
+ * Linhas sem external_id nunca sao filtradas (varios docs sem external_id sao
+ * validos). Retorna as linhas seguras + contagem do que foi pulado.
+ */
+async function filterActiveExternalIdConflicts<
+  T extends { external_id: string | null },
+>(
+  supabase: Awaited<ReturnType<typeof createSupabaseServer>>,
+  projectId: string,
+  rows: T[],
+): Promise<{ rows: T[]; skippedExisting: number; skippedInBatch: number }> {
+  const ids = [
+    ...new Set(rows.map((r) => r.external_id).filter((id): id is string => !!id)),
+  ];
+
+  const existing = new Set<string>();
+  if (ids.length > 0) {
+    const { data } = await supabase
+      .from("documents")
+      .select("external_id")
+      .eq("project_id", projectId)
+      .is("excluded_at", null)
+      .in("external_id", ids);
+    for (const d of data ?? []) {
+      if (d.external_id) existing.add(d.external_id);
+    }
+  }
+
+  const seen = new Set<string>();
+  let skippedExisting = 0;
+  let skippedInBatch = 0;
+  const safe = rows.filter((r) => {
+    if (!r.external_id) return true;
+    if (existing.has(r.external_id)) {
+      skippedExisting++;
+      return false;
+    }
+    if (seen.has(r.external_id)) {
+      skippedInBatch++;
+      return false;
+    }
+    seen.add(r.external_id);
+    return true;
+  });
+
+  return { rows: safe, skippedExisting, skippedInBatch };
+}
+
 export async function uploadDocuments(
   projectId: string,
   documents: DocumentRow[],
@@ -146,9 +201,9 @@ export async function uploadDocuments(
   if (mode === "add_new_only") {
     // Filter out duplicates, only insert new ones
     const newDocs = documents.filter((_, i) => !duplicateIndices.has(i));
-    if (newDocs.length === 0) return { count: 0 };
+    if (newDocs.length === 0) return { count: 0, skipped: 0 };
 
-    const rows = newDocs.map((doc) => ({
+    const baseRows = newDocs.map((doc) => ({
       project_id: projectId,
       external_id: doc.external_id || null,
       title: doc.title || null,
@@ -156,15 +211,21 @@ export async function uploadDocuments(
       text_hash: md5(doc.text),
       metadata: doc.metadata || null,
     }));
+    // Defesa extra contra o indice unico: duplicateMap pode estar stale e o
+    // proprio lote pode repetir external_id.
+    const { rows, skippedExisting, skippedInBatch } =
+      await filterActiveExternalIdConflicts(supabase, projectId, baseRows);
 
-    const { error } = await supabase.from("documents").insert(rows);
-    if (error) return { error: error.message };
+    if (rows.length > 0) {
+      const { error } = await supabase.from("documents").insert(rows);
+      if (error) return { error: error.message };
+    }
 
     if (revalidate) {
       revalidatePath(`/projects/${projectId}/config/documents`);
       revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
     }
-    return { count: rows.length };
+    return { count: rows.length, skipped: skippedExisting + skippedInBatch };
   }
 
   if (mode === "replace_and_add") {
@@ -215,8 +276,9 @@ export async function uploadDocuments(
 
     // Insert new (non-duplicate) documents
     const newDocs = documents.filter((_, i) => !duplicateIndices.has(i));
+    let skipped = 0;
     if (newDocs.length > 0) {
-      const rows = newDocs.map((doc) => ({
+      const baseRows = newDocs.map((doc) => ({
         project_id: projectId,
         external_id: doc.external_id || null,
         title: doc.title || null,
@@ -224,20 +286,28 @@ export async function uploadDocuments(
         text_hash: md5(doc.text),
         metadata: doc.metadata || null,
       }));
+      // Defesa contra o indice unico (duplicateMap stale / repeticao no lote).
+      const { rows, skippedExisting, skippedInBatch } =
+        await filterActiveExternalIdConflicts(supabase, projectId, baseRows);
+      skipped = skippedExisting + skippedInBatch;
 
-      const { error } = await supabase.from("documents").insert(rows);
-      if (error) return { error: error.message };
+      if (rows.length > 0) {
+        const { error } = await supabase.from("documents").insert(rows);
+        if (error) return { error: error.message };
+      }
     }
 
     if (revalidate) {
       revalidatePath(`/projects/${projectId}/config/documents`);
       revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
     }
-    return { count: documents.length };
+    return { count: documents.length - skipped, skipped };
   }
 
-  // Default: add_all — current behavior + compute text_hash
-  const rows = documents.map((doc) => ({
+  // Default: add_all — insere tudo, exceto o que violaria o indice unico
+  // (external_id ja ativo no projeto ou repetido no proprio lote). Sem o filtro,
+  // o INSERT em lote falharia inteiro no primeiro conflito.
+  const allRows = documents.map((doc) => ({
     project_id: projectId,
     external_id: doc.external_id || null,
     title: doc.title || null,
@@ -245,15 +315,19 @@ export async function uploadDocuments(
     text_hash: md5(doc.text),
     metadata: doc.metadata || null,
   }));
+  const { rows, skippedExisting, skippedInBatch } =
+    await filterActiveExternalIdConflicts(supabase, projectId, allRows);
 
-  const { error } = await supabase.from("documents").insert(rows);
-  if (error) return { error: error.message };
+  if (rows.length > 0) {
+    const { error } = await supabase.from("documents").insert(rows);
+    if (error) return { error: error.message };
+  }
 
   if (revalidate) {
       revalidatePath(`/projects/${projectId}/config/documents`);
       revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
     }
-  return { count: rows.length };
+  return { count: rows.length, skipped: skippedExisting + skippedInBatch };
 }
 
 export interface BrowseDocument {

--- a/frontend/src/components/documents/DocumentUpload.tsx
+++ b/frontend/src/components/documents/DocumentUpload.tsx
@@ -135,6 +135,7 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
     try {
       const chunks = chunkByBytes(docs);
       let processed = 0;
+      let totalSkipped = 0;
       for (let ci = 0; ci < chunks.length; ci++) {
         const { items, startIndex } = chunks[ci];
         const endIndex = startIndex + items.length;
@@ -161,10 +162,16 @@ export function DocumentUpload({ projectId }: DocumentUploadProps) {
           localOptions
         );
         if (result.error) throw new Error(result.error);
+        totalSkipped += result.skipped ?? 0;
         processed += items.length;
         setProgress({ current: processed, total: docs.length });
       }
-      toast.success(`${docs.length} documentos importados!`);
+      const imported = docs.length - totalSkipped;
+      toast.success(
+        totalSkipped > 0
+          ? `${imported} documento(s) importado(s); ${totalSkipped} ignorado(s) (já existiam no projeto ou repetidos no arquivo).`
+          : `${docs.length} documentos importados!`
+      );
       setParsedData(null);
       setStep("idle");
       setAnalysis(null);

--- a/frontend/supabase/migrations/20260623130000_documents_unique_external_id.sql
+++ b/frontend/supabase/migrations/20260623130000_documents_unique_external_id.sql
@@ -1,0 +1,19 @@
+-- Impede recorrencia das duplicatas de documentos por re-importacao.
+--
+-- Causa raiz (ver docs/DEDUP_ZOLGENSMA_2026-06.md): documents nao tinha
+-- UNIQUE(project_id, external_id), e uploadDocuments (modo default add_all)
+-- faz INSERT puro -> cada re-import recriava os documentos, espalhando
+-- responses/reviews entre copias e quebrando as comparacoes automaticas.
+--
+-- Indice UNICO PARCIAL: no maximo UMA copia ATIVA por (project_id, external_id).
+-- Compativel com o soft-delete (excluded_at): permite uma copia excluida + uma
+-- ativa, mas bloqueia duas ativas com o mesmo external_id. NULLs em external_id
+-- ficam de fora (varios docs sem external_id sao validos).
+--
+-- Pre-requisito ja satisfeito: as duplicatas ativas pre-existentes dos projetos
+-- Zolgensma (0c6394da) e Zolgensma-Judiciario (00779233) foram resolvidas por
+-- dedup antes desta migration, entao a criacao do indice nao viola.
+
+CREATE UNIQUE INDEX IF NOT EXISTS documents_project_external_id_active_uniq
+  ON documents (project_id, external_id)
+  WHERE external_id IS NOT NULL AND excluded_at IS NULL;


### PR DESCRIPTION
## Contexto

Correção de causa raiz das duplicatas de `documents` por re-importação, descoberta no trabalho de dedup do Zolgensma (PR #214, agora fechado por ser específico de projeto). A tabela `documents` não tinha `UNIQUE(project_id, external_id)` e `uploadDocuments` (modo default `add_all`) faz `INSERT` puro — cada re-importação recriava as cópias, espalhando `responses`/`reviews` entre elas e quebrando as comparações automáticas.

O dedup dos dados já existentes (projetos **Zolgensma** `0c6394da` e **Zolgensma-Judiciário** `00779233`) foi executado por scripts locais (em `pipeline-processos/dedup/`, fora do repo — ver convenção nova no CLAUDE.md). Este PR entrega só a **correção genérica**, que pertence ao repo.

## O que muda

- **Migration `20260623130000`** — índice único **parcial**:
  ```sql
  CREATE UNIQUE INDEX documents_project_external_id_active_uniq
    ON documents (project_id, external_id)
    WHERE external_id IS NOT NULL AND excluded_at IS NULL;
  ```
  No máximo **uma cópia ativa** por `(project_id, external_id)`. Compatível com o soft-delete: permite 1 excluída + 1 ativa, mas bloqueia duas ativas. **Já aplicada em produção** via `db push` (após o dedup deixar 0 duplicatas ativas em todo o banco).

- **`uploadDocuments`** — helper `filterActiveExternalIdConflicts` remove, antes do `INSERT`, as linhas que violariam o índice: (a) `external_id` já **ativo** no projeto (re-import) e (b) `external_id` **repetido no próprio lote**. Aplicado nos 3 modos (`add_all`, `add_new_only`, `replace_and_add`). Sem isso, o `INSERT` em lote falharia inteiro no primeiro 23505, perdendo até as linhas novas válidas. Linhas sem `external_id` nunca são filtradas.

- **`DocumentUpload.tsx`** — acumula os documentos ignorados e os reporta no toast (`N importado(s); M ignorado(s)…`), em vez de afirmar que todos foram importados.

- **Teste** `documents.test.ts` — cobre o filtro em `add_all` (já-ativo, repetição interna, sem external_id).

- **CLAUDE.md** — registra a convenção: scripts one-off de dados específicos de projeto vivem em `pipeline-processos/` (gitignored), não no repo geral.

## Verificação

- `npx vitest run` — 558/558 passam (3 novos).
- `npx tsc --noEmit` — limpo.
- `npm run react-doctor:diff` — sem issues (87/100).
- Prova funcional em produção: tentar inserir duplicata ativa retorna `23505 / HTTP 409` no constraint `documents_project_external_id_active_uniq`.

Closes #214