### PR TITLE
refactor(arbitration): estabiliza handlers de submit com useCallback (follow-up #280)

### DIFF
--- a/frontend/src/hooks/useArbitrationDoc.ts
+++ b/frontend/src/hooks/useArbitrationDoc.ts
@@ -133,7 +133,7 @@ export function useArbitrationDoc({
     if (doc) setBlindOverrideDocId(doc.docId);
   }, [doc]);
 
-  async function handleBlindSubmit() {
+  const handleBlindSubmit = useCallback(async () => {
     if (!doc) return;
     setSubmitting(true);
     const choices: BlindChoice[] = doc.fields
@@ -156,9 +156,9 @@ export function useArbitrationDoc({
     // refresh() repuxa o payload com `reveal` populado; a fase deriva sozinha.
     refresh();
     setSubmitting(false);
-  }
+  }, [doc, blindChoices, projectId, refresh]);
 
-  async function handleFinalSubmit() {
+  const handleFinalSubmit = useCallback(async () => {
     if (!doc) return;
     for (const f of doc.fields) {
       if (effectiveFinalChoices[f.fieldReviewId] === "llm") {
@@ -197,7 +197,17 @@ export function useArbitrationDoc({
     } else {
       refresh();
     }
-  }
+  }, [
+    doc,
+    effectiveFinalChoices,
+    suggestions,
+    comments,
+    projectId,
+    docIndex,
+    docsLength,
+    onNavigate,
+    refresh,
+  ]);
 
   return {
     phase,


### PR DESCRIPTION
Follow-up do #280 (já mergeado). Na revisão do #280 ficou a observação de que `handleBlindSubmit` e `handleFinalSubmit` eram as únicas plain functions do `useArbitrationDoc` — os demais handlers (`onChooseBlind`, `onChooseFinal`, `onSuggestion`, `onComment`, `onBackToBlind`) já usam `useCallback`. Elas eram recriadas a cada render e repassadas como props a `ArbitrationPageHeader`.

## O que mudou

- `handleBlindSubmit` → `useCallback(..., [doc, blindChoices, projectId, refresh])`
- `handleFinalSubmit` → `useCallback(..., [doc, effectiveFinalChoices, suggestions, comments, projectId, docIndex, docsLength, onNavigate, refresh])`

Dependências escolhidas pelo que cada closure efetivamente lê; setters e imports de módulo (`submitBlindVerdicts`, `toast`) são estáveis e não entram. **Sem mudança de comportamento** — só identidade estável das callbacks.

## Verificação

- `npx tsc --noEmit` limpo.
- `npx react-doctor . --diff` → 0 errors, 0 warnings.
- `vitest run` da árvore de arbitragem + `useArbitrationDoc` → **68 passando**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)