### PR TITLE
chore(docker): sobe runtime Node 20 → 24 (Active LTS)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 
 # --- Dependencies ---
 FROM base AS deps


### PR DESCRIPTION
Sobe o runtime do frontend de `node:20-alpine` para `node:24-alpine`.

## Motivação
Dois PRs do Dependabot pressupõem um Node mais novo do que o runtime pinado:

- **#278** (`eslint` 9 → 10) eleva o piso para Node `^20.19 || ^22.13 || >=24`.
- **#275** (`@types/node` ^20 → ^25) tipa APIs de Node 21–25; sob `node:20-alpine` o `tsc` passa mas o runtime pode lançar `TypeError`.

Subir para Node 24 (Active LTS) alinha o runtime ao dev local (Node 24), destrava esses dois PRs e fecha o gap tipos↔runtime.

## Escopo
`frontend/Dockerfile:1` é a **única** referência versionada de Node (não há `.nvmrc`, `engines` em `package.json`, nem `node-version` em workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)