### PR TITLE
refactor(coding): QuestionsPanel zera 6 diagnósticos do react-doctor [Onda 4] (#252)

### DIFF
--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -13,6 +13,7 @@ import { FullscreenNav } from "./FullscreenNav";
 import { saveResponse } from "@/actions/responses";
 import { getDocumentsForBrowse, getDocumentForCoding } from "@/actions/documents";
 import { applyFieldOrder } from "@/lib/field-order";
+import { clearHiddenConditionalAnswers } from "@/lib/conditional";
 import { useUrlState } from "@/hooks/useUrlState";
 import { useFieldOrder } from "@/hooks/useFieldOrder";
 import { useAutosaveOnExit, type AutosavePayload } from "@/hooks/useAutosaveOnExit";
@@ -263,13 +264,16 @@ function CodingPageInner({
     (fieldName: string, value: unknown) => {
       const docId = currentDoc?.id;
       if (!docId) return;
-      setAllAnswers((prev) => ({
-        ...prev,
-        [docId]: { ...prev[docId], [fieldName]: value },
-      }));
+      setAllAnswers((prev) => {
+        const updated = { ...prev[docId], [fieldName]: value };
+        // Ao mudar uma resposta, limpa as condicionais que ficaram órfãs —
+        // invariante mantida aqui (no dono do estado) em vez de num useEffect
+        // do filho (ver #252).
+        return { ...prev, [docId]: clearHiddenConditionalAnswers(fields, updated) };
+      });
       markDirty(docId);
     },
-    [currentDoc?.id, markDirty]
+    [currentDoc?.id, markDirty, fields]
   );
 
   const handleNotesChange = useCallback(
@@ -408,10 +412,12 @@ function CodingPageInner({
 
   const handleBrowseAnswer = useCallback(
     (fieldName: string, value: unknown) => {
-      setBrowseAnswers((prev) => ({ ...prev, [fieldName]: value }));
+      setBrowseAnswers((prev) =>
+        clearHiddenConditionalAnswers(fields, { ...prev, [fieldName]: value }),
+      );
       if (selectedBrowseDoc) markDirty(selectedBrowseDoc.id);
     },
-    [selectedBrowseDoc, markDirty]
+    [selectedBrowseDoc, markDirty, fields]
   );
 
   const handleBrowseSubmit = useCallback(async () => {

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -141,17 +141,12 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
   // Rastreia quais campos estavam visíveis no render anterior para detectar
-  // condicionais que acabaram de aparecer.
-  const prevVisibleNamesRef = useRef<Set<string>>(new Set());
-  // Mudança de schema (prop `fields`) também muda `visibleNames`; este flag
-  // evita scrollar nesse caso — só queremos scrollar em resposta do usuário.
-  const skipScrollRef = useRef(false);
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- limpa os destaques ao trocar o schema (prop fields)
-    setHighlightedFields(new Set());
-    skipScrollRef.current = true;
-  }, [fields]);
+  // condicionais que acabaram de aparecer. Lazy-init (null → semeado abaixo)
+  // para não realocar um Set a cada render.
+  const prevVisibleNamesRef = useRef<Set<string> | null>(null);
+  // Guarda a prop `fields` do render anterior. Troca de schema/reorder também
+  // muda `visibleNames`, mas não deve disparar scroll — só resposta do usuário.
+  const prevFieldsRef = useRef(fields);
 
   const visibleFields = useMemo(
     () =>
@@ -165,31 +160,27 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     [visibleFields],
   );
 
-  useEffect(() => {
-    if (readOnly) return;
-    for (const f of fields) {
-      if (!f.condition) continue;
-      if (visibleNames.has(f.name)) continue;
-      const v = answers[f.name];
-      if (v !== undefined && v !== null && v !== "") {
-        onAnswer(f.name, null);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [visibleNames]);
+  // Semeia o set anterior com o atual no 1º render: no mount `prev === current`,
+  // logo nenhuma condicional conta como "recém-visível" e não há scroll.
+  if (prevVisibleNamesRef.current === null) {
+    prevVisibleNamesRef.current = visibleNames;
+  }
+
+  // A limpeza de respostas órfãs de condicionais que ficaram invisíveis vive no
+  // pai (`CodingPage`), aplicada no updater de `answers` ao mudar uma resposta
+  // (ver #252) — não mais num effect que empurrava dado de volta via `onAnswer`.
 
   // Quando uma resposta libera uma pergunta condicional, o DOM atualiza
   // in-place e o scroll fica parado — o pesquisador pode não perceber a nova
   // pergunta fora da viewport. Detecta o campo condicional que passou de
   // invisível para visível e rola suavemente até ele.
   useEffect(() => {
-    const prev = prevVisibleNamesRef.current;
+    const prev = prevVisibleNamesRef.current ?? new Set<string>();
     prevVisibleNamesRef.current = visibleNames;
+    const fieldsChanged = prevFieldsRef.current !== fields;
+    prevFieldsRef.current = fields;
 
-    if (skipScrollRef.current) {
-      skipScrollRef.current = false;
-      return;
-    }
+    if (fieldsChanged) return; // troca de schema/reorder, não resposta do usuário
     if (readOnly) return;
 
     const newIdx = visibleFields.findIndex(

--- a/frontend/src/lib/__tests__/conditional.test.ts
+++ b/frontend/src/lib/__tests__/conditional.test.ts
@@ -86,4 +86,127 @@ describe("clearHiddenConditionalAnswers", () => {
     clearHiddenConditionalAnswers(fields, answers);
     expect(answers.q2).toBe("a"); // entrada intacta
   });
+
+  // --- Operadores além de `equals` (a suíte original só cobria `equals`). Os
+  // operadores `not_equals`/`not_in`/`exists` invertem visibilidade de forma
+  // não-monotônica — zerar um gatilho pode *revelar* um dependente —, então são
+  // exatamente onde um bug de ponto-fixo se esconderia. Ver #252 / revisão. ---
+
+  it("not_equals: zera a condicional quando o gatilho bate o valor proibido", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", not_equals: "x" } }),
+    ];
+    // q1="x" → not_equals "x" é falso → q2 invisível → resposta órfã zerada.
+    const result = clearHiddenConditionalAnswers(fields, { q1: "x", q2: "a" });
+    expect(result.q2).toBeNull();
+    expect(result.q1).toBe("x");
+  });
+
+  it("not_equals: preserva a condicional quando o gatilho difere do proibido", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", not_equals: "x" } }),
+    ];
+    const answers = { q1: "b", q2: "a" };
+    const result = clearHiddenConditionalAnswers(fields, answers);
+    expect(result).toBe(answers); // visível → nada muda → mesma referência
+    expect(result.q2).toBe("a");
+  });
+
+  it("in: zera a condicional quando o gatilho está fora do conjunto", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", in: ["a", "b"] } }),
+    ];
+    const result = clearHiddenConditionalAnswers(fields, { q1: "c", q2: "a" });
+    expect(result.q2).toBeNull();
+  });
+
+  it("not_in: zera a condicional quando o gatilho está dentro do conjunto", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", not_in: ["a", "b"] } }),
+    ];
+    // q1="a" ∈ {a,b} → not_in é falso → q2 invisível → zerada.
+    const result = clearHiddenConditionalAnswers(fields, { q1: "a", q2: "a" });
+    expect(result.q2).toBeNull();
+  });
+
+  it("exists:false: zera a condicional quando o gatilho existe", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", exists: false } }),
+    ];
+    // q1 presente → exists=true → condição quer false → q2 invisível → zerada.
+    const result = clearHiddenConditionalAnswers(fields, { q1: "x", q2: "a" });
+    expect(result.q2).toBeNull();
+  });
+
+  it("exists: zerar um gatilho REVELA um dependente exists:false (flip não-monotônico, preserva)", () => {
+    const fields = [
+      field({ name: "a" }),
+      field({ name: "b", condition: { field: "a", equals: "sim" } }),
+      // c é visível quando b NÃO existe.
+      field({ name: "c", condition: { field: "b", exists: false } }),
+    ];
+    // a="não" esconde b (zera para null); com b=null, c (exists:false sobre b)
+    // passa a ser VISÍVEL → seu valor deve ser preservado, não zerado.
+    const result = clearHiddenConditionalAnswers(fields, {
+      a: "não",
+      b: "sim",
+      c: "x",
+    });
+    expect(result.b).toBeNull();
+    expect(result.c).toBe("x"); // revelado pelo flip → preservado
+  });
+
+  it("condição com campo aninhado/dotado (getNestedValue)", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1.sub", equals: "x" } }),
+    ];
+    // q1.sub="y" ≠ "x" → q2 invisível → zerada; q1 (objeto) intacto.
+    const result = clearHiddenConditionalAnswers(fields, {
+      q1: { sub: "y" },
+      q2: "a",
+    });
+    expect(result.q2).toBeNull();
+    expect(result.q1).toEqual({ sub: "y" });
+  });
+
+  it("cascata com operadores mistos: equals → not_equals → exists", () => {
+    const fields = [
+      field({ name: "a" }),
+      field({ name: "b", condition: { field: "a", equals: "sim" } }),
+      field({ name: "c", condition: { field: "b", not_equals: "no" } }),
+      field({ name: "d", condition: { field: "c", exists: true } }),
+    ];
+    // a="não" esconde b; b=null torna c invisível (not_equals com null é falso);
+    // c=null torna d invisível (exists:true com null é falso). Tudo zera.
+    const result = clearHiddenConditionalAnswers(fields, {
+      a: "não",
+      b: "sim",
+      c: "x",
+      d: "y",
+    });
+    expect(result.b).toBeNull();
+    expect(result.c).toBeNull();
+    expect(result.d).toBeNull();
+    expect(result.a).toBe("não");
+  });
+
+  it("termina e estabiliza com condições exists mutuamente dependentes (cada campo zera no máximo uma vez)", () => {
+    const fields = [
+      field({ name: "x", condition: { field: "y", exists: false } }),
+      field({ name: "y", condition: { field: "x", exists: false } }),
+    ];
+    // Ambos visíveis só quando o outro não existe. Com x e y preenchidos:
+    // x é invisível (y existe) → zera x; com x=null, y passa a visível → fica.
+    // O laço não oscila: um campo nulo falha o guard `v !== null` e não é
+    // re-zerado, garantindo terminação (≤N passes).
+    const result = clearHiddenConditionalAnswers(fields, { x: "1", y: "2" });
+    expect(result.x).toBeNull();
+    expect(result.y).toBe("2");
+  });
 });

--- a/frontend/src/lib/__tests__/conditional.test.ts
+++ b/frontend/src/lib/__tests__/conditional.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { clearHiddenConditionalAnswers } from "@/lib/conditional";
+import type { PydanticField } from "@/lib/types";
+
+// Helper: monta um PydanticField com defaults mínimos.
+function field(partial: Partial<PydanticField> & { name: string }): PydanticField {
+  return {
+    type: "single",
+    options: ["a", "b"],
+    description: "",
+    ...partial,
+  } as PydanticField;
+}
+
+describe("clearHiddenConditionalAnswers", () => {
+  it("zera a resposta de uma condicional que ficou invisível", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    // q1 mudou para "não" → q2 não está mais visível, mas tem resposta órfã.
+    const result = clearHiddenConditionalAnswers(fields, { q1: "não", q2: "a" });
+    expect(result.q2).toBeNull();
+    expect(result.q1).toBe("não");
+  });
+
+  it("preserva a resposta de uma condicional ainda visível", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const answers = { q1: "sim", q2: "a" };
+    const result = clearHiddenConditionalAnswers(fields, answers);
+    expect(result).toBe(answers); // nada mudou → mesma referência
+    expect(result.q2).toBe("a");
+  });
+
+  it("aplica ponto-fixo em cascata: A esconde B, B esconde C", () => {
+    const fields = [
+      field({ name: "a" }),
+      field({ name: "b", condition: { field: "a", equals: "sim" } }),
+      field({ name: "c", condition: { field: "b", equals: "sim" } }),
+    ];
+    // a="não" esconde b; ao limpar b, c (que dependia de b="sim") também some.
+    const result = clearHiddenConditionalAnswers(fields, {
+      a: "não",
+      b: "sim",
+      c: "x",
+    });
+    expect(result.b).toBeNull();
+    expect(result.c).toBeNull();
+    expect(result.a).toBe("não");
+  });
+
+  it("retorna o mesmo objeto quando não há nada a limpar (identidade preservada)", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const answers = { q1: "sim" }; // q2 visível e sem resposta
+    expect(clearHiddenConditionalAnswers(fields, answers)).toBe(answers);
+  });
+
+  it("não toca campos sem condition (sempre visíveis)", () => {
+    const fields = [field({ name: "q1" }), field({ name: "q2" })];
+    const answers = { q1: "a", q2: "b" };
+    const result = clearHiddenConditionalAnswers(fields, answers);
+    expect(result).toBe(answers);
+  });
+
+  it("não cria churn para condicional invisível já vazia", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const answers = { q1: "não" }; // q2 invisível e sem resposta
+    expect(clearHiddenConditionalAnswers(fields, answers)).toBe(answers);
+  });
+
+  it("não muta o objeto de entrada", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const answers = { q1: "não", q2: "a" };
+    clearHiddenConditionalAnswers(fields, answers);
+    expect(answers.q2).toBe("a"); // entrada intacta
+  });
+});

--- a/frontend/src/lib/conditional.ts
+++ b/frontend/src/lib/conditional.ts
@@ -71,6 +71,33 @@ export function isFieldVisible(
   return evaluateCondition(field.condition, answers);
 }
 
+// Zera as respostas de campos condicionais que não estão mais visíveis. Aplica
+// ponto-fixo: limpar uma condicional pode esconder outra que dependia dela. Não
+// muta a entrada — clona apenas na primeira mudança real (copy-on-write) e
+// retorna o MESMO objeto quando nada muda, preservando a identidade referencial
+// que o React usa para evitar re-renders.
+export function clearHiddenConditionalAnswers(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+): Record<string, unknown> {
+  let next = answers;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const f of fields) {
+      if (!f.condition) continue;
+      if (isFieldVisible(f, next)) continue;
+      const v = next[f.name];
+      if (v !== undefined && v !== null && v !== "") {
+        if (next === answers) next = { ...answers };
+        next[f.name] = null;
+        changed = true;
+      }
+    }
+  }
+  return next;
+}
+
 // Campos que podem servir de gatilho para a condição de `currentFieldName`:
 // apenas campos anteriores (a condição só pode referenciar campos já definidos)
 // e com opções (single/multi). Usado pelos editores de schema.


### PR DESCRIPTION
Parte do épico **Zerar react-doctor** (#239), **Onda 4**.

`components/coding/QuestionsPanel.tsx` acumulava **6 diagnósticos** (1 error + 5 warnings). Este PR os **refatora — não suprime** — eliminando os anti-patterns de `useEffect` que os geravam, com comportamento preservado.

## Diagnósticos eliminados (todos, 6 → 0)

| Regra | Sev. | Como foi resolvido |
|---|---|---|
| `no-prop-callback-in-effect` | warning | limpeza de condicionais órfãs levantada ao pai |
| `no-pass-data-to-parent` | warning | idem (não empurra mais dado via effect) |
| `no-event-handler` | warning | idem (lógica saiu do effect) |
| `no-adjust-state-on-prop-change` | **error** | removido o effect que resetava highlights ao mudar `fields` |
| `no-reset-all-state-on-prop-change` | warning | idem |
| `rerender-lazy-ref-init` | warning | lazy-init do ref de visibilidade |

## O que mudou

**1. `lib/conditional.ts` — novo helper puro `clearHiddenConditionalAnswers`**
Zera respostas de condicionais que ficaram invisíveis. *Copy-on-write* (retorna a mesma referência quando nada muda, preservando identidade para o React) + ponto-fixo (cascata: A esconde B esconde C). Coberto por 7 testes novos.

**2. `CodingPage.tsx` — limpeza levantada ao pai**
`handleAnswer` e `handleBrowseAnswer` aplicam o helper **dentro do updater** de `answers`. A invariante "ao mudar uma resposta, limpe as condicionais órfãs" passa a viver no dono do estado, de forma atômica (um único `setState`, sem render extra), em vez de num `useEffect` do filho que chamava `onAnswer` de volta.

**3. `QuestionsPanel.tsx` — effects de prop removidos**
- Removido o effect que resetava `highlightedFields` ao mudar `fields`. O reset **por documento** já vem do `key={currentDoc?.id}` no pai (remonta). O reset **por schema/reorder** era inerte (nomes de campo são estáveis no reorder; `highlightedFields.has(name)` só é lido para campos visíveis e cada campo limpa o próprio highlight ao ser respondido).
- O effect de scroll passou a ser **auto-suficiente**: detecta mount (seed do `prevVisibleNamesRef` no 1º render) e troca de schema/reorder (compara `prevFieldsRef`), substituindo o flag imperativo `skipScrollRef`.

### Mudança de comportamento (deliberada)

Highlights de validação agora **persistem através de um reorder** em vez de sumirem — comportamento igual-ou-melhor (os erros de validação seguem visíveis ao reordenar). A limpeza de mount do effect antigo (reconciliação de dados pré-existentes) era um no-op na prática: os dados de `allAnswers` vêm de saves anteriores, que sempre passaram por essa mesma limpeza antes de gravar.

## Verificação

- `npx react-doctor . --json` → **0 diagnósticos** com `QuestionsPanel` no caminho (critério de pronto).
- **576 testes** verdes (suíte completa), incluindo os 6 testes de scroll de `QuestionsPanel.test.tsx` (sem edição) e os 7 do helper.
- `tsc --noEmit` limpo; `eslint` sem novos problemas (o único warning é pré-existente em linha não tocada).
- Mantida a supressão de `exhaustive-deps` deste arquivo (effect de scroll), conforme a issue pede.

Verify manual sugerido: responder gatilho (condicional aparece + scroll), reverter gatilho (condicional some + resposta limpa, inclusive em cascata), submeter com obrigatórias faltando (highlights + scroll), reordenar (sem scroll, sem limpar), readOnly.

Closes #252