### PR TITLE
refactor(compare): zera react-doctor em MultiOptionReview (Onda 4)

### DIFF
--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -180,9 +180,9 @@ export function ComparisonPanel({
       <div className="flex-1 overflow-y-auto px-4 py-2">
         {isMulti ? (
           <MultiOptionReview
+            key={`${documentId}|${fieldName}`}
             options={fieldOptions}
             responses={responses}
-            fieldName={fieldName}
             existingVerdict={existingVerdict}
             onSubmit={(verdictJson) => onVerdict(verdictJson)}
           />

--- a/frontend/src/components/compare/MultiOptionReview.tsx
+++ b/frontend/src/components/compare/MultiOptionReview.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -29,7 +29,6 @@ interface ExistingVerdict {
 interface MultiOptionReviewProps {
   options: string[];
   responses: MultiOptionResponse[];
-  fieldName: string;
   existingVerdict: ExistingVerdict | null;
   onSubmit: (verdictJson: string) => void;
 }
@@ -49,10 +48,23 @@ function parseExistingMultiVerdict(
   return null;
 }
 
+// Escolhas iniciais: verdict existente, senão segue a maioria por opção.
+function computeInitialChoices(
+  verdict: string | undefined,
+  optionStats: { option: string; selectedCount: number; totalRespondents: number }[],
+): Record<string, boolean> {
+  const existing = parseExistingMultiVerdict(verdict);
+  if (existing) return existing;
+  const result: Record<string, boolean> = {};
+  for (const stat of optionStats) {
+    result[stat.option] = stat.selectedCount > stat.totalRespondents / 2;
+  }
+  return result;
+}
+
 export function MultiOptionReview({
   options,
   responses,
-  fieldName,
   existingVerdict,
   onSubmit,
 }: MultiOptionReviewProps) {
@@ -85,38 +97,13 @@ export function MultiOptionReview({
     });
   }, [options, responses]);
 
-  // Initialize choices from existing verdict or majority
-  const [choices, setChoices] = useState<Record<string, boolean>>(() => {
-    const existing = parseExistingMultiVerdict(existingVerdict?.verdict);
-    if (existing) return existing;
-    // Default: follow majority
-    const result: Record<string, boolean> = {};
-    for (const stat of optionStats) {
-      result[stat.option] = stat.selectedCount > stat.totalRespondents / 2;
-    }
-    return result;
-  });
-
-  // Stable key derived from optionStats to detect when responses change
-  const statsKey = useMemo(
-    () => optionStats.map((s) => `${s.option}:${s.selectedCount}/${s.totalRespondents}`).join("|"),
-    [optionStats]
+  // Escolhas iniciais: verdict existente, senão a maioria por opção.
+  // O reset ao trocar de documento/campo é feito pelo `key` no pai
+  // (ComparisonPanel, igual ao AgreementGroup): a troca de key remonta o
+  // componente e este inicializador roda de novo — sem effect de derivação.
+  const [choices, setChoices] = useState<Record<string, boolean>>(() =>
+    computeInitialChoices(existingVerdict?.verdict, optionStats),
   );
-
-  // Reset choices when field, verdict, or response stats change
-  useEffect(() => {
-    const existing = parseExistingMultiVerdict(existingVerdict?.verdict);
-    if (existing) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- reseta as escolhas ao trocar de campo/verdict/estatísticas
-      setChoices(existing);
-    } else {
-      const result: Record<string, boolean> = {};
-      for (const stat of optionStats) {
-        result[stat.option] = stat.selectedCount > stat.totalRespondents / 2;
-      }
-      setChoices(result);
-    }
-  }, [fieldName, existingVerdict?.verdict, statsKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const toggleOption = (opt: string) => {
     setChoices((prev) => ({ ...prev, [opt]: !prev[opt] }));
@@ -126,10 +113,19 @@ export function MultiOptionReview({
     onSubmit(JSON.stringify(choices));
   };
 
-  // Keyboard shortcuts: 1-N toggle options, Enter submits
+  // Keyboard shortcuts: 1-N toggle options, Enter submits.
+  // Listener de teclado registra uma vez; handlers frescos chegam via ref
+  // para evitar re-registro a cada tecla.
+  const keyHandlersRef = useRef({ handleSubmit, toggleOption, options });
+  useEffect(() => {
+    keyHandlersRef.current = { handleSubmit, toggleOption, options };
+  });
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+      const { handleSubmit, toggleOption, options } = keyHandlersRef.current;
 
       if (e.key === "Enter") {
         e.preventDefault();
@@ -144,7 +140,7 @@ export function MultiOptionReview({
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [options, choices]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/frontend/src/components/compare/MultiOptionReview.tsx
+++ b/frontend/src/components/compare/MultiOptionReview.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { computeInitialChoices } from "@/lib/compare-multi-choices";
 import {
   Tooltip,
   TooltipTrigger,
@@ -31,35 +32,6 @@ interface MultiOptionReviewProps {
   responses: MultiOptionResponse[];
   existingVerdict: ExistingVerdict | null;
   onSubmit: (verdictJson: string) => void;
-}
-
-function parseExistingMultiVerdict(
-  verdict: string | undefined,
-): Record<string, boolean> | null {
-  if (!verdict || !verdict.startsWith("{")) return null;
-  try {
-    const parsed = JSON.parse(verdict);
-    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-      return parsed as Record<string, boolean>;
-    }
-  } catch {
-    // legacy string verdict — ignore
-  }
-  return null;
-}
-
-// Escolhas iniciais: verdict existente, senão segue a maioria por opção.
-function computeInitialChoices(
-  verdict: string | undefined,
-  optionStats: { option: string; selectedCount: number; totalRespondents: number }[],
-): Record<string, boolean> {
-  const existing = parseExistingMultiVerdict(verdict);
-  if (existing) return existing;
-  const result: Record<string, boolean> = {};
-  for (const stat of optionStats) {
-    result[stat.option] = stat.selectedCount > stat.totalRespondents / 2;
-  }
-  return result;
 }
 
 export function MultiOptionReview({

--- a/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
+++ b/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { MultiOptionReview } from "@/components/compare/MultiOptionReview";
+
+afterEach(cleanup);
+
+describe("MultiOptionReview — atalhos de teclado", () => {
+  it("tecla numérica alterna a opção e Enter submete o estado fresco", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiOptionReview
+        options={["A", "B", "C"]}
+        responses={[]}
+        existingVerdict={null}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Estado inicial (sem respostas): todas as opções desmarcadas.
+    await user.keyboard("1"); // alterna A
+    await user.keyboard("2"); // alterna B
+    await user.keyboard("{Enter}"); // submete
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    // O handler chega fresco via ref: o Enter vê os dois toggles acumulados,
+    // não um estado stale do primeiro registro do listener.
+    expect(JSON.parse(onSubmit.mock.calls[0][0])).toEqual({
+      A: true,
+      B: true,
+      C: false,
+    });
+  });
+
+  it("tecla numérica fora do intervalo de opções não altera nada", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiOptionReview
+        options={["A", "B"]}
+        responses={[]}
+        existingVerdict={null}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.keyboard("9"); // não há 9ª opção → no-op
+    await user.keyboard("{Enter}");
+
+    expect(JSON.parse(onSubmit.mock.calls[0][0])).toEqual({
+      A: false,
+      B: false,
+    });
+  });
+});
+
+describe("MultiOptionReview — reset via key (contrato do ComparisonPanel)", () => {
+  it("trocar a key (novo documento/campo) remonta e re-inicializa as escolhas", async () => {
+    const user = userEvent.setup();
+    // O harness espelha ComparisonPanel.tsx:183: key={`${documentId}|${fieldName}`}.
+    const { rerender } = render(
+      <MultiOptionReview
+        key="doc1|campoA"
+        options={["A", "B"]}
+        responses={[]}
+        existingVerdict={null}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    let boxes = screen.getAllByRole("checkbox");
+    expect(boxes[0].getAttribute("aria-checked")).toBe("false");
+
+    // Usuário marca a opção A no campo atual.
+    await user.click(boxes[0]);
+    expect(screen.getAllByRole("checkbox")[0].getAttribute("aria-checked")).toBe(
+      "true",
+    );
+
+    // Navega para outro campo (key muda) com um verdict salvo diferente.
+    // O remount descarta o toggle em curso e roda o inicializador de novo.
+    rerender(
+      <MultiOptionReview
+        key="doc1|campoB"
+        options={["A", "B"]}
+        responses={[]}
+        existingVerdict={{
+          verdict: '{"A":false,"B":true}',
+          chosenResponseId: null,
+          comment: null,
+        }}
+        onSubmit={vi.fn()}
+      />,
+    );
+
+    boxes = screen.getAllByRole("checkbox");
+    expect(boxes[0].getAttribute("aria-checked")).toBe("false"); // A foi resetado
+    expect(boxes[1].getAttribute("aria-checked")).toBe("true"); // B vem do novo verdict
+  });
+});

--- a/frontend/src/lib/__tests__/compare-multi-choices.test.ts
+++ b/frontend/src/lib/__tests__/compare-multi-choices.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { computeInitialChoices } from "@/lib/compare-multi-choices";
+
+// Helper para montar optionStats com os campos que `computeInitialChoices` lê.
+function stat(option: string, selectedCount: number, totalRespondents: number) {
+  return { option, selectedCount, totalRespondents };
+}
+
+describe("computeInitialChoices — pré-preenchimento (verdict vs. maioria)", () => {
+  it("verdict JSON existente tem precedência sobre a maioria", () => {
+    // A maioria diria { A: false, B: true }; o verdict salvo é o oposto.
+    const stats = [stat("A", 0, 3), stat("B", 3, 3)];
+    expect(computeInitialChoices('{"A":true,"B":false}', stats)).toEqual({
+      A: true,
+      B: false,
+    });
+  });
+
+  it("sem verdict, segue a maioria estrita (selectedCount > total/2)", () => {
+    const stats = [stat("A", 2, 3), stat("B", 1, 3)];
+    expect(computeInitialChoices(undefined, stats)).toEqual({
+      A: true,
+      B: false,
+    });
+  });
+
+  it("empate não marca a opção (maioria é estrita, não >=)", () => {
+    // 1 de 2 e 2 de 4 são empates: ambos ficam false.
+    const stats = [stat("A", 1, 2), stat("B", 2, 4)];
+    expect(computeInitialChoices(undefined, stats)).toEqual({
+      A: false,
+      B: false,
+    });
+  });
+
+  it("verdict legado (string) ou JSON malformado é ignorado e cai na maioria", () => {
+    const stats = [stat("A", 3, 3)]; // maioria → true
+    expect(computeInitialChoices("Deferido", stats)).toEqual({ A: true });
+    expect(computeInitialChoices("{invalido", stats)).toEqual({ A: true });
+  });
+
+  it("verdict ausente com optionStats vazio retorna objeto vazio sem lançar", () => {
+    expect(computeInitialChoices(undefined, [])).toEqual({});
+  });
+});

--- a/frontend/src/lib/compare-multi-choices.ts
+++ b/frontend/src/lib/compare-multi-choices.ts
@@ -1,0 +1,33 @@
+// Lógica pura de pré-preenchimento das escolhas do MultiOptionReview.
+// Vive em lib/ (e não no componente) para que o arquivo de componente só
+// exporte componentes — requisito do Fast Refresh — e para ser testável
+// isoladamente, junto dos demais utilitários puros de comparação.
+
+function parseExistingMultiVerdict(
+  verdict: string | undefined,
+): Record<string, boolean> | null {
+  if (!verdict || !verdict.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(verdict);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, boolean>;
+    }
+  } catch {
+    // legacy string verdict — ignore
+  }
+  return null;
+}
+
+// Escolhas iniciais: verdict existente, senão segue a maioria por opção.
+export function computeInitialChoices(
+  verdict: string | undefined,
+  optionStats: { option: string; selectedCount: number; totalRespondents: number }[],
+): Record<string, boolean> {
+  const existing = parseExistingMultiVerdict(verdict);
+  if (existing) return existing;
+  const result: Record<string, boolean> = {};
+  for (const stat of optionStats) {
+    result[stat.option] = stat.selectedCount > stat.totalRespondents / 2;
+  }
+  return result;
+}


### PR DESCRIPTION
Parte da campanha **Zerar react-doctor** (épico #239), **Onda 4 — Hotspot**. Sub-issue de #235.

Elimina os **4 diagnósticos** do react-doctor em `frontend/src/components/compare/MultiOptionReview.tsx` (2× `no-derived-state` + 2× `exhaustive-deps`), com **0 supressões** — refatorando o padrão, conforme a direção da campanha.

## O que mudou

- **Reset via `key` no pai.** O reset das escolhas ao trocar de documento/campo passa a ser feito pelo `key={documentId|fieldName}` no `ComparisonPanel`, espelhando o componente-irmão `AgreementGroup` (que já usava esse padrão no mesmo arquivo). A troca de key remonta o componente e o inicializador do `useState` roda de novo — some o `useEffect` que copiava valores derivados para o state. Isso mata os 2× `no-derived-state` (:111/:117) e o `exhaustive-deps` do effect de reset (:119). Em consequência, `fieldName` deixa de ser usado pelo filho (sai da interface e da chamada no pai) e `statsKey` (que só alimentava o reset) também sai.
- **Atalhos de teclado com handler fresco via ref.** O listener `keydown` passa a registrar uma única vez (`[]`), com `handleSubmit`/`toggleOption`/`options` frescos chegando por `ref` — padrão já usado em `AutoReviewFieldPanel`. Elimina o último `exhaustive-deps` (:147) e o re-registro do listener a cada toggle.
- **Helper puro `computeInitialChoices`.** A lógica "verdict existente, senão maioria" estava duplicada entre o init do `useState` e o effect de reset; foi extraída.
- Removidos os 3 comentários `eslint-disable` (`set-state-in-effect` + 2× `exhaustive-deps`) agora mortos.

## Por que `key` no pai (e não um fix self-contained)

O padrão "prevKey + setState durante render" no próprio componente não fecha limpo: com `useState` para a guarda, o react-doctor dispara `rerender-state-only-in-handlers` (a guarda nunca é renderizada); com `useRef` lido/escrito no render, o ESLint `react-hooks/refs` dá **erro**. Os dois linters se contradizem. O reset via `key` — a recomendação idiomática do React para "resetar todo o state quando algo muda" — satisfaz ambos e ainda alinha o `MultiOptionReview` ao `AgreementGroup`.

## Verificação

- `npx react-doctor . --scope changed` (mesmo check do hook de pre-commit): **No issues found** — zero diagnósticos introduzidos.
- `MultiOptionReview.tsx`: **4 → 0** diagnósticos do react-doctor.
- `tsc --noEmit` e `eslint` (ambos arquivos): limpos.
- Score global de full-scan sem regressão (os 3 warnings pré-existentes em `ComparisonPanel` estão em linhas não tocadas).
- Sem teste dedicado para o componente.

### Verify manual sugerido (comparação → revisão multi-opção)

- [ ] Pré-preenchimento: verdict existente vs. maioria por opção.
- [ ] Toggle por clique e pelas teclas `1`–`9`; `Enter` confirma.
- [ ] Navegar entre campos/documentos reseta as escolhas corretamente (sem flash).
- [ ] Digitar dentro de input/textarea não dispara atalho.

Closes #256