### PR TITLE
refactor(auto-review): zera react-doctor em AutoReviewPage (Onda 4, #249)

### DIFF
--- a/frontend/src/components/auto-review/AutoReviewEmptyState.tsx
+++ b/frontend/src/components/auto-review/AutoReviewEmptyState.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { AutoReviewQueueOwner } from "./AutoReviewPage";
+
+interface AutoReviewEmptyStateProps {
+  readOnly: boolean;
+  isCoordinator: boolean;
+  reviewers: AutoReviewQueueOwner[];
+  viewAsUserId: string;
+  currentUserId: string;
+  onViewAsChange: (userId: string) => void;
+}
+
+export function AutoReviewEmptyState({
+  readOnly,
+  isCoordinator,
+  reviewers,
+  viewAsUserId,
+  currentUserId,
+  onViewAsChange,
+}: AutoReviewEmptyStateProps) {
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 px-6 py-10 text-center">
+      <h1 className="mb-4 text-2xl font-semibold">Auto-revisão</h1>
+      {readOnly ? (
+        <p className="text-muted-foreground">
+          Este pesquisador não tem auto-revisão pendente no momento.
+        </p>
+      ) : (
+        <p className="text-muted-foreground">
+          Nenhuma auto-revisão pendente. Quando você submeter uma codificação que
+          diverge do LLM, ela aparecerá aqui.
+        </p>
+      )}
+      {isCoordinator ? (
+        <div className="mt-6 space-y-3 border-t pt-4 text-left">
+          {reviewers.length > 1 ? (
+            <div>
+              <p className="mb-1 text-xs text-muted-foreground">
+                Ver fila de outro pesquisador
+              </p>
+              <Select value={viewAsUserId} onValueChange={onViewAsChange}>
+                <SelectTrigger className="w-full max-w-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {reviewers.map((r) => (
+                    <SelectItem key={r.userId} value={r.userId}>
+                      {r.name || r.email || r.userId.slice(0, 8)}
+                      {r.userId === currentUserId ? " (você)" : ""}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+          <p className="text-xs text-muted-foreground">
+            Coordenador: o backlog pode ser reexecutado em{" "}
+            <span className="font-medium">Reviews → Erros LLM</span>.
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/auto-review/AutoReviewPage.tsx
+++ b/frontend/src/components/auto-review/AutoReviewPage.tsx
@@ -1,38 +1,23 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { toast } from "sonner";
 import { DocumentReader } from "@/components/coding/DocumentReader";
-import { submitAutoReview } from "@/actions/field-reviews";
 import {
   AutoReviewDocList,
   type AutoReviewDocListEntry,
 } from "./AutoReviewDocList";
-import {
-  AutoReviewFieldPanel,
-  type AutoReviewField,
-} from "./AutoReviewFieldPanel";
+import type { AutoReviewField } from "./AutoReviewFieldPanel";
+import { AutoReviewEmptyState } from "./AutoReviewEmptyState";
+import { AutoReviewPageHeader } from "./AutoReviewPageHeader";
+import { AutoReviewPageContent } from "./AutoReviewPageContent";
 import type { PydanticField, SelfVerdict } from "@/lib/types";
-import {
-  isAutoReviewFieldDecided,
-  verdictRequiresJustification,
-} from "@/lib/auto-review-decided";
+import { choiceKey, isAutoReviewFieldDecided } from "@/lib/auto-review-decided";
 import { usePinnedDoc } from "@/hooks/usePinnedDoc";
 
 export interface AutoReviewDoc {
@@ -82,7 +67,7 @@ function AutoReviewPageInner({
   reviewers,
   currentUserId,
 }: AutoReviewPageProps) {
-  const { push, refresh } = useRouter();
+  const { push } = useRouter();
   const searchParams = useSearchParams();
 
   const isOwnQueue = viewAsUserId === currentUserId;
@@ -105,26 +90,15 @@ function AutoReviewPageInner({
     return 0;
   }, [docs, pinnedDocId]);
 
-  const [fieldIndex, setFieldIndex] = useState(0);
   const [listCollapsed, setListCollapsed] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
-  // Keyed por `${docId}::${fieldName}` — fieldName se repete entre documentos.
-  // Sem o prefixo do docId, escolher "q1" no doc A pre-selecionaria "q1" do
-  // doc B na navegação. O composto garante isolamento por (doc, campo).
+  // Estado compartilhado entre a contagem de pendentes da sidebar
+  // (docListEntries) e a interação de campo (AutoReviewPageContent); por isso
+  // vive aqui, no pai, e não no Content. Keyed por `${docId}::${fieldName}` —
+  // o composto isola escolha/justificativa por (documento, campo).
   const [choices, setChoices] = useState<Record<string, SelfVerdict>>({});
-  // Justificativa por (doc, campo) — obrigatória quando a escolha é
-  // contesta_llm ou ambiguo.
   const [justifications, setJustifications] = useState<Record<string, string>>(
     {},
   );
-
-  const choiceKey = (docId: string, fieldName: string) =>
-    `${docId}::${fieldName}`;
-
-  useEffect(() => {
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- reseta o campo ao trocar de documento
-    setFieldIndex(0);
-  }, [docIndex]);
 
   function handleDocNavigate(newIndex: number) {
     const clamped = Math.max(0, Math.min(newIndex, docs.length - 1));
@@ -153,11 +127,7 @@ function AutoReviewPageInner({
         const pending = d.fields.filter((f) => {
           if (f.alreadyAnswered) return false;
           const k = choiceKey(d.docId, f.fieldName);
-          return !isAutoReviewFieldDecided(
-            false,
-            choices[k],
-            justifications[k],
-          );
+          return !isAutoReviewFieldDecided(false, choices[k], justifications[k]);
         }).length;
         return {
           id: d.docId,
@@ -172,194 +142,36 @@ function AutoReviewPageInner({
 
   if (docs.length === 0) {
     return (
-      <div className="mx-auto max-w-3xl space-y-4 px-6 py-10 text-center">
-        <h1 className="mb-4 text-2xl font-semibold">Auto-revisão</h1>
-        {readOnly ? (
-          <p className="text-muted-foreground">
-            Este pesquisador não tem auto-revisão pendente no momento.
-          </p>
-        ) : (
-          <p className="text-muted-foreground">
-            Nenhuma auto-revisão pendente. Quando você submeter uma codificação
-            que diverge do LLM, ela aparecerá aqui.
-          </p>
-        )}
-        {isCoordinator ? (
-          <div className="mt-6 space-y-3 border-t pt-4 text-left">
-            {reviewers.length > 1 ? (
-              <div>
-                <p className="mb-1 text-xs text-muted-foreground">
-                  Ver fila de outro pesquisador
-                </p>
-                <Select
-                  value={viewAsUserId}
-                  onValueChange={handleViewAsChange}
-                >
-                  <SelectTrigger className="w-full max-w-sm">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {reviewers.map((r) => (
-                      <SelectItem key={r.userId} value={r.userId}>
-                        {r.name || r.email || r.userId.slice(0, 8)}
-                        {r.userId === currentUserId ? " (você)" : ""}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            ) : null}
-            <p className="text-xs text-muted-foreground">
-              Coordenador: o backlog pode ser reexecutado em{" "}
-              <span className="font-medium">Reviews → Erros LLM</span>.
-            </p>
-          </div>
-        ) : null}
-      </div>
+      <AutoReviewEmptyState
+        readOnly={readOnly}
+        isCoordinator={isCoordinator}
+        reviewers={reviewers}
+        viewAsUserId={viewAsUserId}
+        currentUserId={currentUserId}
+        onViewAsChange={handleViewAsChange}
+      />
     );
   }
 
   const doc = docs[docIndex];
-  const currentField = doc.fields[fieldIndex];
-  // Classifica cada campo do doc na sessão atual:
-  //   ready      = decidido nesta sessão e completo → entra no próximo envio
-  //   incomplete = verdict que exige justificativa escolhido mas sem ela → falta algo
-  //   answered   = já enviado (alreadyAnswered) OU pronto pra enviar
-  const fieldStatus = doc.fields.map((f) => {
-    const key = choiceKey(doc.docId, f.fieldName);
-    const choice = choices[key];
-    const justification = justifications[key];
-    const incomplete =
-      !f.alreadyAnswered &&
-      verdictRequiresJustification(choice) &&
-      !justification?.trim();
-    const ready =
-      !f.alreadyAnswered &&
-      isAutoReviewFieldDecided(false, choice, justification);
-    return { answered: f.alreadyAnswered || ready, incomplete, ready };
-  });
-  const answeredFlags = fieldStatus.map((s) => s.answered);
-  const incompleteFlags = fieldStatus.map((s) => s.incomplete);
-  const readyCount = fieldStatus.filter((s) => s.ready).length;
-  const incompleteCount = fieldStatus.filter((s) => s.incomplete).length;
-  const canSubmit = readyCount > 0 && !submitting;
-
-  async function handleSubmit() {
-    if (readOnly) return;
-    const readyFieldNames = doc.fields
-      .filter((_, i) => fieldStatus[i].ready)
-      .map((f) => f.fieldName);
-    if (readyFieldNames.length === 0) return;
-    setSubmitting(true);
-    const payload = readyFieldNames.map((fieldName) => {
-      const key = choiceKey(doc.docId, fieldName);
-      return {
-        fieldName,
-        verdict: choices[key],
-        justification: justifications[key],
-      };
-    });
-    const result = await submitAutoReview(projectId, doc.docId, payload);
-    setSubmitting(false);
-    if (!result.success) {
-      toast.error(result.error ?? "Falha ao enviar");
-      return;
-    }
-    if (result.warning) {
-      toast.warning(result.warning);
-    } else {
-      toast.success(
-        result.arbitrated
-          ? `Enviado. ${result.arbitrated} campo(s) seguem para arbitragem.`
-          : `Enviado. ${readyFieldNames.length} campo(s) resolvido(s).`,
-      );
-    }
-    // Limpa só os campos enviados — escolhas incompletas (contesta_llm sem
-    // justificativa) permanecem para o usuário continuar de onde parou.
-    setChoices((c) => {
-      const next = { ...c };
-      for (const fieldName of readyFieldNames)
-        delete next[choiceKey(doc.docId, fieldName)];
-      return next;
-    });
-    setJustifications((j) => {
-      const next = { ...j };
-      for (const fieldName of readyFieldNames)
-        delete next[choiceKey(doc.docId, fieldName)];
-      return next;
-    });
-    // Recarrega o estado do servidor: os campos enviados voltam como
-    // alreadyAnswered e o doc sai da fila se todos foram resolvidos.
-    refresh();
-  }
-
   const currentReviewer = reviewers.find((r) => r.userId === viewAsUserId);
   const reviewerLabel =
     currentReviewer?.name ?? currentReviewer?.email ?? viewAsUserId.slice(0, 8);
 
   return (
     <div className="flex h-[calc(100vh-96px)] flex-col">
-      <div className="flex h-10 shrink-0 items-center justify-between border-b px-4 text-sm">
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="truncate font-medium">
-            Auto-revisão humano vs LLM
-          </span>
-          {readOnly ? (
-            <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
-              visualizando {reviewerLabel}
-            </Badge>
-          ) : null}
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {isCoordinator && reviewers.length > 1 ? (
-            <Select value={viewAsUserId} onValueChange={handleViewAsChange}>
-              <SelectTrigger className="h-7 w-[200px] text-xs">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {reviewers.map((r) => (
-                  <SelectItem
-                    key={r.userId}
-                    value={r.userId}
-                    className="text-xs"
-                  >
-                    {r.name || r.email || r.userId.slice(0, 8)}
-                    {r.userId === currentUserId ? " (você)" : ""}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          ) : null}
-          <Badge variant="secondary" className="text-xs">
-            {docs.length} doc{docs.length === 1 ? "" : "s"}
-          </Badge>
-          <div className="flex items-center gap-0.5">
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-6"
-              onClick={() => handleDocNavigate(docIndex - 1)}
-              disabled={docIndex === 0}
-              title="Documento anterior"
-            >
-              <ChevronLeft className="size-4" />
-            </Button>
-            <span className="text-xs text-muted-foreground">
-              {docIndex + 1}/{docs.length}
-            </span>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="size-6"
-              onClick={() => handleDocNavigate(docIndex + 1)}
-              disabled={docIndex === docs.length - 1}
-              title="Próximo documento"
-            >
-              <ChevronRight className="size-4" />
-            </Button>
-          </div>
-        </div>
-      </div>
+      <AutoReviewPageHeader
+        readOnly={readOnly}
+        reviewerLabel={reviewerLabel}
+        isCoordinator={isCoordinator}
+        reviewers={reviewers}
+        viewAsUserId={viewAsUserId}
+        currentUserId={currentUserId}
+        onViewAsChange={handleViewAsChange}
+        docsCount={docs.length}
+        docIndex={docIndex}
+        onNavigate={handleDocNavigate}
+      />
 
       <div className="flex flex-1 overflow-hidden">
         <AutoReviewDocList
@@ -375,39 +187,18 @@ function AutoReviewPageInner({
           </ResizablePanel>
           <ResizableHandle withHandle />
           <ResizablePanel defaultSize={50} minSize={25}>
-            <AutoReviewFieldPanel
-              field={currentField}
-              fieldIndex={fieldIndex}
-              totalFields={doc.fields.length}
-              answered={answeredFlags}
-              incomplete={incompleteFlags}
-              choice={
-                choices[choiceKey(doc.docId, currentField.fieldName)] ?? null
-              }
-              justification={
-                justifications[
-                  choiceKey(doc.docId, currentField.fieldName)
-                ] ?? ""
-              }
+            {/* key={doc.docId}: remonta ao trocar de doc, resetando fieldIndex
+                sem effect; o split (ResizablePanelGroup) fica fora e preserva
+                o tamanho manual entre navegacoes. */}
+            <AutoReviewPageContent
+              key={doc.docId}
+              doc={doc}
+              projectId={projectId}
               readOnly={readOnly}
-              readyCount={readyCount}
-              incompleteCount={incompleteCount}
-              submitting={submitting}
-              canSubmit={canSubmit}
-              onSubmit={handleSubmit}
-              onChoose={(v) =>
-                setChoices((c) => ({
-                  ...c,
-                  [choiceKey(doc.docId, currentField.fieldName)]: v,
-                }))
-              }
-              onJustificationChange={(value) =>
-                setJustifications((j) => ({
-                  ...j,
-                  [choiceKey(doc.docId, currentField.fieldName)]: value,
-                }))
-              }
-              onFieldNavigate={setFieldIndex}
+              choices={choices}
+              justifications={justifications}
+              setChoices={setChoices}
+              setJustifications={setJustifications}
             />
           </ResizablePanel>
         </ResizablePanelGroup>

--- a/frontend/src/components/auto-review/AutoReviewPageContent.tsx
+++ b/frontend/src/components/auto-review/AutoReviewPageContent.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { type Dispatch, type SetStateAction, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { submitAutoReview } from "@/actions/field-reviews";
+import { AutoReviewFieldPanel } from "./AutoReviewFieldPanel";
+import {
+  choiceKey,
+  isAutoReviewFieldDecided,
+  verdictRequiresJustification,
+} from "@/lib/auto-review-decided";
+import type { SelfVerdict } from "@/lib/types";
+import type { AutoReviewDoc } from "./AutoReviewPage";
+
+interface AutoReviewPageContentProps {
+  doc: AutoReviewDoc;
+  projectId: string;
+  readOnly: boolean;
+  choices: Record<string, SelfVerdict>;
+  justifications: Record<string, string>;
+  setChoices: Dispatch<SetStateAction<Record<string, SelfVerdict>>>;
+  setJustifications: Dispatch<SetStateAction<Record<string, string>>>;
+}
+
+// Renderizado pelo pai com `key={doc.docId}`: ao trocar de documento, o
+// componente remonta e `fieldIndex` volta a 0 — sem effect (no-adjust-state-on-
+// prop-change) nem ajuste durante render (useState-prev e marcado pela 0.5.8;
+// useRef-prev e barrado pelo eslint react-hooks/refs). Keyar por docId (e nao
+// por indice) tambem reseta corretamente quando um doc resolvido sai da fila e
+// outro assume o mesmo indice. O ResizablePanelGroup fica no pai, fora desta
+// remontagem, preservando o tamanho do split entre navegacoes.
+export function AutoReviewPageContent({
+  doc,
+  projectId,
+  readOnly,
+  choices,
+  justifications,
+  setChoices,
+  setJustifications,
+}: AutoReviewPageContentProps) {
+  const { refresh } = useRouter();
+  const [fieldIndex, setFieldIndex] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Classifica cada campo do doc na sessao atual:
+  //   ready      = decidido nesta sessao e completo -> entra no proximo envio
+  //   incomplete = verdict que exige justificativa escolhido mas sem ela
+  //   answered   = ja enviado (alreadyAnswered) OU pronto pra enviar
+  const {
+    fieldStatus,
+    answeredFlags,
+    incompleteFlags,
+    readyCount,
+    incompleteCount,
+  } = useMemo(() => {
+    const status = doc.fields.map((f) => {
+      const key = choiceKey(doc.docId, f.fieldName);
+      const choice = choices[key];
+      const justification = justifications[key];
+      const incomplete =
+        !f.alreadyAnswered &&
+        verdictRequiresJustification(choice) &&
+        !justification?.trim();
+      const ready =
+        !f.alreadyAnswered &&
+        isAutoReviewFieldDecided(false, choice, justification);
+      return { answered: f.alreadyAnswered || ready, incomplete, ready };
+    });
+    return {
+      fieldStatus: status,
+      answeredFlags: status.map((s) => s.answered),
+      incompleteFlags: status.map((s) => s.incomplete),
+      readyCount: status.filter((s) => s.ready).length,
+      incompleteCount: status.filter((s) => s.incomplete).length,
+    };
+  }, [doc.docId, doc.fields, choices, justifications]);
+
+  const canSubmit = readyCount > 0 && !submitting;
+  const currentField = doc.fields[fieldIndex];
+  const currentKey = choiceKey(doc.docId, currentField.fieldName);
+
+  async function handleSubmit() {
+    if (readOnly) return;
+    const readyFieldNames = doc.fields
+      .filter((_, i) => fieldStatus[i].ready)
+      .map((f) => f.fieldName);
+    if (readyFieldNames.length === 0) return;
+    setSubmitting(true);
+    const payload = readyFieldNames.map((fieldName) => {
+      const key = choiceKey(doc.docId, fieldName);
+      return {
+        fieldName,
+        verdict: choices[key],
+        justification: justifications[key],
+      };
+    });
+    const result = await submitAutoReview(projectId, doc.docId, payload);
+    setSubmitting(false);
+    if (!result.success) {
+      toast.error(result.error ?? "Falha ao enviar");
+      return;
+    }
+    if (result.warning) {
+      toast.warning(result.warning);
+    } else {
+      toast.success(
+        result.arbitrated
+          ? `Enviado. ${result.arbitrated} campo(s) seguem para arbitragem.`
+          : `Enviado. ${readyFieldNames.length} campo(s) resolvido(s).`,
+      );
+    }
+    // Limpa so os campos enviados — escolhas incompletas (contesta_llm sem
+    // justificativa) permanecem para o usuario continuar de onde parou.
+    setChoices((c) => {
+      const next = { ...c };
+      for (const fieldName of readyFieldNames)
+        delete next[choiceKey(doc.docId, fieldName)];
+      return next;
+    });
+    setJustifications((j) => {
+      const next = { ...j };
+      for (const fieldName of readyFieldNames)
+        delete next[choiceKey(doc.docId, fieldName)];
+      return next;
+    });
+    // Recarrega o estado do servidor: os campos enviados voltam como
+    // alreadyAnswered e o doc sai da fila se todos foram resolvidos.
+    refresh();
+  }
+
+  return (
+    <AutoReviewFieldPanel
+      field={currentField}
+      fieldIndex={fieldIndex}
+      totalFields={doc.fields.length}
+      answered={answeredFlags}
+      incomplete={incompleteFlags}
+      choice={choices[currentKey] ?? null}
+      justification={justifications[currentKey] ?? ""}
+      readOnly={readOnly}
+      readyCount={readyCount}
+      incompleteCount={incompleteCount}
+      submitting={submitting}
+      canSubmit={canSubmit}
+      onSubmit={handleSubmit}
+      onChoose={(v) => setChoices((c) => ({ ...c, [currentKey]: v }))}
+      onJustificationChange={(value) =>
+        setJustifications((j) => ({ ...j, [currentKey]: value }))
+      }
+      onFieldNavigate={setFieldIndex}
+    />
+  );
+}

--- a/frontend/src/components/auto-review/AutoReviewPageHeader.tsx
+++ b/frontend/src/components/auto-review/AutoReviewPageHeader.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { AutoReviewQueueOwner } from "./AutoReviewPage";
+
+interface AutoReviewPageHeaderProps {
+  readOnly: boolean;
+  reviewerLabel: string;
+  isCoordinator: boolean;
+  reviewers: AutoReviewQueueOwner[];
+  viewAsUserId: string;
+  currentUserId: string;
+  onViewAsChange: (userId: string) => void;
+  docsCount: number;
+  docIndex: number;
+  onNavigate: (index: number) => void;
+}
+
+export function AutoReviewPageHeader({
+  readOnly,
+  reviewerLabel,
+  isCoordinator,
+  reviewers,
+  viewAsUserId,
+  currentUserId,
+  onViewAsChange,
+  docsCount,
+  docIndex,
+  onNavigate,
+}: AutoReviewPageHeaderProps) {
+  return (
+    <div className="flex h-10 shrink-0 items-center justify-between border-b px-4 text-sm">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="truncate font-medium">Auto-revisão humano vs LLM</span>
+        {readOnly ? (
+          <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
+            visualizando {reviewerLabel}
+          </Badge>
+        ) : null}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {isCoordinator && reviewers.length > 1 ? (
+          <Select value={viewAsUserId} onValueChange={onViewAsChange}>
+            <SelectTrigger className="h-7 w-[200px] text-xs">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {reviewers.map((r) => (
+                <SelectItem key={r.userId} value={r.userId} className="text-xs">
+                  {r.name || r.email || r.userId.slice(0, 8)}
+                  {r.userId === currentUserId ? " (você)" : ""}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+        <Badge variant="secondary" className="text-xs">
+          {docsCount} doc{docsCount === 1 ? "" : "s"}
+        </Badge>
+        <div className="flex items-center gap-0.5">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={() => onNavigate(docIndex - 1)}
+            disabled={docIndex === 0}
+            title="Documento anterior"
+          >
+            <ChevronLeft className="size-4" />
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            {docIndex + 1}/{docsCount}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-6"
+            onClick={() => onNavigate(docIndex + 1)}
+            disabled={docIndex === docsCount - 1}
+            title="Próximo documento"
+          >
+            <ChevronRight className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/__tests__/auto-review-decided.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-decided.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  choiceKey,
   isAutoReviewFieldDecided,
   verdictRequiresJustification,
 } from "@/lib/auto-review-decided";
@@ -62,5 +63,13 @@ describe("verdictRequiresJustification", () => {
     expect(verdictRequiresJustification("equivalente")).toBe(false);
     expect(verdictRequiresJustification(null)).toBe(false);
     expect(verdictRequiresJustification(undefined)).toBe(false);
+  });
+});
+
+describe("choiceKey", () => {
+  it("compõe docId e fieldName isolando por (documento, campo)", () => {
+    expect(choiceKey("docA", "q1")).toBe("docA::q1");
+    // mesmo fieldName em docs diferentes → chaves distintas (sem colisão)
+    expect(choiceKey("docA", "q1")).not.toBe(choiceKey("docB", "q1"));
   });
 });

--- a/frontend/src/lib/auto-review-decided.ts
+++ b/frontend/src/lib/auto-review-decided.ts
@@ -29,3 +29,12 @@ export function isAutoReviewFieldDecided(
   if (verdictRequiresJustification(choice)) return !!justification?.trim();
   return true;
 }
+
+// Chave de escolha/justificativa por (documento, campo). O fieldName se repete
+// entre documentos; sem o prefixo do docId, escolher "q1" no doc A
+// pre-selecionaria "q1" do doc B na navegacao. O composto garante isolamento.
+// Funcao de modulo (nao recriada a cada render) compartilhada entre
+// AutoReviewPage e AutoReviewPageContent.
+export function choiceKey(docId: string, fieldName: string): string {
+  return `${docId}::${fieldName}`;
+}


### PR DESCRIPTION
Parte da campanha **Zerar react-doctor** (épico #239), **Onda 4 — Hotspot** (sub-issue de #235). Gêmeo do piloto `MyVerdictsView` (#232). Elimina os **5 diagnósticos** do react-doctor em `AutoReviewPage.tsx` **refatorando — não suprimindo** — preservando o comportamento da área auto-revisão.

## O que mudou

| Diagnóstico | Como foi resolvido |
|---|---|
| `prefer-module-scope-pure-function` (:121) | `choiceKey` movida para `lib/auto-review-decided.ts` (módulo puro, client-safe, já compartilhado) |
| `prefer-useReducer` (:84) + `no-giant-component` (:77) | Extraídos `AutoReviewEmptyState`, `AutoReviewPageHeader`, `AutoReviewPageContent`. O pai cai de **341 → 147 linhas** e de **5 → 3 `useState`**. Sem `useReducer` (não há nenhum no repo) |
| `no-adjust-state-on-prop-change` (**error**, :126) + `no-derived-state-effect` (:124) | Reset de `fieldIndex` ao trocar de doc via `key={doc.docId}` no `AutoReviewPageContent` (remontagem), no lugar do `useEffect` |

### Por que `key` e não ajuste-durante-render

O react-doctor **0.5.8** (bump recente, #266) marca o padrão `prev`-prop em `useState` (`rerender-state-only-in-handlers` + `no-derived-useState`), e o eslint `react-hooks/refs` barra a variante com `useRef` durante render. O `key={doc.docId}` é a **única** saída limpa nos dois linters — e é mais correto que o `useEffect` original: keyar por **identidade** (não por índice) reseta o campo mesmo quando um doc resolvido sai da fila e outro assume o mesmo índice. O `ResizablePanelGroup` fica no pai, **fora** da remontagem, então o tamanho do split é preservado entre navegações.

### Fora de escopo

`AutoReviewFieldPanel.tsx` mantém 3 diagnósticos pré-existentes (incl. o effect `:97`) — arquivo diferente, outra onda. A API pública (`AutoReviewPage`/`AutoReviewPageProps`) é inalterada, então o caller da rota não muda.

## Verificação

- **react-doctor**: 0 diagnósticos nos 4 arquivos (`AutoReviewPage` + 3 novos). Global: errors 7→6, warnings 107→103.
- **tsc** `--noEmit`: 0 erros. **eslint** (arquivos tocados): 0. **vitest**: 578/578 (inclui novo teste de `choiceKey`).
- **Gate de pre-commit** (`react-doctor --diff`): limpo.
- Manual recomendado: navegação ◂ ▸ (reset de campo), troca de campo, submissão, seletor de pesquisador do coordenador, e que o split redimensionável **não** reseta ao navegar entre docs.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)