### PR TITLE
refactor(arbitration): zera react-doctor em ArbitrationPage (Onda 4) (#250)

### DIFF
--- a/frontend/src/components/arbitration/ArbitrationEmptyState.tsx
+++ b/frontend/src/components/arbitration/ArbitrationEmptyState.tsx
@@ -1,0 +1,11 @@
+export function ArbitrationEmptyState() {
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 px-6 py-10 text-center">
+      <h1 className="mb-4 text-2xl font-semibold">Arbitragem</h1>
+      <p className="text-muted-foreground">
+        Nenhuma arbitragem pendente. Quando outro pesquisador contestar o LLM em
+        uma codificação atribuída a você, ela aparecerá aqui.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/arbitration/ArbitrationPage.tsx
+++ b/frontend/src/components/arbitration/ArbitrationPage.tsx
@@ -1,30 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@/components/ui/resizable";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { toast } from "sonner";
-import { DocumentReader } from "@/components/coding/DocumentReader";
-import {
-  submitBlindVerdicts,
-  submitFinalVerdicts,
-  type BlindChoice,
-  type FinalChoice,
-} from "@/actions/field-reviews";
-import {
-  ArbitrationDocList,
-  type ArbitrationDocListEntry,
-} from "./ArbitrationDocList";
-import { BlindPhase } from "./BlindPhase";
-import { RevealPhase } from "./RevealPhase";
+import { useMemo, useState } from "react";
+import { usePinnedDoc } from "@/hooks/usePinnedDoc";
+import { useArbitrationDoc } from "@/hooks/useArbitrationDoc";
 import type { ArbitrationVerdict, PydanticField } from "@/lib/types";
+import { type ArbitrationDocListEntry } from "./ArbitrationDocList";
+import { ArbitrationEmptyState } from "./ArbitrationEmptyState";
+import { ArbitrationPageHeader } from "./ArbitrationPageHeader";
+import { ArbitrationPageContent } from "./ArbitrationPageContent";
 
 export interface ArbitrationField {
   fieldReviewId: string;
@@ -58,11 +41,6 @@ export interface ArbitrationPageProps {
   arbitrationBlind: boolean;
 }
 
-function computePhaseForDoc(doc: ArbitrationDoc | undefined): "blind" | "reveal" {
-  if (!doc || doc.fields.length === 0) return "blind";
-  return doc.fields.every((f) => f.blindVerdict !== null) ? "reveal" : "blind";
-}
-
 const STORAGE_KEY_PREFIX = "arbitration:docId:";
 
 export function ArbitrationPage({
@@ -71,16 +49,13 @@ export function ArbitrationPage({
   docs,
   arbitrationBlind,
 }: ArbitrationPageProps) {
-  const { refresh } = useRouter();
   const storageKey = `${STORAGE_KEY_PREFIX}${projectId}`;
-  const [pinnedDocId, setPinnedDocId] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    const v = window.sessionStorage.getItem(storageKey);
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- restaura o doc do sessionStorage (client-only)
-    if (v) setPinnedDocId(v);
-  }, [storageKey]);
+  const validDocIds = useMemo(() => docs.map((d) => d.docId), [docs]);
+  // Seleção persistida em sessionStorage (restore + limpeza de órfão) encapsulada
+  // em usePinnedDoc — o hook lê via useSyncExternalStore (sem effect de restore).
+  const [pinnedDocId, setPinnedDocId] = usePinnedDoc(storageKey, {
+    validIds: validDocIds,
+  });
 
   const docIndex = useMemo(() => {
     if (docs.length === 0) return 0;
@@ -91,64 +66,27 @@ export function ArbitrationPage({
     return 0;
   }, [docs, pinnedDocId]);
 
-  const [phase, setPhase] = useState<"blind" | "reveal">(() =>
-    computePhaseForDoc(docs[0]),
-  );
   const [listCollapsed, setListCollapsed] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  // Todos os states são keyed por fieldReviewId (UUID único globalmente), nunca
-  // por fieldName — fieldName se repete entre documentos, e chavear por ele
-  // faria uma escolha em "q1" do doc A reaparecer pre-selecionada em "q1" do
-  // doc B. fieldReviewId garante isolamento natural por (doc, campo).
-  const [blindChoices, setBlindChoices] = useState<Record<string, "a" | "b">>(
-    {},
-  );
-  const [finalChoices, setFinalChoices] = useState<
-    Record<string, ArbitrationVerdict>
-  >({});
-  const [suggestions, setSuggestions] = useState<Record<string, string>>({});
-  const [comments, setComments] = useState<Record<string, string>>({});
 
   const fieldMeta = useMemo(
     () => new Map(fields.map((f) => [f.name, f])),
     [fields],
   );
 
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- recalcula a fase (blind/reveal) ao trocar de documento
-    setPhase(computePhaseForDoc(docs[docIndex]));
-  }, [docIndex, docs]);
-
-  // Pre-popular finalChoices ao entrar na fase reveal: por padrão mantém a
-  // escolha cega — árbitro só precisa intervir se mudar de ideia.
-  useEffect(() => {
-    if (phase !== "reveal") return;
-    const currentDoc = docs[docIndex];
-    if (!currentDoc) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- pré-popula as escolhas finais com o verdict cego ao entrar na fase reveal
-    setFinalChoices((prev) => {
-      const merged = { ...prev };
-      let changed = false;
-      for (const f of currentDoc.fields) {
-        if (merged[f.fieldReviewId] == null && f.blindVerdict != null) {
-          merged[f.fieldReviewId] = f.blindVerdict;
-          changed = true;
-        }
-      }
-      return changed ? merged : prev;
-    });
-  }, [phase, docIndex, docs]);
-
   function handleDocNavigate(newIndex: number) {
     const clamped = Math.max(0, Math.min(newIndex, docs.length - 1));
     const target = docs[clamped];
-    if (target) {
-      setPinnedDocId(target.docId);
-      if (typeof window !== "undefined") {
-        window.sessionStorage.setItem(storageKey, target.docId);
-      }
-    }
+    if (target) setPinnedDocId(target.docId);
   }
+
+  const doc = docs[docIndex];
+  const arb = useArbitrationDoc({
+    doc,
+    docIndex,
+    docsLength: docs.length,
+    projectId,
+    onNavigate: handleDocNavigate,
+  });
 
   const docListEntries: ArbitrationDocListEntry[] = useMemo(
     () =>
@@ -158,225 +96,53 @@ export function ArbitrationPage({
         externalId: d.externalId,
         totalFields: d.fields.length,
         blindDecided: d.fields.filter((f) => f.blindVerdict !== null).length,
-        // Os campos vêm do server com final_verdict=NULL — o que está aqui é só
-        // a decisão local na sessão (ainda não enviada).
+        // finalDecided deriva de effectiveFinalChoices: para o doc atual inclui
+        // o piso do verdict cego (fase reveal); para os demais, só os overrides
+        // já feitos. Os campos vêm do server com final_verdict=NULL.
         finalDecided: d.fields.filter(
-          (f) => finalChoices[f.fieldReviewId] != null,
+          (f) => arb.effectiveFinalChoices[f.fieldReviewId] != null,
         ).length,
       })),
-    [docs, finalChoices],
+    [docs, arb.effectiveFinalChoices],
   );
 
   if (docs.length === 0) {
-    return (
-      <div className="mx-auto max-w-3xl space-y-4 px-6 py-10 text-center">
-        <h1 className="mb-4 text-2xl font-semibold">Arbitragem</h1>
-        <p className="text-muted-foreground">
-          Nenhuma arbitragem pendente. Quando outro pesquisador contestar o LLM
-          em uma codificação atribuída a você, ela aparecerá aqui.
-        </p>
-      </div>
-    );
-  }
-
-  const doc = docs[docIndex];
-  const allBlindChosen = doc.fields.every(
-    (f) => f.blindVerdict !== null || blindChoices[f.fieldReviewId] != null,
-  );
-  const allFinalChosen = doc.fields.every(
-    (f) => finalChoices[f.fieldReviewId] != null,
-  );
-
-  async function handleBlindSubmit() {
-    setSubmitting(true);
-    const choices: BlindChoice[] = doc.fields
-      .filter((f) => f.blindVerdict === null)
-      .map((f) => ({
-        fieldReviewId: f.fieldReviewId,
-        choice: blindChoices[f.fieldReviewId],
-      }));
-    if (choices.length > 0) {
-      const r = await submitBlindVerdicts(projectId, doc.docId, choices);
-      if (!r.success) {
-        setSubmitting(false);
-        toast.error(r.error ?? "Falha ao registrar veredito cego");
-        return;
-      }
-    }
-    // refresh() repuxa o payload com `reveal` populado para esses
-    // campos. O useEffect acima detecta blindVerdict definido e muda phase
-    // para "reveal" automaticamente.
-    refresh();
-    setSubmitting(false);
-  }
-
-  async function handleFinalSubmit() {
-    for (const f of doc.fields) {
-      if (finalChoices[f.fieldReviewId] === "llm") {
-        if (!suggestions[f.fieldReviewId]?.trim()) {
-          toast.error(
-            `Campo "${f.fieldName}": preencha a sugestão de melhoria.`,
-          );
-          return;
-        }
-      }
-    }
-    setSubmitting(true);
-    const payload: FinalChoice[] = doc.fields.map((f) => ({
-      fieldName: f.fieldName,
-      verdict: finalChoices[f.fieldReviewId],
-      questionImprovementSuggestion:
-        finalChoices[f.fieldReviewId] === "llm"
-          ? suggestions[f.fieldReviewId]
-          : undefined,
-      arbitratorComment: comments[f.fieldReviewId] || undefined,
-    }));
-    const r = await submitFinalVerdicts(projectId, doc.docId, payload);
-    setSubmitting(false);
-    if (!r.success) {
-      toast.error(r.error ?? "Falha ao enviar veredito final");
-      return;
-    }
-    toast.success("Arbitragem concluída para este documento.");
-    setBlindChoices({});
-    setFinalChoices({});
-    setSuggestions({});
-    setComments({});
-    if (docIndex < docs.length - 1) {
-      handleDocNavigate(docIndex + 1);
-    } else {
-      refresh();
-    }
+    return <ArbitrationEmptyState />;
   }
 
   return (
     <div className="flex h-[calc(100vh-96px)] flex-col">
-      <div className="flex h-10 shrink-0 items-center justify-between border-b px-4 text-sm">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="truncate font-medium">Arbitragem humano vs LLM</span>
-          <Badge variant={phase === "blind" ? "default" : "secondary"}>
-            {phase === "blind" ? "Cega" : "Revelação"}
-          </Badge>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Badge variant="secondary" className="text-xs">
-            {docs.length} doc{docs.length === 1 ? "" : "s"}
-          </Badge>
-          <div className="flex items-center gap-0.5">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-6"
-              onClick={() => handleDocNavigate(docIndex - 1)}
-              disabled={docIndex === 0}
-              title="Documento anterior"
-            >
-              <ChevronLeft className="size-4" />
-            </Button>
-            <span className="text-xs text-muted-foreground">
-              {docIndex + 1}/{docs.length}
-            </span>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-6"
-              onClick={() => handleDocNavigate(docIndex + 1)}
-              disabled={docIndex === docs.length - 1}
-              title="Próximo documento"
-            >
-              <ChevronRight className="size-4" />
-            </Button>
-          </div>
-          {phase === "reveal" ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setPhase("blind")}
-              title="Voltar à fase cega (sua decisão fica registrada)"
-            >
-              Voltar à cega
-            </Button>
-          ) : null}
-          {phase === "blind" ? (
-            <Button
-              size="sm"
-              onClick={handleBlindSubmit}
-              disabled={!allBlindChosen || submitting}
-            >
-              {submitting ? "Salvando…" : "Avançar para revelação"}
-            </Button>
-          ) : (
-            <Button
-              size="sm"
-              onClick={handleFinalSubmit}
-              disabled={!allFinalChosen || submitting}
-            >
-              {submitting ? "Enviando…" : "Enviar arbitragem"}
-            </Button>
-          )}
-        </div>
-      </div>
-
-      <div className="flex flex-1 overflow-hidden">
-        <ArbitrationDocList
-          docs={docListEntries}
-          currentIndex={docIndex}
-          onSelect={handleDocNavigate}
-          collapsed={listCollapsed}
-          onToggle={() => setListCollapsed((v) => !v)}
-        />
-        <ResizablePanelGroup className="flex-1">
-          <ResizablePanel defaultSize={50} minSize={25}>
-            <DocumentReader text={doc.text} />
-          </ResizablePanel>
-          <ResizableHandle withHandle />
-          <ResizablePanel defaultSize={50} minSize={25}>
-            <div className="flex h-full flex-col">
-              <div className="shrink-0 border-b px-4 py-2 text-xs text-muted-foreground">
-                {phase === "blind"
-                  ? "Fase 1 (cega): escolha sem ver a justificativa do LLM."
-                  : "Fase 2: agora você vê a justificativa do LLM. Pode manter ou mudar sua escolha."}
-              </div>
-              <div className="flex-1 overflow-y-auto px-4 py-3">
-                {phase === "blind" ? (
-                  <BlindPhase
-                    fields={doc.fields}
-                    fieldMeta={fieldMeta}
-                    choices={blindChoices}
-                    onChoose={(fieldReviewId, choice) =>
-                      setBlindChoices((c) => ({
-                        ...c,
-                        [fieldReviewId]: choice,
-                      }))
-                    }
-                  />
-                ) : (
-                  <RevealPhase
-                    fields={doc.fields}
-                    fieldMeta={fieldMeta}
-                    arbitrationBlind={arbitrationBlind}
-                    finalChoices={finalChoices}
-                    suggestions={suggestions}
-                    comments={comments}
-                    onChooseFinal={(fieldReviewId, verdict) =>
-                      setFinalChoices((c) => ({
-                        ...c,
-                        [fieldReviewId]: verdict,
-                      }))
-                    }
-                    onSuggestion={(fieldReviewId, v) =>
-                      setSuggestions((s) => ({ ...s, [fieldReviewId]: v }))
-                    }
-                    onComment={(fieldReviewId, v) =>
-                      setComments((s) => ({ ...s, [fieldReviewId]: v }))
-                    }
-                  />
-                )}
-              </div>
-            </div>
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      </div>
+      <ArbitrationPageHeader
+        phase={arb.phase}
+        docIndex={docIndex}
+        docsLength={docs.length}
+        submitting={arb.submitting}
+        allBlindChosen={arb.allBlindChosen}
+        allFinalChosen={arb.allFinalChosen}
+        onNavigate={handleDocNavigate}
+        onBackToBlind={arb.onBackToBlind}
+        onBlindSubmit={arb.handleBlindSubmit}
+        onFinalSubmit={arb.handleFinalSubmit}
+      />
+      <ArbitrationPageContent
+        doc={doc}
+        fieldMeta={fieldMeta}
+        phase={arb.phase}
+        arbitrationBlind={arbitrationBlind}
+        docListEntries={docListEntries}
+        docIndex={docIndex}
+        listCollapsed={listCollapsed}
+        onSelectDoc={handleDocNavigate}
+        onToggleList={() => setListCollapsed((v) => !v)}
+        blindChoices={arb.blindChoices}
+        finalChoices={arb.effectiveFinalChoices}
+        suggestions={arb.suggestions}
+        comments={arb.comments}
+        onChooseBlind={arb.onChooseBlind}
+        onChooseFinal={arb.onChooseFinal}
+        onSuggestion={arb.onSuggestion}
+        onComment={arb.onComment}
+      />
     </div>
   );
 }

--- a/frontend/src/components/arbitration/ArbitrationPageContent.tsx
+++ b/frontend/src/components/arbitration/ArbitrationPageContent.tsx
@@ -1,0 +1,103 @@
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { DocumentReader } from "@/components/coding/DocumentReader";
+import type { ArbitrationVerdict, PydanticField } from "@/lib/types";
+import {
+  ArbitrationDocList,
+  type ArbitrationDocListEntry,
+} from "./ArbitrationDocList";
+import type { ArbitrationDoc } from "./ArbitrationPage";
+import { BlindPhase } from "./BlindPhase";
+import { RevealPhase } from "./RevealPhase";
+
+interface ArbitrationPageContentProps {
+  doc: ArbitrationDoc;
+  fieldMeta: Map<string, PydanticField>;
+  phase: "blind" | "reveal";
+  arbitrationBlind: boolean;
+  docListEntries: ArbitrationDocListEntry[];
+  docIndex: number;
+  listCollapsed: boolean;
+  onSelectDoc: (index: number) => void;
+  onToggleList: () => void;
+  blindChoices: Record<string, "a" | "b">;
+  finalChoices: Record<string, ArbitrationVerdict>;
+  suggestions: Record<string, string>;
+  comments: Record<string, string>;
+  onChooseBlind: (fieldReviewId: string, choice: "a" | "b") => void;
+  onChooseFinal: (fieldReviewId: string, verdict: ArbitrationVerdict) => void;
+  onSuggestion: (fieldReviewId: string, v: string) => void;
+  onComment: (fieldReviewId: string, v: string) => void;
+}
+
+export function ArbitrationPageContent({
+  doc,
+  fieldMeta,
+  phase,
+  arbitrationBlind,
+  docListEntries,
+  docIndex,
+  listCollapsed,
+  onSelectDoc,
+  onToggleList,
+  blindChoices,
+  finalChoices,
+  suggestions,
+  comments,
+  onChooseBlind,
+  onChooseFinal,
+  onSuggestion,
+  onComment,
+}: ArbitrationPageContentProps) {
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      <ArbitrationDocList
+        docs={docListEntries}
+        currentIndex={docIndex}
+        onSelect={onSelectDoc}
+        collapsed={listCollapsed}
+        onToggle={onToggleList}
+      />
+      <ResizablePanelGroup className="flex-1">
+        <ResizablePanel defaultSize={50} minSize={25}>
+          <DocumentReader text={doc.text} />
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel defaultSize={50} minSize={25}>
+          <div className="flex h-full flex-col">
+            <div className="shrink-0 border-b px-4 py-2 text-xs text-muted-foreground">
+              {phase === "blind"
+                ? "Fase 1 (cega): escolha sem ver a justificativa do LLM."
+                : "Fase 2: agora você vê a justificativa do LLM. Pode manter ou mudar sua escolha."}
+            </div>
+            <div className="flex-1 overflow-y-auto px-4 py-3">
+              {phase === "blind" ? (
+                <BlindPhase
+                  fields={doc.fields}
+                  fieldMeta={fieldMeta}
+                  choices={blindChoices}
+                  onChoose={onChooseBlind}
+                />
+              ) : (
+                <RevealPhase
+                  fields={doc.fields}
+                  fieldMeta={fieldMeta}
+                  arbitrationBlind={arbitrationBlind}
+                  finalChoices={finalChoices}
+                  suggestions={suggestions}
+                  comments={comments}
+                  onChooseFinal={onChooseFinal}
+                  onSuggestion={onSuggestion}
+                  onComment={onComment}
+                />
+              )}
+            </div>
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </div>
+  );
+}

--- a/frontend/src/components/arbitration/ArbitrationPageHeader.tsx
+++ b/frontend/src/components/arbitration/ArbitrationPageHeader.tsx
@@ -1,0 +1,97 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+interface ArbitrationPageHeaderProps {
+  phase: "blind" | "reveal";
+  docIndex: number;
+  docsLength: number;
+  submitting: boolean;
+  allBlindChosen: boolean;
+  allFinalChosen: boolean;
+  onNavigate: (index: number) => void;
+  onBackToBlind: () => void;
+  onBlindSubmit: () => void;
+  onFinalSubmit: () => void;
+}
+
+export function ArbitrationPageHeader({
+  phase,
+  docIndex,
+  docsLength,
+  submitting,
+  allBlindChosen,
+  allFinalChosen,
+  onNavigate,
+  onBackToBlind,
+  onBlindSubmit,
+  onFinalSubmit,
+}: ArbitrationPageHeaderProps) {
+  return (
+    <div className="flex h-10 shrink-0 items-center justify-between border-b px-4 text-sm">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="truncate font-medium">Arbitragem humano vs LLM</span>
+        <Badge variant={phase === "blind" ? "default" : "secondary"}>
+          {phase === "blind" ? "Cega" : "Revelação"}
+        </Badge>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Badge variant="secondary" className="text-xs">
+          {docsLength} doc{docsLength === 1 ? "" : "s"}
+        </Badge>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={() => onNavigate(docIndex - 1)}
+            disabled={docIndex === 0}
+            title="Documento anterior"
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            {docIndex + 1}/{docsLength}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={() => onNavigate(docIndex + 1)}
+            disabled={docIndex === docsLength - 1}
+            title="Próximo documento"
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+        {phase === "reveal" ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onBackToBlind}
+            title="Voltar à fase cega (sua decisão fica registrada)"
+          >
+            Voltar à cega
+          </Button>
+        ) : null}
+        {phase === "blind" ? (
+          <Button
+            size="sm"
+            onClick={onBlindSubmit}
+            disabled={!allBlindChosen || submitting}
+          >
+            {submitting ? "Salvando…" : "Avançar para revelação"}
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            onClick={onFinalSubmit}
+            disabled={!allFinalChosen || submitting}
+          >
+            {submitting ? "Enviando…" : "Enviar arbitragem"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/arbitration/__tests__/ArbitrationDocList.test.tsx
+++ b/frontend/src/components/arbitration/__tests__/ArbitrationDocList.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import {
+  ArbitrationDocList,
+  type ArbitrationDocListEntry,
+} from "../ArbitrationDocList";
+
+afterEach(cleanup);
+
+function entry(
+  over: Partial<ArbitrationDocListEntry> = {},
+): ArbitrationDocListEntry {
+  return {
+    id: "doc-id-abcdefgh-rest",
+    title: "Documento Um",
+    externalId: null,
+    totalFields: 3,
+    blindDecided: 0,
+    finalDecided: 0,
+    ...over,
+  };
+}
+
+describe("ArbitrationDocList — colapsada", () => {
+  it("mostra só o botão de expandir e dispara onToggle", () => {
+    const onToggle = vi.fn();
+    render(
+      <ArbitrationDocList
+        docs={[entry()]}
+        currentIndex={0}
+        onSelect={vi.fn()}
+        collapsed
+        onToggle={onToggle}
+      />,
+    );
+    expect(screen.queryByText("Fila de arbitragem")).toBeNull();
+    const btn = screen.getByTitle("Mostrar lista de documentos");
+    fireEvent.click(btn);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ArbitrationDocList — expandida", () => {
+  it("lista vazia exibe mensagem dedicada", () => {
+    render(
+      <ArbitrationDocList
+        docs={[]}
+        currentIndex={0}
+        onSelect={vi.fn()}
+        collapsed={false}
+        onToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Nenhum documento na fila.")).toBeTruthy();
+  });
+
+  it("recolher dispara onToggle", () => {
+    const onToggle = vi.fn();
+    render(
+      <ArbitrationDocList
+        docs={[entry()]}
+        currentIndex={0}
+        onSelect={vi.fn()}
+        collapsed={false}
+        onToggle={onToggle}
+      />,
+    );
+    fireEvent.click(screen.getByTitle("Recolher lista"));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("título cai para externalId e depois para os 8 primeiros chars do id", () => {
+    render(
+      <ArbitrationDocList
+        docs={[
+          entry({ id: "a", title: "Tem título" }),
+          entry({ id: "b", title: null, externalId: "EXT-9" }),
+          entry({ id: "abcdefgh-XXXX", title: null, externalId: null }),
+        ]}
+        currentIndex={0}
+        onSelect={vi.fn()}
+        collapsed={false}
+        onToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Tem título")).toBeTruthy();
+    expect(screen.getByText("EXT-9")).toBeTruthy();
+    expect(screen.getByText("abcdefgh")).toBeTruthy();
+  });
+
+  it("badge de fase: 'Revelação' quando blindDecided==total, senão 'Cega'", () => {
+    render(
+      <ArbitrationDocList
+        docs={[
+          entry({ id: "a", title: "Cega ainda", blindDecided: 1, totalFields: 3 }),
+          entry({ id: "b", title: "Revelado", blindDecided: 2, totalFields: 2 }),
+        ]}
+        currentIndex={0}
+        onSelect={vi.fn()}
+        collapsed={false}
+        onToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Cega")).toBeTruthy();
+    expect(screen.getByText("Revelação")).toBeTruthy();
+  });
+
+  it("badge de progresso mostra finalDecided/total", () => {
+    render(
+      <ArbitrationDocList
+        docs={[entry({ finalDecided: 2, totalFields: 3 })]}
+        currentIndex={0}
+        onSelect={vi.fn()}
+        collapsed={false}
+        onToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/2\/3/)).toBeTruthy();
+  });
+
+  it("clicar num documento chama onSelect com o índice", () => {
+    const onSelect = vi.fn();
+    render(
+      <ArbitrationDocList
+        docs={[
+          entry({ id: "a", title: "Primeiro" }),
+          entry({ id: "b", title: "Segundo" }),
+        ]}
+        currentIndex={0}
+        onSelect={onSelect}
+        collapsed={false}
+        onToggle={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Segundo").closest("button")!);
+    expect(onSelect).toHaveBeenCalledWith(1);
+  });
+});

--- a/frontend/src/components/arbitration/__tests__/ArbitrationEmptyState.test.tsx
+++ b/frontend/src/components/arbitration/__tests__/ArbitrationEmptyState.test.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ArbitrationEmptyState } from "../ArbitrationEmptyState";
+
+afterEach(cleanup);
+
+describe("ArbitrationEmptyState", () => {
+  it("renderiza o título e a mensagem de fila vazia", () => {
+    render(<ArbitrationEmptyState />);
+    expect(
+      screen.getByRole("heading", { name: "Arbitragem" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/Nenhuma arbitragem pendente/),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/components/arbitration/__tests__/ArbitrationPage.test.tsx
+++ b/frontend/src/components/arbitration/__tests__/ArbitrationPage.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const { refresh, submitBlindVerdicts, submitFinalVerdicts } = vi.hoisted(
+  () => ({
+    refresh: vi.fn(),
+    submitBlindVerdicts: vi.fn(),
+    submitFinalVerdicts: vi.fn(),
+  }),
+);
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+vi.mock("@/actions/field-reviews", () => ({
+  submitBlindVerdicts,
+  submitFinalVerdicts,
+}));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+vi.mock("@/components/coding/DocumentReader", () => ({
+  DocumentReader: ({ text }: { text: string }) => (
+    <div data-testid="doc-reader">{text}</div>
+  ),
+}));
+
+import { ArbitrationPage } from "../ArbitrationPage";
+import type {
+  ArbitrationDoc,
+  ArbitrationField,
+  ArbitrationPageProps,
+} from "../ArbitrationPage";
+import type { ArbitrationVerdict, PydanticField } from "@/lib/types";
+
+beforeEach(() => sessionStorage.clear());
+afterEach(cleanup);
+
+function field(
+  fieldReviewId: string,
+  blindVerdict: ArbitrationVerdict | null,
+): ArbitrationField {
+  return {
+    fieldReviewId,
+    fieldName: fieldReviewId,
+    aAnswer: "a",
+    bAnswer: "b",
+    blindVerdict,
+    reveal:
+      blindVerdict === null
+        ? null
+        : {
+            aSide: "humano",
+            bSide: "llm",
+            humanName: "Ana",
+            llmName: "GPT",
+            llmJustification: "j-llm",
+            selfJustification: "j-hum",
+          },
+  };
+}
+
+function doc(docId: string, fields: ArbitrationField[], text: string): ArbitrationDoc {
+  return { docId, title: docId, externalId: null, text, fields };
+}
+
+const pydField: PydanticField = {
+  name: "f1",
+  type: "single",
+  options: null,
+  description: "d",
+};
+
+function renderPage(over: Partial<ArbitrationPageProps> = {}) {
+  const props: ArbitrationPageProps = {
+    projectId: "p1",
+    projectName: "Projeto",
+    fields: [pydField],
+    docs: [],
+    arbitrationBlind: false,
+    ...over,
+  };
+  render(<ArbitrationPage {...props} />);
+  return props;
+}
+
+describe("ArbitrationPage — integração", () => {
+  it("sem documentos, mostra o estado vazio", () => {
+    renderPage({ docs: [] });
+    expect(screen.getByText(/Nenhuma arbitragem pendente/)).toBeTruthy();
+    expect(screen.queryByText("Arbitragem humano vs LLM")).toBeNull();
+  });
+
+  it("doc com algum verdict pendente entra na fase cega", () => {
+    renderPage({
+      docs: [doc("d1", [field("f1", null), field("f2", "humano")], "txt-d1")],
+    });
+    // "Cega" aparece no badge do header e no badge da sidebar.
+    expect(screen.getAllByText("Cega").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: "Avançar para revelação" }),
+    ).toBeTruthy();
+    // BlindPhase renderizou (rótulos das opções A/B).
+    expect(screen.getAllByText("Resposta A").length).toBeGreaterThan(0);
+  });
+
+  it("doc com todos os verdicts cegos entra na fase de revelação", () => {
+    renderPage({
+      docs: [doc("d1", [field("f1", "humano")], "txt-d1")],
+    });
+    // "Revelação" aparece no badge do header e no badge da sidebar.
+    expect(screen.getAllByText("Revelação").length).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: "Enviar arbitragem" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Humano acertou" }),
+    ).toBeTruthy();
+  });
+
+  it("mostra a contagem de documentos e o texto do doc atual", () => {
+    renderPage({
+      docs: [
+        doc("d1", [field("f1", null)], "texto um"),
+        doc("d2", [field("f1", null)], "texto dois"),
+      ],
+    });
+    expect(screen.getByText("2 docs")).toBeTruthy();
+    expect(screen.getByTestId("doc-reader").textContent).toBe("texto um");
+  });
+
+  it("navegar para o próximo doc troca o conteúdo e persiste o pin", () => {
+    renderPage({
+      docs: [
+        doc("d1", [field("f1", null)], "texto um"),
+        doc("d2", [field("f1", null)], "texto dois"),
+      ],
+    });
+    fireEvent.click(screen.getByTitle("Próximo documento"));
+    expect(screen.getByTestId("doc-reader").textContent).toBe("texto dois");
+    expect(sessionStorage.getItem("arbitration:docId:p1")).toBe("d2");
+  });
+
+  it("restaura o doc fixado do sessionStorage no primeiro render", () => {
+    sessionStorage.setItem("arbitration:docId:p1", "d2");
+    renderPage({
+      docs: [
+        doc("d1", [field("f1", null)], "texto um"),
+        doc("d2", [field("f1", null)], "texto dois"),
+      ],
+    });
+    expect(screen.getByTestId("doc-reader").textContent).toBe("texto dois");
+    expect(screen.getByText("2/2")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/arbitration/__tests__/ArbitrationPageContent.test.tsx
+++ b/frontend/src/components/arbitration/__tests__/ArbitrationPageContent.test.tsx
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+// Painéis resizable usam ResizeObserver (ausente em jsdom) — passthrough.
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+vi.mock("@/components/coding/DocumentReader", () => ({
+  DocumentReader: ({ text }: { text: string }) => (
+    <div data-testid="doc-reader">{text}</div>
+  ),
+}));
+vi.mock("../BlindPhase", () => ({
+  BlindPhase: ({
+    onChoose,
+  }: {
+    onChoose: (id: string, c: "a" | "b") => void;
+  }) => (
+    <button data-testid="blind-phase" onClick={() => onChoose("f1", "a")}>
+      blind
+    </button>
+  ),
+}));
+vi.mock("../RevealPhase", () => ({
+  RevealPhase: ({
+    onChooseFinal,
+  }: {
+    onChooseFinal: (id: string, v: string) => void;
+  }) => (
+    <button data-testid="reveal-phase" onClick={() => onChooseFinal("f1", "llm")}>
+      reveal
+    </button>
+  ),
+}));
+vi.mock("../ArbitrationDocList", () => ({
+  ArbitrationDocList: ({
+    currentIndex,
+    collapsed,
+    onSelect,
+    onToggle,
+  }: {
+    currentIndex: number;
+    collapsed: boolean;
+    onSelect: (i: number) => void;
+    onToggle: () => void;
+  }) => (
+    <div
+      data-testid="doc-list"
+      data-current={currentIndex}
+      data-collapsed={String(collapsed)}
+    >
+      <button data-testid="select-1" onClick={() => onSelect(1)}>
+        sel
+      </button>
+      <button data-testid="toggle" onClick={onToggle}>
+        toggle
+      </button>
+    </div>
+  ),
+}));
+
+import { ArbitrationPageContent } from "../ArbitrationPageContent";
+import type { ArbitrationDoc } from "../ArbitrationPage";
+
+afterEach(cleanup);
+
+const doc: ArbitrationDoc = {
+  docId: "d1",
+  title: "Doc 1",
+  externalId: null,
+  text: "TEXTO DO DOCUMENTO",
+  fields: [
+    {
+      fieldReviewId: "f1",
+      fieldName: "q1",
+      aAnswer: "a",
+      bAnswer: "b",
+      blindVerdict: null,
+      reveal: null,
+    },
+  ],
+};
+
+type Props = Parameters<typeof ArbitrationPageContent>[0];
+
+function renderContent(over: Partial<Props> = {}) {
+  const props: Props = {
+    doc,
+    fieldMeta: new Map(),
+    phase: "blind",
+    arbitrationBlind: false,
+    docListEntries: [],
+    docIndex: 2,
+    listCollapsed: false,
+    onSelectDoc: vi.fn(),
+    onToggleList: vi.fn(),
+    blindChoices: {},
+    finalChoices: {},
+    suggestions: {},
+    comments: {},
+    onChooseBlind: vi.fn(),
+    onChooseFinal: vi.fn(),
+    onSuggestion: vi.fn(),
+    onComment: vi.fn(),
+    ...over,
+  };
+  render(<ArbitrationPageContent {...props} />);
+  return props;
+}
+
+describe("ArbitrationPageContent", () => {
+  it("renderiza o leitor de documento com o texto do doc", () => {
+    renderContent();
+    expect(screen.getByTestId("doc-reader").textContent).toBe(
+      "TEXTO DO DOCUMENTO",
+    );
+  });
+
+  it("fase blind: renderiza BlindPhase (não RevealPhase) e a dica da fase 1", () => {
+    renderContent({ phase: "blind" });
+    expect(screen.getByTestId("blind-phase")).toBeTruthy();
+    expect(screen.queryByTestId("reveal-phase")).toBeNull();
+    expect(screen.getByText(/Fase 1 \(cega\)/)).toBeTruthy();
+  });
+
+  it("fase reveal: renderiza RevealPhase (não BlindPhase) e a dica da fase 2", () => {
+    renderContent({ phase: "reveal" });
+    expect(screen.getByTestId("reveal-phase")).toBeTruthy();
+    expect(screen.queryByTestId("blind-phase")).toBeNull();
+    expect(screen.getByText(/Fase 2/)).toBeTruthy();
+  });
+
+  it("repassa onChooseBlind ao BlindPhase", () => {
+    const props = renderContent({ phase: "blind" });
+    fireEvent.click(screen.getByTestId("blind-phase"));
+    expect(props.onChooseBlind).toHaveBeenCalledWith("f1", "a");
+  });
+
+  it("repassa onChooseFinal ao RevealPhase", () => {
+    const props = renderContent({ phase: "reveal" });
+    fireEvent.click(screen.getByTestId("reveal-phase"));
+    expect(props.onChooseFinal).toHaveBeenCalledWith("f1", "llm");
+  });
+
+  it("encaminha índice/colapso e os callbacks à sidebar", () => {
+    const props = renderContent({ docIndex: 2, listCollapsed: true });
+    const list = screen.getByTestId("doc-list");
+    expect(list.getAttribute("data-current")).toBe("2");
+    expect(list.getAttribute("data-collapsed")).toBe("true");
+    fireEvent.click(screen.getByTestId("select-1"));
+    expect(props.onSelectDoc).toHaveBeenCalledWith(1);
+    fireEvent.click(screen.getByTestId("toggle"));
+    expect(props.onToggleList).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/arbitration/__tests__/ArbitrationPageHeader.test.tsx
+++ b/frontend/src/components/arbitration/__tests__/ArbitrationPageHeader.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { ArbitrationPageHeader } from "../ArbitrationPageHeader";
+
+afterEach(cleanup);
+
+type Props = Parameters<typeof ArbitrationPageHeader>[0];
+
+function renderHeader(overrides: Partial<Props> = {}) {
+  const props: Props = {
+    phase: "blind",
+    docIndex: 0,
+    docsLength: 3,
+    submitting: false,
+    allBlindChosen: true,
+    allFinalChosen: true,
+    onNavigate: vi.fn(),
+    onBackToBlind: vi.fn(),
+    onBlindSubmit: vi.fn(),
+    onFinalSubmit: vi.fn(),
+    ...overrides,
+  };
+  render(<ArbitrationPageHeader {...props} />);
+  return props;
+}
+
+describe("ArbitrationPageHeader — fase e contagem", () => {
+  it("fase blind: badge 'Cega', botão 'Avançar para revelação' e sem 'Voltar à cega'", () => {
+    renderHeader({ phase: "blind" });
+    expect(screen.getByText("Cega")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Avançar para revelação" }),
+    ).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Voltar à cega" }),
+    ).toBeNull();
+  });
+
+  it("fase reveal: badge 'Revelação', botões 'Voltar à cega' e 'Enviar arbitragem'", () => {
+    renderHeader({ phase: "reveal" });
+    expect(screen.getByText("Revelação")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Voltar à cega" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Enviar arbitragem" }),
+    ).toBeTruthy();
+  });
+
+  it("mostra a contagem de docs (plural e singular) e a posição atual", () => {
+    renderHeader({ docIndex: 1, docsLength: 3 });
+    expect(screen.getByText("3 docs")).toBeTruthy();
+    expect(screen.getByText("2/3")).toBeTruthy();
+    cleanup();
+    renderHeader({ docsLength: 1, docIndex: 0 });
+    expect(screen.getByText("1 doc")).toBeTruthy();
+  });
+});
+
+describe("ArbitrationPageHeader — navegação", () => {
+  it("desabilita 'anterior' no primeiro doc e 'próximo' no último", () => {
+    renderHeader({ docIndex: 0, docsLength: 3 });
+    expect(
+      (screen.getByTitle("Documento anterior") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByTitle("Próximo documento") as HTMLButtonElement).disabled,
+    ).toBe(false);
+    cleanup();
+    renderHeader({ docIndex: 2, docsLength: 3 });
+    expect(
+      (screen.getByTitle("Próximo documento") as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("clicar em anterior/próximo chama onNavigate com índice ±1", () => {
+    const props = renderHeader({ docIndex: 1, docsLength: 3 });
+    fireEvent.click(screen.getByTitle("Documento anterior"));
+    expect(props.onNavigate).toHaveBeenCalledWith(0);
+    fireEvent.click(screen.getByTitle("Próximo documento"));
+    expect(props.onNavigate).toHaveBeenCalledWith(2);
+  });
+});
+
+describe("ArbitrationPageHeader — ações de submit", () => {
+  it("clicar em 'Voltar à cega' chama onBackToBlind", () => {
+    const props = renderHeader({ phase: "reveal" });
+    fireEvent.click(screen.getByRole("button", { name: "Voltar à cega" }));
+    expect(props.onBackToBlind).toHaveBeenCalledTimes(1);
+  });
+
+  it("submit cego desabilitado quando !allBlindChosen; habilitado dispara onBlindSubmit", () => {
+    const blocked = renderHeader({ phase: "blind", allBlindChosen: false });
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Avançar para revelação",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    cleanup();
+    const props = renderHeader({ phase: "blind", allBlindChosen: true });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Avançar para revelação" }),
+    );
+    expect(props.onBlindSubmit).toHaveBeenCalledTimes(1);
+    expect(blocked.onBlindSubmit).not.toHaveBeenCalled();
+  });
+
+  it("submit final desabilitado quando !allFinalChosen; habilitado dispara onFinalSubmit", () => {
+    renderHeader({ phase: "reveal", allFinalChosen: false });
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Enviar arbitragem",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+    cleanup();
+    const props = renderHeader({ phase: "reveal", allFinalChosen: true });
+    fireEvent.click(screen.getByRole("button", { name: "Enviar arbitragem" }));
+    expect(props.onFinalSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("submitting mostra rótulos de progresso e desabilita os botões", () => {
+    renderHeader({ phase: "blind", submitting: true });
+    const blindBtn = screen.getByRole("button", {
+      name: "Salvando…",
+    }) as HTMLButtonElement;
+    expect(blindBtn.disabled).toBe(true);
+    cleanup();
+    renderHeader({ phase: "reveal", submitting: true });
+    const finalBtn = screen.getByRole("button", {
+      name: "Enviando…",
+    }) as HTMLButtonElement;
+    expect(finalBtn.disabled).toBe(true);
+  });
+});

--- a/frontend/src/components/arbitration/__tests__/BlindPhase.test.tsx
+++ b/frontend/src/components/arbitration/__tests__/BlindPhase.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { BlindPhase } from "../BlindPhase";
+import type { ArbitrationField } from "../ArbitrationPage";
+import type { PydanticField } from "@/lib/types";
+
+afterEach(cleanup);
+
+function field(over: Partial<ArbitrationField> = {}): ArbitrationField {
+  return {
+    fieldReviewId: "f1",
+    fieldName: "q1",
+    aAnswer: "Resposta A!",
+    bAnswer: "Resposta B!",
+    blindVerdict: null,
+    reveal: null,
+    ...over,
+  };
+}
+
+const meta = (name: string, description: string): [string, PydanticField] => [
+  name,
+  { name, type: "single", options: null, description },
+];
+
+describe("BlindPhase", () => {
+  it("renderiza um card por campo, com nome e descrição do meta", () => {
+    render(
+      <BlindPhase
+        fields={[
+          field({ fieldReviewId: "f1", fieldName: "q1" }),
+          field({ fieldReviewId: "f2", fieldName: "q2" }),
+        ]}
+        fieldMeta={new Map([meta("q1", "Descrição um"), meta("q2", "Descrição dois")])}
+        choices={{}}
+        onChoose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("q1")).toBeTruthy();
+    expect(screen.getByText("q2")).toBeTruthy();
+    expect(screen.getByText("Descrição um")).toBeTruthy();
+    expect(screen.getByText("Descrição dois")).toBeTruthy();
+  });
+
+  it("clicar em Resposta A/B chama onChoose com a escolha", () => {
+    const onChoose = vi.fn();
+    render(
+      <BlindPhase
+        fields={[field()]}
+        fieldMeta={new Map([meta("q1", "d")])}
+        choices={{}}
+        onChoose={onChoose}
+      />,
+    );
+    fireEvent.click(screen.getByText("Resposta A").closest("button")!);
+    expect(onChoose).toHaveBeenCalledWith("f1", "a");
+    fireEvent.click(screen.getByText("Resposta B").closest("button")!);
+    expect(onChoose).toHaveBeenCalledWith("f1", "b");
+  });
+
+  it("mostra o valor formatado de cada resposta", () => {
+    render(
+      <BlindPhase
+        fields={[field({ aAnswer: "sim", bAnswer: "" })]}
+        fieldMeta={new Map([meta("q1", "d")])}
+        choices={{}}
+        onChoose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("sim")).toBeTruthy();
+    // string vazia → "(vazio)" via formatAnswerDisplay
+    expect(screen.getByText("(vazio)")).toBeTruthy();
+  });
+
+  it("campo já decidido (blindVerdict) trava os botões e mostra aviso", () => {
+    render(
+      <BlindPhase
+        fields={[
+          field({
+            blindVerdict: "humano",
+            reveal: {
+              aSide: "humano",
+              bSide: "llm",
+              humanName: null,
+              llmName: null,
+              llmJustification: null,
+              selfJustification: null,
+            },
+          }),
+        ]}
+        fieldMeta={new Map([meta("q1", "d")])}
+        choices={{}}
+        onChoose={vi.fn()}
+      />,
+    );
+    expect(
+      (screen.getByText("Resposta A").closest("button") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByText("Resposta B").closest("button") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      screen.getByText(/Veredito cego já registrado/),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/components/arbitration/__tests__/RevealPhase.test.tsx
+++ b/frontend/src/components/arbitration/__tests__/RevealPhase.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { RevealPhase } from "../RevealPhase";
+import type { ArbitrationField } from "../ArbitrationPage";
+import type { ArbitrationVerdict, PydanticField } from "@/lib/types";
+
+afterEach(cleanup);
+
+function field(over: Partial<ArbitrationField> = {}): ArbitrationField {
+  return {
+    fieldReviewId: "f1",
+    fieldName: "q1",
+    aAnswer: "valorA",
+    bAnswer: "valorB",
+    blindVerdict: "humano",
+    reveal: {
+      aSide: "humano",
+      bSide: "llm",
+      humanName: "Ana",
+      llmName: "GPT",
+      llmJustification: "Porque LLM",
+      selfJustification: "Porque humano",
+    },
+    ...over,
+  };
+}
+
+const meta = new Map<string, PydanticField>([
+  ["q1", { name: "q1", type: "single", options: null, description: "desc q1" }],
+]);
+
+function renderReveal(over: {
+  field?: Partial<ArbitrationField>;
+  arbitrationBlind?: boolean;
+  finalChoices?: Record<string, ArbitrationVerdict>;
+  suggestions?: Record<string, string>;
+  comments?: Record<string, string>;
+} = {}) {
+  const handlers = {
+    onChooseFinal: vi.fn<(id: string, v: ArbitrationVerdict) => void>(),
+    onSuggestion: vi.fn<(id: string, v: string) => void>(),
+    onComment: vi.fn<(id: string, v: string) => void>(),
+  };
+  render(
+    <RevealPhase
+      fields={[field(over.field)]}
+      fieldMeta={meta}
+      arbitrationBlind={over.arbitrationBlind ?? false}
+      finalChoices={over.finalChoices ?? {}}
+      suggestions={over.suggestions ?? {}}
+      comments={over.comments ?? {}}
+      {...handlers}
+    />,
+  );
+  return handlers;
+}
+
+describe("RevealPhase — rótulos por modo", () => {
+  it("arbitration_blind=false: mostra nomes Humano/LLM", () => {
+    renderReveal({ arbitrationBlind: false });
+    expect(screen.getByText("Humano (Ana)")).toBeTruthy();
+    expect(screen.getByText("LLM (GPT)")).toBeTruthy();
+  });
+
+  it("arbitration_blind=true: mostra Resposta A/B em vez dos papéis", () => {
+    renderReveal({ arbitrationBlind: true });
+    expect(screen.getByText("Resposta A")).toBeTruthy();
+    expect(screen.getByText("Resposta B")).toBeTruthy();
+    expect(screen.queryByText("Humano (Ana)")).toBeNull();
+  });
+});
+
+describe("RevealPhase — escolha final", () => {
+  it("clicar em 'Humano acertou' / 'LLM acertou' chama onChooseFinal", () => {
+    const h = renderReveal();
+    fireEvent.click(screen.getByRole("button", { name: "Humano acertou" }));
+    expect(h.onChooseFinal).toHaveBeenCalledWith("f1", "humano");
+    fireEvent.click(screen.getByRole("button", { name: "LLM acertou" }));
+    expect(h.onChooseFinal).toHaveBeenCalledWith("f1", "llm");
+  });
+
+  it("avisa quando o árbitro mudou de ideia (final != veredito cego)", () => {
+    renderReveal({ finalChoices: { f1: "llm" } }); // blindVerdict é "humano"
+    expect(
+      screen.getByText(/Você mudou de ideia após ver a justificativa/),
+    ).toBeTruthy();
+  });
+
+  it("não avisa quando final coincide com o veredito cego", () => {
+    renderReveal({ finalChoices: { f1: "humano" } });
+    expect(
+      screen.queryByText(/Você mudou de ideia/),
+    ).toBeNull();
+  });
+});
+
+describe("RevealPhase — sugestão e comentário", () => {
+  it("textarea de sugestão aparece só quando final === 'llm'", () => {
+    const placeholder =
+      "Como reformular a pergunta para evitar essa divergência no futuro?";
+    renderReveal({ finalChoices: { f1: "humano" } });
+    expect(screen.queryByPlaceholderText(placeholder)).toBeNull();
+    cleanup();
+    renderReveal({ finalChoices: { f1: "llm" } });
+    expect(screen.getByPlaceholderText(placeholder)).toBeTruthy();
+  });
+
+  it("digitar na sugestão chama onSuggestion", () => {
+    const h = renderReveal({ finalChoices: { f1: "llm" } });
+    const ta = screen.getByPlaceholderText(
+      "Como reformular a pergunta para evitar essa divergência no futuro?",
+    );
+    fireEvent.change(ta, { target: { value: "reformular X" } });
+    expect(h.onSuggestion).toHaveBeenCalledWith("f1", "reformular X");
+  });
+
+  it("digitar no comentário chama onComment", () => {
+    const h = renderReveal();
+    const ta = screen.getByLabelText("Comentário (opcional)");
+    fireEvent.change(ta, { target: { value: "meu comentário" } });
+    expect(h.onComment).toHaveBeenCalledWith("f1", "meu comentário");
+  });
+});
+
+describe("RevealPhase — justificativas", () => {
+  it("exibe as justificativas quando presentes", () => {
+    renderReveal();
+    expect(screen.getByText("Porque humano")).toBeTruthy();
+    expect(screen.getByText("Porque LLM")).toBeTruthy();
+  });
+
+  it("usa textos de fallback quando faltam justificativas", () => {
+    renderReveal({
+      field: {
+        reveal: {
+          aSide: "humano",
+          bSide: "llm",
+          humanName: null,
+          llmName: null,
+          llmJustification: null,
+          selfJustification: null,
+        },
+      },
+    });
+    expect(
+      screen.getByText("Sem justificativa registrada para este campo."),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("LLM não forneceu justificativa para este campo."),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/src/hooks/__tests__/useArbitrationDoc.test.ts
+++ b/frontend/src/hooks/__tests__/useArbitrationDoc.test.ts
@@ -241,4 +241,162 @@ describe("useArbitrationDoc — handleFinalSubmit", () => {
       },
     ]);
   });
+
+  it("comentário vazio não vai no payload (vira undefined)", async () => {
+    submitFinalVerdicts.mockResolvedValue({ success: true });
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]), {
+      docsLength: 1,
+    });
+    act(() => result.current.onComment("f1", ""));
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(submitFinalVerdicts).toHaveBeenCalledWith("p1", "d1", [
+      expect.objectContaining({ arbitratorComment: undefined }),
+    ]);
+  });
+
+  it("exige sugestão só do PRIMEIRO campo 'llm' sem sugestão", async () => {
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", "llm"), field("f2", "q2", "llm")]),
+    );
+    act(() => result.current.onSuggestion("f1", "ok"));
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    // f1 tem sugestão, f2 não → erro cita f2, e nada é enviado.
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("q2"),
+    );
+    expect(submitFinalVerdicts).not.toHaveBeenCalled();
+  });
+
+  it("envia quando todos os campos 'llm' têm sugestão", async () => {
+    submitFinalVerdicts.mockResolvedValue({ success: true });
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", "llm"), field("f2", "q2", "humano")]),
+      { docsLength: 1 },
+    );
+    act(() => result.current.onSuggestion("f1", "melhorar"));
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(submitFinalVerdicts).toHaveBeenCalledTimes(1);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("em erro mostra toast e não navega nem reseta", async () => {
+    submitFinalVerdicts.mockResolvedValue({ success: false, error: "falhou" });
+    const onNavigate = vi.fn();
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]), {
+      docsLength: 2,
+      onNavigate,
+    });
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(toastError).toHaveBeenCalledWith("falhou");
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+});
+
+describe("useArbitrationDoc — limpeza de override e reset de estado", () => {
+  it("avançar (blind submit) limpa o override e a fase volta a reveal", async () => {
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]));
+    act(() => result.current.onBackToBlind());
+    expect(result.current.phase).toBe("blind");
+    await act(async () => {
+      await result.current.handleBlindSubmit();
+    });
+    // Sem campos pendentes → não chama a action, mas limpa o override.
+    expect(submitBlindVerdicts).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("reveal");
+  });
+
+  it("após enviar o final, zera blindChoices/finalChoices/suggestions/comments", async () => {
+    submitFinalVerdicts.mockResolvedValue({ success: true });
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]), {
+      docsLength: 1,
+    });
+    act(() => {
+      result.current.onChooseBlind("f1", "a");
+      result.current.onChooseFinal("f1", "llm");
+      result.current.onSuggestion("f1", "s");
+      result.current.onComment("f1", "c");
+    });
+    expect(result.current.effectiveFinalChoices.f1).toBe("llm");
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(result.current.blindChoices).toEqual({});
+    expect(result.current.suggestions).toEqual({});
+    expect(result.current.comments).toEqual({});
+    // finalChoices cru zerado → effective volta ao default do verdict cego.
+    expect(result.current.effectiveFinalChoices).toEqual({ f1: "humano" });
+  });
+});
+
+describe("useArbitrationDoc — guardas e estado exposto", () => {
+  it("com doc undefined os submits são no-op", async () => {
+    const onNavigate = vi.fn();
+    const { result } = setup(undefined, { onNavigate });
+    await act(async () => {
+      await result.current.handleBlindSubmit();
+      await result.current.handleFinalSubmit();
+    });
+    expect(submitBlindVerdicts).not.toHaveBeenCalled();
+    expect(submitFinalVerdicts).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("blind submit mapeia todos os campos pendentes (multi-campo)", async () => {
+    submitBlindVerdicts.mockResolvedValue({ success: true });
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", null), field("f2", "q2", null)]),
+    );
+    act(() => {
+      result.current.onChooseBlind("f1", "a");
+      result.current.onChooseBlind("f2", "b");
+    });
+    await act(async () => {
+      await result.current.handleBlindSubmit();
+    });
+    expect(submitBlindVerdicts).toHaveBeenCalledWith("p1", "d1", [
+      { fieldReviewId: "f1", choice: "a" },
+      { fieldReviewId: "f2", choice: "b" },
+    ]);
+  });
+
+  it("onSuggestion e onComment expõem o estado por fieldReviewId", () => {
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]));
+    act(() => {
+      result.current.onSuggestion("f1", "sug");
+      result.current.onComment("f1", "com");
+    });
+    expect(result.current.suggestions).toEqual({ f1: "sug" });
+    expect(result.current.comments).toEqual({ f1: "com" });
+  });
+
+  it("submitting fica true durante o envio e volta a false ao fim", async () => {
+    let resolveAction: (v: { success: boolean }) => void = () => {};
+    submitBlindVerdicts.mockReturnValue(
+      new Promise((r) => {
+        resolveAction = r;
+      }),
+    );
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", null)]));
+    act(() => result.current.onChooseBlind("f1", "a"));
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.handleBlindSubmit();
+    });
+    expect(result.current.submitting).toBe(true);
+    await act(async () => {
+      resolveAction({ success: true });
+      await pending;
+    });
+    expect(result.current.submitting).toBe(false);
+  });
 });

--- a/frontend/src/hooks/__tests__/useArbitrationDoc.test.ts
+++ b/frontend/src/hooks/__tests__/useArbitrationDoc.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+
+const {
+  refresh,
+  submitBlindVerdicts,
+  submitFinalVerdicts,
+  toastError,
+  toastSuccess,
+} = vi.hoisted(() => ({
+  refresh: vi.fn(),
+  submitBlindVerdicts: vi.fn(),
+  submitFinalVerdicts: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ refresh }) }));
+vi.mock("@/actions/field-reviews", () => ({
+  submitBlindVerdicts,
+  submitFinalVerdicts,
+}));
+vi.mock("sonner", () => ({ toast: { success: toastSuccess, error: toastError } }));
+
+import { useArbitrationDoc } from "../useArbitrationDoc";
+import type {
+  ArbitrationDoc,
+  ArbitrationField,
+} from "@/components/arbitration/ArbitrationPage";
+import type { ArbitrationVerdict } from "@/lib/types";
+
+function field(
+  fieldReviewId: string,
+  fieldName: string,
+  blindVerdict: ArbitrationVerdict | null = null,
+): ArbitrationField {
+  return { fieldReviewId, fieldName, aAnswer: "A", bAnswer: "B", blindVerdict, reveal: null };
+}
+
+function makeDoc(docId: string, fields: ArbitrationField[]): ArbitrationDoc {
+  return { docId, title: docId, externalId: null, text: "txt", fields };
+}
+
+function setup(
+  doc: ArbitrationDoc | undefined,
+  opts: { docIndex?: number; docsLength?: number; onNavigate?: () => void } = {},
+) {
+  const onNavigate = opts.onNavigate ?? vi.fn();
+  const utils = renderHook(
+    ({ doc }) =>
+      useArbitrationDoc({
+        doc,
+        docIndex: opts.docIndex ?? 0,
+        docsLength: opts.docsLength ?? 1,
+        projectId: "p1",
+        onNavigate,
+      }),
+    { initialProps: { doc } },
+  );
+  return { ...utils, onNavigate };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useArbitrationDoc — derivação de phase", () => {
+  it("'blind' quando algum campo não tem blindVerdict", () => {
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", "humano"), field("f2", "q2", null)]),
+    );
+    expect(result.current.phase).toBe("blind");
+  });
+
+  it("'reveal' quando todos os campos têm blindVerdict", () => {
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", "humano"), field("f2", "q2", "llm")]),
+    );
+    expect(result.current.phase).toBe("reveal");
+  });
+
+  it("'blind' para doc undefined ou sem campos", () => {
+    expect(setup(undefined).result.current.phase).toBe("blind");
+    expect(setup(makeDoc("d1", [])).result.current.phase).toBe("blind");
+  });
+});
+
+describe("useArbitrationDoc — override 'Voltar à cega'", () => {
+  it("força 'blind' sem mudar os dados e some ao trocar de doc", () => {
+    const { result, rerender } = setup(makeDoc("d1", [field("f1", "q1", "humano")]));
+    expect(result.current.phase).toBe("reveal");
+
+    act(() => result.current.onBackToBlind());
+    expect(result.current.phase).toBe("blind");
+
+    // Override é chaveado por docId → outro doc revela conforme os dados.
+    rerender({ doc: makeDoc("d2", [field("f2", "q2", "llm")]) });
+    expect(result.current.phase).toBe("reveal");
+  });
+});
+
+describe("useArbitrationDoc — effectiveFinalChoices", () => {
+  it("preenche o verdict cego como default na reveal e marca allFinalChosen", () => {
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", "humano"), field("f2", "q2", "llm")]),
+    );
+    expect(result.current.effectiveFinalChoices).toEqual({ f1: "humano", f2: "llm" });
+    expect(result.current.allFinalChosen).toBe(true);
+  });
+
+  it("override explícito do usuário vence o default no merge", () => {
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]));
+    act(() => result.current.onChooseFinal("f1", "llm"));
+    expect(result.current.effectiveFinalChoices.f1).toBe("llm");
+  });
+
+  it("na fase blind é só os overrides (sem default cego)", () => {
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", null)]));
+    expect(result.current.phase).toBe("blind");
+    expect(result.current.effectiveFinalChoices).toEqual({});
+  });
+});
+
+describe("useArbitrationDoc — allBlindChosen", () => {
+  it("reflete blindVerdict do server OU escolha local", () => {
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", null), field("f2", "q2", "humano")]),
+    );
+    expect(result.current.allBlindChosen).toBe(false);
+    act(() => result.current.onChooseBlind("f1", "a"));
+    expect(result.current.allBlindChosen).toBe(true);
+  });
+});
+
+describe("useArbitrationDoc — handleBlindSubmit", () => {
+  it("envia só os campos sem blindVerdict e dá refresh", async () => {
+    submitBlindVerdicts.mockResolvedValue({ success: true });
+    const { result } = setup(
+      makeDoc("d1", [field("f1", "q1", null), field("f2", "q2", "humano")]),
+    );
+    act(() => result.current.onChooseBlind("f1", "a"));
+    await act(async () => {
+      await result.current.handleBlindSubmit();
+    });
+    expect(submitBlindVerdicts).toHaveBeenCalledWith("p1", "d1", [
+      { fieldReviewId: "f1", choice: "a" },
+    ]);
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("não chama a action quando todos já têm blindVerdict (só refresh)", async () => {
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]));
+    await act(async () => {
+      await result.current.handleBlindSubmit();
+    });
+    expect(submitBlindVerdicts).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("em erro mostra toast e não dá refresh", async () => {
+    submitBlindVerdicts.mockResolvedValue({ success: false, error: "boom" });
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", null)]));
+    act(() => result.current.onChooseBlind("f1", "b"));
+    await act(async () => {
+      await result.current.handleBlindSubmit();
+    });
+    expect(toastError).toHaveBeenCalledWith("boom");
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});
+
+describe("useArbitrationDoc — handleFinalSubmit", () => {
+  it("exige sugestão quando o verdict é 'llm' e não envia", async () => {
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "llm")]));
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(toastError).toHaveBeenCalled();
+    expect(submitFinalVerdicts).not.toHaveBeenCalled();
+  });
+
+  it("monta payload com effectiveFinalChoices e avança ao próximo doc", async () => {
+    submitFinalVerdicts.mockResolvedValue({ success: true });
+    const onNavigate = vi.fn();
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]), {
+      docIndex: 0,
+      docsLength: 2,
+      onNavigate,
+    });
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(submitFinalVerdicts).toHaveBeenCalledWith("p1", "d1", [
+      {
+        fieldName: "q1",
+        verdict: "humano",
+        questionImprovementSuggestion: undefined,
+        arbitratorComment: undefined,
+      },
+    ]);
+    expect(toastSuccess).toHaveBeenCalled();
+    expect(onNavigate).toHaveBeenCalledWith(1);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("no último doc dá refresh em vez de navegar", async () => {
+    submitFinalVerdicts.mockResolvedValue({ success: true });
+    const onNavigate = vi.fn();
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "humano")]), {
+      docIndex: 1,
+      docsLength: 2,
+      onNavigate,
+    });
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("inclui sugestão e comentário no payload do verdict 'llm'", async () => {
+    submitFinalVerdicts.mockResolvedValue({ success: true });
+    const { result } = setup(makeDoc("d1", [field("f1", "q1", "llm")]), {
+      docsLength: 1,
+    });
+    act(() => {
+      result.current.onSuggestion("f1", "melhorar X");
+      result.current.onComment("f1", "comentário");
+    });
+    await act(async () => {
+      await result.current.handleFinalSubmit();
+    });
+    expect(submitFinalVerdicts).toHaveBeenCalledWith("p1", "d1", [
+      {
+        fieldName: "q1",
+        verdict: "llm",
+        questionImprovementSuggestion: "melhorar X",
+        arbitratorComment: "comentário",
+      },
+    ]);
+  });
+});

--- a/frontend/src/hooks/useArbitrationDoc.ts
+++ b/frontend/src/hooks/useArbitrationDoc.ts
@@ -1,0 +1,219 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  submitBlindVerdicts,
+  submitFinalVerdicts,
+  type BlindChoice,
+  type FinalChoice,
+} from "@/actions/field-reviews";
+import type { ArbitrationVerdict } from "@/lib/types";
+import type {
+  ArbitrationDoc,
+  ArbitrationField,
+} from "@/components/arbitration/ArbitrationPage";
+
+function computePhaseForDoc(
+  doc: ArbitrationDoc | undefined,
+): "blind" | "reveal" {
+  if (!doc || doc.fields.length === 0) return "blind";
+  return doc.fields.every((f) => f.blindVerdict !== null) ? "reveal" : "blind";
+}
+
+export interface UseArbitrationDocParams {
+  doc: ArbitrationDoc | undefined;
+  docIndex: number;
+  docsLength: number;
+  projectId: string;
+  onNavigate: (index: number) => void;
+}
+
+export interface UseArbitrationDoc {
+  phase: "blind" | "reveal";
+  submitting: boolean;
+  allBlindChosen: boolean;
+  allFinalChosen: boolean;
+  // States keyed por fieldReviewId (UUID único por (doc, campo)) — ver nota em
+  // ArbitrationPage sobre por que nunca chavear por fieldName.
+  blindChoices: Record<string, "a" | "b">;
+  effectiveFinalChoices: Record<string, ArbitrationVerdict>;
+  suggestions: Record<string, string>;
+  comments: Record<string, string>;
+  onChooseBlind: (fieldReviewId: string, choice: "a" | "b") => void;
+  onChooseFinal: (fieldReviewId: string, verdict: ArbitrationVerdict) => void;
+  onSuggestion: (fieldReviewId: string, v: string) => void;
+  onComment: (fieldReviewId: string, v: string) => void;
+  onBackToBlind: () => void;
+  handleBlindSubmit: () => Promise<void>;
+  handleFinalSubmit: () => Promise<void>;
+}
+
+/**
+ * Estado e ações de interação da arbitragem de UM documento.
+ *
+ * Agrupa o estado coeso da página (escolhas cega/final, sugestões, comentários,
+ * envio) num hook em vez de espalhá-lo em vários `useState` no componente — assim
+ * `ArbitrationPage` fica enxuto e legível, na linha dos hooks de state/effect
+ * extraídos em #231/#244.
+ *
+ * Pontos de design:
+ * - `phase` é DERIVADA no render (`computePhaseForDoc`), não guardada em state.
+ *   O botão "Voltar à cega" é um override explícito chaveado por `docId`
+ *   (`blindOverrideDocId`): navegar para outro doc reverte sozinho para a fase
+ *   dos dados, sem `useEffect`. O override é limpo ao enviar (cego ou final).
+ * - `effectiveFinalChoices` faz o merge do `blindVerdict` (default) com os
+ *   overrides do usuário na fase reveal — também no render, em vez de pré-popular
+ *   `finalChoices` por effect. O árbitro mantém a escolha cega por padrão.
+ */
+export function useArbitrationDoc({
+  doc,
+  docIndex,
+  docsLength,
+  projectId,
+  onNavigate,
+}: UseArbitrationDocParams): UseArbitrationDoc {
+  const { refresh } = useRouter();
+
+  const [submitting, setSubmitting] = useState(false);
+  const [blindOverrideDocId, setBlindOverrideDocId] = useState<string | null>(
+    null,
+  );
+  const [blindChoices, setBlindChoices] = useState<Record<string, "a" | "b">>(
+    {},
+  );
+  const [finalChoices, setFinalChoices] = useState<
+    Record<string, ArbitrationVerdict>
+  >({});
+  const [suggestions, setSuggestions] = useState<Record<string, string>>({});
+  const [comments, setComments] = useState<Record<string, string>>({});
+
+  const dataPhase = computePhaseForDoc(doc);
+  const phase: "blind" | "reveal" =
+    doc && blindOverrideDocId === doc.docId ? "blind" : dataPhase;
+
+  // Merge do verdict cego (default) com os overrides do usuário, só na reveal.
+  const effectiveFinalChoices = useMemo(() => {
+    if (phase !== "reveal" || !doc) return finalChoices;
+    const merged = { ...finalChoices };
+    for (const f of doc.fields) {
+      if (merged[f.fieldReviewId] == null && f.blindVerdict != null) {
+        merged[f.fieldReviewId] = f.blindVerdict;
+      }
+    }
+    return merged;
+  }, [phase, doc, finalChoices]);
+
+  const allBlindChosen = doc
+    ? doc.fields.every(
+        (f) => f.blindVerdict !== null || blindChoices[f.fieldReviewId] != null,
+      )
+    : false;
+  const allFinalChosen = doc
+    ? doc.fields.every((f) => effectiveFinalChoices[f.fieldReviewId] != null)
+    : false;
+
+  const onChooseBlind = useCallback((fieldReviewId: string, choice: "a" | "b") => {
+    setBlindChoices((c) => ({ ...c, [fieldReviewId]: choice }));
+  }, []);
+  const onChooseFinal = useCallback(
+    (fieldReviewId: string, verdict: ArbitrationVerdict) => {
+      setFinalChoices((c) => ({ ...c, [fieldReviewId]: verdict }));
+    },
+    [],
+  );
+  const onSuggestion = useCallback((fieldReviewId: string, v: string) => {
+    setSuggestions((s) => ({ ...s, [fieldReviewId]: v }));
+  }, []);
+  const onComment = useCallback((fieldReviewId: string, v: string) => {
+    setComments((s) => ({ ...s, [fieldReviewId]: v }));
+  }, []);
+  const onBackToBlind = useCallback(() => {
+    if (doc) setBlindOverrideDocId(doc.docId);
+  }, [doc]);
+
+  async function handleBlindSubmit() {
+    if (!doc) return;
+    setSubmitting(true);
+    const choices: BlindChoice[] = doc.fields
+      .filter((f) => f.blindVerdict === null)
+      .map((f) => ({
+        fieldReviewId: f.fieldReviewId,
+        choice: blindChoices[f.fieldReviewId],
+      }));
+    if (choices.length > 0) {
+      const r = await submitBlindVerdicts(projectId, doc.docId, choices);
+      if (!r.success) {
+        setSubmitting(false);
+        toast.error(r.error ?? "Falha ao registrar veredito cego");
+        return;
+      }
+    }
+    // Limpa o override para que, após o refresh, a fase derivada dos dados
+    // (agora "reveal") apareça — inclusive se o usuário tinha voltado à cega.
+    setBlindOverrideDocId(null);
+    // refresh() repuxa o payload com `reveal` populado; a fase deriva sozinha.
+    refresh();
+    setSubmitting(false);
+  }
+
+  async function handleFinalSubmit() {
+    if (!doc) return;
+    for (const f of doc.fields) {
+      if (effectiveFinalChoices[f.fieldReviewId] === "llm") {
+        if (!suggestions[f.fieldReviewId]?.trim()) {
+          toast.error(
+            `Campo "${f.fieldName}": preencha a sugestão de melhoria.`,
+          );
+          return;
+        }
+      }
+    }
+    setSubmitting(true);
+    const payload: FinalChoice[] = doc.fields.map((f: ArbitrationField) => ({
+      fieldName: f.fieldName,
+      verdict: effectiveFinalChoices[f.fieldReviewId],
+      questionImprovementSuggestion:
+        effectiveFinalChoices[f.fieldReviewId] === "llm"
+          ? suggestions[f.fieldReviewId]
+          : undefined,
+      arbitratorComment: comments[f.fieldReviewId] || undefined,
+    }));
+    const r = await submitFinalVerdicts(projectId, doc.docId, payload);
+    setSubmitting(false);
+    if (!r.success) {
+      toast.error(r.error ?? "Falha ao enviar veredito final");
+      return;
+    }
+    toast.success("Arbitragem concluída para este documento.");
+    setBlindChoices({});
+    setFinalChoices({});
+    setSuggestions({});
+    setComments({});
+    setBlindOverrideDocId(null);
+    if (docIndex < docsLength - 1) {
+      onNavigate(docIndex + 1);
+    } else {
+      refresh();
+    }
+  }
+
+  return {
+    phase,
+    submitting,
+    allBlindChosen,
+    allFinalChosen,
+    blindChoices,
+    effectiveFinalChoices,
+    suggestions,
+    comments,
+    onChooseBlind,
+    onChooseFinal,
+    onSuggestion,
+    onComment,
+    onBackToBlind,
+    handleBlindSubmit,
+    handleFinalSubmit,
+  };
+}


### PR DESCRIPTION
Parte da campanha **Zerar react-doctor** (épico #239), Onda 4 — Hotspot. Zera os **8 diagnósticos** (0 error, 8 warning) de `components/arbitration/ArbitrationPage.tsx`, refatorando (não suprimindo). Confirmados na branch antes da mudança e reconfirmados zerados depois via `npx react-doctor . --json`.

## O que mudou

| Diagnóstico | Como foi resolvido |
|---|---|
| `no-event-handler` (:75) + `no-derived-state` (:82) | `usePinnedDoc` substitui o `pinnedDocId` em `useState` + effect de restore + persist manual no `sessionStorage` (mesmo hook já usado por `AutoReviewPage`). |
| `no-derived-state-effect` (:117) + `no-derived-state` (:119) | `phase` passa a ser **derivada no render**. O botão "Voltar à cega" vira um override explícito chaveado por `docId` (`blindOverrideDocId`) — navegar reverte sozinho, sem effect; o override é limpo ao enviar. |
| `no-effect-chain` (:124) + `no-derived-state` (:129) | `effectiveFinalChoices` (`useMemo`) faz o merge do verdict cego na fase reveal, no lugar da pré-população via `setFinalChoices` em effect. `finalChoices` guarda só os overrides do usuário. |
| `prefer-useReducer` (:73) + `no-giant-component` (:68) | Estado de interação extraído para o hook `useArbitrationDoc`; JSX dividido em `ArbitrationPageHeader` / `ArbitrationPageContent` / `ArbitrationEmptyState`. **Sem introduzir `useReducer`.** |

> Nota de design: o `prefer-useReducer` dispara a partir de **5 `useState` por componente** (medido: `AutoReviewPage`/`DocumentSelector`/`SuggestFieldDialog` estão flagueados com 5). Extração só presentacional não bastaria — por isso o estado coeso foi para um custom hook, que a regra não conta. `ArbitrationPage` fica com 1 `useState` (`listCollapsed`).

`BlindPhase`, `RevealPhase` e `ArbitrationDocList` ficaram **intactos** — o hook expõe exatamente as mesmas props.

## Arquivos

- **Modificado:** `ArbitrationPage.tsx` (382 → 60 linhas; orquestrador enxuto).
- **Criados:** `hooks/useArbitrationDoc.ts`, `arbitration/ArbitrationPageHeader.tsx`, `arbitration/ArbitrationPageContent.tsx`, `arbitration/ArbitrationEmptyState.tsx`.

## Verificação

- `npx react-doctor . --json` → **0 diagnósticos** nos 5 arquivos (eram 8 no `ArbitrationPage`).
- `npx tsc --noEmit` limpo; `npm run lint` sem errors (warnings remanescentes são pré-existentes e alheios à mudança).
- `vitest run` dos testes de arbitragem/comparação → **38 passando**.
- Verify manual recomendado da área **arbitragem**: navegação prev/próximo + sidebar, doc fixado sobrevive a reload, fluxo cega → revelação com escolhas pré-preenchidas, "Voltar à cega" (read-only), submissão final (sugestão obrigatória em `llm`), badges da fila.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)