### PR TITLE
refactor(llm): DocumentSelector — deriva fetch/seleção em handler, sem useEffect (#251)

### DIFF
--- a/frontend/src/components/llm/DocumentSelector.tsx
+++ b/frontend/src/components/llm/DocumentSelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -29,34 +29,35 @@ export function DocumentSelector({
   onSelectionChange,
 }: DocumentSelectorProps) {
   const [open, setOpen] = useState(false);
-  const [docs, setDocs] = useState<DocSelectionItem[]>([]);
-  const [loading, setLoading] = useState(false);
+  const [resource, setResource] = useState<{
+    loading: boolean;
+    items: DocSelectionItem[];
+  }>({ loading: false, items: [] });
   const [search, setSearch] = useState("");
-  const [localSelected, setLocalSelected] = useState<Set<string>>(
-    new Set(selectedIds)
-  );
+  const [localSelected, setLocalSelected] = useState<Set<string>>(new Set());
 
-  useEffect(() => {
-    if (open) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- inicia o fetch dos docs ao abrir (sincronização com backend)
-      setLoading(true);
+  // Abrir o dialog é um evento: ao abrir, semeia o draft a partir do prop
+  // atual e dispara o fetch dos documentos. (Sem useEffect — ver issue #251.)
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
       setLocalSelected(new Set(selectedIds));
+      setResource({ loading: true, items: [] });
       getDocumentsForSelection(projectId)
-        .then((data) => setDocs(data))
-        .catch(() => setDocs([]))
-        .finally(() => setLoading(false));
+        .then((items) => setResource({ loading: false, items }))
+        .catch(() => setResource({ loading: false, items: [] }));
     }
-  }, [open, projectId, selectedIds]);
+  };
 
   const filtered = useMemo(() => {
-    if (!search.trim()) return docs;
+    if (!search.trim()) return resource.items;
     const q = search.toLowerCase();
-    return docs.filter(
+    return resource.items.filter(
       (d) =>
         d.title?.toLowerCase().includes(q) ||
         d.external_id?.toLowerCase().includes(q)
     );
-  }, [docs, search]);
+  }, [resource.items, search]);
 
   const toggle = (id: string) => {
     setLocalSelected((prev) => {
@@ -88,7 +89,7 @@ export function DocumentSelector({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm">
           {selectedIds.length > 0
@@ -127,12 +128,12 @@ export function DocumentSelector({
         </div>
 
         <div className="flex-1 min-h-0 overflow-y-auto border rounded-md divide-y">
-          {loading && (
+          {resource.loading && (
             <p className="p-4 text-sm text-muted-foreground text-center">
               Carregando…
             </p>
           )}
-          {!loading && filtered.length === 0 && (
+          {!resource.loading && filtered.length === 0 && (
             <p className="p-4 text-sm text-muted-foreground text-center">
               Nenhum documento encontrado.
             </p>

--- a/frontend/src/components/llm/__tests__/DocumentSelector.test.tsx
+++ b/frontend/src/components/llm/__tests__/DocumentSelector.test.tsx
@@ -124,7 +124,7 @@ describe("DocumentSelector", () => {
     expect(onSelectionChange).not.toHaveBeenCalled();
   });
 
-  it("re-semeia o draft a partir de selectedIds a cada abertura", async () => {
+  it("re-semeia o draft a partir de selectedIds a cada abertura, descartando edições não confirmadas", async () => {
     const user = setup();
     render(
       <DocumentSelector
@@ -134,13 +134,29 @@ describe("DocumentSelector", () => {
       />
     );
 
+    // 1ª abertura: o draft reflete selectedIds (d1).
     await user.click(
       screen.getByRole("button", { name: /1 documento selecionado/i })
     );
     await screen.findByText("Documento Um");
 
-    const checkboxes = screen.getAllByRole("checkbox");
+    let checkboxes = screen.getAllByRole("checkbox");
     expect(checkboxes[0].getAttribute("aria-checked")).toBe("true"); // d1
     expect(checkboxes[1].getAttribute("aria-checked")).toBe("false"); // d2
+
+    // Edita o draft (marca d2) e cancela — sem propagar, selectedIds segue ["d1"].
+    await user.click(checkboxes[1]); // d2
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("true");
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    // Reabertura: o draft é re-semeado de selectedIds, descartando a marcação de d2.
+    await user.click(
+      screen.getByRole("button", { name: /1 documento selecionado/i })
+    );
+    await screen.findByText("Documento Um");
+
+    checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0].getAttribute("aria-checked")).toBe("true"); // d1
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("false"); // d2 descartado
   });
 });

--- a/frontend/src/components/llm/__tests__/DocumentSelector.test.tsx
+++ b/frontend/src/components/llm/__tests__/DocumentSelector.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { DocSelectionItem } from "@/actions/llm";
+
+// `getDocumentsForSelection` é uma server action; mocká-la corta a cadeia de
+// imports server-only (supabase) e nos dá controle sobre o fetch ao abrir.
+const getDocumentsForSelection = vi.hoisted(() => vi.fn());
+vi.mock("@/actions/llm", () => ({ getDocumentsForSelection }));
+
+import { DocumentSelector } from "@/components/llm/DocumentSelector";
+
+const sampleDocs: DocSelectionItem[] = [
+  {
+    id: "d1",
+    title: "Documento Um",
+    external_id: "EXT-1",
+    hasHumanResponse: true,
+    llmResponseCount: 0,
+  },
+  {
+    id: "d2",
+    title: "Documento Dois",
+    external_id: "EXT-2",
+    hasHumanResponse: false,
+    llmResponseCount: 2,
+  },
+];
+
+// O Radix (Dialog/Checkbox) usa APIs de Pointer/observer que o jsdom não
+// implementa; sem estes shims a abertura do dialog quebra.
+beforeAll(() => {
+  const proto = Element.prototype as unknown as Record<string, unknown>;
+  proto.scrollIntoView = () => {};
+  proto.hasPointerCapture = () => false;
+  proto.setPointerCapture = () => {};
+  proto.releasePointerCapture = () => {};
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+});
+
+beforeEach(() => {
+  getDocumentsForSelection.mockResolvedValue(sampleDocs);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// pointerEventsCheck: 0 — o overlay do Radix usa pointer-events que confundem
+// a checagem padrão do user-event em jsdom.
+const setup = () => userEvent.setup({ pointerEventsCheck: 0 });
+
+describe("DocumentSelector", () => {
+  it("busca os documentos ao abrir o dialog", async () => {
+    const user = setup();
+    render(
+      <DocumentSelector
+        projectId="p1"
+        selectedIds={[]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /selecionar documentos/i })
+    );
+
+    await screen.findByText("Documento Um");
+    expect(getDocumentsForSelection).toHaveBeenCalledWith("p1");
+  });
+
+  it("Confirmar propaga a seleção via onSelectionChange", async () => {
+    const user = setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <DocumentSelector
+        projectId="p1"
+        selectedIds={[]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /selecionar documentos/i })
+    );
+    await screen.findByText("Documento Um");
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[0]); // d1
+
+    await user.click(screen.getByRole("button", { name: /confirmar/i }));
+
+    expect(onSelectionChange).toHaveBeenCalledWith(["d1"]);
+  });
+
+  it("Cancelar fecha sem propagar a seleção", async () => {
+    const user = setup();
+    const onSelectionChange = vi.fn();
+    render(
+      <DocumentSelector
+        projectId="p1"
+        selectedIds={[]}
+        onSelectionChange={onSelectionChange}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /selecionar documentos/i })
+    );
+    await screen.findByText("Documento Um");
+
+    await user.click(screen.getAllByRole("checkbox")[0]);
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onSelectionChange).not.toHaveBeenCalled();
+  });
+
+  it("re-semeia o draft a partir de selectedIds a cada abertura", async () => {
+    const user = setup();
+    render(
+      <DocumentSelector
+        projectId="p1"
+        selectedIds={["d1"]}
+        onSelectionChange={vi.fn()}
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /1 documento selecionado/i })
+    );
+    await screen.findByText("Documento Um");
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes[0].getAttribute("aria-checked")).toBe("true"); // d1
+    expect(checkboxes[1].getAttribute("aria-checked")).toBe("false"); // d2
+  });
+});


### PR DESCRIPTION
## Contexto

Parte da campanha **Zerar react-doctor** (épico #239, **Onda 4 — Hotspot**). O `DocumentSelector` acumulava **7 diagnósticos** do react-doctor pinado (`0.5.6`) — 1 error + 6 warnings — todos concentrados num `useEffect` que misturava fetch, reset de state e sincronização de prop, mais contagem alta de `useState`. A issue pede **refatorar, não suprimir**.

## Causa raiz

O `useEffect(() => { if (open) { … } }, [open, projectId, selectedIds])` era um *event handler disfarçado*: disparava o fetch dos documentos e re-semeava `localSelected` a partir do prop `selectedIds` quando o dialog abria.

## O que mudou

1. **Remove o `useEffect`**; move fetch + re-semeio do draft para o handler `onOpenChange`. Abrir o dialog é um evento, não uma sincronização reativa. Mata `no-cascading-set-state`, `no-event-handler`, `no-adjust-state-on-prop-change`, `no-chain-state-updates` (x2) e `no-derived-state` — todas baseadas no effect.
2. **Consolida `docs` + `loading`** num único state `resource` (5 → 4 `useState`), zerando `prefer-useReducer` **sem introduzir `useReducer`** (como a issue exige).
3. **`localSelected` inicia vazio** e é semeado no `onOpenChange` — sem leitura de prop em initializer/render, eliminando risco residual de re-disparo.

### Comportamento preservado

O re-semeio passa a ocorrer só na abertura. Como `selectedIds`/`projectId` não mudam enquanto o dialog está aberto (o único caller é `LlmConfigurePane`, e `selectedIds` só muda via `onSelectionChange` deste componente, que fecha o dialog), o comportamento observável é idêntico — e mais correto (não clobbera edições em progresso).

## Teste

Adiciona o **1º teste de componente do repo** (`__tests__/DocumentSelector.test.tsx`, jsdom + testing-library): fetch ao abrir, Confirmar propaga via `onSelectionChange`, Cancelar não propaga, e re-semeio do draft na reabertura.

## Verificação

- `react-doctor` no `DocumentSelector.tsx` + teste: **0 diagnósticos** (era 7). Score global: 52 → 55.
- `react-doctor --diff origin/main`: **0** diagnósticos novos introduzidos.
- `vitest run`: **573** testes passam (incl. 4 novos).
- `tsc --noEmit` e `eslint`: limpos.

Closes #251