### PR TITLE
refactor(compare): extrai hooks/view e zera react-doctor no ComparePage (#253)

### DIFF
--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -1,66 +1,23 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
-import { DocumentReader } from "../coding/DocumentReader";
+import { useCallback, useRef, useState } from "react";
 import { FullscreenNav } from "../coding/FullscreenNav";
-import {
-  ResizablePanelGroup,
-  ResizablePanel,
-  ResizableHandle,
-} from "@/components/ui/resizable";
 import { CompareNav } from "./CompareNav";
-import { ComparisonPanel } from "./ComparisonPanel";
 import { CompareDocList, type DocListEntry } from "./CompareDocList";
-import { submitVerdict, markCompareDocReviewed, type ResponseSnapshotEntry } from "@/actions/reviews";
-import {
-  confirmEquivalentVerdict,
-  unmarkEquivalencePair,
-} from "@/actions/equivalences";
-import { toast } from "sonner";
-import { normalizeForComparison } from "@/lib/utils";
-import {
-  isFreeTextField,
-  isDocComplete,
-  findNextPendingDocIndex,
-} from "@/lib/compare-divergence";
-import { buildResponseGroupKeys } from "@/lib/equivalence";
+import { CompareWorkspace } from "./CompareWorkspace";
+import { useCompareReviews } from "./useCompareReviews";
+import { useCompareNavigation } from "./useCompareNavigation";
+import { useCompareFieldData } from "./useCompareFieldData";
+import { useCompareVerdicts } from "./useCompareVerdicts";
+import { useCompareKeyboard } from "./useCompareKeyboard";
+import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import type { DocCoverage } from "@/app/(app)/projects/[id]/analyze/compare/page";
-
-interface EquivalencePairWire {
-  id: string;
-  response_a_id: string;
-  response_b_id: string;
-  reviewer_id: string | null;
-}
-
-interface CompareResponse {
-  id: string;
-  respondent_type: "humano" | "llm";
-  respondent_name: string;
-  answers: Record<string, unknown>;
-  justifications: Record<string, string> | null;
-  is_latest: boolean;
-  pydantic_hash: string | null;
-  answer_field_hashes: Record<string, string> | null;
-  schema_version_major: number | null;
-  schema_version_minor: number | null;
-  schema_version_patch: number | null;
-  created_at: string;
-}
-
-interface CompareDocument {
-  id: string;
-  title: string | null;
-  external_id: string | null;
-  text: string;
-}
-
-interface ExistingVerdictInfo {
-  verdict: string;
-  chosenResponseId: string | null;
-  comment: string | null;
-}
+import type {
+  CompareDocument,
+  CompareResponse,
+  EquivalencePairWire,
+} from "./compare-types";
 
 interface ComparePageProps {
   projectId: string;
@@ -68,7 +25,7 @@ interface ComparePageProps {
   responses: Record<string, CompareResponse[]>;
   divergentFields: Record<string, string[]>;
   fields: PydanticField[];
-  existingReviews: Record<string, Record<string, ExistingVerdictInfo>>;
+  existingReviews: ReviewsByDoc;
   projectPydanticHash: string | null;
   respondentNames: string[];
   // Default de "mín. humanos" derivado do automation_mode (compareDefaultsForMode):
@@ -108,387 +65,119 @@ export function ComparePage({
   currentUserId,
   canManageAnyPair,
 }: ComparePageProps) {
-  const [pinnedDocId, setPinnedDocId] = useState<string | null>(null);
-  const [fieldIndex, setFieldIndex] = useState(0);
-  const [filter, setFilter] = useState("all");
-  const [comment, setComment] = useState("");
-  const [isFullscreen, setIsFullscreen] = useState(false);
-  const [listCollapsed, setListCollapsed] = useState(false);
+  const { localReviews, recordReview } = useCompareReviews(existingReviews);
 
-  const [localReviews, setLocalReviews] = useState<
-    Record<string, Record<string, ExistingVerdictInfo>>
-  >(existingReviews);
+  const {
+    docIndex,
+    currentDoc,
+    allDocDivergent,
+    docFields,
+    fieldIndex,
+    setFieldIndex,
+    filter,
+    changeFilter,
+    currentFieldName,
+    currentField,
+    isCurrentFieldDivergent,
+    isCurrentDocComplete,
+    reviewedDocsCount,
+    hasNextDoc,
+    handleDocNavigate,
+    handleNextDoc,
+    goNextField,
+    goPrevField,
+  } = useCompareNavigation({ documents, divergentFields, fields, localReviews });
 
-  // O parecer atual é derivado de `pinnedDocId` (última escolha explícita do
-  // usuário). `documents` é reordenado pelo Server Component a cada
-  // `revalidatePath` (sort por pendências); rastrear por índice numérico
-  // faria o parecer mudar sob o usuário a cada veredito. Quando o ID atual
-  // some da lista (filtro mudou, etc.) caímos para `documents[0]`.
-  const docIndex = useMemo(() => {
-    if (documents.length === 0) return 0;
-    if (pinnedDocId) {
-      const i = documents.findIndex((d) => d.id === pinnedDocId);
-      if (i >= 0) return i;
-    }
-    return 0;
-  }, [documents, pinnedDocId]);
-
-  // Avisa quando o doc pinado some da lista (ex.: foi excluído). O
-  // `docIndex` memo já cai para `documents[0]` automaticamente; aqui só
-  // disparamos o toast uma vez, na transição "estava lá → sumiu".
-  const lastValidPinnedRef = useRef<string | null>(null);
-  useEffect(() => {
-    if (!pinnedDocId || documents.length === 0) {
-      lastValidPinnedRef.current = pinnedDocId;
-      return;
-    }
-    const exists = documents.some((d) => d.id === pinnedDocId);
-    if (exists) {
-      lastValidPinnedRef.current = pinnedDocId;
-    } else if (lastValidPinnedRef.current === pinnedDocId) {
-      toast.info("Documento removido da fila — voltando ao topo.");
-      lastValidPinnedRef.current = null;
-    }
-  }, [pinnedDocId, documents]);
-
-  const currentDoc = documents[docIndex];
-  const allDocDivergent = useMemo(
-    () => (currentDoc ? divergentFields[currentDoc.id] || [] : []),
-    [currentDoc, divergentFields],
-  );
-  const divergentSet = useMemo(() => new Set(allDocDivergent), [allDocDivergent]);
-
-  const docFields = filter === "all"
-    ? allDocDivergent
-    : allDocDivergent.filter((fn) => fn === filter);
-  const currentFieldName = docFields[fieldIndex];
-  const currentField = fields.find((f) => f.name === currentFieldName);
-  const isCurrentFieldDivergent = divergentSet.has(currentFieldName);
-  const docResponses = currentDoc ? (responses[currentDoc.id] || []) : [];
-
-  const reviewed = docFields.map((fn) => !!localReviews[currentDoc?.id]?.[fn]);
-
-  const reviewedDocsCount = useMemo(
-    () =>
-      documents.filter((doc) =>
-        isDocComplete(divergentFields[doc.id], localReviews[doc.id]),
-      ).length,
-    [documents, divergentFields, localReviews],
-  );
-
-  // Documento "concluído" = todos os campos divergentes têm veredito. Quando
-  // verdadeiro, a UI mostra o botão "Próximo parecer" (com foco automático)
-  // em vez de avançar por timer cego.
-  const isCurrentDocComplete = useMemo(
-    () =>
-      !!currentDoc && isDocComplete(allDocDivergent, localReviews[currentDoc.id]),
-    [currentDoc, allDocDivergent, localReviews],
-  );
-
-  // `documents` é reordenado pelo servidor a cada revalidate (docs concluídos
-  // afundam para o fim da fila), então o "próximo parecer" precisa ser o
-  // próximo doc com pendências — não `docIndex + 1`, que apontaria para fora
-  // da fila assim que o doc atual fosse concluído.
-  const nextPendingDocIndex = useMemo(
-    () =>
-      findNextPendingDocIndex(
-        documents.map((d) => d.id),
-        divergentFields,
-        localReviews,
-        currentDoc?.id,
-      ),
-    [documents, divergentFields, localReviews, currentDoc],
-  );
-
-  const hasNextDoc = nextPendingDocIndex >= 0;
-
-  const handleNextDoc = useCallback(() => {
-    if (nextPendingDocIndex >= 0) {
-      setPinnedDocId(documents[nextPendingDocIndex].id);
-      setFieldIndex(0);
-    }
-  }, [nextPendingDocIndex, documents]);
-
-  const currentVerdict = currentDoc && currentFieldName
-    ? localReviews[currentDoc.id]?.[currentFieldName] ?? null
-    : null;
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- sincroniza o comentário editável com o verdict do contexto atual
-    setComment(currentVerdict?.comment || "");
-  }, [currentFieldName, currentDoc?.id, currentVerdict?.comment]);
-
-  const currentFieldHashes = useMemo(() => {
-    const map: Record<string, string> = {};
-    for (const f of fields) {
-      if (f.hash) map[f.name] = f.hash;
-    }
-    return map;
-  }, [fields]);
-
-  const fieldResponses = docResponses.map((r) => {
-    let isFieldStale = false;
-    if (r.answer_field_hashes) {
-      const savedHash = r.answer_field_hashes[currentFieldName];
-      const currentHash = currentFieldHashes[currentFieldName];
-      isFieldStale = !savedHash || !currentHash || savedHash !== currentHash;
-    } else {
-      isFieldStale = !!projectPydanticHash && r.pydantic_hash !== projectPydanticHash;
-    }
-    const version =
-      r.schema_version_major !== null
-        ? `${r.schema_version_major}.${r.schema_version_minor ?? 0}.${r.schema_version_patch ?? 0}`
-        : null;
-    return {
-      id: r.id,
-      respondent_type: r.respondent_type,
-      respondent_name: r.respondent_name,
-      answer: Object.prototype.hasOwnProperty.call(r.answers, currentFieldName)
-        ? r.answers[currentFieldName]
-        : undefined,
-      justification: r.justifications?.[currentFieldName],
-      is_latest: r.is_latest,
-      isFieldStale,
-      schemaVersion: version,
-    };
+  const {
+    fieldResponses,
+    answerGroups,
+    currentFieldEquivalences,
+    allowEquivalence,
+  } = useCompareFieldData({
+    currentDoc,
+    currentFieldName,
+    currentField,
+    responses,
+    fields,
+    projectPydanticHash,
+    equivalencesByDocField,
   });
 
-  const currentFieldEquivalences = useMemo<EquivalencePairWire[]>(() => {
-    if (!currentDoc || !currentFieldName) return [];
-    return equivalencesByDocField[currentDoc.id]?.[currentFieldName] ?? [];
-  }, [equivalencesByDocField, currentDoc, currentFieldName]);
+  const currentVerdict =
+    currentDoc && currentFieldName
+      ? localReviews[currentDoc.id]?.[currentFieldName] ?? null
+      : null;
 
-  const allowEquivalence = useMemo(() => {
-    return !!currentField && isFreeTextField(currentField);
-  }, [currentField]);
+  // Comentário editável, semeado do veredito do contexto atual. Resetado por
+  // GUARD DE RENDER (não por effect) quando muda o par (doc, campo): elimina o
+  // `no-derived-state` que o effect disparava. O prev-tracker é um `useRef`
+  // (não `useState`) para não recair em `rerender-state-only-in-handlers`, e o
+  // estado inicia em "" (literal, não prop) para não disparar `no-derived-useState`.
+  const [comment, setComment] = useState("");
+  const commentCtxKey =
+    currentDoc && currentFieldName
+      ? `${currentDoc.id}|${currentFieldName}`
+      : null;
+  // Sentinela `undefined` (≠ qualquer chave e ≠ null) força o guard a disparar
+  // no PRIMEIRO render, semeando o comentário do veredito existente já na
+  // montagem — o effect original fazia isso (depois do paint); aqui é antes.
+  const commentCtxRef = useRef<string | null | undefined>(undefined);
+  if (commentCtxKey !== commentCtxRef.current) {
+    commentCtxRef.current = commentCtxKey;
+    setComment(currentVerdict?.comment ?? "");
+  }
+  const clearComment = useCallback(() => setComment(""), []);
 
-  const answerGroups = useMemo(() => {
-    const present = fieldResponses.filter((r) => r.answer !== undefined);
-    const groupKeys = buildResponseGroupKeys(
-      present,
-      currentFieldEquivalences,
-      (r) => normalizeForComparison(r.answer),
-    );
-    const map = new Map<string, typeof fieldResponses>();
-    for (const r of present) {
-      const key = groupKeys.get(r.id) ?? r.id;
-      if (!map.has(key)) map.set(key, []);
-      map.get(key)!.push(r);
-    }
-    return Array.from(map.values()).toSorted((a, b) => b.length - a.length);
-  }, [fieldResponses, currentFieldEquivalences]);
+  const {
+    handleVerdict,
+    handleConfirmEquivalent,
+    handleMarkReviewed,
+    handleUnmarkPair,
+  } = useCompareVerdicts({
+    projectId,
+    currentDoc,
+    currentFieldName,
+    isCurrentFieldDivergent,
+    allDocDivergent,
+    localReviews,
+    fieldResponses,
+    comment,
+    recordReview,
+    goNextField,
+    clearComment,
+  });
 
-  const handleVerdict = useCallback(
-    async (verdict: string, chosenResponseId?: string) => {
-      if (!currentDoc || !currentFieldName || !isCurrentFieldDivergent) return;
-
-      const verdictComment = comment || undefined;
-
-      const nextDocReviews = {
-        ...localReviews[currentDoc.id],
-        [currentFieldName]: {
-          verdict,
-          chosenResponseId: chosenResponseId ?? null,
-          comment: verdictComment ?? null,
-        },
-      };
-      setLocalReviews((prev) => ({
-        ...prev,
-        [currentDoc.id]: { ...prev[currentDoc.id], ...nextDocReviews },
-      }));
-
-      const snapshot: ResponseSnapshotEntry[] = fieldResponses
-        .filter((r) => r.answer !== undefined)
-        .map((r) => ({
-          id: r.id,
-          respondent_name: r.respondent_name,
-          respondent_type: r.respondent_type,
-          answer: r.answer,
-          ...(r.justification ? { justification: r.justification } : {}),
-        }));
-
-      await submitVerdict(projectId, currentDoc.id, currentFieldName, verdict, chosenResponseId, verdictComment, snapshot);
-
-      setComment("");
-      toast.success("Veredito salvo!");
-
-      // Usa `nextDocReviews` (já contém o veredito recém-emitido) em vez de
-      // `localReviews`, que ainda reflete o estado pré-setState neste closure.
-      const allFieldsReviewed = allDocDivergent.every((fn) => !!nextDocReviews[fn]);
-
-      if (allFieldsReviewed) {
-        toast.success("Revisão do documento concluída!");
-      } else if (fieldIndex < docFields.length - 1) {
-        setFieldIndex((idx) => idx + 1);
-      }
-    },
-    [projectId, currentDoc, currentFieldName, isCurrentFieldDivergent, fieldIndex, docFields, allDocDivergent, localReviews, comment, fieldResponses]
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const toggleFullscreen = useCallback(
+    () => setIsFullscreen((prev) => !prev),
+    [],
   );
+  const exitFullscreen = useCallback(() => setIsFullscreen(false), []);
+  const [listCollapsed, setListCollapsed] = useState(false);
+  const toggleList = useCallback(() => setListCollapsed((v) => !v), []);
 
-  const handleDocNavigate = useCallback(
-    (newIndex: number) => {
-      if (documents.length === 0) return;
-      const clamped = Math.max(0, Math.min(newIndex, documents.length - 1));
-      setPinnedDocId(documents[clamped].id);
-      setFieldIndex(0);
-    },
-    [documents]
+  useCompareKeyboard({
+    isFullscreen,
+    isCurrentDocComplete,
+    isCurrentFieldDivergent,
+    currentField,
+    answerGroups,
+    onToggleFullscreen: toggleFullscreen,
+    onExitFullscreen: exitFullscreen,
+    onNextField: goNextField,
+    onPrevField: goPrevField,
+    onVerdict: handleVerdict,
+  });
+
+  const reviewed = docFields.map(
+    (fn) => !!localReviews[currentDoc?.id ?? ""]?.[fn],
   );
-
-  const toggleFullscreen = useCallback(() => setIsFullscreen((prev) => !prev), []);
-
-  const handleMarkReviewed = useCallback(async () => {
-    if (!currentDoc) return;
-    await markCompareDocReviewed(projectId, currentDoc.id);
-    toast.success("Documento marcado como revisado.");
-  }, [projectId, currentDoc]);
-
-  const handleConfirmEquivalent = useCallback(
-    async (
-      responseIds: string[],
-      gabaritoId: string,
-      verdictDisplay: string,
-    ) => {
-      if (!currentDoc || !currentFieldName || !isCurrentFieldDivergent) return;
-
-      const verdictComment = comment || undefined;
-      const docId = currentDoc.id;
-      const fieldName = currentFieldName;
-
-      const nextDocReviews = {
-        ...localReviews[docId],
-        [fieldName]: {
-          verdict: verdictDisplay,
-          chosenResponseId: gabaritoId,
-          comment: verdictComment ?? null,
-        },
-      };
-      setLocalReviews((prev) => ({
-        ...prev,
-        [docId]: { ...prev[docId], ...nextDocReviews },
-      }));
-
-      const snapshot: ResponseSnapshotEntry[] = fieldResponses
-        .filter((r) => r.answer !== undefined)
-        .map((r) => ({
-          id: r.id,
-          respondent_name: r.respondent_name,
-          respondent_type: r.respondent_type,
-          answer: r.answer,
-          ...(r.justification ? { justification: r.justification } : {}),
-        }));
-
-      try {
-        await confirmEquivalentVerdict(
-          projectId,
-          docId,
-          fieldName,
-          responseIds,
-          gabaritoId,
-          verdictDisplay,
-          verdictComment,
-          snapshot,
-        );
-        setComment("");
-        toast.success(
-          `${responseIds.length} respostas marcadas como equivalentes.`,
-        );
-
-        // Usa `nextDocReviews` (já contém o veredito recém-emitido) em vez de
-        // `localReviews`, que ainda reflete o estado pré-setState neste closure.
-        const allFieldsReviewed = allDocDivergent.every(
-          (fn) => !!nextDocReviews[fn],
-        );
-        if (allFieldsReviewed) {
-          toast.success("Revisão do documento concluída!");
-        } else if (fieldIndex < docFields.length - 1) {
-          setFieldIndex((idx) => idx + 1);
-        }
-      } catch (err) {
-        toast.error(
-          err instanceof Error ? err.message : "Falha ao marcar equivalentes.",
-        );
-      }
-    },
-    [
-      projectId,
-      currentDoc,
-      currentFieldName,
-      isCurrentFieldDivergent,
-      fieldIndex,
-      docFields,
-      allDocDivergent,
-      localReviews,
-      comment,
-      fieldResponses,
-    ],
-  );
-
-  const handleUnmarkPair = useCallback(
-    async (pairId: string) => {
-      try {
-        await unmarkEquivalencePair(projectId, pairId);
-        toast.success("Equivalência removida.");
-      } catch (err) {
-        toast.error(
-          err instanceof Error ? err.message : "Falha ao desfazer equivalência.",
-        );
-      }
-    },
-    [projectId],
-  );
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-
-      if (e.key === "F" && e.ctrlKey && e.shiftKey) {
-        e.preventDefault();
-        setIsFullscreen((prev) => !prev);
-        return;
-      }
-      if (e.key === "Escape" && isFullscreen) {
-        setIsFullscreen(false);
-        return;
-      }
-
-      if (e.key === "n" && fieldIndex < docFields.length - 1) { setFieldIndex((idx) => idx + 1); return; }
-      if (e.key === "p" && fieldIndex > 0) { setFieldIndex((idx) => idx - 1); return; }
-
-      // Doc concluído: o avanço é por ação explícita (botão "Próximo parecer"
-      // recebe foco; Enter nele é nativo). Não deixar 1-9/a/s re-disparar
-      // veredito sobre um documento já fechado.
-      if (isCurrentDocComplete) return;
-
-      if (!isCurrentFieldDivergent) return;
-
-      const isMultiField = currentField?.type === "multi" && currentField.options?.length;
-      if (isMultiField) {
-        if (e.key === "a") handleVerdict("ambiguo");
-        if (e.key === "s") handleVerdict("pular");
-        return;
-      }
-
-      const num = parseInt(e.key);
-      if (num >= 1 && num <= answerGroups.length) {
-        const group = answerGroups[num - 1];
-        const answer = group[0].answer;
-        const displayAnswer = answer == null ? "" : Array.isArray(answer) ? answer.join(", ") : String(answer);
-        handleVerdict(displayAnswer, group[0].id);
-        return;
-      }
-
-      if (e.key === "a") handleVerdict("ambiguo");
-      if (e.key === "s") handleVerdict("pular");
-    };
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [answerGroups, handleVerdict, fieldIndex, docFields.length, isFullscreen, isCurrentFieldDivergent, isCurrentDocComplete, currentField]);
 
   const docListEntries: DocListEntry[] = documents.map((d) => {
     const c = coverageByDoc[d.id];
     const reviewedOverride = localReviews[d.id]
-      ? (divergentFields[d.id] ?? []).filter((fn) => !!localReviews[d.id][fn]).length
+      ? (divergentFields[d.id] ?? []).filter((fn) => !!localReviews[d.id][fn])
+          .length
       : c?.reviewedCount ?? 0;
     return {
       id: d.id,
@@ -512,7 +201,7 @@ export function ComparePage({
           currentIndex={docIndex}
           onSelect={handleDocNavigate}
           collapsed={listCollapsed}
-          onToggle={() => setListCollapsed((v) => !v)}
+          onToggle={toggleList}
         />
         <div className="flex flex-1 items-center justify-center text-muted-foreground">
           {documents.length === 0
@@ -555,7 +244,7 @@ export function ComparePage({
           totalDocs={documents.length}
           onDocNavigate={handleDocNavigate}
           filter={filter}
-          onFilterChange={(v) => { setFilter(v); setFieldIndex(0); }}
+          onFilterChange={changeFilter}
           fields={fields}
           reviewedDocsCount={reviewedDocsCount}
           onToggleFullscreen={toggleFullscreen}
@@ -566,60 +255,50 @@ export function ComparePage({
           latestMajorLabel={latestMajorLabel}
           currentProjectVersion={currentProjectVersion}
           projectId={projectId}
-          documentId={currentDoc?.id}
+          documentId={currentDoc.id}
         />
       )}
 
-      <div className="flex flex-1 overflow-hidden">
-        <CompareDocList
-          docs={docListEntries}
-          currentIndex={docIndex}
-          onSelect={handleDocNavigate}
-          collapsed={listCollapsed}
-          onToggle={() => setListCollapsed((v) => !v)}
-        />
-
-        <ResizablePanelGroup className="flex-1">
-          <ResizablePanel defaultSize={50} minSize={25}>
-            <DocumentReader text={currentDoc.text} />
-          </ResizablePanel>
-          <ResizableHandle withHandle />
-          <ResizablePanel defaultSize={50} minSize={25}>
-            <ComparisonPanel
-              projectId={projectId}
-              documentId={currentDoc?.id}
-              documentTitle={docTitle}
-              fieldName={currentFieldName}
-              fieldDescription={currentField?.description || currentFieldName}
-              fieldType={currentField?.type}
-              fieldOptions={currentField?.options}
-              fields={fields}
-              fieldIndex={fieldIndex}
-              totalFields={docFields.length}
-              responses={fieldResponses}
-              existingVerdict={currentVerdict}
-              reviewed={reviewed}
-              isDivergent={isCurrentFieldDivergent}
-              isDocComplete={isCurrentDocComplete}
-              hasNextDoc={hasNextDoc}
-              onNextDoc={handleNextDoc}
-              onFieldNavigate={setFieldIndex}
-              onVerdict={handleVerdict}
-              onMarkReviewed={handleMarkReviewed}
-              comment={comment}
-              onCommentChange={setComment}
-              commentCount={fieldCommentCount}
-              suggestionCount={fieldSuggestionCount}
-              allowEquivalence={allowEquivalence}
-              equivalences={currentFieldEquivalences}
-              onConfirmEquivalent={handleConfirmEquivalent}
-              onUnmarkEquivalencePair={handleUnmarkPair}
-              currentUserId={currentUserId}
-              canManageAnyPair={canManageAnyPair}
-            />
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      </div>
+      <CompareWorkspace
+        docs={docListEntries}
+        docIndex={docIndex}
+        onDocNavigate={handleDocNavigate}
+        listCollapsed={listCollapsed}
+        onToggleList={toggleList}
+        documentText={currentDoc.text}
+        comparisonPanel={{
+          projectId,
+          documentId: currentDoc.id,
+          documentTitle: docTitle,
+          fieldName: currentFieldName,
+          fieldDescription: currentField?.description || currentFieldName,
+          fieldType: currentField?.type,
+          fieldOptions: currentField?.options,
+          fields,
+          fieldIndex,
+          totalFields: docFields.length,
+          responses: fieldResponses,
+          existingVerdict: currentVerdict,
+          reviewed,
+          isDivergent: isCurrentFieldDivergent,
+          isDocComplete: isCurrentDocComplete,
+          hasNextDoc,
+          onNextDoc: handleNextDoc,
+          onFieldNavigate: setFieldIndex,
+          onVerdict: handleVerdict,
+          onMarkReviewed: handleMarkReviewed,
+          comment,
+          onCommentChange: setComment,
+          commentCount: fieldCommentCount,
+          suggestionCount: fieldSuggestionCount,
+          allowEquivalence,
+          equivalences: currentFieldEquivalences,
+          onConfirmEquivalent: handleConfirmEquivalent,
+          onUnmarkEquivalencePair: handleUnmarkPair,
+          currentUserId,
+          canManageAnyPair,
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -113,6 +113,10 @@ export function ComparePage({
   // `no-derived-state` que o effect disparava. O prev-tracker é um `useRef`
   // (não `useState`) para não recair em `rerender-state-only-in-handlers`, e o
   // estado inicia em "" (literal, não prop) para não disparar `no-derived-useState`.
+  // A chave é só (doc, campo): trocar de campo re-semeia do veredito do novo
+  // campo; permanecer no mesmo campo (após emitir um veredito sem avanço)
+  // preserva o comentário recém-digitado/salvo — por isso `useCompareVerdicts`
+  // não limpa a caixa no sucesso.
   const [comment, setComment] = useState("");
   const commentCtxKey =
     currentDoc && currentFieldName
@@ -126,7 +130,6 @@ export function ComparePage({
     commentCtxRef.current = commentCtxKey;
     setComment(currentVerdict?.comment ?? "");
   }
-  const clearComment = useCallback(() => setComment(""), []);
 
   const {
     handleVerdict,
@@ -144,7 +147,6 @@ export function ComparePage({
     comment,
     recordReview,
     goNextField,
-    clearComment,
   });
 
   const [isFullscreen, setIsFullscreen] = useState(false);

--- a/frontend/src/components/compare/CompareWorkspace.tsx
+++ b/frontend/src/components/compare/CompareWorkspace.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { DocumentReader } from "../coding/DocumentReader";
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from "@/components/ui/resizable";
+import { ComparisonPanel } from "./ComparisonPanel";
+import { CompareDocList, type DocListEntry } from "./CompareDocList";
+
+interface CompareWorkspaceProps {
+  docs: DocListEntry[];
+  docIndex: number;
+  onDocNavigate: (index: number) => void;
+  listCollapsed: boolean;
+  onToggleList: () => void;
+  documentText: string;
+  comparisonPanel: React.ComponentProps<typeof ComparisonPanel>;
+}
+
+/**
+ * Corpo presentacional da Comparação: lista de documentos + leitor do texto e
+ * o painel de comparação, lado a lado e redimensionáveis. Extraído de
+ * `ComparePage` para reduzir o tamanho do container (`no-giant-component`).
+ */
+export function CompareWorkspace({
+  docs,
+  docIndex,
+  onDocNavigate,
+  listCollapsed,
+  onToggleList,
+  documentText,
+  comparisonPanel,
+}: CompareWorkspaceProps) {
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      <CompareDocList
+        docs={docs}
+        currentIndex={docIndex}
+        onSelect={onDocNavigate}
+        collapsed={listCollapsed}
+        onToggle={onToggleList}
+      />
+
+      <ResizablePanelGroup className="flex-1">
+        <ResizablePanel defaultSize={50} minSize={25}>
+          <DocumentReader text={documentText} />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize={50} minSize={25}>
+          <ComparisonPanel {...comparisonPanel} />
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+}

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// Smoke de ÁRVORE REAL: renderiza os filhos reais (CompareNav, ComparisonPanel,
+// CompareWorkspace) para garantir que o container os monta com props válidas e
+// que um veredito clicado no painel real chega ao Server Action. Só o
+// DocumentReader é mockado (usa react-markdown via next/dynamic, ruidoso em
+// jsdom e irrelevante para esta verificação).
+const { submitVerdict, markCompareDocReviewed } = vi.hoisted(() => ({
+  submitVerdict: vi.fn(async () => {}),
+  markCompareDocReviewed: vi.fn(async () => {}),
+}));
+const { confirmEquivalentVerdict, unmarkEquivalencePair } = vi.hoisted(() => ({
+  confirmEquivalentVerdict: vi.fn(async () => {}),
+  unmarkEquivalencePair: vi.fn(async () => {}),
+}));
+
+vi.mock("@/actions/reviews", () => ({ submitVerdict, markCompareDocReviewed }));
+vi.mock("@/actions/equivalences", () => ({
+  confirmEquivalentVerdict,
+  unmarkEquivalencePair,
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+vi.mock("@/components/coding/DocumentReader", () => ({
+  DocumentReader: ({ text }: { text: string }) => (
+    <div data-testid="doc-reader">{text}</div>
+  ),
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/analyze/compare",
+}));
+
+import { ComparePage } from "@/components/compare/ComparePage";
+import type { PydanticField } from "@/lib/types";
+import type { CompareResponse } from "@/components/compare/compare-types";
+
+const fields: PydanticField[] = [
+  { name: "campoA", type: "text", options: null, description: "Pergunta A", hash: "hA" },
+  { name: "campoB", type: "text", options: null, description: "Pergunta B", hash: "hB" },
+];
+
+const documents = [
+  { id: "d1", title: "Doc 1", external_id: null, text: "Texto do documento 1" },
+];
+
+function resp(
+  id: string,
+  type: "humano" | "llm",
+  name: string,
+  answers: Record<string, unknown>,
+): CompareResponse {
+  return {
+    id,
+    respondent_type: type,
+    respondent_name: name,
+    answers,
+    justifications: null,
+    is_latest: true,
+    pydantic_hash: null,
+    answer_field_hashes: null,
+    schema_version_major: null,
+    schema_version_minor: null,
+    schema_version_patch: null,
+    created_at: "2026-01-01",
+  };
+}
+
+const props = {
+  projectId: "p1",
+  documents,
+  responses: {
+    d1: [
+      resp("r1", "humano", "Ana", { campoA: "Deferido", campoB: "Sim" }),
+      resp("r2", "llm", "GPT", { campoA: "Indeferido", campoB: "Não" }),
+    ],
+  },
+  divergentFields: { d1: ["campoA", "campoB"] },
+  fields,
+  existingReviews: {},
+  projectPydanticHash: null,
+  respondentNames: ["Ana", "GPT"],
+  defaultMinHumans: 2,
+  coverageByDoc: {
+    d1: {
+      docId: "d1",
+      humanCount: 1,
+      totalCount: 2,
+      assignedCodingCount: 1,
+      humansFromAssigned: 1,
+      divergentCount: 2,
+      reviewedCount: 0,
+      assignmentStatus: null,
+    },
+  },
+  commentCountsByKey: {},
+  suggestionCountsByField: {},
+  availableVersions: ["1.0.0"],
+  latestMajorLabel: null,
+  currentProjectVersion: "1.0.0",
+  equivalencesByDocField: {},
+  currentUserId: "u1",
+  canManageAnyPair: false,
+};
+
+const renderReal = () =>
+  render(
+    <TooltipProvider>
+      <ComparePage {...props} />
+    </TooltipProvider>,
+  );
+
+// jsdom não tem ResizeObserver — exigido por react-resizable-panels.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+beforeEach(() => submitVerdict.mockClear());
+afterEach(cleanup);
+
+describe("ComparePage — árvore real (smoke)", () => {
+  it("monta os filhos reais e exibe o texto do documento e as respostas", () => {
+    renderReal();
+    expect(screen.getByTestId("doc-reader").textContent).toBe(
+      "Texto do documento 1",
+    );
+    // O ComparisonPanel real renderiza as respostas divergentes do campo atual.
+    expect(screen.getByText("Deferido")).not.toBeNull();
+    expect(screen.getByText("Indeferido")).not.toBeNull();
+  });
+
+  it("clicar 'Ambiguo' no painel real dispara submitVerdict", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    await user.click(screen.getByRole("button", { name: /Ambiguo/i }));
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+    expect(submitVerdict).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      "campoA",
+      "ambiguo",
+      undefined,
+      undefined,
+      expect.any(Array),
+    );
+  });
+});

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Mocks dos Server Actions e do toast (efeitos colaterais fora do escopo do
+// teste de lógica do container).
+const { submitVerdict, markCompareDocReviewed } = vi.hoisted(() => ({
+  submitVerdict: vi.fn(async () => {}),
+  markCompareDocReviewed: vi.fn(async () => {}),
+}));
+const { confirmEquivalentVerdict, unmarkEquivalencePair } = vi.hoisted(() => ({
+  confirmEquivalentVerdict: vi.fn(async () => {}),
+  unmarkEquivalencePair: vi.fn(async () => {}),
+}));
+
+vi.mock("@/actions/reviews", () => ({ submitVerdict, markCompareDocReviewed }));
+vi.mock("@/actions/equivalences", () => ({
+  confirmEquivalentVerdict,
+  unmarkEquivalencePair,
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+// Mock das views: expõem só os controles necessários para dirigir a lógica do
+// container (input de comentário, troca de campo/doc, emissão de veredito).
+interface MockComparisonPanel {
+  fieldName: string;
+  fieldIndex: number;
+  comment: string;
+  onCommentChange: (v: string) => void;
+  onFieldNavigate: (i: number) => void;
+  onVerdict: (verdict: string, chosenResponseId?: string) => void;
+}
+
+vi.mock("@/components/compare/CompareWorkspace", () => ({
+  CompareWorkspace: ({
+    documentText,
+    comparisonPanel,
+  }: {
+    documentText: string;
+    comparisonPanel: MockComparisonPanel;
+  }) => (
+    <div>
+      <span data-testid="doc-text">{documentText}</span>
+      <span data-testid="field-name">{comparisonPanel.fieldName}</span>
+      <input
+        data-testid="comment"
+        value={comparisonPanel.comment}
+        onChange={(e) => comparisonPanel.onCommentChange(e.target.value)}
+      />
+      <button
+        data-testid="next-field"
+        onClick={() =>
+          comparisonPanel.onFieldNavigate(comparisonPanel.fieldIndex + 1)
+        }
+      >
+        next field
+      </button>
+      <button
+        data-testid="emit-verdict"
+        onClick={() => comparisonPanel.onVerdict("Deferido", "r1")}
+      >
+        verdict
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/compare/CompareNav", () => ({
+  CompareNav: ({
+    docIndex,
+    onFilterChange,
+    onDocNavigate,
+  }: {
+    docIndex: number;
+    onFilterChange: (v: string) => void;
+    onDocNavigate: (i: number) => void;
+  }) => (
+    <div>
+      <span data-testid="nav-doc-index">{docIndex}</span>
+      <button data-testid="set-filter-all" onClick={() => onFilterChange("all")}>
+        filter all
+      </button>
+      <button data-testid="nav-next-doc" onClick={() => onDocNavigate(1)}>
+        nav doc 1
+      </button>
+    </div>
+  ),
+}));
+
+import { ComparePage } from "@/components/compare/ComparePage";
+import type { PydanticField } from "@/lib/types";
+import type { ReviewsByDoc } from "@/lib/compare-reviews";
+
+const fields: PydanticField[] = [
+  { name: "campoA", type: "text", options: null, description: "Campo A", hash: "hA" },
+  { name: "campoB", type: "text", options: null, description: "Campo B", hash: "hB" },
+];
+
+const documents = [
+  { id: "d1", title: "Doc 1", external_id: null, text: "Texto do documento 1" },
+  { id: "d2", title: "Doc 2", external_id: null, text: "Texto do documento 2" },
+];
+
+const divergentFields: Record<string, string[]> = {
+  d1: ["campoA", "campoB"],
+  d2: ["campoA"],
+};
+
+const coverage = (docId: string) => ({
+  docId,
+  humanCount: 2,
+  totalCount: 2,
+  assignedCodingCount: 2,
+  humansFromAssigned: 2,
+  divergentCount: divergentFields[docId].length,
+  reviewedCount: 0,
+  assignmentStatus: null,
+});
+
+function makeProps(existingReviews: ReviewsByDoc = {}) {
+  return {
+    projectId: "p1",
+    documents,
+    responses: { d1: [], d2: [] },
+    divergentFields,
+    fields,
+    existingReviews,
+    projectPydanticHash: null,
+    respondentNames: ["Ana", "Bia"],
+    defaultMinHumans: 2,
+    coverageByDoc: { d1: coverage("d1"), d2: coverage("d2") },
+    commentCountsByKey: {},
+    suggestionCountsByField: {},
+    availableVersions: ["1.0.0"],
+    latestMajorLabel: null,
+    currentProjectVersion: "1.0.0",
+    equivalencesByDocField: {},
+    currentUserId: "u1",
+    canManageAnyPair: false,
+  };
+}
+
+const text = (id: string) => screen.getByTestId(id).textContent;
+const commentInput = () => screen.getByTestId("comment") as HTMLInputElement;
+
+beforeEach(() => {
+  submitVerdict.mockClear();
+  markCompareDocReviewed.mockClear();
+  confirmEquivalentVerdict.mockClear();
+  unmarkEquivalencePair.mockClear();
+});
+
+afterEach(cleanup);
+
+describe("ComparePage — lógica do container após refatoração", () => {
+  it("semeia o comentário do veredito existente já na montagem", () => {
+    render(
+      <ComparePage
+        {...makeProps({
+          d1: {
+            campoA: {
+              verdict: "X",
+              chosenResponseId: null,
+              comment: "nota inicial",
+            },
+          },
+        })}
+      />,
+    );
+    expect(text("field-name")).toBe("campoA");
+    expect(commentInput().value).toBe("nota inicial");
+  });
+
+  it("reseta o comentário ao trocar de campo (descarta rascunho, semeia do novo veredito)", async () => {
+    const user = userEvent.setup();
+    render(
+      <ComparePage
+        {...makeProps({
+          d1: {
+            campoB: {
+              verdict: "Deferido",
+              chosenResponseId: null,
+              comment: "comentário do campo B",
+            },
+          },
+        })}
+      />,
+    );
+
+    expect(text("field-name")).toBe("campoA");
+    expect(commentInput().value).toBe("");
+
+    await user.type(commentInput(), "rascunho");
+    expect(commentInput().value).toBe("rascunho");
+
+    await user.click(screen.getByTestId("next-field"));
+
+    expect(text("field-name")).toBe("campoB");
+    expect(commentInput().value).toBe("comentário do campo B");
+  });
+
+  it("trocar o filtro reseta o índice de campo para o primeiro", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.click(screen.getByTestId("next-field"));
+    expect(text("field-name")).toBe("campoB");
+
+    await user.click(screen.getByTestId("set-filter-all"));
+    expect(text("field-name")).toBe("campoA");
+  });
+
+  it("navegar de documento fixa o doc e cai no primeiro campo divergente dele", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    expect(text("doc-text")).toBe("Texto do documento 1");
+
+    await user.click(screen.getByTestId("nav-next-doc"));
+
+    expect(text("doc-text")).toBe("Texto do documento 2");
+    expect(text("field-name")).toBe("campoA");
+  });
+
+  it("teclas 'n'/'p' navegam entre campos (atalhos extraídos para useCompareKeyboard)", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    expect(text("field-name")).toBe("campoA");
+    await user.keyboard("n");
+    expect(text("field-name")).toBe("campoB");
+    await user.keyboard("p");
+    expect(text("field-name")).toBe("campoA");
+  });
+
+  it("emitir veredito chama submitVerdict e avança para o próximo campo", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    expect(text("field-name")).toBe("campoA");
+
+    await user.click(screen.getByTestId("emit-verdict"));
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+    expect(submitVerdict).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      "campoA",
+      "Deferido",
+      "r1",
+      undefined,
+      expect.any(Array),
+    );
+    // campoA fechou, campoB ainda pendente → avança para campoB.
+    await waitFor(() => expect(text("field-name")).toBe("campoB"));
+  });
+});

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -24,7 +24,8 @@ vi.mock("sonner", () => ({
 }));
 
 // Mock das views: expõem só os controles necessários para dirigir a lógica do
-// container (input de comentário, troca de campo/doc, emissão de veredito).
+// container. NÃO testam o render dos filhos reais (CompareNav/ComparisonPanel/
+// DocumentReader), que este PR não altera e têm contrato garantido por tsc.
 interface MockComparisonPanel {
   fieldName: string;
   fieldIndex: number;
@@ -32,6 +33,12 @@ interface MockComparisonPanel {
   onCommentChange: (v: string) => void;
   onFieldNavigate: (i: number) => void;
   onVerdict: (verdict: string, chosenResponseId?: string) => void;
+  onConfirmEquivalent: (
+    responseIds: string[],
+    gabaritoId: string,
+    verdictDisplay: string,
+  ) => Promise<void>;
+  onMarkReviewed: () => void;
 }
 
 vi.mock("@/components/compare/CompareWorkspace", () => ({
@@ -64,6 +71,20 @@ vi.mock("@/components/compare/CompareWorkspace", () => ({
       >
         verdict
       </button>
+      <button
+        data-testid="confirm-equiv"
+        onClick={() =>
+          comparisonPanel.onConfirmEquivalent(["r1", "r2"], "r1", "Equivalentes")
+        }
+      >
+        equiv
+      </button>
+      <button
+        data-testid="mark-reviewed"
+        onClick={() => comparisonPanel.onMarkReviewed()}
+      >
+        mark reviewed
+      </button>
     </div>
   ),
 }));
@@ -83,6 +104,12 @@ vi.mock("@/components/compare/CompareNav", () => ({
       <button data-testid="set-filter-all" onClick={() => onFilterChange("all")}>
         filter all
       </button>
+      <button
+        data-testid="set-filter-b"
+        onClick={() => onFilterChange("campoB")}
+      >
+        filter campoB
+      </button>
       <button data-testid="nav-next-doc" onClick={() => onDocNavigate(1)}>
         nav doc 1
       </button>
@@ -90,9 +117,16 @@ vi.mock("@/components/compare/CompareNav", () => ({
   ),
 }));
 
+vi.mock("@/components/coding/FullscreenNav", () => ({
+  FullscreenNav: ({ title }: { title: string }) => (
+    <div data-testid="fullscreen-nav">{title}</div>
+  ),
+}));
+
 import { ComparePage } from "@/components/compare/ComparePage";
 import type { PydanticField } from "@/lib/types";
 import type { ReviewsByDoc } from "@/lib/compare-reviews";
+import type { CompareResponse } from "@/components/compare/compare-types";
 
 const fields: PydanticField[] = [
   { name: "campoA", type: "text", options: null, description: "Campo A", hash: "hA" },
@@ -107,6 +141,36 @@ const documents = [
 const divergentFields: Record<string, string[]> = {
   d1: ["campoA", "campoB"],
   d2: ["campoA"],
+};
+
+function resp(
+  id: string,
+  type: "humano" | "llm",
+  name: string,
+  answers: Record<string, unknown>,
+): CompareResponse {
+  return {
+    id,
+    respondent_type: type,
+    respondent_name: name,
+    answers,
+    justifications: null,
+    is_latest: true,
+    pydantic_hash: null,
+    answer_field_hashes: null,
+    schema_version_major: null,
+    schema_version_minor: null,
+    schema_version_patch: null,
+    created_at: "2026-01-01",
+  };
+}
+
+const responses: Record<string, CompareResponse[]> = {
+  d1: [
+    resp("r1", "humano", "Ana", { campoA: "Deferido", campoB: "Sim" }),
+    resp("r2", "llm", "GPT", { campoA: "Indeferido", campoB: "Não" }),
+  ],
+  d2: [resp("r3", "humano", "Ana", { campoA: "Deferido" })],
 };
 
 const coverage = (docId: string) => ({
@@ -124,7 +188,7 @@ function makeProps(existingReviews: ReviewsByDoc = {}) {
   return {
     projectId: "p1",
     documents,
-    responses: { d1: [], d2: [] },
+    responses,
     divergentFields,
     fields,
     existingReviews,
@@ -145,6 +209,11 @@ function makeProps(existingReviews: ReviewsByDoc = {}) {
 
 const text = (id: string) => screen.getByTestId(id).textContent;
 const commentInput = () => screen.getByTestId("comment") as HTMLInputElement;
+const verdict = (verdictName: string, comment: string | null = null) => ({
+  verdict: verdictName,
+  chosenResponseId: null,
+  comment,
+});
 
 beforeEach(() => {
   submitVerdict.mockClear();
@@ -155,19 +224,11 @@ beforeEach(() => {
 
 afterEach(cleanup);
 
-describe("ComparePage — lógica do container após refatoração", () => {
+describe("ComparePage — comentário (fix no-derived-state)", () => {
   it("semeia o comentário do veredito existente já na montagem", () => {
     render(
       <ComparePage
-        {...makeProps({
-          d1: {
-            campoA: {
-              verdict: "X",
-              chosenResponseId: null,
-              comment: "nota inicial",
-            },
-          },
-        })}
+        {...makeProps({ d1: { campoA: verdict("X", "nota inicial") } })}
       />,
     );
     expect(text("field-name")).toBe("campoA");
@@ -178,15 +239,7 @@ describe("ComparePage — lógica do container após refatoração", () => {
     const user = userEvent.setup();
     render(
       <ComparePage
-        {...makeProps({
-          d1: {
-            campoB: {
-              verdict: "Deferido",
-              chosenResponseId: null,
-              comment: "comentário do campo B",
-            },
-          },
-        })}
+        {...makeProps({ d1: { campoB: verdict("Deferido", "comentário do campo B") } })}
       />,
     );
 
@@ -201,7 +254,9 @@ describe("ComparePage — lógica do container após refatoração", () => {
     expect(text("field-name")).toBe("campoB");
     expect(commentInput().value).toBe("comentário do campo B");
   });
+});
 
+describe("ComparePage — navegação e filtro", () => {
   it("trocar o filtro reseta o índice de campo para o primeiro", async () => {
     const user = userEvent.setup();
     render(<ComparePage {...makeProps()} />);
@@ -211,6 +266,18 @@ describe("ComparePage — lógica do container após refatoração", () => {
 
     await user.click(screen.getByTestId("set-filter-all"));
     expect(text("field-name")).toBe("campoA");
+  });
+
+  it("filtrar por um campo estreita a fila e o avanço fica preso nele", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.click(screen.getByTestId("set-filter-b"));
+    expect(text("field-name")).toBe("campoB");
+
+    // Só há campoB na fila filtrada → a tecla 'n' (goNextField) fica presa nele.
+    await user.keyboard("n");
+    expect(text("field-name")).toBe("campoB");
   });
 
   it("navegar de documento fixa o doc e cai no primeiro campo divergente dele", async () => {
@@ -224,8 +291,10 @@ describe("ComparePage — lógica do container após refatoração", () => {
     expect(text("doc-text")).toBe("Texto do documento 2");
     expect(text("field-name")).toBe("campoA");
   });
+});
 
-  it("teclas 'n'/'p' navegam entre campos (atalhos extraídos para useCompareKeyboard)", async () => {
+describe("ComparePage — atalhos de teclado (fix no-cascading-set-state)", () => {
+  it("teclas 'n'/'p' navegam entre campos", async () => {
     const user = userEvent.setup();
     render(<ComparePage {...makeProps()} />);
 
@@ -236,6 +305,96 @@ describe("ComparePage — lógica do container após refatoração", () => {
     expect(text("field-name")).toBe("campoA");
   });
 
+  it("número emite veredito do grupo de resposta correspondente", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    // campoA: grupos [Deferido(r1), Indeferido(r2)] → '2' escolhe Indeferido.
+    await user.keyboard("2");
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+    expect(submitVerdict).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      "campoA",
+      "Indeferido",
+      "r2",
+      undefined,
+      expect.any(Array),
+    );
+  });
+
+  it("tecla 'a' emite veredito 'ambiguo' e 's' emite 'pular'", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.keyboard("a");
+    expect(submitVerdict).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      "campoA",
+      "ambiguo",
+      undefined,
+      undefined,
+      expect.any(Array),
+    );
+  });
+
+  it("o comentário digitado segue junto no veredito por teclado", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.type(commentInput(), "minha nota");
+    // Atalhos ficam desativados com foco no input; sair do campo reabilita.
+    commentInput().blur();
+
+    await user.keyboard("1");
+
+    expect(submitVerdict).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      "campoA",
+      "Deferido",
+      "r1",
+      "minha nota",
+      expect.any(Array),
+    );
+  });
+
+  it("não dispara veredito por teclado quando o documento já está concluído", async () => {
+    const user = userEvent.setup();
+    render(
+      <ComparePage
+        {...makeProps({
+          d1: { campoA: verdict("Deferido"), campoB: verdict("Sim") },
+        })}
+      />,
+    );
+
+    await user.keyboard("1");
+    await user.keyboard("a");
+    expect(submitVerdict).not.toHaveBeenCalled();
+  });
+
+  it("Ctrl+Shift+F entra em tela cheia e Esc sai", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    // Não-fullscreen: CompareNav (mock) presente, FullscreenNav ausente.
+    expect(screen.queryByTestId("nav-doc-index")).not.toBeNull();
+    expect(screen.queryByTestId("fullscreen-nav")).toBeNull();
+
+    await user.keyboard("{Control>}{Shift>}F{/Shift}{/Control}");
+    expect(screen.queryByTestId("fullscreen-nav")).not.toBeNull();
+    expect(screen.queryByTestId("nav-doc-index")).toBeNull();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByTestId("fullscreen-nav")).toBeNull();
+    expect(screen.queryByTestId("nav-doc-index")).not.toBeNull();
+  });
+});
+
+describe("ComparePage — vereditos e equivalências (useCompareVerdicts)", () => {
   it("emitir veredito chama submitVerdict e avança para o próximo campo", async () => {
     const user = userEvent.setup();
     render(<ComparePage {...makeProps()} />);
@@ -254,7 +413,35 @@ describe("ComparePage — lógica do container após refatoração", () => {
       undefined,
       expect.any(Array),
     );
-    // campoA fechou, campoB ainda pendente → avança para campoB.
     await waitFor(() => expect(text("field-name")).toBe("campoB"));
+  });
+
+  it("confirmar equivalência chama confirmEquivalentVerdict e avança o campo", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.click(screen.getByTestId("confirm-equiv"));
+
+    expect(confirmEquivalentVerdict).toHaveBeenCalledTimes(1);
+    expect(confirmEquivalentVerdict).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      "campoA",
+      ["r1", "r2"],
+      "r1",
+      "Equivalentes",
+      undefined,
+      expect.any(Array),
+    );
+    await waitFor(() => expect(text("field-name")).toBe("campoB"));
+  });
+
+  it("marcar revisado chama markCompareDocReviewed do doc atual", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.click(screen.getByTestId("mark-reviewed"));
+
+    expect(markCompareDocReviewed).toHaveBeenCalledWith("p1", "d1");
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -254,6 +254,25 @@ describe("ComparePage — comentário (fix no-derived-state)", () => {
     expect(text("field-name")).toBe("campoB");
     expect(commentInput().value).toBe("comentário do campo B");
   });
+
+  it("preserva o comentário na caixa após emitir veredito sem avançar de campo", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    // Filtra para um único campo → emitir veredito não troca de campo (a fila
+    // filtrada tem só campoB), então a caixa deve manter o comentário salvo.
+    await user.click(screen.getByTestId("set-filter-b"));
+    expect(text("field-name")).toBe("campoB");
+
+    await user.type(commentInput(), "minha nota");
+    expect(commentInput().value).toBe("minha nota");
+
+    await user.click(screen.getByTestId("emit-verdict"));
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+    expect(text("field-name")).toBe("campoB");
+    expect(commentInput().value).toBe("minha nota");
+  });
 });
 
 describe("ComparePage — navegação e filtro", () => {
@@ -290,6 +309,37 @@ describe("ComparePage — navegação e filtro", () => {
 
     expect(text("doc-text")).toBe("Texto do documento 2");
     expect(text("field-name")).toBe("campoA");
+  });
+
+  it("clampa o índice de campo quando divergentFields encolhe (não vira undefined)", async () => {
+    const user = userEvent.setup();
+    const fieldsABC: PydanticField[] = [
+      ...fields,
+      { name: "campoC", type: "text", options: null, description: "Campo C", hash: "hC" },
+    ];
+    const base = {
+      ...makeProps(),
+      fields: fieldsABC,
+      divergentFields: { d1: ["campoA", "campoB", "campoC"], d2: ["campoA"] },
+    };
+    const { rerender } = render(<ComparePage {...base} />);
+
+    // Navega até o último campo (campoC) → fieldIndex interno = 2.
+    await user.keyboard("n");
+    await user.keyboard("n");
+    expect(text("field-name")).toBe("campoC");
+
+    // Servidor revalida e o doc passa a ter só 2 campos divergentes; o filtro e
+    // o doc não mudaram, então fieldIndex (=2) fica fora de range.
+    rerender(
+      <ComparePage
+        {...base}
+        divergentFields={{ d1: ["campoA", "campoB"], d2: ["campoA"] }}
+      />,
+    );
+
+    // Sem o clamp, docFields[2] seria undefined; com clamp cai no último válido.
+    expect(text("field-name")).toBe("campoB");
   });
 });
 

--- a/frontend/src/components/compare/compare-types.ts
+++ b/frontend/src/components/compare/compare-types.ts
@@ -1,0 +1,44 @@
+// Tipos "wire" compartilhados entre `ComparePage`, seus hooks e a view
+// `CompareWorkspace`. Extraídos de `ComparePage` para evitar import circular de
+// tipos quando os hooks foram destacados do container.
+
+export interface EquivalencePairWire {
+  id: string;
+  response_a_id: string;
+  response_b_id: string;
+  reviewer_id: string | null;
+}
+
+export interface CompareResponse {
+  id: string;
+  respondent_type: "humano" | "llm";
+  respondent_name: string;
+  answers: Record<string, unknown>;
+  justifications: Record<string, string> | null;
+  is_latest: boolean;
+  pydantic_hash: string | null;
+  answer_field_hashes: Record<string, string> | null;
+  schema_version_major: number | null;
+  schema_version_minor: number | null;
+  schema_version_patch: number | null;
+  created_at: string;
+}
+
+export interface CompareDocument {
+  id: string;
+  title: string | null;
+  external_id: string | null;
+  text: string;
+}
+
+/** Forma de cada item em `fieldResponses` (derivado por `useCompareFieldData`). */
+export interface FieldResponse {
+  id: string;
+  respondent_type: "humano" | "llm";
+  respondent_name: string;
+  answer: unknown;
+  justification: string | undefined;
+  is_latest: boolean;
+  isFieldStale: boolean;
+  schemaVersion: string | null;
+}

--- a/frontend/src/components/compare/useCompareFieldData.ts
+++ b/frontend/src/components/compare/useCompareFieldData.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo } from "react";
+import { normalizeForComparison } from "@/lib/utils";
+import { isFreeTextField } from "@/lib/compare-divergence";
+import { buildResponseGroupKeys } from "@/lib/equivalence";
+import type { PydanticField } from "@/lib/types";
+import type {
+  CompareDocument,
+  CompareResponse,
+  EquivalencePairWire,
+  FieldResponse,
+} from "./compare-types";
+
+interface UseCompareFieldDataParams {
+  currentDoc: CompareDocument | undefined;
+  currentFieldName: string;
+  currentField: PydanticField | undefined;
+  responses: Record<string, CompareResponse[]>;
+  fields: PydanticField[];
+  projectPydanticHash: string | null;
+  equivalencesByDocField: Record<
+    string,
+    Record<string, EquivalencePairWire[]>
+  >;
+}
+
+export interface CompareFieldData {
+  fieldResponses: FieldResponse[];
+  answerGroups: FieldResponse[][];
+  currentFieldEquivalences: EquivalencePairWire[];
+  allowEquivalence: boolean;
+}
+
+/**
+ * Derivações das respostas do campo atual (staleness por hash, versão de
+ * schema, agrupamento por equivalência). Extraído de `ComparePage` para
+ * reduzir o tamanho do container (`no-giant-component`).
+ */
+export function useCompareFieldData({
+  currentDoc,
+  currentFieldName,
+  currentField,
+  responses,
+  fields,
+  projectPydanticHash,
+  equivalencesByDocField,
+}: UseCompareFieldDataParams): CompareFieldData {
+  const docResponses = currentDoc ? responses[currentDoc.id] || [] : [];
+
+  const currentFieldHashes = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const f of fields) {
+      if (f.hash) map[f.name] = f.hash;
+    }
+    return map;
+  }, [fields]);
+
+  const fieldResponses: FieldResponse[] = docResponses.map((r) => {
+    let isFieldStale = false;
+    if (r.answer_field_hashes) {
+      const savedHash = r.answer_field_hashes[currentFieldName];
+      const currentHash = currentFieldHashes[currentFieldName];
+      isFieldStale = !savedHash || !currentHash || savedHash !== currentHash;
+    } else {
+      isFieldStale =
+        !!projectPydanticHash && r.pydantic_hash !== projectPydanticHash;
+    }
+    const version =
+      r.schema_version_major !== null
+        ? `${r.schema_version_major}.${r.schema_version_minor ?? 0}.${r.schema_version_patch ?? 0}`
+        : null;
+    return {
+      id: r.id,
+      respondent_type: r.respondent_type,
+      respondent_name: r.respondent_name,
+      answer: Object.prototype.hasOwnProperty.call(r.answers, currentFieldName)
+        ? r.answers[currentFieldName]
+        : undefined,
+      justification: r.justifications?.[currentFieldName],
+      is_latest: r.is_latest,
+      isFieldStale,
+      schemaVersion: version,
+    };
+  });
+
+  const currentFieldEquivalences = useMemo<EquivalencePairWire[]>(() => {
+    if (!currentDoc || !currentFieldName) return [];
+    return equivalencesByDocField[currentDoc.id]?.[currentFieldName] ?? [];
+  }, [equivalencesByDocField, currentDoc, currentFieldName]);
+
+  const allowEquivalence = useMemo(() => {
+    return !!currentField && isFreeTextField(currentField);
+  }, [currentField]);
+
+  const answerGroups = useMemo(() => {
+    const present = fieldResponses.filter((r) => r.answer !== undefined);
+    const groupKeys = buildResponseGroupKeys(
+      present,
+      currentFieldEquivalences,
+      (r) => normalizeForComparison(r.answer),
+    );
+    const map = new Map<string, FieldResponse[]>();
+    for (const r of present) {
+      const key = groupKeys.get(r.id) ?? r.id;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(r);
+    }
+    return Array.from(map.values()).toSorted((a, b) => b.length - a.length);
+  }, [fieldResponses, currentFieldEquivalences]);
+
+  return {
+    fieldResponses,
+    answerGroups,
+    currentFieldEquivalences,
+    allowEquivalence,
+  };
+}

--- a/frontend/src/components/compare/useCompareKeyboard.ts
+++ b/frontend/src/components/compare/useCompareKeyboard.ts
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect } from "react";
+import type { PydanticField } from "@/lib/types";
+import type { FieldResponse } from "./compare-types";
+
+interface UseCompareKeyboardParams {
+  isFullscreen: boolean;
+  isCurrentDocComplete: boolean;
+  isCurrentFieldDivergent: boolean;
+  currentField: PydanticField | undefined;
+  answerGroups: FieldResponse[][];
+  onToggleFullscreen: () => void;
+  onExitFullscreen: () => void;
+  onNextField: () => void;
+  onPrevField: () => void;
+  onVerdict: (verdict: string, chosenResponseId?: string) => void;
+}
+
+/**
+ * Atalhos de teclado da Comparação. Extraído de `ComparePage`: o corpo do
+ * effect só chama callbacks recebidos por prop (`onToggleFullscreen`,
+ * `onNextField`, `onVerdict`, …) — nenhum `setState` léxico —, o que zera o
+ * `no-cascading-set-state` que o effect inline disparava sem precisar de
+ * `useReducer`. `onNextField`/`onPrevField` já fazem o clamp de limite
+ * internamente, então as teclas `n`/`p` chamam incondicionalmente.
+ */
+export function useCompareKeyboard({
+  isFullscreen,
+  isCurrentDocComplete,
+  isCurrentFieldDivergent,
+  currentField,
+  answerGroups,
+  onToggleFullscreen,
+  onExitFullscreen,
+  onNextField,
+  onPrevField,
+  onVerdict,
+}: UseCompareKeyboardParams): void {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      )
+        return;
+
+      if (e.key === "F" && e.ctrlKey && e.shiftKey) {
+        e.preventDefault();
+        onToggleFullscreen();
+        return;
+      }
+      if (e.key === "Escape" && isFullscreen) {
+        onExitFullscreen();
+        return;
+      }
+
+      if (e.key === "n") {
+        onNextField();
+        return;
+      }
+      if (e.key === "p") {
+        onPrevField();
+        return;
+      }
+
+      // Doc concluído: o avanço é por ação explícita (botão "Próximo parecer"
+      // recebe foco; Enter nele é nativo). Não deixar 1-9/a/s re-disparar
+      // veredito sobre um documento já fechado.
+      if (isCurrentDocComplete) return;
+
+      if (!isCurrentFieldDivergent) return;
+
+      const isMultiField =
+        currentField?.type === "multi" && currentField.options?.length;
+      if (isMultiField) {
+        if (e.key === "a") onVerdict("ambiguo");
+        if (e.key === "s") onVerdict("pular");
+        return;
+      }
+
+      const num = parseInt(e.key);
+      if (num >= 1 && num <= answerGroups.length) {
+        const group = answerGroups[num - 1];
+        const answer = group[0].answer;
+        const displayAnswer =
+          answer == null
+            ? ""
+            : Array.isArray(answer)
+              ? answer.join(", ")
+              : String(answer);
+        onVerdict(displayAnswer, group[0].id);
+        return;
+      }
+
+      if (e.key === "a") onVerdict("ambiguo");
+      if (e.key === "s") onVerdict("pular");
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [
+    answerGroups,
+    currentField,
+    isCurrentDocComplete,
+    isCurrentFieldDivergent,
+    isFullscreen,
+    onExitFullscreen,
+    onNextField,
+    onPrevField,
+    onToggleFullscreen,
+    onVerdict,
+  ]);
+}

--- a/frontend/src/components/compare/useCompareNavigation.ts
+++ b/frontend/src/components/compare/useCompareNavigation.ts
@@ -96,7 +96,13 @@ export function useCompareNavigation({
     filter === "all"
       ? allDocDivergent
       : allDocDivergent.filter((fn) => fn === filter);
-  const currentFieldName = docFields[fieldIndex];
+  // `fieldIndex` pode ficar fora de range se `docFields` encolher sob o usuário
+  // (ex.: um revalidate reduziu os campos divergentes do doc fixado) sem que o
+  // filtro ou o doc — os únicos pontos que resetam `fieldIndex` — mudem. Clampa
+  // na leitura para `currentFieldName` nunca cair em `undefined` havendo campos.
+  const clampedFieldIndex =
+    docFields.length > 0 ? Math.min(fieldIndex, docFields.length - 1) : 0;
+  const currentFieldName = docFields[clampedFieldIndex];
   const currentField = fields.find((f) => f.name === currentFieldName);
   const isCurrentFieldDivergent = divergentSet.has(currentFieldName);
 
@@ -152,13 +158,20 @@ export function useCompareNavigation({
     [documents],
   );
 
+  // Parte do índice CLAMPADO (não do `idx` cru do estado): se o estado ficou
+  // fora de range por um encolhimento de `docFields`, navegar a partir do índice
+  // exibido evita ficar preso num índice morto.
   const docFieldsLength = docFields.length;
   const goNextField = useCallback(() => {
-    setFieldIndex((idx) => (idx < docFieldsLength - 1 ? idx + 1 : idx));
-  }, [docFieldsLength]);
+    setFieldIndex(
+      clampedFieldIndex < docFieldsLength - 1
+        ? clampedFieldIndex + 1
+        : clampedFieldIndex,
+    );
+  }, [clampedFieldIndex, docFieldsLength]);
   const goPrevField = useCallback(() => {
-    setFieldIndex((idx) => (idx > 0 ? idx - 1 : idx));
-  }, []);
+    setFieldIndex(clampedFieldIndex > 0 ? clampedFieldIndex - 1 : clampedFieldIndex);
+  }, [clampedFieldIndex]);
 
   const changeFilter = useCallback((value: string) => {
     setFilter(value);
@@ -170,7 +183,7 @@ export function useCompareNavigation({
     currentDoc,
     allDocDivergent,
     docFields,
-    fieldIndex,
+    fieldIndex: clampedFieldIndex,
     setFieldIndex,
     filter,
     changeFilter,

--- a/frontend/src/components/compare/useCompareNavigation.ts
+++ b/frontend/src/components/compare/useCompareNavigation.ts
@@ -1,0 +1,188 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { isDocComplete, findNextPendingDocIndex } from "@/lib/compare-divergence";
+import type { ReviewsByDoc } from "@/lib/compare-reviews";
+import type { PydanticField } from "@/lib/types";
+import type { CompareDocument } from "./compare-types";
+
+interface UseCompareNavigationParams {
+  documents: CompareDocument[];
+  divergentFields: Record<string, string[]>;
+  fields: PydanticField[];
+  localReviews: ReviewsByDoc;
+}
+
+export interface CompareNavigation {
+  docIndex: number;
+  currentDoc: CompareDocument | undefined;
+  allDocDivergent: string[];
+  docFields: string[];
+  fieldIndex: number;
+  setFieldIndex: (index: number) => void;
+  filter: string;
+  changeFilter: (value: string) => void;
+  currentFieldName: string;
+  currentField: PydanticField | undefined;
+  isCurrentFieldDivergent: boolean;
+  isCurrentDocComplete: boolean;
+  reviewedDocsCount: number;
+  hasNextDoc: boolean;
+  handleDocNavigate: (newIndex: number) => void;
+  handleNextDoc: () => void;
+  goNextField: () => void;
+  goPrevField: () => void;
+}
+
+/**
+ * Seleção de documento/campo/filtro da Comparação + derivações e navegação.
+ * Extraído de `ComparePage` para tirar 3 `useState` do container (mata
+ * `prefer-useReducer`) e ~80 linhas de derivação (ajuda `no-giant-component`).
+ */
+export function useCompareNavigation({
+  documents,
+  divergentFields,
+  fields,
+  localReviews,
+}: UseCompareNavigationParams): CompareNavigation {
+  const [pinnedDocId, setPinnedDocId] = useState<string | null>(null);
+  const [fieldIndex, setFieldIndex] = useState(0);
+  const [filter, setFilter] = useState("all");
+
+  // O parecer atual é derivado de `pinnedDocId` (última escolha explícita do
+  // usuário). `documents` é reordenado pelo Server Component a cada
+  // `revalidatePath` (sort por pendências); rastrear por índice numérico faria
+  // o parecer mudar sob o usuário a cada veredito. Quando o ID atual some da
+  // lista (filtro mudou, etc.) caímos para `documents[0]`.
+  const docIndex = useMemo(() => {
+    if (documents.length === 0) return 0;
+    if (pinnedDocId) {
+      const i = documents.findIndex((d) => d.id === pinnedDocId);
+      if (i >= 0) return i;
+    }
+    return 0;
+  }, [documents, pinnedDocId]);
+
+  // Avisa quando o doc pinado some da lista (ex.: foi excluído). O `docIndex`
+  // memo já cai para `documents[0]` automaticamente; aqui só disparamos o toast
+  // uma vez, na transição "estava lá → sumiu".
+  const lastValidPinnedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pinnedDocId || documents.length === 0) {
+      lastValidPinnedRef.current = pinnedDocId;
+      return;
+    }
+    const exists = documents.some((d) => d.id === pinnedDocId);
+    if (exists) {
+      lastValidPinnedRef.current = pinnedDocId;
+    } else if (lastValidPinnedRef.current === pinnedDocId) {
+      toast.info("Documento removido da fila — voltando ao topo.");
+      lastValidPinnedRef.current = null;
+    }
+  }, [pinnedDocId, documents]);
+
+  const currentDoc = documents[docIndex];
+  const allDocDivergent = useMemo(
+    () => (currentDoc ? divergentFields[currentDoc.id] || [] : []),
+    [currentDoc, divergentFields],
+  );
+  const divergentSet = useMemo(
+    () => new Set(allDocDivergent),
+    [allDocDivergent],
+  );
+
+  const docFields =
+    filter === "all"
+      ? allDocDivergent
+      : allDocDivergent.filter((fn) => fn === filter);
+  const currentFieldName = docFields[fieldIndex];
+  const currentField = fields.find((f) => f.name === currentFieldName);
+  const isCurrentFieldDivergent = divergentSet.has(currentFieldName);
+
+  const reviewedDocsCount = useMemo(
+    () =>
+      documents.filter((doc) =>
+        isDocComplete(divergentFields[doc.id], localReviews[doc.id]),
+      ).length,
+    [documents, divergentFields, localReviews],
+  );
+
+  // Documento "concluído" = todos os campos divergentes têm veredito. Quando
+  // verdadeiro, a UI mostra o botão "Próximo parecer" (com foco automático) em
+  // vez de avançar por timer cego.
+  const isCurrentDocComplete = useMemo(
+    () =>
+      !!currentDoc &&
+      isDocComplete(allDocDivergent, localReviews[currentDoc.id]),
+    [currentDoc, allDocDivergent, localReviews],
+  );
+
+  // `documents` é reordenado pelo servidor a cada revalidate (docs concluídos
+  // afundam para o fim da fila), então o "próximo parecer" precisa ser o
+  // próximo doc com pendências — não `docIndex + 1`, que apontaria para fora da
+  // fila assim que o doc atual fosse concluído.
+  const nextPendingDocIndex = useMemo(
+    () =>
+      findNextPendingDocIndex(
+        documents.map((d) => d.id),
+        divergentFields,
+        localReviews,
+        currentDoc?.id,
+      ),
+    [documents, divergentFields, localReviews, currentDoc],
+  );
+
+  const hasNextDoc = nextPendingDocIndex >= 0;
+
+  const handleNextDoc = useCallback(() => {
+    if (nextPendingDocIndex >= 0) {
+      setPinnedDocId(documents[nextPendingDocIndex].id);
+      setFieldIndex(0);
+    }
+  }, [nextPendingDocIndex, documents]);
+
+  const handleDocNavigate = useCallback(
+    (newIndex: number) => {
+      if (documents.length === 0) return;
+      const clamped = Math.max(0, Math.min(newIndex, documents.length - 1));
+      setPinnedDocId(documents[clamped].id);
+      setFieldIndex(0);
+    },
+    [documents],
+  );
+
+  const docFieldsLength = docFields.length;
+  const goNextField = useCallback(() => {
+    setFieldIndex((idx) => (idx < docFieldsLength - 1 ? idx + 1 : idx));
+  }, [docFieldsLength]);
+  const goPrevField = useCallback(() => {
+    setFieldIndex((idx) => (idx > 0 ? idx - 1 : idx));
+  }, []);
+
+  const changeFilter = useCallback((value: string) => {
+    setFilter(value);
+    setFieldIndex(0);
+  }, []);
+
+  return {
+    docIndex,
+    currentDoc,
+    allDocDivergent,
+    docFields,
+    fieldIndex,
+    setFieldIndex,
+    filter,
+    changeFilter,
+    currentFieldName,
+    currentField,
+    isCurrentFieldDivergent,
+    isCurrentDocComplete,
+    reviewedDocsCount,
+    hasNextDoc,
+    handleDocNavigate,
+    handleNextDoc,
+    goNextField,
+    goPrevField,
+  };
+}

--- a/frontend/src/components/compare/useCompareReviews.ts
+++ b/frontend/src/components/compare/useCompareReviews.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  mergeReviews,
+  type ReviewsByDoc,
+  type VerdictInfo,
+} from "@/lib/compare-reviews";
+
+/**
+ * Vereditos da Comparação: mantém em estado apenas os deltas otimistas da
+ * sessão (`overrides`) e deriva `localReviews` mesclando-os sobre a prop
+ * `existingReviews` do servidor. Extraído de `ComparePage` para tirar o
+ * `useState(prop)` (que disparava `no-derived-useState`) do container e fazer
+ * mudanças do servidor fluírem para a UI.
+ */
+export function useCompareReviews(existingReviews: ReviewsByDoc): {
+  localReviews: ReviewsByDoc;
+  recordReview: (docId: string, fieldName: string, info: VerdictInfo) => void;
+} {
+  const [overrides, setOverrides] = useState<ReviewsByDoc>({});
+
+  const localReviews = useMemo(
+    () => mergeReviews(existingReviews, overrides),
+    [existingReviews, overrides],
+  );
+
+  const recordReview = useCallback(
+    (docId: string, fieldName: string, info: VerdictInfo) => {
+      setOverrides((prev) => ({
+        ...prev,
+        [docId]: { ...prev[docId], [fieldName]: info },
+      }));
+    },
+    [],
+  );
+
+  return { localReviews, recordReview };
+}

--- a/frontend/src/components/compare/useCompareVerdicts.ts
+++ b/frontend/src/components/compare/useCompareVerdicts.ts
@@ -1,0 +1,222 @@
+"use client";
+
+import { useCallback } from "react";
+import { toast } from "sonner";
+import {
+  submitVerdict,
+  markCompareDocReviewed,
+  type ResponseSnapshotEntry,
+} from "@/actions/reviews";
+import {
+  confirmEquivalentVerdict,
+  unmarkEquivalencePair,
+} from "@/actions/equivalences";
+import type { ReviewsByDoc, VerdictInfo } from "@/lib/compare-reviews";
+import type { CompareDocument, FieldResponse } from "./compare-types";
+
+interface UseCompareVerdictsParams {
+  projectId: string;
+  currentDoc: CompareDocument | undefined;
+  currentFieldName: string;
+  isCurrentFieldDivergent: boolean;
+  allDocDivergent: string[];
+  localReviews: ReviewsByDoc;
+  fieldResponses: FieldResponse[];
+  comment: string;
+  recordReview: (docId: string, fieldName: string, info: VerdictInfo) => void;
+  goNextField: () => void;
+  clearComment: () => void;
+}
+
+export interface CompareVerdicts {
+  handleVerdict: (verdict: string, chosenResponseId?: string) => Promise<void>;
+  handleConfirmEquivalent: (
+    responseIds: string[],
+    gabaritoId: string,
+    verdictDisplay: string,
+  ) => Promise<void>;
+  handleMarkReviewed: () => Promise<void>;
+  handleUnmarkPair: (pairId: string) => Promise<void>;
+}
+
+/** Snapshot das respostas presentes no momento do veredito (auditoria). */
+function buildSnapshot(fieldResponses: FieldResponse[]): ResponseSnapshotEntry[] {
+  return fieldResponses
+    .filter((r) => r.answer !== undefined)
+    .map((r) => ({
+      id: r.id,
+      respondent_name: r.respondent_name,
+      respondent_type: r.respondent_type,
+      answer: r.answer,
+      ...(r.justification ? { justification: r.justification } : {}),
+    }));
+}
+
+/**
+ * Handlers de submissão de veredito (regular e por equivalência) + marcar
+ * revisado / desfazer equivalência. Extraído de `ComparePage` para tirar ~140
+ * linhas do container (`no-giant-component`). A escrita otimista vai por
+ * `recordReview` (overrides); o avanço de campo por `goNextField` (que já faz
+ * o clamp de limite).
+ */
+export function useCompareVerdicts({
+  projectId,
+  currentDoc,
+  currentFieldName,
+  isCurrentFieldDivergent,
+  allDocDivergent,
+  localReviews,
+  fieldResponses,
+  comment,
+  recordReview,
+  goNextField,
+  clearComment,
+}: UseCompareVerdictsParams): CompareVerdicts {
+  const handleVerdict = useCallback(
+    async (verdict: string, chosenResponseId?: string) => {
+      if (!currentDoc || !currentFieldName || !isCurrentFieldDivergent) return;
+
+      const verdictComment = comment || undefined;
+      const info: VerdictInfo = {
+        verdict,
+        chosenResponseId: chosenResponseId ?? null,
+        comment: verdictComment ?? null,
+      };
+      recordReview(currentDoc.id, currentFieldName, info);
+
+      await submitVerdict(
+        projectId,
+        currentDoc.id,
+        currentFieldName,
+        verdict,
+        chosenResponseId,
+        verdictComment,
+        buildSnapshot(fieldResponses),
+      );
+
+      clearComment();
+      toast.success("Veredito salvo!");
+
+      // Usa `info` recém-emitido sobre o estado atual (que o setState ainda não
+      // refletiu neste closure) para decidir se o documento fechou.
+      const nextDocReviews = {
+        ...localReviews[currentDoc.id],
+        [currentFieldName]: info,
+      };
+      const allFieldsReviewed = allDocDivergent.every(
+        (fn) => !!nextDocReviews[fn],
+      );
+      if (allFieldsReviewed) {
+        toast.success("Revisão do documento concluída!");
+      } else {
+        goNextField();
+      }
+    },
+    [
+      projectId,
+      currentDoc,
+      currentFieldName,
+      isCurrentFieldDivergent,
+      allDocDivergent,
+      localReviews,
+      comment,
+      fieldResponses,
+      recordReview,
+      goNextField,
+      clearComment,
+    ],
+  );
+
+  const handleConfirmEquivalent = useCallback(
+    async (
+      responseIds: string[],
+      gabaritoId: string,
+      verdictDisplay: string,
+    ) => {
+      if (!currentDoc || !currentFieldName || !isCurrentFieldDivergent) return;
+
+      const verdictComment = comment || undefined;
+      const docId = currentDoc.id;
+      const fieldName = currentFieldName;
+      const info: VerdictInfo = {
+        verdict: verdictDisplay,
+        chosenResponseId: gabaritoId,
+        comment: verdictComment ?? null,
+      };
+      recordReview(docId, fieldName, info);
+
+      try {
+        await confirmEquivalentVerdict(
+          projectId,
+          docId,
+          fieldName,
+          responseIds,
+          gabaritoId,
+          verdictDisplay,
+          verdictComment,
+          buildSnapshot(fieldResponses),
+        );
+        clearComment();
+        toast.success(
+          `${responseIds.length} respostas marcadas como equivalentes.`,
+        );
+
+        const nextDocReviews = { ...localReviews[docId], [fieldName]: info };
+        const allFieldsReviewed = allDocDivergent.every(
+          (fn) => !!nextDocReviews[fn],
+        );
+        if (allFieldsReviewed) {
+          toast.success("Revisão do documento concluída!");
+        } else {
+          goNextField();
+        }
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Falha ao marcar equivalentes.",
+        );
+      }
+    },
+    [
+      projectId,
+      currentDoc,
+      currentFieldName,
+      isCurrentFieldDivergent,
+      allDocDivergent,
+      localReviews,
+      comment,
+      fieldResponses,
+      recordReview,
+      goNextField,
+      clearComment,
+    ],
+  );
+
+  const handleMarkReviewed = useCallback(async () => {
+    if (!currentDoc) return;
+    await markCompareDocReviewed(projectId, currentDoc.id);
+    toast.success("Documento marcado como revisado.");
+  }, [projectId, currentDoc]);
+
+  const handleUnmarkPair = useCallback(
+    async (pairId: string) => {
+      try {
+        await unmarkEquivalencePair(projectId, pairId);
+        toast.success("Equivalência removida.");
+      } catch (err) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : "Falha ao desfazer equivalência.",
+        );
+      }
+    },
+    [projectId],
+  );
+
+  return {
+    handleVerdict,
+    handleConfirmEquivalent,
+    handleMarkReviewed,
+    handleUnmarkPair,
+  };
+}

--- a/frontend/src/components/compare/useCompareVerdicts.ts
+++ b/frontend/src/components/compare/useCompareVerdicts.ts
@@ -25,7 +25,6 @@ interface UseCompareVerdictsParams {
   comment: string;
   recordReview: (docId: string, fieldName: string, info: VerdictInfo) => void;
   goNextField: () => void;
-  clearComment: () => void;
 }
 
 export interface CompareVerdicts {
@@ -58,6 +57,11 @@ function buildSnapshot(fieldResponses: FieldResponse[]): ResponseSnapshotEntry[]
  * linhas do container (`no-giant-component`). A escrita otimista vai por
  * `recordReview` (overrides); o avanço de campo por `goNextField` (que já faz
  * o clamp de limite).
+ *
+ * O comentário NÃO é limpo aqui após o sucesso: quando há avanço, o guard de
+ * render de `ComparePage` re-semeia a caixa do veredito do novo campo (""); se
+ * o campo permanece (filtro de campo único ou último campo divergente), o
+ * comentário recém-salvo continua visível na caixa, em vez de sumir.
  */
 export function useCompareVerdicts({
   projectId,
@@ -70,7 +74,6 @@ export function useCompareVerdicts({
   comment,
   recordReview,
   goNextField,
-  clearComment,
 }: UseCompareVerdictsParams): CompareVerdicts {
   const handleVerdict = useCallback(
     async (verdict: string, chosenResponseId?: string) => {
@@ -94,7 +97,6 @@ export function useCompareVerdicts({
         buildSnapshot(fieldResponses),
       );
 
-      clearComment();
       toast.success("Veredito salvo!");
 
       // Usa `info` recém-emitido sobre o estado atual (que o setState ainda não
@@ -123,7 +125,6 @@ export function useCompareVerdicts({
       fieldResponses,
       recordReview,
       goNextField,
-      clearComment,
     ],
   );
 
@@ -156,7 +157,6 @@ export function useCompareVerdicts({
           verdictComment,
           buildSnapshot(fieldResponses),
         );
-        clearComment();
         toast.success(
           `${responseIds.length} respostas marcadas como equivalentes.`,
         );
@@ -187,7 +187,6 @@ export function useCompareVerdicts({
       fieldResponses,
       recordReview,
       goNextField,
-      clearComment,
     ],
   );
 

--- a/frontend/src/lib/__tests__/compare-reviews.test.ts
+++ b/frontend/src/lib/__tests__/compare-reviews.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeReviews,
+  type ReviewsByDoc,
+  type VerdictInfo,
+} from "@/lib/compare-reviews";
+
+const v = (verdict: string, comment: string | null = null): VerdictInfo => ({
+  verdict,
+  chosenResponseId: null,
+  comment,
+});
+
+describe("mergeReviews", () => {
+  it("retorna a MESMA referência de `existing` quando não há overrides", () => {
+    const existing: ReviewsByDoc = { doc1: { campoA: v("deferido") } };
+    const merged = mergeReviews(existing, {});
+    // Identidade referencial importa: o useMemo a jusante não deve invalidar.
+    expect(merged).toBe(existing);
+  });
+
+  it("adiciona um veredito novo num documento já existente sem perder os antigos", () => {
+    const existing: ReviewsByDoc = { doc1: { campoA: v("deferido") } };
+    const overrides: ReviewsByDoc = { doc1: { campoB: v("indeferido") } };
+    const merged = mergeReviews(existing, overrides);
+
+    expect(merged.doc1).toEqual({
+      campoA: v("deferido"),
+      campoB: v("indeferido"),
+    });
+    // Não muta a entrada original.
+    expect(existing.doc1).toEqual({ campoA: v("deferido") });
+  });
+
+  it("override substitui o veredito do mesmo campo", () => {
+    const existing: ReviewsByDoc = { doc1: { campoA: v("deferido") } };
+    const overrides: ReviewsByDoc = {
+      doc1: { campoA: v("indeferido", "revisado") },
+    };
+    const merged = mergeReviews(existing, overrides);
+
+    expect(merged.doc1.campoA).toEqual(v("indeferido", "revisado"));
+  });
+
+  it("introduz um documento que só existe nos overrides", () => {
+    const existing: ReviewsByDoc = { doc1: { campoA: v("deferido") } };
+    const overrides: ReviewsByDoc = { doc2: { campoX: v("ambiguo") } };
+    const merged = mergeReviews(existing, overrides);
+
+    expect(merged.doc1).toEqual({ campoA: v("deferido") });
+    expect(merged.doc2).toEqual({ campoX: v("ambiguo") });
+  });
+
+  it("um campo NÃO sobrescrito reflete a mudança vinda do servidor (existing)", () => {
+    // Cenário do bug latente: o servidor revalidou e trouxe o veredito de outro
+    // revisor em campoA; o override local só tocou campoB. A visão mesclada
+    // deve refletir o campoA novo do servidor.
+    const existing: ReviewsByDoc = {
+      doc1: { campoA: v("deferido", "por outro revisor") },
+    };
+    const overrides: ReviewsByDoc = { doc1: { campoB: v("pular") } };
+    const merged = mergeReviews(existing, overrides);
+
+    expect(merged.doc1.campoA).toEqual(v("deferido", "por outro revisor"));
+    expect(merged.doc1.campoB).toEqual(v("pular"));
+  });
+});

--- a/frontend/src/lib/compare-reviews.ts
+++ b/frontend/src/lib/compare-reviews.ts
@@ -1,0 +1,37 @@
+// Tipos e fusão dos vereditos de revisão da Comparação.
+//
+// `localReviews` na UI é a sobreposição do que veio do servidor
+// (`existingReviews`, prop) com os vereditos otimistas emitidos na sessão
+// (`overrides`). Manter só os deltas em estado e derivar a visão mesclada por
+// render evita copiar a prop para `useState` (react-doctor `no-derived-useState`)
+// e, de quebra, deixa mudanças do servidor (após `revalidatePath`) fluírem para
+// a tela — coisa que a cópia única de prop não fazia.
+
+export interface VerdictInfo {
+  verdict: string;
+  chosenResponseId: string | null;
+  comment: string | null;
+}
+
+/** Vereditos indexados por documento e depois por campo. */
+export type ReviewsByDoc = Record<string, Record<string, VerdictInfo>>;
+
+/**
+ * Mescla os vereditos do servidor com os overrides otimistas. Override vence
+ * por campo (merge raso por documento). Retorna a referência de `existing`
+ * intacta quando não há nenhum override — assim o `useMemo` que a consome não
+ * invalida memos a jusante à toa.
+ */
+export function mergeReviews(
+  existing: ReviewsByDoc,
+  overrides: ReviewsByDoc,
+): ReviewsByDoc {
+  const docIds = Object.keys(overrides);
+  if (docIds.length === 0) return existing;
+
+  const merged: ReviewsByDoc = { ...existing };
+  for (const docId of docIds) {
+    merged[docId] = { ...existing[docId], ...overrides[docId] };
+  }
+  return merged;
+}


### PR DESCRIPTION
Parte da campanha **Zerar react-doctor** (épico #239), **Onda 4 — Hotspot** (issue #253). Refatora — **não suprime** — os 5 diagnósticos de `ComparePage.tsx` (corpo da função ~535 linhas → ~250).

## Diagnósticos eliminados

| Linha | Regra | Como foi resolvido |
|---|---|---|
| `:91` | `no-giant-component` | Extração de hooks + view (corpo < 300 linhas) |
| `:110` | `prefer-useReducer` | 7 → 3 `useState` no container (state movido para hooks; **sem** `useReducer`) |
| `:118` | `no-derived-useState` | `localReviews` derivado de prop + overrides via `useMemo(mergeReviews)` |
| `:218` | `no-derived-state` | `comment` resetado por **guard de render** (prev-tracker em `useRef`), não por effect |
| `:441` | `no-cascading-set-state` | keydown vira `useCompareKeyboard`; effect só chama callbacks (zero `setState` léxico) |

## Estrutura (espelha a Onda 4 #233/#234)

Hooks co-locados em `components/compare/`: `useCompareReviews`, `useCompareNavigation`, `useCompareFieldData`, `useCompareVerdicts`, `useCompareKeyboard`. View presentacional `CompareWorkspace`. Helper puro `lib/compare-reviews.ts` (`mergeReviews` + tipos). Tipos wire em `compare-types.ts`.

PR **self-contained**: não depende do merge de #233/#234 nem toca `frontend/src/hooks/` compartilhado.

## Ganho além do linter

O fix de `:118` conserta um **bug latente** que a regra apontava: hoje a cópia única de `existingReviews` para `useState` ignora mudanças do servidor após `revalidatePath`; com a derivação por merge (prop + overrides otimistas), vereditos de outros revisores passam a fluir para a UI.

## Verificação

- `react-doctor`: **0 diagnósticos** em `ComparePage.tsx`; score global **54 → 55**; arquivos novos sem diagnóstico.
- `tsc --noEmit`, `npm run lint` (0 novos warnings), **590 testes** verdes.
- **Testes adicionados (cobrem o que antes era verify manual):**
  - `lib/__tests__/compare-reviews.test.ts` — `mergeReviews` (5): merge, override, identidade referencial, fluxo do servidor.
  - `components/compare/__tests__/ComparePage.test.tsx` (14) — semeadura/reset do comentário, filtro (reset de índice + narrowing), navegação de doc; **atalhos de teclado**: número→grupo certo, `a`/`s`→ambiguo/pular, `n`/`p`, comentário levado junto no veredito por teclado, doc concluído bloqueia 1-9/a/s, Ctrl+Shift+F/Esc; veredito/equivalência/marcar-revisado chamam os Server Actions corretos.
  - `components/compare/__tests__/ComparePage.integration.test.tsx` (2) — **árvore real** (CompareNav/ComparisonPanel/CompareWorkspace reais): clicar "Ambiguo" no painel real chega ao `submitVerdict`.
- Resta como smoke opcional só o render visual dos filhos (inalterados neste PR): cores/layout dos painéis, dropdown de filtro do `CompareNav`, markdown do `DocumentReader`.

Closes #253