### PR TITLE
refactor(documents): unifica fetch de texto do DocumentPreview em useDocumentText (#255)

### DIFF
--- a/frontend/src/actions/__tests__/documents.test.ts
+++ b/frontend/src/actions/__tests__/documents.test.ts
@@ -38,6 +38,10 @@ async function loadUpload() {
   return (await import("@/actions/documents")).uploadDocuments;
 }
 
+async function loadGetDocumentText() {
+  return (await import("@/actions/documents")).getDocumentText;
+}
+
 function insertedExternalIds(): (string | null)[] {
   const call = writeCalls.find(
     (c) => c.table === "documents" && c.op === "insert",
@@ -198,5 +202,41 @@ describe("uploadDocuments — replace_and_add propaga erro de UPDATE", () => {
     expect(
       writeCalls.some((c) => c.table === "documents" && c.op === "insert"),
     ).toBe(false);
+  });
+});
+
+describe("getDocumentText", () => {
+  it("retorna texto e titulo quando o doc existe", async () => {
+    serverTableResults = {
+      documents: [{ data: { title: "Titulo", text: "conteudo" } }],
+    };
+    const getDocumentText = await loadGetDocumentText();
+
+    const r = await getDocumentText("proj-1", "doc-1");
+
+    expect(r).toEqual({ text: "conteudo", title: "Titulo" });
+  });
+
+  it("retorna null (sem lancar) quando o doc nao existe", async () => {
+    // maybeSingle devolve data:null em 0 linhas; nao pode lancar (era .single()).
+    serverTableResults = { documents: [{ data: null }] };
+    const getDocumentText = await loadGetDocumentText();
+
+    await expect(getDocumentText("proj-1", "missing")).resolves.toBeNull();
+  });
+
+  it("lanca quando a query retorna erro, em vez de silenciar como nao-encontrado", async () => {
+    serverTableResults = {
+      documents: [{ error: { message: "rls denied", code: "42501" } }],
+    };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const getDocumentText = await loadGetDocumentText();
+
+    await expect(getDocumentText("proj-1", "doc-1")).rejects.toMatchObject({
+      message: "rls denied",
+    });
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
   });
 });

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -463,20 +463,24 @@ export async function getDocumentForCoding(
 export async function getDocumentText(
   projectId: string,
   documentId: string,
-  allowExcluded = false,
 ): Promise<{ text: string; title: string } | null> {
   const supabase = await createSupabaseServer();
-  let query = supabase
+  // Busca o texto de um doc por id (RLS aplica). Nao filtra excluded_at de
+  // proposito: a visibilidade de soft-deleted e decidida nas queries de lista
+  // (getDocumentsForBrowse, a pagina de documentos via ?show=excluded), nao no
+  // fetch de texto por id. Quem chega a pedir o texto ja escolheu o doc na lista.
+  const { data, error } = await supabase
     .from("documents")
     .select("title, text")
     .eq("id", documentId)
-    .eq("project_id", projectId);
-  // Por padrao oculta soft-deleted, alinhado com getDocumentsForBrowse /
-  // getDocumentForCoding. So o preview no modo "Mostrar excluidos" passa true.
-  if (!allowExcluded) {
-    query = query.is("excluded_at", null);
+    .eq("project_id", projectId)
+    .maybeSingle();
+  // Distingue erro real (RLS/transporte/schema) de doc inexistente: sem isto,
+  // um doc que existe mas falhou na query viraria "(nao encontrado)" silencioso.
+  if (error) {
+    console.error("[getDocumentText] erro de query", { projectId, documentId, error });
+    throw error;
   }
-  const { data } = await query.maybeSingle();
   if (!data) return null;
   return { text: data.text, title: data.title || documentId };
 }

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -463,14 +463,20 @@ export async function getDocumentForCoding(
 export async function getDocumentText(
   projectId: string,
   documentId: string,
+  allowExcluded = false,
 ): Promise<{ text: string; title: string } | null> {
   const supabase = await createSupabaseServer();
-  const { data } = await supabase
+  let query = supabase
     .from("documents")
     .select("title, text")
     .eq("id", documentId)
-    .eq("project_id", projectId)
-    .single();
+    .eq("project_id", projectId);
+  // Por padrao oculta soft-deleted, alinhado com getDocumentsForBrowse /
+  // getDocumentForCoding. So o preview no modo "Mostrar excluidos" passa true.
+  if (!allowExcluded) {
+    query = query.is("excluded_at", null);
+  }
+  const { data } = await query.maybeSingle();
   if (!data) return null;
   return { text: data.text, title: data.title || documentId };
 }

--- a/frontend/src/components/documents/DocumentPreview.tsx
+++ b/frontend/src/components/documents/DocumentPreview.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { useAuth } from "@clerk/nextjs";
-import { createBrowserClient } from "@/lib/supabase/client";
+import { useDocumentText } from "@/hooks/useDocumentText";
 
 interface DocumentPreviewProps {
   documentId: string | null;
   title: string;
   open: boolean;
   onClose: () => void;
+  /**
+   * projectId do documento — usado pelo fetch de texto via `getDocumentText`.
+   * Sempre presente no caller real (DocumentsPageClient, rota projects/[id]).
+   */
+  projectId?: string;
   /**
    * Por padrao, preview nao carrega texto de doc soft-deleted — alinhado com
    * o resto da UI que esconde excluidos. Setar true quando o caller estiver
@@ -23,41 +26,12 @@ export function DocumentPreview({
   title,
   open,
   onClose,
+  projectId,
   allowExcluded = false,
 }: DocumentPreviewProps) {
-  const [text, setText] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const { getToken } = useAuth();
-
-  useEffect(() => {
-    if (!documentId || !open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset ao fechar o preview / sem doc selecionado
-      setText(null);
-      return;
-    }
-    setLoading(true);
-    getToken({ template: "supabase" })
-      .then((token) => {
-        const supabase = createBrowserClient(token);
-        let query = supabase
-          .from("documents")
-          .select("text")
-          .eq("id", documentId);
-        if (!allowExcluded) {
-          query = query.is("excluded_at", null);
-        }
-        return query.maybeSingle();
-      })
-      .then(({ data }) => {
-        setText(data?.text ?? null);
-      })
-      .catch(() => {
-        setText(null);
-      })
-      .finally(() => {
-        setLoading(false);
-      });
-  }, [documentId, open, getToken, allowExcluded]);
+  const { text, loading } = useDocumentText(projectId, open ? documentId : null, {
+    allowExcluded,
+  });
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>

--- a/frontend/src/components/documents/DocumentPreview.tsx
+++ b/frontend/src/components/documents/DocumentPreview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { useDocumentText } from "@/hooks/useDocumentText";
 
 interface DocumentPreviewProps {
@@ -19,7 +20,10 @@ export function DocumentPreview({
   onClose,
   projectId,
 }: DocumentPreviewProps) {
-  const { text, loading } = useDocumentText(projectId, open ? documentId : null);
+  const { text, loading, error, retry } = useDocumentText(
+    projectId,
+    open ? documentId : null,
+  );
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
@@ -32,6 +36,13 @@ export function DocumentPreview({
             <div className="h-4 w-full animate-pulse rounded bg-muted" />
             <div className="h-4 w-3/4 animate-pulse rounded bg-muted" />
             <div className="h-4 w-1/2 animate-pulse rounded bg-muted" />
+          </div>
+        ) : error ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">{text}</p>
+            <Button variant="outline" size="sm" onClick={retry}>
+              Tentar novamente
+            </Button>
           </div>
         ) : (
           <div className="whitespace-pre-wrap text-sm leading-relaxed">

--- a/frontend/src/components/documents/DocumentPreview.tsx
+++ b/frontend/src/components/documents/DocumentPreview.tsx
@@ -8,17 +8,8 @@ interface DocumentPreviewProps {
   title: string;
   open: boolean;
   onClose: () => void;
-  /**
-   * projectId do documento — usado pelo fetch de texto via `getDocumentText`.
-   * Sempre presente no caller real (DocumentsPageClient, rota projects/[id]).
-   */
-  projectId?: string;
-  /**
-   * Por padrao, preview nao carrega texto de doc soft-deleted — alinhado com
-   * o resto da UI que esconde excluidos. Setar true quando o caller estiver
-   * no modo "Mostrar excluidos" para permitir visualizacao do historico.
-   */
-  allowExcluded?: boolean;
+  /** projectId do documento — usado pelo fetch de texto via `getDocumentText`. */
+  projectId: string;
 }
 
 export function DocumentPreview({
@@ -27,11 +18,8 @@ export function DocumentPreview({
   open,
   onClose,
   projectId,
-  allowExcluded = false,
 }: DocumentPreviewProps) {
-  const { text, loading } = useDocumentText(projectId, open ? documentId : null, {
-    allowExcluded,
-  });
+  const { text, loading } = useDocumentText(projectId, open ? documentId : null);
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -245,14 +245,15 @@ export function DocumentsPageClient({
         showExcluded={showExcluded}
       />
 
-      <DocumentPreview
-        documentId={selectedDoc?.id ?? null}
-        title={selectedDoc?.title ?? selectedDoc?.external_id ?? "Documento"}
-        open={!!selectedDoc}
-        onClose={() => setSelectedDocId(null)}
-        projectId={projectId}
-        allowExcluded={showExcluded}
-      />
+      {projectId && (
+        <DocumentPreview
+          documentId={selectedDoc?.id ?? null}
+          title={selectedDoc?.title ?? selectedDoc?.external_id ?? "Documento"}
+          open={!!selectedDoc}
+          onClose={() => setSelectedDocId(null)}
+          projectId={projectId}
+        />
+      )}
 
       {/* Soft delete (excluir = reversivel) */}
       <AlertDialog

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -250,6 +250,7 @@ export function DocumentsPageClient({
         title={selectedDoc?.title ?? selectedDoc?.external_id ?? "Documento"}
         open={!!selectedDoc}
         onClose={() => setSelectedDocId(null)}
+        projectId={projectId}
         allowExcluded={showExcluded}
       />
 

--- a/frontend/src/hooks/__tests__/useDocumentText.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentText.test.ts
@@ -55,6 +55,15 @@ describe("useDocumentText", () => {
     expect(result.current.text).toBe("(Documento não encontrado)");
   });
 
+  it("destrava loading com sentinela de erro quando a action rejeita", async () => {
+    // Sem .catch o loading derivado ficaria preso para sempre (skeleton infinito).
+    mockGet.mockRejectedValue(new Error("falha de transporte"));
+    const { result } = renderHook(() => useDocumentText("p1", "d1"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.text).toBe("(Erro ao carregar o documento)");
+  });
+
   it("não busca quando documentId é null", () => {
     const { result } = renderHook(() => useDocumentText("p1", null));
 

--- a/frontend/src/hooks/__tests__/useDocumentText.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentText.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { renderHook, waitFor, cleanup, act } from "@testing-library/react";
 import { useDocumentText } from "../useDocumentText";
 import { getDocumentText } from "@/actions/documents";
 
@@ -62,6 +62,42 @@ describe("useDocumentText", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.text).toBe("(Erro ao carregar o documento)");
+  });
+
+  it("expõe error e retry(): re-tenta sem renavegar e mostra skeleton em voo", async () => {
+    // Fica parado no doc que falhou: retry() limpa a marca de falha (destrava o
+    // loading) e re-busca imperativamente; o sucesso passa a exibir o texto.
+    let d1Calls = 0;
+    let resolveSecond: ((v: { text: string; title: string }) => void) | null =
+      null;
+    mockGet.mockImplementation(() => {
+      d1Calls += 1;
+      if (d1Calls === 1) return Promise.reject(new Error("blip"));
+      return new Promise((resolve) => {
+        resolveSecond = resolve;
+      });
+    });
+
+    const { result } = renderHook(() => useDocumentText("p1", "d1"));
+
+    await waitFor(() => expect(result.current.error).toBe(true));
+    expect(result.current.text).toBe("(Erro ao carregar o documento)");
+    expect(result.current.loading).toBe(false);
+
+    // Re-tentativa manual: skeleton volta enquanto a 2ª busca está em voo.
+    act(() => {
+      result.current.retry();
+    });
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(result.current.error).toBe(false);
+
+    // Resolve a 2ª busca → texto recuperado, sem erro.
+    await act(async () => {
+      resolveSecond!({ text: "d1-recuperado", title: "d1" });
+    });
+    await waitFor(() => expect(result.current.text).toBe("d1-recuperado"));
+    expect(result.current.error).toBe(false);
+    expect(d1Calls).toBe(2);
   });
 
   it("re-tenta ao renavegar: erro não fica memoizado no cache", async () => {

--- a/frontend/src/hooks/__tests__/useDocumentText.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentText.test.ts
@@ -56,12 +56,43 @@ describe("useDocumentText", () => {
   });
 
   it("destrava loading com sentinela de erro quando a action rejeita", async () => {
-    // Sem .catch o loading derivado ficaria preso para sempre (skeleton infinito).
+    // Sem o ramo de erro o loading derivado ficaria preso para sempre (skeleton infinito).
     mockGet.mockRejectedValue(new Error("falha de transporte"));
     const { result } = renderHook(() => useDocumentText("p1", "d1"));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.text).toBe("(Erro ao carregar o documento)");
+  });
+
+  it("re-tenta ao renavegar: erro não fica memoizado no cache", async () => {
+    // A 1ª busca de d1 falha (blip transitório); ao voltar para d1, o hook deve
+    // re-buscar — o erro vai para `failed` (evictável), não para o `cache`.
+    let d1Calls = 0;
+    mockGet.mockImplementation(async (_p, id) => {
+      if (id === "d1") {
+        d1Calls += 1;
+        if (d1Calls === 1) throw new Error("blip");
+        return { text: "d1-recuperado", title: "d1" };
+      }
+      return { text: `txt-${id}`, title: id };
+    });
+
+    const { result, rerender } = renderHook(
+      ({ id }) => useDocumentText("p1", id),
+      { initialProps: { id: "d1" } },
+    );
+
+    await waitFor(() =>
+      expect(result.current.text).toBe("(Erro ao carregar o documento)"),
+    );
+
+    // Renavega para outro doc e volta — a volta dispara nova tentativa de d1.
+    rerender({ id: "d2" });
+    await waitFor(() => expect(result.current.text).toBe("txt-d2"));
+
+    rerender({ id: "d1" });
+    await waitFor(() => expect(result.current.text).toBe("d1-recuperado"));
+    expect(d1Calls).toBe(2);
   });
 
   it("não busca quando documentId é null", () => {

--- a/frontend/src/hooks/useDocumentText.ts
+++ b/frontend/src/hooks/useDocumentText.ts
@@ -9,16 +9,22 @@ const LOAD_ERROR = "(Erro ao carregar o documento)";
 /**
  * Lazy-load do texto de um documento, com cache por id e flag `loading`.
  *
- * O `loading` é derivado (`!!documentId && !(documentId in cache)`) em vez de
- * guardado num `useState` — isso elimina o `setState` síncrono no effect que
- * antes exigia `eslint-disable react-hooks/set-state-in-effect`. O `setCache`
- * fica no `.then`/`.catch` (assíncrono), que a regra não sinaliza. O `cache`
- * entra nas deps do effect com um early-return (`documentId in cache`),
- * dispensando o `eslint-disable react-hooks/exhaustive-deps`.
+ * O `loading` é derivado (`!!documentId && !(documentId in cache) && !(documentId
+ * in failed)`) em vez de guardado num `useState` — isso elimina o `setState`
+ * síncrono no effect que antes exigia `eslint-disable
+ * react-hooks/set-state-in-effect`. Os `setCache`/`setFailed` ficam no
+ * `.then`/`.catch` (assíncrono), que a regra não sinaliza. O `cache` entra nas
+ * deps do effect com um early-return (`documentId in cache`), dispensando o
+ * `eslint-disable react-hooks/exhaustive-deps`.
  *
- * Se a Server Action rejeitar, o `.catch` grava `LOAD_ERROR` no cache — isso
- * também destrava o `loading` (sem ele o preview ficaria preso no skeleton para
- * sempre) e mostra mensagem distinta de `NOT_FOUND` (doc inexistente).
+ * Sucesso/inexistência são memoizados em `cache` (resultados estáveis). Já o
+ * erro de fetch vai para um mapa `failed` SEPARADO, fora da guarda do effect
+ * (`documentId in cache`): assim ele destrava o `loading` e mostra `LOAD_ERROR`
+ * (distinto de `NOT_FOUND`), mas NÃO envenena o cache — reabrir/renavegar para o
+ * mesmo doc dispara nova tentativa (erro transitório, ex.: blip de rede, se
+ * recupera). `setFailed` não está nas deps, então registrar a falha não
+ * re-dispara o effect (sem loop de refetch); só uma troca de `documentId`/`cache`
+ * o faz.
  *
  * Cobre os três consumidores do texto de documento: `DocumentPreview`,
  * `CommentsSplitView` e `MyVerdictsView`.
@@ -28,6 +34,7 @@ export function useDocumentText(
   documentId: string | null | undefined,
 ): { text: string | undefined; loading: boolean } {
   const [cache, setCache] = useState<Record<string, string>>({});
+  const [failed, setFailed] = useState<Record<string, true>>({});
 
   useEffect(() => {
     if (!documentId || documentId in cache) return;
@@ -39,14 +46,17 @@ export function useDocumentText(
       })
       .catch(() => {
         if (cancelled) return;
-        setCache((prev) => ({ ...prev, [documentId]: LOAD_ERROR }));
+        setFailed((prev) => ({ ...prev, [documentId]: true }));
       });
     return () => {
       cancelled = true;
     };
   }, [projectId, documentId, cache]);
 
-  const text = documentId ? cache[documentId] : undefined;
-  const loading = !!documentId && !(documentId in cache);
+  const text = documentId
+    ? (cache[documentId] ?? (documentId in failed ? LOAD_ERROR : undefined))
+    : undefined;
+  const loading =
+    !!documentId && !(documentId in cache) && !(documentId in failed);
   return { text, loading };
 }

--- a/frontend/src/hooks/useDocumentText.ts
+++ b/frontend/src/hooks/useDocumentText.ts
@@ -6,41 +6,51 @@ import { getDocumentText } from "@/actions/documents";
 const NOT_FOUND = "(Documento não encontrado)";
 
 /**
- * Lazy-load do texto de um documento, com cache por id e flag `loading`.
+ * Lazy-load do texto de um documento, com cache por chave e flag `loading`.
  *
- * O `loading` é derivado (`!!documentId && !(documentId in cache)`) em vez de
- * guardado num `useState` — isso elimina o `setState` síncrono no effect que
- * antes exigia `eslint-disable react-hooks/set-state-in-effect`. O `setCache`
- * fica no `.then` (assíncrono), que a regra não sinaliza. O `cache` entra nas
- * deps do effect com um early-return (`documentId in cache`), dispensando o
- * `eslint-disable react-hooks/exhaustive-deps`.
+ * O `loading` é derivado (`!!key && !(key in cache)`) em vez de guardado num
+ * `useState` — isso elimina o `setState` síncrono no effect que antes exigia
+ * `eslint-disable react-hooks/set-state-in-effect`. O `setCache` fica no `.then`
+ * (assíncrono), que a regra não sinaliza. O `cache` entra nas deps do effect com
+ * um early-return (`key in cache`), dispensando o `eslint-disable
+ * react-hooks/exhaustive-deps`.
  *
- * Cobre o padrão Server Action (`getDocumentText`) + cache compartilhado por
- * `MyVerdictsView` e `CommentsSplitView`. Não cobre `DocumentPreview`, que usa
- * outro caminho de dados (Supabase browser client + `allowExcluded`).
+ * A chave de cache inclui `allowExcluded` (`${documentId}::${allowExcluded}`)
+ * porque um mesmo documento pode ser buscado com e sem o filtro de excluído — e
+ * `allowExcluded` pode alternar em runtime (ex.: o coordenador liga "Mostrar
+ * excluídos" com o `DocumentPreview` aberto).
+ *
+ * Cobre os três consumidores do texto de documento: `DocumentPreview`
+ * (`allowExcluded` vindo do toggle), `CommentsSplitView` e `MyVerdictsView`
+ * (ambos com o default `false`, que oculta soft-deleted).
  */
 export function useDocumentText(
-  projectId: string,
+  projectId: string | undefined,
   documentId: string | null | undefined,
+  options?: { allowExcluded?: boolean },
 ): { text: string | undefined; loading: boolean } {
+  const allowExcluded = options?.allowExcluded ?? false;
   const [cache, setCache] = useState<Record<string, string>>({});
 
+  const key =
+    projectId && documentId ? `${documentId}::${allowExcluded}` : null;
+
   useEffect(() => {
-    if (!documentId || documentId in cache) return;
+    if (!key || !projectId || !documentId || key in cache) return;
     let cancelled = false;
-    getDocumentText(projectId, documentId).then((result) => {
+    getDocumentText(projectId, documentId, allowExcluded).then((result) => {
       if (cancelled) return;
       setCache((prev) => ({
         ...prev,
-        [documentId]: result?.text ?? NOT_FOUND,
+        [key]: result?.text ?? NOT_FOUND,
       }));
     });
     return () => {
       cancelled = true;
     };
-  }, [projectId, documentId, cache]);
+  }, [key, projectId, documentId, allowExcluded, cache]);
 
-  const text = documentId ? cache[documentId] : undefined;
-  const loading = !!documentId && !(documentId in cache);
+  const text = key ? cache[key] : undefined;
+  const loading = !!key && !(key in cache);
   return { text, loading };
 }

--- a/frontend/src/hooks/useDocumentText.ts
+++ b/frontend/src/hooks/useDocumentText.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { getDocumentText } from "@/actions/documents";
 
 const NOT_FOUND = "(Documento não encontrado)";
@@ -26,37 +26,74 @@ const LOAD_ERROR = "(Erro ao carregar o documento)";
  * re-dispara o effect (sem loop de refetch); só uma troca de `documentId`/`cache`
  * o faz.
  *
+ * Além do auto-retry ao renavegar, o hook expõe `error` + `retry()` para o caso
+ * de o usuário ficar parado no doc que falhou: `retry()` limpa a marca em
+ * `failed` (setState num event handler, não no effect — react-doctor-limpo) e
+ * re-busca imperativamente. Limpar `failed` destrava o `loading`, então a
+ * re-tentativa manual exibe o skeleton (em vez do erro antigo) enquanto a busca
+ * está em voo. O refetch é imperativo de propósito: `failed` não está nas deps
+ * do effect, então só limpar a marca não re-dispararia a busca.
+ *
  * Cobre os três consumidores do texto de documento: `DocumentPreview`,
  * `CommentsSplitView` e `MyVerdictsView`.
  */
 export function useDocumentText(
   projectId: string,
   documentId: string | null | undefined,
-): { text: string | undefined; loading: boolean } {
+): {
+  text: string | undefined;
+  loading: boolean;
+  error: boolean;
+  retry: () => void;
+} {
   const [cache, setCache] = useState<Record<string, string>>({});
   const [failed, setFailed] = useState<Record<string, true>>({});
 
+  // Busca compartilhada pelo effect (carga inicial / auto-retry ao renavegar) e
+  // pelo `retry()` manual. O setState fica no `.then`/`.catch` (assíncrono), que
+  // a regra `set-state-in-effect` não sinaliza. Retorna o cleanup de cancelamento.
+  const fetchText = useCallback(
+    (id: string) => {
+      let cancelled = false;
+      getDocumentText(projectId, id)
+        .then((result) => {
+          if (cancelled) return;
+          setCache((prev) => ({ ...prev, [id]: result?.text ?? NOT_FOUND }));
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setFailed((prev) => ({ ...prev, [id]: true }));
+        });
+      return () => {
+        cancelled = true;
+      };
+    },
+    [projectId],
+  );
+
   useEffect(() => {
     if (!documentId || documentId in cache) return;
-    let cancelled = false;
-    getDocumentText(projectId, documentId)
-      .then((result) => {
-        if (cancelled) return;
-        setCache((prev) => ({ ...prev, [documentId]: result?.text ?? NOT_FOUND }));
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setFailed((prev) => ({ ...prev, [documentId]: true }));
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [projectId, documentId, cache]);
+    return fetchText(documentId);
+  }, [documentId, cache, fetchText]);
+
+  const retry = useCallback(() => {
+    if (!documentId) return;
+    // Limpa a marca de falha (no handler) para destravar o skeleton e re-busca.
+    setFailed((prev) => {
+      if (!(documentId in prev)) return prev;
+      const rest = { ...prev };
+      delete rest[documentId];
+      return rest;
+    });
+    fetchText(documentId);
+  }, [documentId, fetchText]);
 
   const text = documentId
     ? (cache[documentId] ?? (documentId in failed ? LOAD_ERROR : undefined))
     : undefined;
   const loading =
     !!documentId && !(documentId in cache) && !(documentId in failed);
-  return { text, loading };
+  const error =
+    !!documentId && documentId in failed && !(documentId in cache);
+  return { text, loading, error, retry };
 }

--- a/frontend/src/hooks/useDocumentText.ts
+++ b/frontend/src/hooks/useDocumentText.ts
@@ -4,53 +4,49 @@ import { useEffect, useState } from "react";
 import { getDocumentText } from "@/actions/documents";
 
 const NOT_FOUND = "(Documento não encontrado)";
+const LOAD_ERROR = "(Erro ao carregar o documento)";
 
 /**
- * Lazy-load do texto de um documento, com cache por chave e flag `loading`.
+ * Lazy-load do texto de um documento, com cache por id e flag `loading`.
  *
- * O `loading` é derivado (`!!key && !(key in cache)`) em vez de guardado num
- * `useState` — isso elimina o `setState` síncrono no effect que antes exigia
- * `eslint-disable react-hooks/set-state-in-effect`. O `setCache` fica no `.then`
- * (assíncrono), que a regra não sinaliza. O `cache` entra nas deps do effect com
- * um early-return (`key in cache`), dispensando o `eslint-disable
- * react-hooks/exhaustive-deps`.
+ * O `loading` é derivado (`!!documentId && !(documentId in cache)`) em vez de
+ * guardado num `useState` — isso elimina o `setState` síncrono no effect que
+ * antes exigia `eslint-disable react-hooks/set-state-in-effect`. O `setCache`
+ * fica no `.then`/`.catch` (assíncrono), que a regra não sinaliza. O `cache`
+ * entra nas deps do effect com um early-return (`documentId in cache`),
+ * dispensando o `eslint-disable react-hooks/exhaustive-deps`.
  *
- * A chave de cache inclui `allowExcluded` (`${documentId}::${allowExcluded}`)
- * porque um mesmo documento pode ser buscado com e sem o filtro de excluído — e
- * `allowExcluded` pode alternar em runtime (ex.: o coordenador liga "Mostrar
- * excluídos" com o `DocumentPreview` aberto).
+ * Se a Server Action rejeitar, o `.catch` grava `LOAD_ERROR` no cache — isso
+ * também destrava o `loading` (sem ele o preview ficaria preso no skeleton para
+ * sempre) e mostra mensagem distinta de `NOT_FOUND` (doc inexistente).
  *
- * Cobre os três consumidores do texto de documento: `DocumentPreview`
- * (`allowExcluded` vindo do toggle), `CommentsSplitView` e `MyVerdictsView`
- * (ambos com o default `false`, que oculta soft-deleted).
+ * Cobre os três consumidores do texto de documento: `DocumentPreview`,
+ * `CommentsSplitView` e `MyVerdictsView`.
  */
 export function useDocumentText(
-  projectId: string | undefined,
+  projectId: string,
   documentId: string | null | undefined,
-  options?: { allowExcluded?: boolean },
 ): { text: string | undefined; loading: boolean } {
-  const allowExcluded = options?.allowExcluded ?? false;
   const [cache, setCache] = useState<Record<string, string>>({});
 
-  const key =
-    projectId && documentId ? `${documentId}::${allowExcluded}` : null;
-
   useEffect(() => {
-    if (!key || !projectId || !documentId || key in cache) return;
+    if (!documentId || documentId in cache) return;
     let cancelled = false;
-    getDocumentText(projectId, documentId, allowExcluded).then((result) => {
-      if (cancelled) return;
-      setCache((prev) => ({
-        ...prev,
-        [key]: result?.text ?? NOT_FOUND,
-      }));
-    });
+    getDocumentText(projectId, documentId)
+      .then((result) => {
+        if (cancelled) return;
+        setCache((prev) => ({ ...prev, [documentId]: result?.text ?? NOT_FOUND }));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCache((prev) => ({ ...prev, [documentId]: LOAD_ERROR }));
+      });
     return () => {
       cancelled = true;
     };
-  }, [key, projectId, documentId, allowExcluded, cache]);
+  }, [projectId, documentId, cache]);
 
-  const text = key ? cache[key] : undefined;
-  const loading = !!key && !(key in cache);
+  const text = documentId ? cache[documentId] : undefined;
+  const loading = !!documentId && !(documentId in cache);
   return { text, loading };
 }


### PR DESCRIPTION
Onda 4 da campanha **Zerar react-doctor** (épico #239). Closes #255.

## O que muda

Elimina os **4 diagnósticos** do react-doctor em `DocumentPreview.tsx` — `no-adjust-state-on-prop-change` (×2, error), `no-cascading-set-state`, `no-event-handler` — **deletando o `useEffect` inteiro**, não patcheando-o. O preview passa a consumir o hook `useDocumentText`, que já segue o idioma loading-derivado + cache + cleanup que passa limpo na ferramenta.

## Decisão de arquitetura (a pendência do issue)

O issue travava numa decisão (owner): (a) consertar localmente mantendo o fetch via Supabase browser client, ou (b) unificar com `getDocumentText`/`useDocumentText`. A arqueologia decidiu por **(b)**:

- O caminho browser-client do preview era **legado** (anterior às Server Actions). `DocumentPreview` era o **único componente client usando `createBrowserClient` direto** — fora do padrão "Server Actions para mutations, RSC para reads".
- O `allowExcluded` nasceu no PR #98 como **filtro de UI de application-layer** (esconder soft-deleted no preview), não fronteira de arquitetura. A RLS de `documents` **não** filtra `excluded_at`.

## Mudanças

- **`getDocumentText`**: troca `.single()` por `.maybeSingle()` e passa a **lançar** em erro de query (RLS/transporte/schema) em vez de silenciar — sem isto, um doc que existe mas falhou na query viraria "(não encontrado)" silencioso. **Não filtra `excluded_at`** (mantém o comportamento anterior): a visibilidade de soft-deleted é decidida nas queries de **lista** (`getDocumentsForBrowse`, a página de documentos via `?show=excluded`), não no fetch de texto por id. Quem chega a pedir o texto já escolheu o doc na lista — e a query da página é mutuamente exclusiva (`excluded_at IS NULL` xor `NOT NULL`), então o preview nunca recebe um doc fora do modo de visibilidade atual.
- **`useDocumentText`**: o ramo de erro destrava o `loading` e mostra `LOAD_ERROR` (mensagem distinta de `NOT_FOUND`). O cache é por **`documentId`**. Sucesso/inexistência são memoizados; **erro de fetch fica num mapa `failed` evictável** (não envenena o cache), de modo que reabrir/renavegar para o mesmo doc re-tenta — importante para erro transitório de rede.
- **`DocumentPreview`**: perde `useEffect`/`useState`/`useAuth`/`createBrowserClient`, ganha prop `projectId`, vira só JSX + 1 chamada de hook.
- **`DocumentsPageClient`**: passa `projectId` ao preview (sempre disponível — caller único na rota `projects/[id]`).

## Verificação

- ✅ `npm run react-doctor`: zero diagnósticos em `DocumentPreview.tsx` e `useDocumentText.ts` (critério de pronto do issue). Nenhum diagnóstico novo introduzido (hooks 100/100).
- ✅ `npx tsc --noEmit`: limpo (confirma retrocompat das assinaturas).
- ✅ `npm run lint`: 0 errors.
- ✅ `vitest`: cobre `getDocumentText` (texto/null/throw) e `useDocumentText` (fetch, cache, not-found, erro destrava loading, **retry ao renavegar**).
- ⏳ **Verify manual** (sugerido na revisão), em `projects/[id]/config/documents`: abrir/fechar preview de doc ativo; ligar "Mostrar excluídos" e abrir preview de doc excluído; reabrir o mesmo doc (agora instantâneo via cache); forçar um erro e confirmar mensagem com **retry ao reabrir**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
