### PR TITLE
fix(compare): default da fila foca na versão corrente (latest_major) [#247]

### DIFF
--- a/frontend/src/actions/__tests__/comparisons-retry.test.ts
+++ b/frontend/src/actions/__tests__/comparisons-retry.test.ts
@@ -74,6 +74,10 @@ vi.mock("@/lib/supabase/admin", () => ({
 const FIELDS: PydanticField[] = [
   { name: "q1", type: "text", options: null, description: "", required: true },
 ];
+// Hash do schema corrente: o backlog (scanComparisonBacklog) aplica o piso vivo
+// `latest_major` (#247), então as respostas precisam qualificar — usam o hash
+// atual com semver NULL (caminho de fallback por hash em responseQualifiesForVersion).
+const CURRENT_HASH = "hash-atual";
 const human = (respondent_id: string, q1: string, document_id = "doc1") => ({
   id: `r-${respondent_id}-${document_id}`,
   project_id: "p1",
@@ -83,13 +87,21 @@ const human = (respondent_id: string, q1: string, document_id = "doc1") => ({
   is_latest: true,
   answers: { q1 },
   answer_field_hashes: null,
+  pydantic_hash: CURRENT_HASH,
+  schema_version_major: null,
+  schema_version_minor: null,
+  schema_version_patch: null,
 });
 const projectRow = (over: Record<string, unknown> = {}) => ({
   id: "p1",
   pydantic_fields: FIELDS,
+  pydantic_hash: CURRENT_HASH,
   min_responses_for_comparison: 2,
   comparison_includes_llm: true,
   automation_mode: "compare_humans",
+  schema_version_major: null,
+  schema_version_minor: null,
+  schema_version_patch: null,
   ...over,
 });
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -12,6 +12,7 @@ import {
   assignedCompareDocIds,
 } from "@/lib/compare-filters";
 import {
+  deriveProjectVersionContext,
   resolveMinVersion,
   responseQualifiesForVersion,
   latestMajorAnchor,
@@ -164,16 +165,13 @@ export default async function ComparePageRoute({
   );
   const filters = readCompareFilters(sp, compareDefaults);
 
-  const projectVersion = {
-    major: project?.schema_version_major ?? 0,
-    minor: project?.schema_version_minor ?? 1,
-    patch: project?.schema_version_patch ?? 0,
-  };
+  // Contexto de versão do helper compartilhado (compare-version.ts) — a MESMA
+  // fonte e fallback {0,1,0} do fecho (compare-sync.ts) e do gatilho
+  // (auto-comparison.ts). A página resolve seu `minVersion` a partir da URL
+  // (`filters.version`, que pode ser uma lente manual), não da constante.
+  const { version: projectVersion, ctx: projectVersionCtx } =
+    deriveProjectVersionContext(project ?? {});
   const minVersion = resolveMinVersion(filters.version, projectVersion);
-  const projectVersionCtx = {
-    pydanticHash: project?.pydantic_hash ?? null,
-    version: projectVersion,
-  };
   const sinceMs = filters.since ? new Date(filters.since).getTime() : null;
 
   // Build distinct ordered version list desc — une versões do schema_change_log

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -477,6 +477,7 @@ export default async function ComparePageRoute({
         projectPydanticHash={project?.pydantic_hash ?? null}
         respondentNames={respondentNames}
         defaultMinHumans={compareDefaults.minHumans}
+        defaultVersion={compareDefaults.version}
         coverageByDoc={coverageByDoc}
         commentCountsByKey={commentCountsByKey}
         suggestionCountsByField={suggestionCountsByField}

--- a/frontend/src/components/compare/CompareFilters.tsx
+++ b/frontend/src/components/compare/CompareFilters.tsx
@@ -31,6 +31,12 @@ interface CompareFiltersProps {
   // (compareDefaultsForMode). Mantém o controle coerente com o filtro aplicado
   // no servidor — em compare_llm o default é 1, não o global 2.
   defaultMinHumans: number;
+  // Default VIVO de versão da fila (compareDefaultsForMode → COMPARE_DEFAULT_
+  // VERSION, "latest_major"). Sem ele o seletor usaria DEFAULT_COMPARE_FILTERS.
+  // version ("all") e divergiria do servidor: exibiria "Todas as versões"
+  // enquanto a fila já está em latest_major, e "Todas as versões" ficaria
+  // inalcançável (o `update` apagaria o param por coincidir com o default). #247
+  defaultVersion: string;
   availableVersions: string[]; // ["X.Y.Z", ...] ordered desc
   latestMajorLabel: string | null; // "1.0.0" ou null
 }
@@ -48,6 +54,7 @@ export function CompareFilters(props: CompareFiltersProps) {
 function CompareFiltersInner({
   respondentNames,
   defaultMinHumans,
+  defaultVersion,
   availableVersions,
   latestMajorLabel,
 }: CompareFiltersProps) {
@@ -56,13 +63,19 @@ function CompareFiltersInner({
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();
 
-  // Defaults coerentes com o modo de automação (o servidor deriva o piso de
-  // humanos de compareDefaultsForMode). Sem isto o filtro exibiria "2" enquanto
-  // a página lista docs de 1 humano em compare_llm, e marcar "2" pareceria o
-  // default mas esconderia esses docs.
+  // Defaults coerentes com o que o servidor aplica (ambos derivados de
+  // compareDefaultsForMode): o piso de humanos e o default de versão. Sem o
+  // minHumans o filtro exibiria "2" enquanto a página lista docs de 1 humano em
+  // compare_llm; sem a version exibiria "all" enquanto a fila já está em
+  // latest_major — e, pior, selecionar "Todas as versões" apagaria o param (por
+  // coincidir com o default) e a visão completa ficaria inalcançável (#247).
   const effectiveDefaults = useMemo(
-    () => ({ ...DEFAULT_COMPARE_FILTERS, minHumans: defaultMinHumans }),
-    [defaultMinHumans],
+    () => ({
+      ...DEFAULT_COMPARE_FILTERS,
+      minHumans: defaultMinHumans,
+      version: defaultVersion,
+    }),
+    [defaultMinHumans, defaultVersion],
   );
   const current = readCompareFilters(searchParams, effectiveDefaults);
 
@@ -170,11 +183,13 @@ function CompareFiltersInner({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="all">Todas as versões</SelectItem>
-                {latestMajorLabel && (
-                  <SelectItem value="latest_major">
-                    Última MAJOR ({latestMajorLabel})
-                  </SelectItem>
-                )}
+                {/* Sempre renderizado: "latest_major" é o default VIVO (#247),
+                    então precisa ter item correspondente mesmo se o label da
+                    versão não vier — senão o Select controlado fica com `value`
+                    sem option. O label da MAJOR aparece só quando disponível. */}
+                <SelectItem value="latest_major">
+                  Última MAJOR{latestMajorLabel ? ` (${latestMajorLabel})` : ""}
+                </SelectItem>
                 {availableVersions.map((v) => (
                   <SelectItem key={v} value={v}>
                     {v}

--- a/frontend/src/components/compare/CompareFilters.tsx
+++ b/frontend/src/components/compare/CompareFilters.tsx
@@ -24,6 +24,10 @@ import {
   readCompareFilters,
   type CompareFiltersValue,
 } from "@/lib/compare-filters";
+import {
+  VERSION_FILTER_ALL,
+  VERSION_FILTER_LATEST_MAJOR,
+} from "@/lib/compare-version";
 
 interface CompareFiltersProps {
   respondentNames: string[];
@@ -182,12 +186,14 @@ function CompareFiltersInner({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">Todas as versões</SelectItem>
+                <SelectItem value={VERSION_FILTER_ALL}>
+                  Todas as versões
+                </SelectItem>
                 {/* Sempre renderizado: "latest_major" é o default VIVO (#247),
                     então precisa ter item correspondente mesmo se o label da
                     versão não vier — senão o Select controlado fica com `value`
                     sem option. O label da MAJOR aparece só quando disponível. */}
-                <SelectItem value="latest_major">
+                <SelectItem value={VERSION_FILTER_LATEST_MAJOR}>
                   Última MAJOR{latestMajorLabel ? ` (${latestMajorLabel})` : ""}
                 </SelectItem>
                 {availableVersions.map((v) => (

--- a/frontend/src/components/compare/CompareNav.tsx
+++ b/frontend/src/components/compare/CompareNav.tsx
@@ -22,6 +22,7 @@ interface CompareNavProps {
   parecerUrl?: string;
   respondentNames: string[];
   defaultMinHumans: number;
+  defaultVersion: string;
   availableVersions: string[];
   latestMajorLabel: string | null;
   currentProjectVersion: string;
@@ -42,6 +43,7 @@ export function CompareNav({
   parecerUrl,
   respondentNames,
   defaultMinHumans,
+  defaultVersion,
   availableVersions,
   latestMajorLabel,
   currentProjectVersion,
@@ -68,6 +70,7 @@ export function CompareNav({
         <CompareFilters
           respondentNames={respondentNames}
           defaultMinHumans={defaultMinHumans}
+          defaultVersion={defaultVersion}
           availableVersions={availableVersions}
           latestMajorLabel={latestMajorLabel}
         />

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -71,9 +71,13 @@ interface ComparePageProps {
   existingReviews: Record<string, Record<string, ExistingVerdictInfo>>;
   projectPydanticHash: string | null;
   respondentNames: string[];
-  // Default de "mín. humanos" derivado do automation_mode (compareDefaultsForMode):
-  // mantém o filtro da UI coerente com o piso aplicado no servidor.
+  // Defaults VIVOS derivados do automation_mode/projeto (compareDefaultsForMode):
+  // mantêm o filtro da UI coerente com o que o servidor aplica. `defaultMinHumans`
+  // é o piso de humanos; `defaultVersion` é o default de versão da fila
+  // ("latest_major") — sem ele o seletor exibiria "all" enquanto a fila já está
+  // filtrada, e "Todas as versões" ficaria inalcançável (ver #247).
   defaultMinHumans: number;
+  defaultVersion: string;
   coverageByDoc: Record<string, DocCoverage>;
   commentCountsByKey: Record<string, number>;
   suggestionCountsByField: Record<string, number>;
@@ -98,6 +102,7 @@ export function ComparePage({
   projectPydanticHash,
   respondentNames,
   defaultMinHumans,
+  defaultVersion,
   coverageByDoc,
   commentCountsByKey,
   suggestionCountsByField,
@@ -562,6 +567,7 @@ export function ComparePage({
           parecerUrl={parecerUrl}
           respondentNames={respondentNames}
           defaultMinHumans={defaultMinHumans}
+          defaultVersion={defaultVersion}
           availableVersions={availableVersions}
           latestMajorLabel={latestMajorLabel}
           currentProjectVersion={currentProjectVersion}

--- a/frontend/src/components/compare/__tests__/CompareFilters.test.tsx
+++ b/frontend/src/components/compare/__tests__/CompareFilters.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// next/navigation mockado: capturamos o `push` para inspecionar a URL que o
+// filtro monta. `useSearchParams` devolve um URLSearchParams real (readCompare
+// Filters faz `instanceof URLSearchParams`).
+const push = vi.hoisted(() => vi.fn());
+let searchParams: URLSearchParams;
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+  useSearchParams: () => searchParams,
+  usePathname: () => "/projects/p1/analyze/compare",
+}));
+
+import { CompareFilters } from "@/components/compare/CompareFilters";
+
+// Radix (Popover/Select) usa APIs de Pointer/observer que o jsdom não tem.
+beforeAll(() => {
+  const proto = Element.prototype as unknown as Record<string, unknown>;
+  proto.scrollIntoView = () => {};
+  proto.hasPointerCapture = () => false;
+  proto.setPointerCapture = () => {};
+  proto.releasePointerCapture = () => {};
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+beforeEach(() => {
+  push.mockClear();
+  searchParams = new URLSearchParams("");
+});
+afterEach(() => cleanup());
+
+async function openVersionSelect(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole("button", { name: /Filtros/i }));
+  // O seletor "Desde a versão" é o primeiro combobox do popover.
+  const comboboxes = await screen.findAllByRole("combobox");
+  await user.click(comboboxes[0]);
+}
+
+describe("CompareFilters — alcançabilidade de 'Todas as versões' (#247/#286)", () => {
+  // REGRESSÃO #247: com o default VIVO latest_major, "Todas as versões" só é
+  // alcançável se o param `version=all` for ESCRITO na URL — porque `update`
+  // apaga params que coincidem com o default, e 'all' ≠ 'latest_major'. Este é o
+  // locus real do fix (o `update()` do componente), que os testes puros de
+  // readCompareFilters não exercitavam.
+  it("default latest_major: selecionar 'Todas as versões' escreve version=all na URL", async () => {
+    const user = userEvent.setup();
+    render(
+      <CompareFilters
+        respondentNames={[]}
+        defaultMinHumans={2}
+        defaultVersion="latest_major"
+        availableVersions={[]}
+        latestMajorLabel="2.0.0"
+      />,
+    );
+    await openVersionSelect(user);
+    const listbox = await screen.findByRole("listbox");
+    await user.click(within(listbox).getByText("Todas as versões"));
+
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push.mock.calls[0][0]).toContain("version=all");
+  });
+
+  it("default latest_major: re-selecionar 'Última MAJOR' apaga o param (volta ao default)", async () => {
+    const user = userEvent.setup();
+    searchParams = new URLSearchParams("version=all");
+    render(
+      <CompareFilters
+        respondentNames={[]}
+        defaultMinHumans={2}
+        defaultVersion="latest_major"
+        availableVersions={[]}
+        latestMajorLabel="2.0.0"
+      />,
+    );
+    await openVersionSelect(user);
+    const listbox = await screen.findByRole("listbox");
+    await user.click(within(listbox).getByText(/Última MAJOR/));
+
+    expect(push).toHaveBeenCalledTimes(1);
+    // 'latest_major' === default → o param é removido (não fica preso na URL).
+    expect(push.mock.calls[0][0]).not.toContain("version=");
+  });
+
+  it("default all: selecionar 'Todas as versões' apaga o param (coincide com o default)", async () => {
+    const user = userEvent.setup();
+    searchParams = new URLSearchParams("version=latest_major");
+    render(
+      <CompareFilters
+        respondentNames={[]}
+        defaultMinHumans={2}
+        defaultVersion="all"
+        availableVersions={[]}
+        latestMajorLabel="2.0.0"
+      />,
+    );
+    await openVersionSelect(user);
+    const listbox = await screen.findByRole("listbox");
+    await user.click(within(listbox).getByText("Todas as versões"));
+
+    expect(push).toHaveBeenCalledTimes(1);
+    expect(push.mock.calls[0][0]).not.toContain("version=");
+  });
+});

--- a/frontend/src/lib/__tests__/auto-comparison.test.ts
+++ b/frontend/src/lib/__tests__/auto-comparison.test.ts
@@ -106,7 +106,17 @@ const FIELDS: PydanticField[] = [
   { name: "q1", type: "text", options: null, description: "", required: true },
 ];
 
-// Helpers de fixture
+// Hash do schema corrente do projeto. As fixtures default usam-no como
+// `pydantic_hash`, com semver NULL, para qualificar pelo fallback de hash em
+// `responseQualifiesForVersion` sob o piso vivo `latest_major` (#247). Casos de
+// versão antiga passam `pydantic_hash: "hash-antigo"` ou um semver < piso.
+const CURRENT_HASH = "hash-atual";
+
+// Helpers de fixture. Campos de versão (pydantic_hash, schema_version_*) entram
+// no shape porque o gatilho agora aplica o piso `latest_major` antes de medir
+// divergência (#247). Default = versão corrente (qualifica); `extra` sobrescreve
+// para emular rodadas antigas. Semver explícito como NULL (não undefined) para
+// espelhar o que o Postgres devolve em respostas pré-versionamento.
 const human = (
   respondent_id: string,
   q1: string,
@@ -120,9 +130,13 @@ const human = (
   is_latest: true,
   answers: { q1 },
   answer_field_hashes: null,
+  pydantic_hash: CURRENT_HASH,
+  schema_version_major: null,
+  schema_version_minor: null,
+  schema_version_patch: null,
   ...extra,
 });
-const llm = (q1: string) => ({
+const llm = (q1: string, extra: Record<string, unknown> = {}) => ({
   id: "r-llm",
   project_id: "p1",
   document_id: "doc1",
@@ -130,6 +144,11 @@ const llm = (q1: string) => ({
   is_latest: true,
   answers: { q1 },
   answer_field_hashes: null,
+  pydantic_hash: CURRENT_HASH,
+  schema_version_major: null,
+  schema_version_minor: null,
+  schema_version_patch: null,
+  ...extra,
 });
 const member = (user_id: string) => ({
   user_id,
@@ -139,9 +158,16 @@ const member = (user_id: string) => ({
 const projectRow = (over: Record<string, unknown> = {}) => ({
   id: "p1",
   pydantic_fields: FIELDS,
+  pydantic_hash: CURRENT_HASH,
   min_responses_for_comparison: 2,
   comparison_includes_llm: true,
   automation_mode: "compare_humans",
+  // Sem semver explícito: cai nos fallbacks {0,1,0} (como page.tsx/compare-sync),
+  // e o piso `latest_major` ancora em {0,1,0}. Casos que exercitam o caminho
+  // semver passam schema_version_* aqui.
+  schema_version_major: null,
+  schema_version_minor: null,
+  schema_version_patch: null,
   ...over,
 });
 
@@ -344,6 +370,111 @@ describe("createAutoComparisonIfDiverges — compare_llm", () => {
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
     expect(r.assigned).toBe(false);
     expect(r.noPool).toBe(true);
+  });
+});
+
+// O gatilho aplica o MESMO piso de versão (`latest_major`) que a fila
+// (compare/page.tsx) e o fecho (compare-sync.ts) — fecha a NOTA de follow-up do
+// #286 e restaura o acoplamento gatilho==fila==fecho. Divergência que só existe
+// entre rodadas antigas NÃO materializa assignment (era o "fantasma" da NOTA).
+describe("createAutoComparisonIfDiverges — piso de versão latest_major (#247)", () => {
+  it("divergência só entre codificações de versão ANTIGA (hash) não materializa", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    // Dois humanos completos que DIVERGEM, mas ambos de um schema anterior
+    // (pydantic_hash != atual, semver NULL) → descartados pelo piso → 0 < 2.
+    tableData.responses = [
+      human("userA", "A", { pydantic_hash: "hash-antigo" }),
+      human("userB", "B", { pydantic_hash: "hash-antigo" }),
+    ];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("divergência só entre codificações de MAJOR anterior (semver) não materializa", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    // Projeto na major 2; respostas divergentes da major 1 → abaixo do piso.
+    tableData.projects = [
+      projectRow({ schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+    ];
+    tableData.responses = [
+      human("userA", "A", { schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
+      human("userB", "B", { schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
+    ];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("divergência na MAJOR corrente ainda materializa (semver)", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [
+      projectRow({ schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+    ];
+    tableData.responses = [
+      human("userA", "A", { schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+      human("userB", "B", { schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+    ];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(true);
+    expect(upsertCallsOf("assignments")).toHaveLength(1);
+  });
+
+  it("mistura: 1 corrente + 1 antiga divergem → antiga descartada, sobra 1 < mínimo", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.responses = [
+      human("userA", "A"), // corrente (hash atual)
+      human("userB", "B", { pydantic_hash: "hash-antigo" }), // antiga
+    ];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("compare_llm: humano corrente diverge de LLM de schema antigo → LLM descartado, sem 2ª resposta", async () => {
+    const { createAutoComparisonIfDiverges } = await loadLib();
+    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [
+      human("userA", "A"),
+      llm("B", { pydantic_hash: "hash-antigo" }),
+    ];
+    tableData.project_members = [member("userC")];
+    const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
+    // LLM antigo não qualifica → falta a 2ª resposta → não dispara.
+    expect(r.assigned).toBe(false);
+    expect(upsertCallsOf("assignments")).toHaveLength(0);
+  });
+});
+
+describe("scanComparisonBacklog — piso de versão latest_major (#247)", () => {
+  it("doc cuja divergência só existe em versão antiga fica fora do backlog", async () => {
+    const { scanComparisonBacklog } = await loadLib();
+    tableData.responses = [
+      human("userA", "A", { pydantic_hash: "hash-antigo" }),
+      human("userB", "B", { pydantic_hash: "hash-antigo" }),
+    ];
+    const backlog = await scanComparisonBacklog(
+      makeClient() as never,
+      "p1",
+      "compare_humans",
+    );
+    expect(backlog).toHaveLength(0);
+  });
+
+  it("doc divergente na versão corrente entra no backlog", async () => {
+    const { scanComparisonBacklog } = await loadLib();
+    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    const backlog = await scanComparisonBacklog(
+      makeClient() as never,
+      "p1",
+      "compare_humans",
+    );
+    expect(backlog).toHaveLength(1);
+    expect(backlog[0].documentId).toBe("doc1");
   });
 });
 

--- a/frontend/src/lib/__tests__/auto-comparison.test.ts
+++ b/frontend/src/lib/__tests__/auto-comparison.test.ts
@@ -395,12 +395,17 @@ describe("createAutoComparisonIfDiverges — piso de versão latest_major (#247)
   it("divergência só entre codificações de MAJOR anterior (semver) não materializa", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
     // Projeto na major 2; respostas divergentes da major 1 → abaixo do piso.
+    // `pydantic_hash` antigo junto do semver antigo: é o que o Postgres devolve
+    // de verdade (uma resposta de major anterior carrega o hash daquele schema,
+    // não o atual). Assim o descarte acontece pelo branch semver (major 1 < 2) E
+    // o fallback por hash também recusaria (hash != atual) — não depende da ordem
+    // dos branches em responseQualifiesForVersion.
     tableData.projects = [
       projectRow({ schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
     ];
     tableData.responses = [
-      human("userA", "A", { schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
-      human("userB", "B", { schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
+      human("userA", "A", { pydantic_hash: "hash-antigo", schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
+      human("userB", "B", { pydantic_hash: "hash-antigo", schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
     ];
     tableData.project_members = [member("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");

--- a/frontend/src/lib/__tests__/compare-filters.test.ts
+++ b/frontend/src/lib/__tests__/compare-filters.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   DEFAULT_COMPARE_FILTERS,
+  COMPARE_DEFAULT_VERSION,
   readCompareFilters,
   compareDefaultsForMode,
   assignedCompareDocIds,
@@ -36,13 +37,21 @@ describe("compareDefaultsForMode", () => {
     expect(compareDefaultsForMode("valor_legado", 2).minHumans).toBe(2);
   });
 
-  it("default vivo de versão é latest_major, não o 'all' da constante base (#247)", () => {
+  it("default vivo de versão é COMPARE_DEFAULT_VERSION (latest_major), não o 'all' da base (#247)", () => {
     // A página foca na versão corrente por padrão; o seletor ainda oferece
-    // "all" para revisar rodadas antigas. DEFAULT_COMPARE_FILTERS.version segue
-    // "all" para os callers/testes que não passam por compareDefaultsForMode.
-    expect(compareDefaultsForMode("compare_llm", 2).version).toBe("latest_major");
-    expect(compareDefaultsForMode("compare_humans", 2).version).toBe("latest_major");
-    expect(compareDefaultsForMode(null, 2).version).toBe("latest_major");
+    // "all" para revisar rodadas antigas. O default vivo é a constante única
+    // COMPARE_DEFAULT_VERSION, consumida também pelo fecho (compare-sync.ts) e
+    // plumbada ao filtro do cliente (CompareFilters.effectiveDefaults).
+    // DEFAULT_COMPARE_FILTERS.version segue "all" para os callers/testes que não
+    // passam por compareDefaultsForMode.
+    expect(COMPARE_DEFAULT_VERSION).toBe("latest_major");
+    expect(compareDefaultsForMode("compare_llm", 2).version).toBe(
+      COMPARE_DEFAULT_VERSION,
+    );
+    expect(compareDefaultsForMode("compare_humans", 2).version).toBe(
+      COMPARE_DEFAULT_VERSION,
+    );
+    expect(compareDefaultsForMode(null, 2).version).toBe(COMPARE_DEFAULT_VERSION);
     expect(DEFAULT_COMPARE_FILTERS.version).toBe("all");
   });
 
@@ -64,6 +73,20 @@ describe("readCompareFilters com defaults por modo", () => {
   it("param min_humans na URL sobrepõe o default do modo (a revisora pode estreitar)", () => {
     const defaults = compareDefaultsForMode("compare_llm", 2);
     expect(readCompareFilters({ min_humans: "3" }, defaults).minHumans).toBe(3);
+  });
+
+  it("sem param de versão, herda o default vivo (latest_major) do modo", () => {
+    const defaults = compareDefaultsForMode("compare_humans", 2);
+    expect(readCompareFilters({}, defaults).version).toBe(COMPARE_DEFAULT_VERSION);
+  });
+
+  it("param version=all na URL alcança 'all' por cima do default latest_major (#247)", () => {
+    // Regressão #1: com o default vivo latest_major, "Todas as versões" só é
+    // alcançável se o param explícito vencer o default — é o que o cliente passa
+    // a fazer quando effectiveDefaults.version = latest_major (≠ "all"), evitando
+    // que o seletor apague o param e fique preso em latest_major.
+    const defaults = compareDefaultsForMode("compare_humans", 2);
+    expect(readCompareFilters({ version: "all" }, defaults).version).toBe("all");
   });
 
   it("sem defaults explícitos, mantém o comportamento legado (piso 2)", () => {

--- a/frontend/src/lib/__tests__/compare-filters.test.ts
+++ b/frontend/src/lib/__tests__/compare-filters.test.ts
@@ -36,9 +36,18 @@ describe("compareDefaultsForMode", () => {
     expect(compareDefaultsForMode("valor_legado", 2).minHumans).toBe(2);
   });
 
-  it("preserva os demais defaults globais (só mexe em minHumans)", () => {
+  it("default vivo de versão é latest_major, não o 'all' da constante base (#247)", () => {
+    // A página foca na versão corrente por padrão; o seletor ainda oferece
+    // "all" para revisar rodadas antigas. DEFAULT_COMPARE_FILTERS.version segue
+    // "all" para os callers/testes que não passam por compareDefaultsForMode.
+    expect(compareDefaultsForMode("compare_llm", 2).version).toBe("latest_major");
+    expect(compareDefaultsForMode("compare_humans", 2).version).toBe("latest_major");
+    expect(compareDefaultsForMode(null, 2).version).toBe("latest_major");
+    expect(DEFAULT_COMPARE_FILTERS.version).toBe("all");
+  });
+
+  it("preserva os demais defaults globais (só mexe em minHumans e version)", () => {
     const d = compareDefaultsForMode("compare_llm", 2);
-    expect(d.version).toBe(DEFAULT_COMPARE_FILTERS.version);
     expect(d.minTotal).toBe(DEFAULT_COMPARE_FILTERS.minTotal);
     expect(d.minAssignedPct).toBe(DEFAULT_COMPARE_FILTERS.minAssignedPct);
     expect(d.since).toBe(DEFAULT_COMPARE_FILTERS.since);

--- a/frontend/src/lib/__tests__/compare-sync.test.ts
+++ b/frontend/src/lib/__tests__/compare-sync.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { PydanticField } from "@/lib/types";
+
+// compare-sync.ts abre com `import "server-only"`, que LANÇA fora de um Server
+// Component. Mocká-lo para no-op deixa o módulo importável no Vitest (node).
+vi.mock("server-only", () => ({}));
+
+// Mock supabase chainable e FILTER-AWARE (mesmo padrão de auto-comparison.test.ts):
+// aplica .eq/.neq/.in às linhas e registra os writes (.update) para asserção.
+// syncCompareAssignment recebe o client como argumento, então basta passá-lo.
+type WriteCall = { table: string; op: string; payload: unknown };
+let writeCalls: WriteCall[];
+let tableData: Record<string, unknown[]>;
+
+const updateCallsOf = (table?: string) =>
+  writeCalls.filter((c) => c.op === "update" && (!table || c.table === table));
+
+function makeClient() {
+  return {
+    from: (table: string) => {
+      const eqs: Array<[string, unknown]> = [];
+      const neqs: Array<[string, unknown]> = [];
+      const ins: Array<[string, unknown[]]> = [];
+      let op = "select";
+
+      const builder: Record<string, unknown> = {};
+      builder.select = () => builder;
+      builder.eq = (c: string, v: unknown) => {
+        eqs.push([c, v]);
+        return builder;
+      };
+      builder.neq = (c: string, v: unknown) => {
+        neqs.push([c, v]);
+        return builder;
+      };
+      builder.in = (c: string, v: unknown[]) => {
+        ins.push([c, v]);
+        return builder;
+      };
+      builder.update = (payload: unknown) => {
+        writeCalls.push({ table, op: "update", payload });
+        op = "update";
+        return builder;
+      };
+
+      const rows = () => {
+        const data = (tableData[table] ?? []) as Array<Record<string, unknown>>;
+        return data.filter((r) => {
+          for (const [c, v] of eqs) if (r[c] !== v) return false;
+          for (const [c, v] of neqs) if (r[c] === v) return false;
+          for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
+          return true;
+        });
+      };
+
+      builder.single = () =>
+        Promise.resolve({ data: rows()[0] ?? null, error: null });
+      builder.maybeSingle = () =>
+        Promise.resolve({ data: rows()[0] ?? null, error: null });
+      builder.then = (resolve: (v: unknown) => unknown) =>
+        resolve({ data: op === "update" ? null : rows(), error: null });
+      return builder;
+    },
+  };
+}
+
+const FIELDS: PydanticField[] = [
+  {
+    name: "decisao",
+    type: "single",
+    options: ["proc", "improc"],
+    description: "",
+    target: "all",
+  },
+];
+
+const CURRENT_HASH = "hash-atual";
+
+// Resposta da MAJOR corrente (qualifica sob o piso latest_major). `extra`
+// sobrescreve para emular rodadas antigas / pré-versionamento.
+const resp = (
+  id: string,
+  decisao: string,
+  extra: Record<string, unknown> = {},
+) => ({
+  id,
+  project_id: "p1",
+  document_id: "doc1",
+  respondent_type: "humano",
+  is_latest: true,
+  pydantic_hash: CURRENT_HASH,
+  schema_version_major: 2,
+  schema_version_minor: 0,
+  schema_version_patch: 0,
+  answers: { decisao },
+  answer_field_hashes: null,
+  ...extra,
+});
+
+const projectRow = (over: Record<string, unknown> = {}) => ({
+  id: "p1",
+  pydantic_fields: FIELDS,
+  pydantic_hash: CURRENT_HASH,
+  schema_version_major: 2,
+  schema_version_minor: 0,
+  schema_version_patch: 0,
+  ...over,
+});
+
+const assignment = (status: string) => ({
+  id: "a1",
+  project_id: "p1",
+  document_id: "doc1",
+  user_id: "rev1",
+  type: "comparacao",
+  status,
+});
+
+beforeEach(() => {
+  writeCalls = [];
+  tableData = {
+    projects: [projectRow()],
+    assignments: [assignment("pendente")],
+    responses: [],
+    reviews: [],
+    response_equivalences: [],
+  };
+});
+
+async function loadLib() {
+  return import("@/lib/compare-sync");
+}
+
+describe("syncCompareAssignment — piso de versão latest_major (#247/#286)", () => {
+  // TRIP-WIRE do acoplamento visão==fecho: exercita o MÓDULO de produção (não
+  // uma réplica da lógica). Reverter compare-sync.ts para o piso 'all'
+  // (DEFAULT_COMPARE_FILTERS.version) faria a codificação da major antiga voltar
+  // a contar, "decisao" divergir e o status NÃO virar concluido — quebrando este
+  // teste. É a proteção que faltava (o achado de revisão do #286).
+  it("aplica o piso: codificação de major anterior é descartada no fecho", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.responses = [
+      resp("a", "proc"), // major 2 (corrente)
+      resp("b", "proc"), // major 2 (corrente) — concordam
+      resp("c", "improc", {
+        pydantic_hash: "hash-antigo",
+        schema_version_major: 1,
+      }), // major 1 → abaixo do piso, descartada
+    ];
+    const client = makeClient();
+    await syncCompareAssignment(client as never, "p1", "doc1", "rev1");
+    // Sob latest_major só a/b contam → concordam → sem divergência → concluido.
+    expect(updateCallsOf("assignments")).toHaveLength(1);
+    expect(updateCallsOf("assignments")[0].payload).toMatchObject({
+      status: "concluido",
+    });
+  });
+
+  it("divergência na major corrente, sem veredito → não fecha (em_andamento/pendente)", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.responses = [resp("a", "proc"), resp("b", "improc")];
+    const client = makeClient();
+    await syncCompareAssignment(client as never, "p1", "doc1", "rev1");
+    // Diverge e ninguém revisou: status alvo = pendente; como o assignment já é
+    // pendente, não há update.
+    expect(updateCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("divergência corrente resolvida pela revisora → fecha (concluido)", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.responses = [resp("a", "proc"), resp("b", "improc")];
+    tableData.reviews = [
+      { project_id: "p1", document_id: "doc1", reviewer_id: "rev1", field_name: "decisao" },
+    ];
+    const client = makeClient();
+    await syncCompareAssignment(client as never, "p1", "doc1", "rev1");
+    expect(updateCallsOf("assignments")).toHaveLength(1);
+    expect(updateCallsOf("assignments")[0].payload).toMatchObject({
+      status: "concluido",
+    });
+  });
+});
+
+describe("syncCompareAssignment — guarda de <2 respostas qualificadas (#286)", () => {
+  // Sem ao menos 2 respostas qualificadas não há par a comparar; o fecho NÃO
+  // deve declarar "concluido" (marcaria como revisado um doc que ninguém
+  // comparou na versão corrente). Sem a guarda, 1 resposta → divergência vazia →
+  // concluido espúrio. O teste falha se a guarda for removida.
+  it("1 corrente + 1 pré-versionamento → só 1 qualifica → não fecha (sem update)", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.responses = [
+      resp("a", "proc"), // corrente, qualifica
+      resp("b", "proc", { pydantic_hash: null, schema_version_major: null }), // pré-versionamento → descartada
+    ];
+    const client = makeClient();
+    await syncCompareAssignment(client as never, "p1", "doc1", "rev1");
+    expect(updateCallsOf("assignments")).toHaveLength(0);
+  });
+
+  it("doc só com codificações pré-versionamento → 0 qualificam → não fecha", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.responses = [
+      resp("a", "proc", { pydantic_hash: null, schema_version_major: null }),
+      resp("b", "improc", { pydantic_hash: null, schema_version_major: null }),
+    ];
+    const client = makeClient();
+    await syncCompareAssignment(client as never, "p1", "doc1", "rev1");
+    expect(updateCallsOf("assignments")).toHaveLength(0);
+  });
+});

--- a/frontend/src/lib/__tests__/compare-version.test.ts
+++ b/frontend/src/lib/__tests__/compare-version.test.ts
@@ -9,7 +9,11 @@ import {
   type SchemaVersion,
   type VersionedResponse,
 } from "@/lib/compare-version";
-import { DEFAULT_COMPARE_FILTERS } from "@/lib/compare-filters";
+import {
+  DEFAULT_COMPARE_FILTERS,
+  COMPARE_DEFAULT_VERSION,
+  compareDefaultsForMode,
+} from "@/lib/compare-filters";
 import {
   computeDivergentFieldNames,
   resolveCompareStatus,
@@ -163,33 +167,44 @@ describe("responseQualifiesForVersion", () => {
 });
 
 // O fecho do parecer (compare-sync.ts) deriva seu piso de versão do MESMO
-// default da UI que compare/page.tsx usa, via
-// resolveMinVersion(DEFAULT_COMPARE_FILTERS.version, ...). Estes testes travam
-// esse contrato e reproduzem o incidente #217/#218 no pipeline puro do sync,
-// sem Supabase.
-describe("fecho espelha o filtro default da UI (#217/#218)", () => {
-  it("resolveMinVersion com o default da UI não impõe piso (default = 'all')", () => {
-    // Se alguém mudar DEFAULT_COMPARE_FILTERS.version sem revisar o sync, este
-    // teste quebra — a intenção é manter sync e visão default acoplados.
+// default VIVO da UI que compare/page.tsx usa — `COMPARE_DEFAULT_VERSION`
+// ("latest_major"), o mesmo valor que `compareDefaultsForMode` retorna —, via
+// `resolveMinVersion`. Estes testes travam esse contrato e reproduzem o
+// incidente #217/#218 no pipeline puro do sync, sem Supabase.
+describe("fecho espelha o filtro default da UI (#217/#218/#247)", () => {
+  it("o default VIVO é latest_major e impõe o piso latestMajorAnchor", () => {
+    // Trip-wire do acoplamento sync↔visão. Vigia o default VIVO (o que a página
+    // de fato aplica via compareDefaultsForMode), NÃO DEFAULT_COMPARE_FILTERS —
+    // foi exatamente esse descasamento que deixou o #247 regredir o #217 passar
+    // batido. Se alguém mudar o default vivo sem realinhar o fecho, isto quebra.
+    expect(COMPARE_DEFAULT_VERSION).toBe("latest_major");
+    expect(compareDefaultsForMode("compare_humans", 2).version).toBe(
+      COMPARE_DEFAULT_VERSION,
+    );
+    // DEFAULT_COMPARE_FILTERS.version segue "all" (base de outros callers), mas
+    // NÃO é o piso do fecho — o fecho usa COMPARE_DEFAULT_VERSION.
     expect(DEFAULT_COMPARE_FILTERS.version).toBe("all");
-    expect(
-      resolveMinVersion(DEFAULT_COMPARE_FILTERS.version, v(0, 20, 0)),
-    ).toBeNull();
+    expect(resolveMinVersion(COMPARE_DEFAULT_VERSION, v(0, 20, 0))).toEqual(
+      latestMajorAnchor(v(0, 20, 0)),
+    );
   });
 
-  // Incidente Zolgensma: doc com várias codificações humanas — uma SUPERSEDED
-  // (is_latest=false), uma pré-versionamento (pydantic_hash NULL), uma de minor
-  // antiga (0.18.0) e duas da corrente (0.20.0). O sync antigo
-  // (`is_latest || respondent_type === "humano"`) contava a superseded, que a
-  // tela não mostra, criando divergência invisível → trava. Sob o default 'all'
-  // (minVersion null), o fecho descarta SÓ a superseded e mantém o resto,
-  // espelhando o que a revisora vê "sem filtro".
+  // Incidente Zolgensma sob o default vivo latest_major: doc com codificações
+  // humanas — uma SUPERSEDED (is_latest=false), uma pré-versionamento
+  // (pydantic_hash NULL), uma de minor antiga (0.18.0) divergindo em "decisao",
+  // e duas da MAJOR corrente (0.20.0) concordando. Sob latest_major o fecho
+  // descarta superseded, pré-versionamento E a minor antiga, sobrando só a major
+  // corrente — exatamente o que a revisora vê na fila default. A divergência que
+  // só existe na rodada antiga (improc vs proc) NÃO trava o fecho: é o que
+  // restaura o acoplamento visão==fecho do #218 (e evita a regressão do #217).
   type Row = VersionedResponse & {
     id: string;
     answers: Record<string, unknown>;
   };
   const proj = { pydanticHash: "hash-atual", version: v(0, 20, 0) };
-  const minVersion = resolveMinVersion(
+  const minVersion = resolveMinVersion(COMPARE_DEFAULT_VERSION, v(0, 20, 0));
+  // Piso antigo ('all' = null), para contraste com o comportamento que travava.
+  const minVersionLegado = resolveMinVersion(
     DEFAULT_COMPARE_FILTERS.version,
     v(0, 20, 0),
   );
@@ -210,12 +225,10 @@ describe("fecho espelha o filtro default da UI (#217/#218)", () => {
     ...over,
   });
 
-  // "decisao" diverge entre os ativos (improc vs proc); "obs" só diverge se a
-  // superseded entrar (ativos concordam em "irrelevante").
   const rows: Row[] = [
     human(
       "sup",
-      { decisao: "improc", obs: "diferente" },
+      { decisao: "improc", obs: "irrelevante" },
       { is_latest: false, pydantic_hash: "hash-antigo", schema_version_minor: 18 },
     ),
     human(
@@ -230,7 +243,7 @@ describe("fecho espelha o filtro default da UI (#217/#218)", () => {
     ),
     human(
       "v18",
-      { decisao: "proc", obs: "irrelevante" },
+      { decisao: "improc", obs: "irrelevante" },
       { pydantic_hash: "hash-018", schema_version_minor: 18 },
     ),
     human("v20a", { decisao: "proc", obs: "irrelevante" }, {}),
@@ -251,24 +264,33 @@ describe("fecho espelha o filtro default da UI (#217/#218)", () => {
   const active = rows.filter((r) =>
     responseQualifiesForVersion(r, minVersion, proj),
   );
+  const activeLegado = rows.filter((r) =>
+    responseQualifiesForVersion(r, minVersionLegado, proj),
+  );
 
-  it("o fecho descarta só a superseded, mantendo pré-versionamento e minor antiga", () => {
-    expect(active.map((r) => r.id)).toEqual(["pre", "v18", "v20a", "v20b"]);
+  it("sob latest_major o fecho mantém só a major corrente (descarta antigas)", () => {
+    expect(active.map((r) => r.id)).toEqual(["v20a", "v20b"]);
   });
 
-  it("incluir a superseded (bug antigo) inflaria 'obs' como divergência invisível", () => {
-    const withSuperseded = computeDivergentFieldNames(fields, rows);
-    expect(withSuperseded).toContain("obs");
+  it("a divergência só existe nas rodadas antigas — invisível na fila default", () => {
+    // Na major corrente os ativos concordam: nenhum campo diverge.
+    expect(computeDivergentFieldNames(fields, active)).toEqual([]);
   });
 
-  it("sem a superseded, 'obs' não diverge — só 'decisao' exige veredito", () => {
+  it("parecer fecha sem veredito pendente (acoplamento visão==fecho)", () => {
     const divergent = computeDivergentFieldNames(fields, active);
-    expect(divergent).toEqual(["decisao"]);
+    expect(resolveCompareStatus(divergent, new Set())).toBe("concluido");
   });
 
-  it("resolvido o campo divergente visível, o parecer fecha (concluido)", () => {
-    const divergent = computeDivergentFieldNames(fields, active);
-    expect(resolveCompareStatus(divergent, new Set(["decisao"]))).toBe(
+  it("sob o piso antigo 'all', a divergência da rodada antiga travaria o fecho (regressão #217)", () => {
+    // Contraste: com 'all' (minVersion null) a minor 0.18.0 e a pré-versionamento
+    // voltam a contar, "decisao" diverge (improc vs proc) e o parecer NÃO fecha
+    // sem resolver um campo que a fila latest_major nem mostra. É o cenário que o
+    // default vivo latest_major evita.
+    expect(activeLegado.map((r) => r.id)).toEqual(["pre", "v18", "v20a", "v20b"]);
+    const divergentLegado = computeDivergentFieldNames(fields, activeLegado);
+    expect(divergentLegado).toContain("decisao");
+    expect(resolveCompareStatus(divergentLegado, new Set())).not.toBe(
       "concluido",
     );
   });

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -1,6 +1,14 @@
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import { isCodingComplete } from "@/lib/coding-completeness";
+import { COMPARE_DEFAULT_VERSION } from "@/lib/compare-filters";
+import {
+  resolveMinVersion,
+  responseQualifiesForVersion,
+  type SchemaVersion,
+  type ProjectVersionContext,
+  type VersionedResponse,
+} from "@/lib/compare-version";
 import type { EquivalencePair } from "@/lib/equivalence";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
@@ -29,6 +37,13 @@ interface ResponseRow {
   respondent_id?: string | null;
   answers: Record<string, unknown> | null;
   answer_field_hashes: AnswerFieldHashes | null;
+  // Campos de versão: necessários para aplicar o piso `latest_major` (#247),
+  // o MESMO que a fila (compare/page.tsx) e o fecho (compare-sync.ts) usam.
+  is_latest?: boolean;
+  pydantic_hash?: string | null;
+  schema_version_major?: number | null;
+  schema_version_minor?: number | null;
+  schema_version_patch?: number | null;
 }
 
 function toResponseLike(r: ResponseRow) {
@@ -36,6 +51,50 @@ function toResponseLike(r: ResponseRow) {
     id: r.id,
     answers: (r.answers as Record<string, unknown>) ?? {},
     answerFieldHashes: r.answer_field_hashes as AnswerFieldHashes,
+  };
+}
+
+// Colunas SELECT comuns para as duas queries de `responses` do gatilho: além de
+// answers/hashes, traz os campos de versão para o piso `latest_major`.
+const RESPONSE_VERSION_COLS =
+  "pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch";
+
+// Monta o shape `VersionedResponse` a partir de uma linha de `responses`. As
+// linhas chegam já com `is_latest=true` da query, mas o predicado exige o campo;
+// `respondent_type` é fixado pela query (humano/llm), aqui é irrelevante para a
+// decisão de versão e entra só para satisfazer o tipo.
+function toVersioned(
+  r: ResponseRow,
+  respondentType: "humano" | "llm",
+): VersionedResponse {
+  return {
+    respondent_type: respondentType,
+    is_latest: r.is_latest ?? true,
+    pydantic_hash: r.pydantic_hash ?? null,
+    schema_version_major: r.schema_version_major ?? null,
+    schema_version_minor: r.schema_version_minor ?? null,
+    schema_version_patch: r.schema_version_patch ?? null,
+  };
+}
+
+// Contexto de versão do projeto + piso `latest_major`, derivados da linha de
+// `projects`. Mesmos fallbacks de page.tsx/compare-sync ({major 0, minor 1,
+// patch 0}) e a MESMA constante `COMPARE_DEFAULT_VERSION`, mantendo o
+// acoplamento gatilho==fila==fecho (#247).
+function versionGate(project: {
+  pydantic_hash?: string | null;
+  schema_version_major?: number | null;
+  schema_version_minor?: number | null;
+  schema_version_patch?: number | null;
+}): { minVersion: SchemaVersion | null; ctx: ProjectVersionContext } {
+  const version: SchemaVersion = {
+    major: project.schema_version_major ?? 0,
+    minor: project.schema_version_minor ?? 1,
+    patch: project.schema_version_patch ?? 0,
+  };
+  return {
+    minVersion: resolveMinVersion(COMPARE_DEFAULT_VERSION, version),
+    ctx: { pydanticHash: project.pydantic_hash ?? null, version },
   };
 }
 
@@ -153,19 +212,21 @@ export async function createAutoComparisonIfDiverges(
   ] = await Promise.all([
     admin
       .from("projects")
-      .select("pydantic_fields, min_responses_for_comparison, comparison_includes_llm")
+      .select(
+        `pydantic_fields, min_responses_for_comparison, comparison_includes_llm, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch`,
+      )
       .eq("id", projectId)
       .single(),
     admin
       .from("responses")
-      .select("id, respondent_id, answers, answer_field_hashes")
+      .select(`id, respondent_id, answers, answer_field_hashes, ${RESPONSE_VERSION_COLS}`)
       .eq("project_id", projectId)
       .eq("document_id", documentId)
       .eq("respondent_type", "humano")
       .eq("is_latest", true),
     admin
       .from("responses")
-      .select("id, answers, answer_field_hashes")
+      .select(`id, answers, answer_field_hashes, ${RESPONSE_VERSION_COLS}`)
       .eq("project_id", projectId)
       .eq("document_id", documentId)
       .eq("respondent_type", "llm")
@@ -198,18 +259,24 @@ export async function createAutoComparisonIfDiverges(
     return { assigned: false, noPool: false };
   }
 
-  // So codificacoes humanas completas contam para o gatilho (#174).
-  // NOTA (#247, follow-up): este gatilho conta toda resposta `is_latest`, sem
-  // aplicar o piso de versao do default vivo (COMPARE_DEFAULT_VERSION =
-  // "latest_major"). A fila (compare/page.tsx) e o fecho (compare-sync.ts) ja
-  // usam esse piso; aqui ainda nao. Efeito: uma divergencia que so existe entre
-  // majors antigos pode materializar um assignment que a fila nao mostra e que o
-  // fecho (latest_major) considera concluivel de imediato — fantasma cosmetico,
-  // nao a trava do #217. Alinhar exige buscar schema_version/pydantic_hash e
-  // aplicar responseQualifiesForVersion aqui; deixado como follow-up.
-  const completeHumans = (humanResponses ?? []).filter((r) =>
-    isCodingComplete(fields, (r.answers as Record<string, unknown>) ?? {}),
-  );
+  // So codificacoes humanas completas contam para o gatilho (#174), E que
+  // qualificam sob o piso `latest_major` (#247) — o MESMO que a fila
+  // (compare/page.tsx) e o fecho (compare-sync.ts) aplicam, restaurando o
+  // acoplamento gatilho==fila==fecho. Sem este filtro, uma divergencia que so
+  // existe entre rodadas antigas materializaria um assignment que a fila nao
+  // mostra e que o fecho ja considera concluivel — o "fantasma" da NOTA antiga.
+  const { minVersion, ctx: projectVersionCtx } = versionGate(project);
+  const completeHumans = (humanResponses ?? [])
+    .filter((r) =>
+      isCodingComplete(fields, (r.answers as Record<string, unknown>) ?? {}),
+    )
+    .filter((r) =>
+      responseQualifiesForVersion(
+        toVersioned(r as ResponseRow, "humano"),
+        minVersion,
+        projectVersionCtx,
+      ),
+    );
 
   const minHumans =
     mode === "compare_humans" ? (project.min_responses_for_comparison ?? 2) : 1;
@@ -223,7 +290,18 @@ export async function createAutoComparisonIfDiverges(
     });
     return { assigned: false, noPool: false };
   }
-  if (mode === "compare_llm" && !llmResponse) {
+
+  // LLM tambem passa pelo piso de versao: um LLM de schema antigo nao conta.
+  const qualifyingLlm =
+    llmResponse &&
+    responseQualifiesForVersion(
+      toVersioned(llmResponse as ResponseRow, "llm"),
+      minVersion,
+      projectVersionCtx,
+    )
+      ? llmResponse
+      : null;
+  if (mode === "compare_llm" && !qualifyingLlm) {
     log("skip_insufficient", { projectId, documentId, mode, reason: "no_llm" });
     return { assigned: false, noPool: false };
   }
@@ -235,8 +313,8 @@ export async function createAutoComparisonIfDiverges(
   const responsesForDivergence = completeHumans.map((r) =>
     toResponseLike(r as ResponseRow),
   );
-  if (includeLlm && llmResponse) {
-    responsesForDivergence.push(toResponseLike(llmResponse as ResponseRow));
+  if (includeLlm && qualifyingLlm) {
+    responsesForDivergence.push(toResponseLike(qualifyingLlm as ResponseRow));
   }
   if (responsesForDivergence.length < 2) {
     log("skip_insufficient", {
@@ -289,7 +367,9 @@ export async function scanComparisonBacklog(
     await Promise.all([
       admin
         .from("projects")
-        .select("pydantic_fields, min_responses_for_comparison, comparison_includes_llm")
+        .select(
+          `pydantic_fields, min_responses_for_comparison, comparison_includes_llm, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch`,
+        )
         .eq("id", projectId)
         .single(),
       admin
@@ -339,14 +419,14 @@ export async function scanComparisonBacklog(
     await Promise.all([
       admin
         .from("responses")
-        .select("id, document_id, respondent_id, answers, answer_field_hashes")
+        .select(`id, document_id, respondent_id, answers, answer_field_hashes, ${RESPONSE_VERSION_COLS}`)
         .eq("project_id", projectId)
         .eq("respondent_type", "humano")
         .eq("is_latest", true)
         .in("document_id", candidates),
       admin
         .from("responses")
-        .select("id, document_id, answers, answer_field_hashes")
+        .select(`id, document_id, answers, answer_field_hashes, ${RESPONSE_VERSION_COLS}`)
         .eq("project_id", projectId)
         .eq("respondent_type", "llm")
         .eq("is_latest", true)
@@ -380,13 +460,34 @@ export async function scanComparisonBacklog(
     equivByDoc.set(docId, byField);
   }
 
+  // Piso `latest_major` (#247), aplicado por doc — mesmo gate do gatilho e do
+  // fecho. O contexto de versao do projeto e unico; so as respostas variam.
+  const { minVersion, ctx: projectVersionCtx } = versionGate(project);
+
   const result: Array<{ documentId: string; coderIds: Set<string> }> = [];
   for (const docId of candidates) {
-    const completeHumans = (humansFullByDoc.get(docId) ?? []).filter((r) =>
-      isCodingComplete(fields, (r.answers as Record<string, unknown>) ?? {}),
-    );
+    const completeHumans = (humansFullByDoc.get(docId) ?? [])
+      .filter((r) =>
+        isCodingComplete(fields, (r.answers as Record<string, unknown>) ?? {}),
+      )
+      .filter((r) =>
+        responseQualifiesForVersion(
+          toVersioned(r, "humano"),
+          minVersion,
+          projectVersionCtx,
+        ),
+      );
     if (completeHumans.length < minHumans) continue;
-    const llm = llmByDoc.get(docId);
+    const rawLlm = llmByDoc.get(docId);
+    const llm =
+      rawLlm &&
+      responseQualifiesForVersion(
+        toVersioned(rawLlm, "llm"),
+        minVersion,
+        projectVersionCtx,
+      )
+        ? rawLlm
+        : undefined;
     if (mode === "compare_llm" && !llm) continue;
 
     const includeLlm =

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -1,14 +1,9 @@
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import { isCodingComplete } from "@/lib/coding-completeness";
-import { COMPARE_DEFAULT_VERSION } from "@/lib/compare-filters";
 import {
-  deriveProjectVersionContext,
-  resolveMinVersion,
   responseQualifiesForVersion,
-  type SchemaVersion,
-  type ProjectVersionContext,
-  type ProjectVersionRow,
+  versionGate,
   type VersionedResponse,
 } from "@/lib/compare-version";
 import type { EquivalencePair } from "@/lib/equivalence";
@@ -89,18 +84,6 @@ function toVersioned(
     schema_version_minor: r.schema_version_minor ?? null,
     schema_version_patch: r.schema_version_patch ?? null,
   };
-}
-
-// Contexto de versão do projeto + piso `latest_major`, derivados da linha de
-// `projects`. O contexto vem do helper compartilhado `deriveProjectVersionContext`
-// (compare-version.ts) — a MESMA fonte que page.tsx e compare-sync.ts usam, sem
-// re-hardcodar o fallback {0,1,0} —, e o piso da MESMA constante
-// `COMPARE_DEFAULT_VERSION`, mantendo o acoplamento gatilho==fila==fecho (#247).
-function versionGate(
-  project: ProjectVersionRow,
-): { minVersion: SchemaVersion | null; ctx: ProjectVersionContext } {
-  const { version, ctx } = deriveProjectVersionContext(project);
-  return { minVersion: resolveMinVersion(COMPARE_DEFAULT_VERSION, version), ctx };
 }
 
 function buildEquivByField(

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -199,6 +199,14 @@ export async function createAutoComparisonIfDiverges(
   }
 
   // So codificacoes humanas completas contam para o gatilho (#174).
+  // NOTA (#247, follow-up): este gatilho conta toda resposta `is_latest`, sem
+  // aplicar o piso de versao do default vivo (COMPARE_DEFAULT_VERSION =
+  // "latest_major"). A fila (compare/page.tsx) e o fecho (compare-sync.ts) ja
+  // usam esse piso; aqui ainda nao. Efeito: uma divergencia que so existe entre
+  // majors antigos pode materializar um assignment que a fila nao mostra e que o
+  // fecho (latest_major) considera concluivel de imediato — fantasma cosmetico,
+  // nao a trava do #217. Alinhar exige buscar schema_version/pydantic_hash e
+  // aplicar responseQualifiesForVersion aqui; deixado como follow-up.
   const completeHumans = (humanResponses ?? []).filter((r) =>
     isCodingComplete(fields, (r.answers as Record<string, unknown>) ?? {}),
   );

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -3,10 +3,12 @@ import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import { isCodingComplete } from "@/lib/coding-completeness";
 import { COMPARE_DEFAULT_VERSION } from "@/lib/compare-filters";
 import {
+  deriveProjectVersionContext,
   resolveMinVersion,
   responseQualifiesForVersion,
   type SchemaVersion,
   type ProjectVersionContext,
+  type ProjectVersionRow,
   type VersionedResponse,
 } from "@/lib/compare-version";
 import type { EquivalencePair } from "@/lib/equivalence";
@@ -54,17 +56,29 @@ function toResponseLike(r: ResponseRow) {
   };
 }
 
-// Colunas SELECT comuns para as duas queries de `responses` do gatilho: além de
-// answers/hashes, traz os campos de versão para o piso `latest_major`.
+// Colunas SELECT comuns para as queries de `responses` do gatilho: além de
+// answers/hashes, traz os campos de versão para o piso `latest_major` E
+// `is_latest`. O `is_latest` é redundante com o filtro `.eq("is_latest", true)`
+// das queries, mas selecioná-lo deixa a regra 1 de `responseQualifiesForVersion`
+// (superseded → fora) ser defesa REAL no dado, não só uma garantia implícita do
+// WHERE: se um caller futuro relaxar/copiar a query sem o filtro, o predicado
+// ainda exclui superseded em vez de contá-los (regressão #213).
 const RESPONSE_VERSION_COLS =
-  "pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch";
+  "is_latest, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch";
 
-// Monta o shape `VersionedResponse` a partir de uma linha de `responses`. As
-// linhas chegam já com `is_latest=true` da query, mas o predicado exige o campo;
-// `respondent_type` é fixado pela query (humano/llm), aqui é irrelevante para a
-// decisão de versão e entra só para satisfazer o tipo.
+// Monta o shape `VersionedResponse` a partir de uma linha de `responses`.
+// `is_latest` agora vem do SELECT (ver RESPONSE_VERSION_COLS); o `?? true` é só
+// um guarda de tipo para o campo opcional. `respondent_type` é fixado pela query
+// (humano/llm), irrelevante para a decisão de versão, entra só para o tipo.
 function toVersioned(
-  r: ResponseRow,
+  r: Pick<
+    ResponseRow,
+    | "is_latest"
+    | "pydantic_hash"
+    | "schema_version_major"
+    | "schema_version_minor"
+    | "schema_version_patch"
+  >,
   respondentType: "humano" | "llm",
 ): VersionedResponse {
   return {
@@ -78,24 +92,15 @@ function toVersioned(
 }
 
 // Contexto de versão do projeto + piso `latest_major`, derivados da linha de
-// `projects`. Mesmos fallbacks de page.tsx/compare-sync ({major 0, minor 1,
-// patch 0}) e a MESMA constante `COMPARE_DEFAULT_VERSION`, mantendo o
-// acoplamento gatilho==fila==fecho (#247).
-function versionGate(project: {
-  pydantic_hash?: string | null;
-  schema_version_major?: number | null;
-  schema_version_minor?: number | null;
-  schema_version_patch?: number | null;
-}): { minVersion: SchemaVersion | null; ctx: ProjectVersionContext } {
-  const version: SchemaVersion = {
-    major: project.schema_version_major ?? 0,
-    minor: project.schema_version_minor ?? 1,
-    patch: project.schema_version_patch ?? 0,
-  };
-  return {
-    minVersion: resolveMinVersion(COMPARE_DEFAULT_VERSION, version),
-    ctx: { pydanticHash: project.pydantic_hash ?? null, version },
-  };
+// `projects`. O contexto vem do helper compartilhado `deriveProjectVersionContext`
+// (compare-version.ts) — a MESMA fonte que page.tsx e compare-sync.ts usam, sem
+// re-hardcodar o fallback {0,1,0} —, e o piso da MESMA constante
+// `COMPARE_DEFAULT_VERSION`, mantendo o acoplamento gatilho==fila==fecho (#247).
+function versionGate(
+  project: ProjectVersionRow,
+): { minVersion: SchemaVersion | null; ctx: ProjectVersionContext } {
+  const { version, ctx } = deriveProjectVersionContext(project);
+  return { minVersion: resolveMinVersion(COMPARE_DEFAULT_VERSION, version), ctx };
 }
 
 function buildEquivByField(
@@ -374,7 +379,7 @@ export async function scanComparisonBacklog(
         .single(),
       admin
         .from("responses")
-        .select("document_id, respondent_id")
+        .select(`document_id, respondent_id, ${RESPONSE_VERSION_COLS}`)
         .eq("project_id", projectId)
         .eq("respondent_type", "humano")
         .eq("is_latest", true),
@@ -394,11 +399,28 @@ export async function scanComparisonBacklog(
     (activeAsg ?? []).map((a) => a.document_id as string),
   );
 
+  // Piso `latest_major` (#247), aplicado já na fase 1 com as colunas LEVES de
+  // versão (RESPONSE_VERSION_COLS, sem `answers`): docs cujos humanos estão
+  // todos abaixo do piso são podados ANTES da fase 2, evitando o fetch pesado de
+  // `answers`/equivalências para docs que nunca entrariam no backlog (regra
+  // "fetch em 2 fases para dados pesados", CLAUDE.md). O contexto é único; só as
+  // respostas variam. A completude (`isCodingComplete`) segue conferida na fase
+  // 2, que precisa de `answers`.
+  const { minVersion, ctx: projectVersionCtx } = versionGate(project);
+
   const humansByDoc = new Map<string, Set<string>>();
   for (const r of humanMeta ?? []) {
     const docId = r.document_id as string;
     const respId = r.respondent_id as string | null;
     if (!respId) continue;
+    if (
+      !responseQualifiesForVersion(
+        toVersioned(r, "humano"),
+        minVersion,
+        projectVersionCtx,
+      )
+    )
+      continue;
     const set = humansByDoc.get(docId) ?? new Set<string>();
     set.add(respId);
     humansByDoc.set(docId, set);
@@ -459,10 +481,6 @@ export async function scanComparisonBacklog(
     byField.set(eq.field_name, list);
     equivByDoc.set(docId, byField);
   }
-
-  // Piso `latest_major` (#247), aplicado por doc — mesmo gate do gatilho e do
-  // fecho. O contexto de versao do projeto e unico; so as respostas variam.
-  const { minVersion, ctx: projectVersionCtx } = versionGate(project);
 
   const result: Array<{ documentId: string; coderIds: Set<string> }> = [];
   for (const docId of candidates) {

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -63,6 +63,13 @@ export function readCompareFilters(
 // `mode` é string solta (não o tipo AutomationMode) de propósito: mantém este
 // módulo de baixo nível sem depender de types.ts e tolera o valor null/legado
 // de projetos antes da migration do automation_mode.
+//
+// Versão: o default VIVO da página é "latest_major" (não o "all" de
+// DEFAULT_COMPARE_FILTERS). Pesquisadores do Natjus (issue #247) estranharam ver
+// na fila comparações de codificações feitas sob schemas anteriores; o esperado
+// é focar na versão corrente por padrão. "all" continua disponível no seletor
+// para quem precisa revisar rodadas antigas, e DEFAULT_COMPARE_FILTERS.version
+// segue "all" (usado por outros callers/testes que não passam por aqui).
 export function compareDefaultsForMode(
   mode: string | null | undefined,
   minResponsesForComparison: number,
@@ -73,7 +80,7 @@ export function compareDefaultsForMode(
   } else if (mode === "compare_humans") {
     minHumans = Math.max(1, minResponsesForComparison);
   }
-  return { ...DEFAULT_COMPARE_FILTERS, minHumans };
+  return { ...DEFAULT_COMPARE_FILTERS, minHumans, version: "latest_major" };
 }
 
 // Conjunto de document_ids que um usuário pode VER na fila de comparação.

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -22,6 +22,20 @@ export const DEFAULT_COMPARE_FILTERS: CompareFiltersValue = {
   respondent: "all",
 };
 
+// Default VIVO de versão da aba Comparar — fonte única consumida pelos TRÊS
+// pontos que precisam concordar sobre "qual versão a fila reflete por padrão":
+//   1. a página (compareDefaultsForMode, via compare/page.tsx);
+//   2. o filtro do cliente (CompareFilters.effectiveDefaults, via prop
+//      defaultVersion plumbada por page → ComparePage → CompareNav);
+//   3. o fecho do parecer (compare-sync.ts, via resolveMinVersion).
+// É distinto de DEFAULT_COMPARE_FILTERS.version ("all"), que é a base para
+// callers/testes que NÃO derivam do automation_mode. Centralizar aqui evita o
+// drift silencioso em que página, filtro e fecho discordam (ver #247, e o
+// acoplamento visão==fecho do #217/#218). O default de versão é independente do
+// modo de automação — só `minHumans` varia por modo —, por isso uma constante
+// basta como fonte única, sem precisar do `mode`.
+export const COMPARE_DEFAULT_VERSION = "latest_major";
+
 export function readCompareFilters(
   params: URLSearchParams | Record<string, string | undefined>,
   // Defaults aplicados quando o param não vem na URL. Por padrão são os globais
@@ -64,12 +78,14 @@ export function readCompareFilters(
 // módulo de baixo nível sem depender de types.ts e tolera o valor null/legado
 // de projetos antes da migration do automation_mode.
 //
-// Versão: o default VIVO da página é "latest_major" (não o "all" de
-// DEFAULT_COMPARE_FILTERS). Pesquisadores do Natjus (issue #247) estranharam ver
-// na fila comparações de codificações feitas sob schemas anteriores; o esperado
-// é focar na versão corrente por padrão. "all" continua disponível no seletor
-// para quem precisa revisar rodadas antigas, e DEFAULT_COMPARE_FILTERS.version
-// segue "all" (usado por outros callers/testes que não passam por aqui).
+// Versão: o default VIVO é COMPARE_DEFAULT_VERSION ("latest_major"), não o "all"
+// de DEFAULT_COMPARE_FILTERS. Pesquisadores do Natjus (issue #247) estranharam
+// ver na fila comparações de codificações feitas sob schemas anteriores; o
+// esperado é focar na versão corrente por padrão. "all" continua disponível no
+// seletor para quem precisa revisar rodadas antigas, e DEFAULT_COMPARE_FILTERS.
+// version segue "all" (usado por outros callers/testes que não passam por aqui).
+// O fecho do parecer (compare-sync.ts) usa a MESMA constante, mantendo o
+// acoplamento visão==fecho do #217/#218 (ver COMPARE_DEFAULT_VERSION acima).
 export function compareDefaultsForMode(
   mode: string | null | undefined,
   minResponsesForComparison: number,
@@ -80,7 +96,7 @@ export function compareDefaultsForMode(
   } else if (mode === "compare_humans") {
     minHumans = Math.max(1, minResponsesForComparison);
   }
-  return { ...DEFAULT_COMPARE_FILTERS, minHumans, version: "latest_major" };
+  return { ...DEFAULT_COMPARE_FILTERS, minHumans, version: COMPARE_DEFAULT_VERSION };
 }
 
 // Conjunto de document_ids que um usuário pode VER na fila de comparação.

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -1,4 +1,4 @@
-import { VERSION_FILTER_LATEST_MAJOR } from "@/lib/compare-version";
+import { COMPARE_DEFAULT_VERSION } from "@/lib/compare-version";
 
 export interface CompareFiltersValue {
   version: string; // "all" | "latest_major" | "X.Y.Z"
@@ -24,21 +24,14 @@ export const DEFAULT_COMPARE_FILTERS: CompareFiltersValue = {
   respondent: "all",
 };
 
-// Default VIVO de versão da aba Comparar — fonte única consumida pelos TRÊS
-// pontos que precisam concordar sobre "qual versão a fila reflete por padrão":
-//   1. a página (compareDefaultsForMode, via compare/page.tsx);
-//   2. o filtro do cliente (CompareFilters.effectiveDefaults, via prop
-//      defaultVersion plumbada por page → ComparePage → CompareNav);
-//   3. o fecho do parecer (compare-sync.ts, via resolveMinVersion).
-// É distinto de DEFAULT_COMPARE_FILTERS.version ("all"), que é a base para
-// callers/testes que NÃO derivam do automation_mode. Centralizar aqui evita o
-// drift silencioso em que página, filtro e fecho discordam (ver #247, e o
-// acoplamento visão==fecho do #217/#218). O default de versão é independente do
-// modo de automação — só `minHumans` varia por modo —, por isso uma constante
-// basta como fonte única, sem precisar do `mode`. O VALOR vem do sentinela
-// canônico em compare-version.ts (mesma string que `resolveMinVersion` casa e
-// que o `SelectItem` do filtro usa), então trocar o default não dessincroniza.
-export const COMPARE_DEFAULT_VERSION = VERSION_FILTER_LATEST_MAJOR;
+// Default VIVO de versão da aba Comparar (compareDefaultsForMode o aplica). É
+// distinto de DEFAULT_COMPARE_FILTERS.version ("all"), a base para callers/testes
+// que NÃO derivam do automation_mode. Re-exportado de compare-version.ts (sua
+// fonte única, ao lado do `versionGate` que o consome) para que os importadores
+// existentes — compare-sync.ts, auto-comparison.ts, testes — não precisem mudar
+// o caminho de import (importado no topo). Ver o comentário em compare-version.ts
+// (#247, #217/#218).
+export { COMPARE_DEFAULT_VERSION };
 
 export function readCompareFilters(
   params: URLSearchParams | Record<string, string | undefined>,

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -1,3 +1,5 @@
+import { VERSION_FILTER_LATEST_MAJOR } from "@/lib/compare-version";
+
 export interface CompareFiltersValue {
   version: string; // "all" | "latest_major" | "X.Y.Z"
   minHumans: number;
@@ -33,8 +35,10 @@ export const DEFAULT_COMPARE_FILTERS: CompareFiltersValue = {
 // drift silencioso em que página, filtro e fecho discordam (ver #247, e o
 // acoplamento visão==fecho do #217/#218). O default de versão é independente do
 // modo de automação — só `minHumans` varia por modo —, por isso uma constante
-// basta como fonte única, sem precisar do `mode`.
-export const COMPARE_DEFAULT_VERSION = "latest_major";
+// basta como fonte única, sem precisar do `mode`. O VALOR vem do sentinela
+// canônico em compare-version.ts (mesma string que `resolveMinVersion` casa e
+// que o `SelectItem` do filtro usa), então trocar o default não dessincroniza.
+export const COMPARE_DEFAULT_VERSION = VERSION_FILTER_LATEST_MAJOR;
 
 export function readCompareFilters(
   params: URLSearchParams | Record<string, string | undefined>,

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -13,7 +13,7 @@ import {
   type SchemaVersion,
   type VersionedResponse,
 } from "@/lib/compare-version";
-import { DEFAULT_COMPARE_FILTERS } from "@/lib/compare-filters";
+import { COMPARE_DEFAULT_VERSION } from "@/lib/compare-filters";
 import type { EquivalencePair } from "@/lib/equivalence";
 
 // Recomputes assignment status (pendente / em_andamento / concluido) for the
@@ -75,30 +75,33 @@ export async function syncCompareAssignment(
 
   // Conclusão usa o MESMO predicado (`responseQualifiesForVersion`, anti-drift
   // #217) e o MESMO piso de versão que a página aplica no estado DEFAULT da UI
-  // — derivado de `DEFAULT_COMPARE_FILTERS.version` via `resolveMinVersion`, a
-  // mesma função que `compare/page.tsx` chama. Hoje o default é "all"
-  // (compare-filters.ts), então `minVersion` é null (sem piso) e o fecho
-  // considera toda resposta `is_latest`, de qualquer versão — exatamente o que
-  // a revisora vê "sem filtro". Por construção, no estado default a visão e o
-  // fecho coincidem: resolver as divergências visíveis sempre fecha o parecer.
+  // — derivado de `COMPARE_DEFAULT_VERSION` (compare-filters.ts) via
+  // `resolveMinVersion`, a mesma constante e função que `compare/page.tsx` usa
+  // através de `compareDefaultsForMode`. O default vivo é "latest_major" (#247),
+  // então `minVersion` é o `latestMajorAnchor` do projeto: o fecho considera só
+  // as respostas `is_latest` da MAJOR corrente — exatamente o que a revisora vê
+  // na fila default. Por construção, no estado default a visão e o fecho
+  // coincidem: resolver as divergências visíveis sempre fecha o parecer.
   //
-  // O que muda em relação ao sync antigo (`is_latest || respondent_type ===
-  // "humano"`) é só a exclusão de codificações SUPERSEDED (`is_latest=false`,
-  // humanas inclusive) — que o antigo contava e a tela não mostrava, a causa
-  // real da trava do #217. Pré-versionamento (`pydantic_hash` NULL) e rodadas
-  // antigas permanecem no fecho, espelhando o default `all`.
+  // Codificações de majors anteriores (`is_latest`, schema antigo) e as
+  // pré-versionamento (`pydantic_hash` NULL) ficam de fora do fecho E da fila —
+  // "deixam de contar por padrão" (#247). Isso restaura o acoplamento
+  // visão==fecho que o #218 garantia: antes, com piso `all`, o fecho contava
+  // rodadas antigas que a fila `latest_major` escondia, e o parecer não fechava
+  // apesar de a revisora ter resolvido tudo o que via (regressão do #217).
+  // Codificações SUPERSEDED (`is_latest=false`) seguem fora, como sempre.
   //
-  // Filtros efêmeros (versão manual, `since`, `respondent`) são lentes de
-  // inspeção: NÃO redefinem "concluído". Se a revisora escolher uma lente mais
-  // estreita que o default, a tela pode mostrar menos do que o fecho exige —
-  // comportamento esperado de uma lente, fora do fluxo "sem filtro".
+  // Filtros efêmeros (versão manual mais larga/estreita, `since`, `respondent`)
+  // são lentes de inspeção: NÃO redefinem "concluído". Se a revisora escolher
+  // uma lente mais estreita que o default, a tela pode mostrar menos do que o
+  // fecho exige — comportamento esperado de uma lente, fora do fluxo "default".
   const projectVersion: SchemaVersion = {
     major: project?.schema_version_major ?? 0,
     minor: project?.schema_version_minor ?? 1,
     patch: project?.schema_version_patch ?? 0,
   };
   const minVersion = resolveMinVersion(
-    DEFAULT_COMPARE_FILTERS.version,
+    COMPARE_DEFAULT_VERSION,
     projectVersion,
   );
   const projectVersionCtx = {

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -8,9 +8,9 @@ import {
   resolveCompareStatus,
 } from "@/lib/compare-divergence";
 import {
+  deriveProjectVersionContext,
   resolveMinVersion,
   responseQualifiesForVersion,
-  type SchemaVersion,
   type VersionedResponse,
 } from "@/lib/compare-version";
 import { COMPARE_DEFAULT_VERSION } from "@/lib/compare-filters";
@@ -95,19 +95,11 @@ export async function syncCompareAssignment(
   // são lentes de inspeção: NÃO redefinem "concluído". Se a revisora escolher
   // uma lente mais estreita que o default, a tela pode mostrar menos do que o
   // fecho exige — comportamento esperado de uma lente, fora do fluxo "default".
-  const projectVersion: SchemaVersion = {
-    major: project?.schema_version_major ?? 0,
-    minor: project?.schema_version_minor ?? 1,
-    patch: project?.schema_version_patch ?? 0,
-  };
-  const minVersion = resolveMinVersion(
-    COMPARE_DEFAULT_VERSION,
-    projectVersion,
-  );
-  const projectVersionCtx = {
-    pydanticHash: project?.pydantic_hash ?? null,
-    version: projectVersion,
-  };
+  // Contexto de versão do helper compartilhado (compare-version.ts) — a MESMA
+  // fonte e fallback {0,1,0} de page.tsx e auto-comparison.ts, sem re-hardcodar.
+  const { version: projectVersion, ctx: projectVersionCtx } =
+    deriveProjectVersionContext(project ?? {});
+  const minVersion = resolveMinVersion(COMPARE_DEFAULT_VERSION, projectVersion);
 
   type ActiveResponse = {
     id: string;
@@ -127,6 +119,19 @@ export async function syncCompareAssignment(
       answers: (r.answers ?? {}) as Record<string, unknown>,
       answerFieldHashes: r.answer_field_hashes as AnswerFieldHashes,
     }));
+
+  // Sem ao menos 2 respostas qualificadas sob o piso corrente não há PAR a
+  // comparar — então não há divergência a "resolver". Aqui o conjunto vazio/único
+  // faria `computeDivergentFieldNames` devolver [] e o status virar "concluido",
+  // marcando como revisado um doc que ninguém comparou na versão corrente (ex.:
+  // doc só com codificações pré-versionamento, ou cujas rodadas antigas caíram
+  // abaixo do piso após um bump estrutural). Preserva o status atual: a fila
+  // default também não mostra o doc (filtro de mín. humanos), então o assignment
+  // fica fora de vista sem fechar à toa. "concluido" continua reservado para o
+  // caso legítimo de ≥2 respostas cujas divergências foram todas resolvidas/fundidas
+  // (#217). Não regride um assignment já concluído nem reabre — só evita o fecho
+  // espúrio.
+  if (activeResponses.length < 2) return;
 
   const equivalencesByField = new Map<string, EquivalencePair[]>();
   for (const eq of equivalences ?? []) {

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -8,12 +8,10 @@ import {
   resolveCompareStatus,
 } from "@/lib/compare-divergence";
 import {
-  deriveProjectVersionContext,
-  resolveMinVersion,
   responseQualifiesForVersion,
+  versionGate,
   type VersionedResponse,
 } from "@/lib/compare-version";
-import { COMPARE_DEFAULT_VERSION } from "@/lib/compare-filters";
 import type { EquivalencePair } from "@/lib/equivalence";
 
 // Recomputes assignment status (pendente / em_andamento / concluido) for the
@@ -95,11 +93,11 @@ export async function syncCompareAssignment(
   // são lentes de inspeção: NÃO redefinem "concluído". Se a revisora escolher
   // uma lente mais estreita que o default, a tela pode mostrar menos do que o
   // fecho exige — comportamento esperado de uma lente, fora do fluxo "default".
-  // Contexto de versão do helper compartilhado (compare-version.ts) — a MESMA
-  // fonte e fallback {0,1,0} de page.tsx e auto-comparison.ts, sem re-hardcodar.
-  const { version: projectVersion, ctx: projectVersionCtx } =
-    deriveProjectVersionContext(project ?? {});
-  const minVersion = resolveMinVersion(COMPARE_DEFAULT_VERSION, projectVersion);
+  // Piso `latest_major` + contexto do helper compartilhado `versionGate`
+  // (compare-version.ts) — a MESMA fonte, fallback {0,1,0} e constante
+  // COMPARE_DEFAULT_VERSION que o gatilho (auto-comparison.ts) usa; a página
+  // deriva o contexto da mesma origem mas resolve o piso a partir da URL.
+  const { minVersion, ctx: projectVersionCtx } = versionGate(project ?? {});
 
   type ActiveResponse = {
     id: string;

--- a/frontend/src/lib/compare-version.ts
+++ b/frontend/src/lib/compare-version.ts
@@ -9,6 +9,16 @@
 // que era a causa do assignment de comparação não fechar (ver #168 e o
 // princípio anti-drift do CLAUDE.md, mesmo racional do #63 para schema-utils).
 
+// Sentinelas do filtro de versão da aba Comparar. São a FONTE ÚNICA das strings
+// mágicas: `resolveMinVersion` casa contra elas, `COMPARE_DEFAULT_VERSION`
+// (compare-filters.ts) é definido a partir delas e o `SelectItem` do filtro
+// (CompareFilters.tsx) usa-as como `value`. Sem isto, trocar o valor do default
+// num lugar (ex.: a constante) deixaria `resolveMinVersion` cair no
+// `parseVersionStr → null` e desativar o piso silenciosamente em fila/gatilho/
+// fecho, além de o `Select` controlado ficar com `value` sem option (#247).
+export const VERSION_FILTER_ALL = "all";
+export const VERSION_FILTER_LATEST_MAJOR = "latest_major";
+
 export interface SchemaVersion {
   major: number;
   minor: number;
@@ -71,8 +81,9 @@ export function resolveMinVersion(
   filter: string,
   projectCurrent: SchemaVersion,
 ): SchemaVersion | null {
-  if (filter === "all") return null;
-  if (filter === "latest_major") return latestMajorAnchor(projectCurrent);
+  if (filter === VERSION_FILTER_ALL) return null;
+  if (filter === VERSION_FILTER_LATEST_MAJOR)
+    return latestMajorAnchor(projectCurrent);
   return parseVersionStr(filter);
 }
 
@@ -80,6 +91,39 @@ export function resolveMinVersion(
 export interface ProjectVersionContext {
   pydanticHash: string | null;
   version: SchemaVersion;
+}
+
+// Linha de `projects` reduzida ao mínimo para derivar o contexto de versão.
+export interface ProjectVersionRow {
+  pydantic_hash?: string | null;
+  schema_version_major?: number | null;
+  schema_version_minor?: number | null;
+  schema_version_patch?: number | null;
+}
+
+// Deriva o `SchemaVersion` corrente do projeto e o `ProjectVersionContext` a
+// partir de uma linha de `projects`, com os fallbacks canônicos
+// {major 0, minor 1, patch 0}. FONTE ÚNICA dessa derivação, consumida por
+// compare/page.tsx, compare-sync.ts e auto-comparison.ts — antes ela vivia
+// copiada (verbatim) nos três, e o fallback `minor: 1` é load-bearing
+// (`latestMajorAnchor` ancora em {0,minor,0} para projetos 0.x): uma cópia
+// "corrigida" para `minor: 0` num só lugar dessincronizaria gatilho/fila/fecho,
+// a exata classe de drift que este módulo existe para evitar (ver cabeçalho e
+// #247). Cada caller resolve seu próprio `minVersion`: a página a partir da URL
+// (`filters.version`), o fecho/gatilho a partir de `COMPARE_DEFAULT_VERSION`.
+export function deriveProjectVersionContext(project: ProjectVersionRow): {
+  version: SchemaVersion;
+  ctx: ProjectVersionContext;
+} {
+  const version: SchemaVersion = {
+    major: project.schema_version_major ?? 0,
+    minor: project.schema_version_minor ?? 1,
+    patch: project.schema_version_patch ?? 0,
+  };
+  return {
+    version,
+    ctx: { pydanticHash: project.pydantic_hash ?? null, version },
+  };
 }
 
 // Predicado único de qualificação de uma resposta sob um piso de versão.

--- a/frontend/src/lib/compare-version.ts
+++ b/frontend/src/lib/compare-version.ts
@@ -19,6 +19,22 @@
 export const VERSION_FILTER_ALL = "all";
 export const VERSION_FILTER_LATEST_MAJOR = "latest_major";
 
+// Default VIVO de versão da aba Comparar — fonte única consumida pelos TRÊS
+// pontos que precisam concordar sobre "qual versão a fila reflete por padrão":
+//   1. a página (compareDefaultsForMode, via compare/page.tsx);
+//   2. o filtro do cliente (CompareFilters.effectiveDefaults, via prop
+//      defaultVersion plumbada por page → ComparePage → CompareNav);
+//   3. o fecho do parecer (compare-sync.ts) e o gatilho (auto-comparison.ts),
+//      ambos via `versionGate` abaixo.
+// É distinto de DEFAULT_COMPARE_FILTERS.version ("all"), a base para
+// callers/testes que NÃO derivam do automation_mode. Vive aqui (e é
+// re-exportado por compare-filters.ts) para que `versionGate` o use sem import
+// circular — o VALOR é o sentinela canônico VERSION_FILTER_LATEST_MAJOR (mesma
+// string que `resolveMinVersion` casa e que o `SelectItem` do filtro usa), então
+// trocar o default não dessincroniza fila/filtro/gatilho/fecho (ver #247, e o
+// acoplamento visão==fecho do #217/#218).
+export const COMPARE_DEFAULT_VERSION = VERSION_FILTER_LATEST_MAJOR;
+
 export interface SchemaVersion {
   major: number;
   minor: number;
@@ -124,6 +140,21 @@ export function deriveProjectVersionContext(project: ProjectVersionRow): {
     version,
     ctx: { pydanticHash: project.pydantic_hash ?? null, version },
   };
+}
+
+// Gate de versão do estado DEFAULT da fila: deriva o contexto do projeto e
+// resolve o piso a partir de `COMPARE_DEFAULT_VERSION` ("latest_major"). FONTE
+// ÚNICA do par {minVersion, ctx} aplicado fora da página — o gatilho
+// (auto-comparison.ts) e o fecho (compare-sync.ts) usam ESTE helper, mantendo o
+// acoplamento gatilho==fila==fecho do #247. A página NÃO usa `versionGate`: ela
+// resolve `minVersion` a partir da URL (`filters.version`, que pode ser uma
+// lente manual), mas a partir do MESMO `deriveProjectVersionContext`.
+export function versionGate(project: ProjectVersionRow): {
+  minVersion: SchemaVersion | null;
+  ctx: ProjectVersionContext;
+} {
+  const { version, ctx } = deriveProjectVersionContext(project);
+  return { minVersion: resolveMinVersion(COMPARE_DEFAULT_VERSION, version), ctx };
 }
 
 // Predicado único de qualificação de uma resposta sob um piso de versão.


### PR DESCRIPTION
## Contexto

Parte da issue #247 (ponto 1). Pesquisadores do Natjus estranharam ver na fila de **Comparar** codificações feitas sob schemas anteriores — o esperado é focar na versão corrente por padrão.

## Mudança

O default **vivo** da página (`compareDefaultsForMode`) passa de `all` para `latest_major`: por padrão a fila reflete só a versão corrente do schema. O seletor de versão continua oferecendo **Todas as versões** para quem precisa revisar rodadas antigas.

`DEFAULT_COMPARE_FILTERS.version` segue `all` (usado por outros callers/testes que não derivam do `automation_mode`), então o blast radius fica contido na aba Comparar.

### Tradeoff

Com `latest_major`, codificações de schemas anteriores deixam de contar por padrão (são descartadas inteiras, não campo a campo). É o comportamento pedido na issue; quem precisar do antigo seleciona "Todas as versões".

## Testes

- `npm run test` em `compare-filters` / `compare-version` / `components/compare` — 41 passam.
- Asserção nova fixando `compareDefaultsForMode(...).version === 'latest_major'` e `DEFAULT_COMPARE_FILTERS.version === 'all'`.

Parte de #247 (demais pontos em PRs separados).