### PR TITLE
fix(upload): hardening do fluxo de import (erros de query, sucesso parcial, parse)

### DIFF
--- a/frontend/src/actions/__tests__/documents.test.ts
+++ b/frontend/src/actions/__tests__/documents.test.ts
@@ -38,6 +38,10 @@ async function loadUpload() {
   return (await import("@/actions/documents")).uploadDocuments;
 }
 
+async function loadCheck() {
+  return (await import("@/actions/documents")).checkDuplicates;
+}
+
 function insertedExternalIds(): (string | null)[] {
   const call = writeCalls.find(
     (c) => c.table === "documents" && c.op === "insert",
@@ -198,5 +202,62 @@ describe("uploadDocuments — replace_and_add propaga erro de UPDATE", () => {
     expect(
       writeCalls.some((c) => c.table === "documents" && c.op === "insert"),
     ).toBe(false);
+  });
+});
+
+describe("checkDuplicates — propaga erro de query (não engole silenciosamente)", () => {
+  it("lança quando a query por external_id falha", async () => {
+    serverTableResults = {
+      documents: [{ error: { message: "db down" } }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    await expect(
+      checkDuplicates("proj-1", [
+        { external_id: "X", text_hash: "h1", csvIndex: 0 },
+      ]),
+    ).rejects.toThrow(/ID externo/);
+  });
+
+  it("lança quando a query por text_hash falha (docs sem external_id)", async () => {
+    // Sem external_id, o bloco 1 é pulado e a query de hash é a 1ª em documents.
+    serverTableResults = {
+      documents: [{ error: { message: "hash fail" } }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    await expect(
+      checkDuplicates("proj-1", [{ text_hash: "h1", csvIndex: 0 }]),
+    ).rejects.toThrow(/hash de conteúdo/);
+  });
+
+  it("lança quando a query de responses falha", async () => {
+    // extId acha 1 duplicata → dispara a query de responses, que falha.
+    serverTableResults = {
+      documents: [{ data: [{ id: "d1", external_id: "X" }] }],
+      responses: [{ error: { message: "resp fail" } }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    await expect(
+      checkDuplicates("proj-1", [
+        { external_id: "X", text_hash: "h1", csvIndex: 0 },
+      ]),
+    ).rejects.toThrow(/respostas das duplicatas/);
+  });
+
+  it("caminho feliz: retorna duplicatas sem lançar quando não há erro", async () => {
+    serverTableResults = {
+      documents: [{ data: [{ id: "d1", external_id: "X" }] }],
+      responses: [{ data: [] }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    const r = await checkDuplicates("proj-1", [
+      { external_id: "X", text_hash: "h1", csvIndex: 0 },
+    ]);
+
+    expect(r.duplicates).toHaveLength(1);
+    expect(r.duplicatesWithResponses).toBe(0);
   });
 });

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -53,7 +53,7 @@ export async function checkDuplicates(
   // 1. Match by external_id (excluidos sao ignorados — re-upload de doc
   //    excluido por engano cria um novo registro normal)
   if (externalIds.length > 0) {
-    const { data: byExtId } = await supabase
+    const { data: byExtId, error: byExtIdErr } = await supabase
       .from("documents")
       .select("id, external_id")
       .eq("project_id", projectId)
@@ -61,6 +61,10 @@ export async function checkDuplicates(
       .in(
         "external_id",
         externalIds.map((e) => e.id!)
+      );
+    if (byExtIdErr)
+      throw new Error(
+        `Falha ao verificar duplicatas por ID externo: ${byExtIdErr.message}`,
       );
 
     if (byExtId) {
@@ -86,12 +90,16 @@ export async function checkDuplicates(
 
   if (unmatchedHashes.length > 0) {
     const uniqueHashes = [...new Set(unmatchedHashes.map((h) => h.hash))];
-    const { data: byHash } = await supabase
+    const { data: byHash, error: byHashErr } = await supabase
       .from("documents")
       .select("id, text_hash")
       .eq("project_id", projectId)
       .is("excluded_at", null)
       .in("text_hash", uniqueHashes);
+    if (byHashErr)
+      throw new Error(
+        `Falha ao verificar duplicatas por hash de conteúdo: ${byHashErr.message}`,
+      );
 
     if (byHash) {
       const hashMap = new Map(byHash.map((d) => [d.text_hash, d.id]));
@@ -112,11 +120,15 @@ export async function checkDuplicates(
   let duplicatesWithResponses = 0;
   if (duplicates.length > 0) {
     const docIds = duplicates.map((d) => d.existingDocId);
-    const { data: responses } = await supabase
+    const { data: responses, error: responsesErr } = await supabase
       .from("responses")
       .select("document_id")
       .eq("project_id", projectId)
       .in("document_id", docIds);
+    if (responsesErr)
+      throw new Error(
+        `Falha ao verificar respostas das duplicatas: ${responsesErr.message}`,
+      );
 
     if (responses) {
       const docsWithResponses = new Set(responses.map((r) => r.document_id));
@@ -188,6 +200,15 @@ async function filterActiveExternalIdConflicts<
   });
 
   return { rows: safe, skippedExisting, skippedInBatch };
+}
+
+// Revalida o cache de documentos do projeto: o path dinâmico de config e a tag
+// usada pela página cacheada de assignments — o mesmo par que uploadDocuments
+// dispara no último chunk. Usado quando um upload em chunks falha no meio, para
+// que os chunks já inseridos apareçam mesmo sem o revalidate do último chunk.
+export async function revalidateProjectDocuments(projectId: string) {
+  revalidatePath(`/projects/${projectId}/config/documents`);
+  revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
 }
 
 export async function uploadDocuments(

--- a/frontend/src/hooks/__tests__/useDocumentUpload.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentUpload.test.ts
@@ -5,10 +5,12 @@ import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
 // papaparse não tinha precedente de mock no projeto: handleFile faz
 // `(await import("papaparse")).default`, então mockamos o default export.
 const { parse } = vi.hoisted(() => ({ parse: vi.fn() }));
-const { checkDuplicates, uploadDocuments } = vi.hoisted(() => ({
-  checkDuplicates: vi.fn(),
-  uploadDocuments: vi.fn(),
-}));
+const { checkDuplicates, uploadDocuments, revalidateProjectDocuments } =
+  vi.hoisted(() => ({
+    checkDuplicates: vi.fn(),
+    uploadDocuments: vi.fn(),
+    revalidateProjectDocuments: vi.fn(async () => {}),
+  }));
 const { toastSuccess, toastError, toastWarning } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
@@ -16,7 +18,11 @@ const { toastSuccess, toastError, toastWarning } = vi.hoisted(() => ({
 }));
 
 vi.mock("papaparse", () => ({ default: { parse } }));
-vi.mock("@/actions/documents", () => ({ checkDuplicates, uploadDocuments }));
+vi.mock("@/actions/documents", () => ({
+  checkDuplicates,
+  uploadDocuments,
+  revalidateProjectDocuments,
+}));
 vi.mock("sonner", () => ({
   toast: { success: toastSuccess, error: toastError, warning: toastWarning },
 }));
@@ -98,5 +104,79 @@ describe("useDocumentUpload — recuperação de falha (returnTo)", () => {
     if (result.current.phase.kind === "analysis") {
       expect(result.current.phase.analysis.docs).toHaveLength(1);
     }
+  });
+});
+
+describe("useDocumentUpload — sucesso parcial em upload multi-chunk", () => {
+  it("revalida e reporta o parcial quando um chunk falha após outros entrarem", async () => {
+    // 501 docs → 2 chunks (teto de 500 por chunk); o 2º falha.
+    const rows = Array.from({ length: 501 }, (_, i) => ({ text_col: `linha ${i}` }));
+    checkDuplicates.mockResolvedValue({ duplicates: [], duplicatesWithResponses: 0 });
+    uploadDocuments
+      .mockResolvedValueOnce({ count: 500, skipped: 0 })
+      .mockResolvedValueOnce({ error: "boom" });
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    feedCsv(rows, ["text_col"]);
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+    act(() =>
+      result.current.setMapping({ text: "text_col", title: "", external_id: "" })
+    );
+
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+
+    expect(uploadDocuments).toHaveBeenCalledTimes(2);
+    expect(revalidateProjectDocuments).toHaveBeenCalledWith("p1");
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("500"));
+    expect(result.current.phase.kind).toBe("mapping");
+  });
+
+  it("não revalida quando a falha ocorre no primeiro chunk (nada inserido)", async () => {
+    checkDuplicates.mockResolvedValue({ duplicates: [], duplicatesWithResponses: 0 });
+    uploadDocuments.mockResolvedValue({ error: "boom" });
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    await primeMapping(result);
+
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+
+    expect(revalidateProjectDocuments).not.toHaveBeenCalled();
+    expect(result.current.phase.kind).toBe("mapping");
+  });
+});
+
+describe("useDocumentUpload — erros de parsing do CSV", () => {
+  it("erro fatal do Papa.parse aborta em 'idle' com toast", async () => {
+    parse.mockImplementation(
+      (_file: unknown, opts: { error: (e: Error) => void }) => {
+        opts.error(new Error("arquivo corrompido"));
+      }
+    );
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+
+    expect(toastError).toHaveBeenCalled();
+    expect(result.current.phase.kind).toBe("idle");
+  });
+
+  it("avisos de parsing (results.errors) seguem para 'mapping'", async () => {
+    feedCsv([{ text_col: "ok" }], ["text_col"], [{ type: "Quotes" }]);
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+
+    expect(toastWarning).toHaveBeenCalled();
+    expect(result.current.phase.kind).toBe("mapping");
   });
 });

--- a/frontend/src/hooks/useDocumentUpload.ts
+++ b/frontend/src/hooks/useDocumentUpload.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import {
   uploadDocuments,
   checkDuplicates,
+  revalidateProjectDocuments,
   type DuplicateMatch,
   type UploadDoc,
   type UploadOptions,
@@ -69,11 +70,26 @@ export function useDocumentUpload(projectId: string) {
     Papa.parse(file, {
       header: true,
       complete: (results) => {
+        // PapaParse é tolerante: popula `errors` em problemas recuperáveis
+        // (aspas, contagem de campos) mas ainda devolve linhas. Avisa e segue —
+        // linhas parciais costumam ser mapeáveis.
+        if (results.errors?.length) {
+          console.warn("[useDocumentUpload] Papa.parse avisos", results.errors);
+          toast.warning(
+            `CSV lido com ${results.errors.length} aviso(s) de parsing; confira as linhas afetadas.`
+          );
+        }
         const rows = results.data as Record<string, string>[];
         const columns = results.meta.fields || [];
         setCsv({ rows, columns });
         setMapping({ text: "", title: "", external_id: "" });
         setPhase({ kind: "mapping" });
+      },
+      // Erro fatal de leitura/parsing: aborta sem sair de `idle` (a dropzone
+      // continua visível para nova tentativa).
+      error: (err) => {
+        console.error("[useDocumentUpload] Papa.parse falhou", err);
+        toast.error(`Não foi possível ler o CSV: ${err.message}`);
       },
     });
   }, []);
@@ -98,9 +114,12 @@ export function useDocumentUpload(projectId: string) {
   ) => {
     setPhase({ kind: "uploading", current: 0, total: docs.length });
 
+    // Hoisted out of the try so the catch can report how many docs landed
+    // before a failure (counts docs in completed chunks, not the net inserted —
+    // uploadDocuments may skip some via duplicate filtering).
+    let processed = 0;
     try {
       const chunks = chunkByBytes(docs);
-      let processed = 0;
       for (let ci = 0; ci < chunks.length; ci++) {
         const { items, startIndex } = chunks[ci];
         const endIndex = startIndex + items.length;
@@ -138,12 +157,24 @@ export function useDocumentUpload(projectId: string) {
       setCsv(null);
       setPhase({ kind: "idle" });
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "";
-      toast.error(
-        isPayloadTooLarge(msg)
-          ? PAYLOAD_TOO_LARGE_MESSAGE
-          : msg || "Erro ao importar documentos"
-      );
+      console.error("[useDocumentUpload] doUpload falhou", e);
+      const msg = e instanceof Error ? e.message : typeof e === "string" ? e : "";
+      if (processed > 0) {
+        // Chunks 0..N-1 já foram commitados, mas só o último chunk revalida o
+        // cache; revalida aqui para que esses docs apareçam na lista.
+        await revalidateProjectDocuments(projectId);
+        toast.error(
+          isPayloadTooLarge(msg)
+            ? `${processed}/${docs.length} importados. ${PAYLOAD_TOO_LARGE_MESSAGE}`
+            : `${processed} de ${docs.length} documentos importados antes de uma falha${msg ? `: ${msg}` : ""}`
+        );
+      } else {
+        toast.error(
+          isPayloadTooLarge(msg)
+            ? PAYLOAD_TOO_LARGE_MESSAGE
+            : msg || "Erro ao importar documentos"
+        );
+      }
       setPhase(returnTo);
     }
   };
@@ -212,7 +243,8 @@ export function useDocumentUpload(projectId: string) {
         });
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "";
+      console.error("[useDocumentUpload] handleCheckAndUpload falhou", e);
+      const msg = e instanceof Error ? e.message : typeof e === "string" ? e : "";
       toast.error(
         isPayloadTooLarge(msg)
           ? PAYLOAD_TOO_LARGE_MESSAGE


### PR DESCRIPTION
**PR empilhado sobre #264** (base = `worktree-react-doctor-documentupload-254`). O GitHub re-aponta para `main` quando #264 mesclar; até lá, o diff mostra só este hardening. Decorre da revisão do #264, que aprovou o refactor e apontou quatro riscos de **falha silenciosa herdados** do código movido — nenhum introduzido por aquele PR.

## O que muda

| Risco | Onde | Correção |
|---|---|---|
| **B — `checkDuplicates` engolia erro de query** 🔴 | `actions/documents.ts` | As 3 queries `.select()` ignoravam `error` e retornavam `{ duplicates: [] }` em falha de RLS/timeout/rede — o hook importava **tudo como novo**, reinserindo duplicatas casadas por hash sem aviso. Agora cada query propaga (`throw`); o `catch` de `handleCheckAndUpload` mostra o toast e volta a `mapping`. |
| **C — sucesso parcial invisível** | `useDocumentUpload.ts` + nova action | Falha no chunk N deixava 0..N-1 inseridos, mas só o último chunk revalida → docs invisíveis + toast genérico. Nova action `revalidateProjectDocuments` é chamada no `catch` quando `processed > 0`, e o toast reporta o parcial (`"X de Y importados antes de uma falha"`). |
| **D — `Papa.parse` sem tratamento de erro** | `useDocumentUpload.ts` | `handleFile` não tinha callback `error` nem olhava `results.errors`. Agora erro fatal aborta em `idle` (dropzone visível); avisos de parsing emitem `toast.warning` e seguem para `mapping`. |
| **E — catches sem logging** | `useDocumentUpload.ts` | Os dois `catch` passam a `console.error` o erro bruto e a tratar erros não-`Error` (string lançada). |

### Por que `revalidateProjectDocuments` basta (sem `router.refresh()`)
Validado por paridade in-repo: `excludeDocuments`/`restoreDocuments` rodam na mesma página `config/documents` e atualizam a lista usando apenas `revalidatePath` + `revalidateTag`. A página de config é dinâmica (coberta por `revalidatePath`) e a de assignments é cacheada pela tag `project-${id}-documents` (coberta por `revalidateTag`) — o mesmo par que `uploadDocuments` já dispara no último chunk.

## Testes
- `checkDuplicates` lançando nas 3 queries + regressão do caminho feliz (`documents.test.ts`).
- Sucesso parcial revalida e reporta; falha no 1º chunk **não** revalida; erro fatal e avisos do `Papa.parse` (`useDocumentUpload.test.ts`).
- **587 testes** passam; `tsc`/`eslint` limpos; react-doctor 100/100 no diff.

## Validação manual recomendada (não rodada — sem env Clerk/Supabase)
Exercer no preview: caminho sem/com duplicatas; **sucesso parcial** (CSV >500 docs com falha forçada no meio → docs já inseridos aparecem na lista após o toast); CSV malformado dispara aviso/erro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)