### PR TITLE
fix(upload): hardening do import reconciliado sobre a main (resgate do #279)

### DIFF
--- a/frontend/src/actions/__tests__/documents.test.ts
+++ b/frontend/src/actions/__tests__/documents.test.ts
@@ -42,6 +42,10 @@ async function loadGetDocumentText() {
   return (await import("@/actions/documents")).getDocumentText;
 }
 
+async function loadCheck() {
+  return (await import("@/actions/documents")).checkDuplicates;
+}
+
 function insertedExternalIds(): (string | null)[] {
   const call = writeCalls.find(
     (c) => c.table === "documents" && c.op === "insert",
@@ -202,6 +206,91 @@ describe("uploadDocuments — replace_and_add propaga erro de UPDATE", () => {
     expect(
       writeCalls.some((c) => c.table === "documents" && c.op === "insert"),
     ).toBe(false);
+  });
+});
+
+describe("uploadDocuments — replace_and_add fail-loud nos deletes", () => {
+  it("retorna error quando o delete de responses falha (não segue para update/insert)", async () => {
+    // reviews.delete (sem entrada → ok), responses.delete → erro. A action deve
+    // abortar com {error} antes de tocar documents (update dos duplicados/insert).
+    serverTableResults = {
+      responses: [{ error: { message: "delete de responses falhou" } }],
+    };
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [{ external_id: "DOC-1", text: "substitui" }],
+      false,
+      {
+        mode: "replace_and_add",
+        deleteResponses: true,
+        duplicateMap: [
+          { csvIndex: 0, existingDocId: "id-1", matchType: "external_id" },
+        ],
+      },
+    );
+
+    expect(r.error).toContain("delete de responses falhou");
+    // Falha silenciosa evitada: não chega ao UPDATE/INSERT de documents.
+    expect(writeCalls.some((c) => c.table === "documents")).toBe(false);
+  });
+});
+
+describe("checkDuplicates — propaga erro de query (não engole silenciosamente)", () => {
+  it("lança quando a query por external_id falha", async () => {
+    serverTableResults = {
+      documents: [{ error: { message: "db down" } }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    await expect(
+      checkDuplicates("proj-1", [
+        { external_id: "X", text_hash: "h1", csvIndex: 0 },
+      ]),
+    ).rejects.toThrow(/ID externo/);
+  });
+
+  it("lança quando a query por text_hash falha (docs sem external_id)", async () => {
+    // Sem external_id, o bloco 1 é pulado e a query de hash é a 1ª em documents.
+    serverTableResults = {
+      documents: [{ error: { message: "hash fail" } }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    await expect(
+      checkDuplicates("proj-1", [{ text_hash: "h1", csvIndex: 0 }]),
+    ).rejects.toThrow(/hash de conteúdo/);
+  });
+
+  it("lança quando a query de responses falha", async () => {
+    // extId acha 1 duplicata → dispara a query de responses, que falha.
+    serverTableResults = {
+      documents: [{ data: [{ id: "d1", external_id: "X" }] }],
+      responses: [{ error: { message: "resp fail" } }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    await expect(
+      checkDuplicates("proj-1", [
+        { external_id: "X", text_hash: "h1", csvIndex: 0 },
+      ]),
+    ).rejects.toThrow(/respostas das duplicatas/);
+  });
+
+  it("caminho feliz: retorna duplicatas sem lançar quando não há erro", async () => {
+    serverTableResults = {
+      documents: [{ data: [{ id: "d1", external_id: "X" }] }],
+      responses: [{ data: [] }],
+    };
+    const checkDuplicates = await loadCheck();
+
+    const r = await checkDuplicates("proj-1", [
+      { external_id: "X", text_hash: "h1", csvIndex: 0 },
+    ]);
+
+    expect(r.duplicates).toHaveLength(1);
+    expect(r.duplicatesWithResponses).toBe(0);
   });
 });
 

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -53,7 +53,7 @@ export async function checkDuplicates(
   // 1. Match by external_id (excluidos sao ignorados — re-upload de doc
   //    excluido por engano cria um novo registro normal)
   if (externalIds.length > 0) {
-    const { data: byExtId } = await supabase
+    const { data: byExtId, error: byExtIdErr } = await supabase
       .from("documents")
       .select("id, external_id")
       .eq("project_id", projectId)
@@ -61,6 +61,10 @@ export async function checkDuplicates(
       .in(
         "external_id",
         externalIds.map((e) => e.id!)
+      );
+    if (byExtIdErr)
+      throw new Error(
+        `Falha ao verificar duplicatas por ID externo: ${byExtIdErr.message}`,
       );
 
     if (byExtId) {
@@ -86,12 +90,16 @@ export async function checkDuplicates(
 
   if (unmatchedHashes.length > 0) {
     const uniqueHashes = [...new Set(unmatchedHashes.map((h) => h.hash))];
-    const { data: byHash } = await supabase
+    const { data: byHash, error: byHashErr } = await supabase
       .from("documents")
       .select("id, text_hash")
       .eq("project_id", projectId)
       .is("excluded_at", null)
       .in("text_hash", uniqueHashes);
+    if (byHashErr)
+      throw new Error(
+        `Falha ao verificar duplicatas por hash de conteúdo: ${byHashErr.message}`,
+      );
 
     if (byHash) {
       const hashMap = new Map(byHash.map((d) => [d.text_hash, d.id]));
@@ -112,11 +120,15 @@ export async function checkDuplicates(
   let duplicatesWithResponses = 0;
   if (duplicates.length > 0) {
     const docIds = duplicates.map((d) => d.existingDocId);
-    const { data: responses } = await supabase
+    const { data: responses, error: responsesErr } = await supabase
       .from("responses")
       .select("document_id")
       .eq("project_id", projectId)
       .in("document_id", docIds);
+    if (responsesErr)
+      throw new Error(
+        `Falha ao verificar respostas das duplicatas: ${responsesErr.message}`,
+      );
 
     if (responses) {
       const docsWithResponses = new Set(responses.map((r) => r.document_id));
@@ -190,6 +202,25 @@ async function filterActiveExternalIdConflicts<
   return { rows: safe, skippedExisting, skippedInBatch };
 }
 
+// Revalida o cache de documentos do projeto: o path dinâmico de config, a tag
+// da página cacheada de assignments e a tag de progresso (contagens de docs) —
+// o mesmo conjunto que excludeDocuments/restoreDocuments/hardDeleteDocuments
+// revalidam. Fonte única usada tanto pelo último chunk de uploadDocuments quanto
+// pelo recovery do hook quando um upload em chunks falha no meio.
+// Best-effort: uma falha de revalidação de cache não pode propagar como erro da
+// action (caso contrário um INSERT já commitado seria reportado como falha, ou o
+// catch do hook ficaria preso). Um cache stale é recuperável; um upload "perdido"
+// não.
+export async function revalidateProjectDocuments(projectId: string) {
+  try {
+    revalidatePath(`/projects/${projectId}/config/documents`);
+    revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+    revalidateTag(`project-${projectId}-progress`, { expire: 60 });
+  } catch (e) {
+    console.error("[revalidateProjectDocuments] falha ao revalidar cache", e);
+  }
+}
+
 export async function uploadDocuments(
   projectId: string,
   documents: DocumentRow[],
@@ -229,10 +260,7 @@ export async function uploadDocuments(
       if (error) return { error: error.message };
     }
 
-    if (revalidate) {
-      revalidatePath(`/projects/${projectId}/config/documents`);
-      revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
-    }
+    if (revalidate) await revalidateProjectDocuments(projectId);
     return {
       count: rows.length,
       skipped: skippedDuplicates + skippedExisting + skippedInBatch,
@@ -244,26 +272,34 @@ export async function uploadDocuments(
     const existingDocIds = duplicateMap.map((d) => d.existingDocId);
 
     if (options?.deleteResponses && existingDocIds.length > 0) {
+      // Fail-loud: cada passo checa erro e aborta. A sequencia NAO e atomica (um
+      // delete pode ter ocorrido antes de outro falhar) — o hook avisa o usuario
+      // que respostas/revisoes podem ja ter sido removidas. Atomicidade real
+      // depende do RPC transacional (issue #284).
+
       // Delete reviews first (FK chosen_response_id -> responses without CASCADE)
-      await supabase
+      const { error: delReviewsErr } = await supabase
         .from("reviews")
         .delete()
         .eq("project_id", projectId)
         .in("document_id", existingDocIds);
+      if (delReviewsErr) return { error: delReviewsErr.message };
 
       // Then delete responses
-      await supabase
+      const { error: delResponsesErr } = await supabase
         .from("responses")
         .delete()
         .eq("project_id", projectId)
         .in("document_id", existingDocIds);
+      if (delResponsesErr) return { error: delResponsesErr.message };
 
       // Reset assignments to 'pendente'
-      await supabase
+      const { error: resetAssignErr } = await supabase
         .from("assignments")
         .update({ status: "pendente" })
         .eq("project_id", projectId)
         .in("document_id", existingDocIds);
+      if (resetAssignErr) return { error: resetAssignErr.message };
     }
 
     // Batch update duplicate documents (avoid N+1)
@@ -314,10 +350,7 @@ export async function uploadDocuments(
       }
     }
 
-    if (revalidate) {
-      revalidatePath(`/projects/${projectId}/config/documents`);
-      revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
-    }
+    if (revalidate) await revalidateProjectDocuments(projectId);
     return { count: documents.length - skipped, skipped };
   }
 
@@ -340,10 +373,7 @@ export async function uploadDocuments(
     if (error) return { error: error.message };
   }
 
-  if (revalidate) {
-      revalidatePath(`/projects/${projectId}/config/documents`);
-      revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
-    }
+  if (revalidate) await revalidateProjectDocuments(projectId);
   return { count: rows.length, skipped: skippedExisting + skippedInBatch };
 }
 
@@ -517,9 +547,7 @@ export async function excludeDocuments(
     .in("id", documentIds);
 
   if (error) return { error: error.message };
-  revalidatePath(`/projects/${projectId}/config/documents`);
-  revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
-  revalidateTag(`project-${projectId}-progress`, { expire: 60 });
+  await revalidateProjectDocuments(projectId);
   return { count: documentIds.length };
 }
 
@@ -547,9 +575,7 @@ export async function restoreDocuments(
     .in("id", documentIds);
 
   if (error) return { error: error.message };
-  revalidatePath(`/projects/${projectId}/config/documents`);
-  revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
-  revalidateTag(`project-${projectId}-progress`, { expire: 60 });
+  await revalidateProjectDocuments(projectId);
   return { count: documentIds.length };
 }
 
@@ -576,8 +602,6 @@ export async function hardDeleteDocuments(
     .in("id", documentIds);
 
   if (error) return { error: error.message };
-  revalidatePath(`/projects/${projectId}/config/documents`);
-  revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
-  revalidateTag(`project-${projectId}-progress`, { expire: 60 });
+  await revalidateProjectDocuments(projectId);
   return { count: documentIds.length };
 }

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -1,7 +1,11 @@
 "use server";
 
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser, isProjectCoordinator } from "@/lib/auth";
+import {
+  getAuthUser,
+  getProjectAccessContext,
+  isProjectCoordinator,
+} from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 
 const TAG_PROFILE = Object.freeze({ expire: 300 });
@@ -211,7 +215,11 @@ async function filterActiveExternalIdConflicts<
 // action (caso contrário um INSERT já commitado seria reportado como falha, ou o
 // catch do hook ficaria preso). Um cache stale é recuperável; um upload "perdido"
 // não.
-export async function revalidateProjectDocuments(projectId: string) {
+//
+// Privada (não-exportada): os chamadores internos deste módulo já passaram pelo
+// RLS de escrita, então não pagam o custo do gate de autorização. O ponto de
+// entrada client é o wrapper `revalidateProjectDocuments` abaixo.
+async function revalidateProjectDocumentsCache(projectId: string) {
   try {
     revalidatePath(`/projects/${projectId}/config/documents`);
     revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
@@ -219,6 +227,25 @@ export async function revalidateProjectDocuments(projectId: string) {
   } catch (e) {
     console.error("[revalidateProjectDocuments] falha ao revalidar cache", e);
   }
+}
+
+// Server action client-callable (o hook de upload chama no recovery de falha
+// parcial). Diferente dos chamadores internos — que já passaram pelo RLS de
+// escrita — esta é exposta ao client, então gateia por acesso de leitura ao
+// projeto antes de revalidar: sem o gate, qualquer usuário autenticado poderia
+// invalidar o cache de um projeto alheio. Gate permissivo (qualquer membro que
+// enxerga o projeto via RLS, não só coordenador) e fail-closed (sem acesso →
+// não revalida).
+export async function revalidateProjectDocuments(projectId: string) {
+  const user = await getAuthUser();
+  if (!user) return;
+  const { project } = await getProjectAccessContext(
+    projectId,
+    user.id,
+    user.isMaster,
+  );
+  if (!project) return;
+  await revalidateProjectDocumentsCache(projectId);
 }
 
 export async function uploadDocuments(
@@ -260,7 +287,7 @@ export async function uploadDocuments(
       if (error) return { error: error.message };
     }
 
-    if (revalidate) await revalidateProjectDocuments(projectId);
+    if (revalidate) await revalidateProjectDocumentsCache(projectId);
     return {
       count: rows.length,
       skipped: skippedDuplicates + skippedExisting + skippedInBatch,
@@ -350,7 +377,7 @@ export async function uploadDocuments(
       }
     }
 
-    if (revalidate) await revalidateProjectDocuments(projectId);
+    if (revalidate) await revalidateProjectDocumentsCache(projectId);
     return { count: documents.length - skipped, skipped };
   }
 
@@ -373,7 +400,7 @@ export async function uploadDocuments(
     if (error) return { error: error.message };
   }
 
-  if (revalidate) await revalidateProjectDocuments(projectId);
+  if (revalidate) await revalidateProjectDocumentsCache(projectId);
   return { count: rows.length, skipped: skippedExisting + skippedInBatch };
 }
 
@@ -547,7 +574,7 @@ export async function excludeDocuments(
     .in("id", documentIds);
 
   if (error) return { error: error.message };
-  await revalidateProjectDocuments(projectId);
+  await revalidateProjectDocumentsCache(projectId);
   return { count: documentIds.length };
 }
 
@@ -575,7 +602,7 @@ export async function restoreDocuments(
     .in("id", documentIds);
 
   if (error) return { error: error.message };
-  await revalidateProjectDocuments(projectId);
+  await revalidateProjectDocumentsCache(projectId);
   return { count: documentIds.length };
 }
 
@@ -602,6 +629,6 @@ export async function hardDeleteDocuments(
     .in("id", documentIds);
 
   if (error) return { error: error.message };
-  await revalidateProjectDocuments(projectId);
+  await revalidateProjectDocumentsCache(projectId);
   return { count: documentIds.length };
 }

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -15,6 +15,7 @@ import {
   type ChangeType,
 } from "@/lib/schema-utils";
 import { updateOrThrow } from "@/lib/supabase/rls-guard";
+import { errorMessage } from "@/lib/utils";
 import crypto from "crypto";
 
 interface ValidateResponse {
@@ -35,10 +36,9 @@ export async function validateSchema(code: string): Promise<ValidateResponse> {
 // a message de erros lançados em Server Actions em produção (o client recebe
 // mensagem genérica + digest), então a copy pt-BR só chega ao toast pelo
 // retorno. Os helpers de rls-guard continuam lançando — o catch fica na
-// fronteira da action.
-function errorMessage(e: unknown, fallback: string): string {
-  return e instanceof Error ? e.message : fallback;
-}
+// fronteira da action. A extração da message usa `errorMessage` de @/lib/utils
+// (fonte única, compartilhada com o hook de upload); `|| fallback` cobre o caso
+// de `e` não ser Error/string.
 
 export async function saveSchema(
   projectId: string,
@@ -66,7 +66,7 @@ export async function saveSchema(
         "Não foi possível salvar o schema: sem permissão para alterar este projeto.",
     });
   } catch (e) {
-    return { error: errorMessage(e, "Erro ao salvar o schema") };
+    return { error: errorMessage(e) || "Erro ao salvar o schema" };
   }
 
   // is_latest não é flipado para false aqui — staleness é detectada no
@@ -96,7 +96,7 @@ export async function savePrompt(
       { message: "Não foi possível salvar o prompt: sem permissão para alterar este projeto." },
     );
   } catch (e) {
-    return { error: errorMessage(e, "Erro ao salvar o prompt") };
+    return { error: errorMessage(e) || "Erro ao salvar o prompt" };
   }
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/llm/configure`);
@@ -239,7 +239,7 @@ export async function backfillSchemaVersionHistory(
   try {
     return { stats: await runBackfill(projectId) };
   } catch (e) {
-    return { error: errorMessage(e, "Erro ao reconstruir o histórico de versões") };
+    return { error: errorMessage(e) || "Erro ao reconstruir o histórico de versões" };
   }
 }
 
@@ -621,7 +621,7 @@ export async function publishMajorVersion(
       { message: "Não foi possível publicar a MAJOR: sem permissão para alterar este projeto." },
     );
   } catch (e) {
-    return { error: errorMessage(e, "Erro ao publicar a MAJOR") };
+    return { error: errorMessage(e) || "Erro ao publicar a MAJOR" };
   }
 
   const { error: logErr } = await supabase.from("schema_change_log").insert({
@@ -691,7 +691,7 @@ export async function saveLlmConfig(
         "Não foi possível salvar a configuração do LLM: sem permissão para alterar este projeto.",
     });
   } catch (e) {
-    return { error: errorMessage(e, "Erro ao salvar a configuração do LLM") };
+    return { error: errorMessage(e) || "Erro ao salvar a configuração do LLM" };
   }
   revalidatePath(`/projects/${projectId}/llm/configure`);
   revalidatePath(`/projects/${projectId}/config`);

--- a/frontend/src/hooks/__tests__/useDocumentUpload.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentUpload.test.ts
@@ -283,6 +283,45 @@ describe("useDocumentUpload — replace destrutivo falhando", () => {
     );
     await waitFor(() => expect(result.current.phase.kind).toBe("analysis"));
   });
+
+  it("multi-chunk parcial (totalInserted > 0) ainda avisa da remoção destrutiva", async () => {
+    // 501 docs com duplicatas → analysis → replace destrutivo. 2 chunks: o 1º
+    // entra (count 500), o 2º falha após já ter apagado responses/reviews. Como
+    // totalInserted > 0, cai no ramo de parcial — que NÃO pode engolir o aviso de
+    // remoção (os dois ramos não são exclusivos num replace multi-chunk).
+    const rows = Array.from({ length: 501 }, (_, i) => ({ text_col: `linha ${i}` }));
+    checkDuplicates.mockResolvedValue({
+      duplicates: [{ csvIndex: 0, existingDocId: "d1", matchType: "external_id" }],
+      duplicatesWithResponses: 1,
+    });
+    uploadDocuments
+      .mockResolvedValueOnce({ count: 500 })
+      .mockResolvedValueOnce({ error: "boom" });
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    feedCsv(rows, ["text_col"]);
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+    act(() =>
+      result.current.setMapping({ text: "text_col", title: "", external_id: "" })
+    );
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+    expect(result.current.phase.kind).toBe("analysis");
+
+    act(() => result.current.handleReplaceAndImport(true));
+
+    await waitFor(() => expect(uploadDocuments).toHaveBeenCalledTimes(2));
+    // Reporta o parcial (500) E avisa da remoção — sem o fix, "removidas" sumiria.
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(expect.stringContaining("500"))
+    );
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(expect.stringContaining("removidas"))
+    );
+  });
 });
 
 describe("useDocumentUpload — erros de parsing do CSV", () => {

--- a/frontend/src/hooks/__tests__/useDocumentUpload.test.ts
+++ b/frontend/src/hooks/__tests__/useDocumentUpload.test.ts
@@ -5,10 +5,12 @@ import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
 // papaparse não tinha precedente de mock no projeto: handleFile faz
 // `(await import("papaparse")).default`, então mockamos o default export.
 const { parse } = vi.hoisted(() => ({ parse: vi.fn() }));
-const { checkDuplicates, uploadDocuments } = vi.hoisted(() => ({
-  checkDuplicates: vi.fn(),
-  uploadDocuments: vi.fn(),
-}));
+const { checkDuplicates, uploadDocuments, revalidateProjectDocuments } =
+  vi.hoisted(() => ({
+    checkDuplicates: vi.fn(),
+    uploadDocuments: vi.fn(),
+    revalidateProjectDocuments: vi.fn(async () => {}),
+  }));
 const { toastSuccess, toastError, toastWarning } = vi.hoisted(() => ({
   toastSuccess: vi.fn(),
   toastError: vi.fn(),
@@ -16,7 +18,11 @@ const { toastSuccess, toastError, toastWarning } = vi.hoisted(() => ({
 }));
 
 vi.mock("papaparse", () => ({ default: { parse } }));
-vi.mock("@/actions/documents", () => ({ checkDuplicates, uploadDocuments }));
+vi.mock("@/actions/documents", () => ({
+  checkDuplicates,
+  uploadDocuments,
+  revalidateProjectDocuments,
+}));
 vi.mock("sonner", () => ({
   toast: { success: toastSuccess, error: toastError, warning: toastWarning },
 }));
@@ -146,5 +152,167 @@ describe("useDocumentUpload — contagem do toast de sucesso", () => {
     // 0 importados, 1 ignorado — não pode afirmar "1 documentos importados!".
     expect(msg).toContain("ignorado");
     expect(msg).toMatch(/0 documento/);
+  });
+
+  it("agrega count quando 2+ chunks entram (todos com sucesso)", async () => {
+    // 501 docs → 2 chunks (teto de 500); ambos entram. totalInserted = 500 + 1.
+    const rows = Array.from({ length: 501 }, (_, i) => ({ text_col: `linha ${i}` }));
+    checkDuplicates.mockResolvedValue({ duplicates: [], duplicatesWithResponses: 0 });
+    uploadDocuments
+      .mockResolvedValueOnce({ count: 500 })
+      .mockResolvedValueOnce({ count: 1 });
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    feedCsv(rows, ["text_col"]);
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+    act(() =>
+      result.current.setMapping({ text: "text_col", title: "", external_id: "" })
+    );
+
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+
+    expect(uploadDocuments).toHaveBeenCalledTimes(2);
+    // A soma entre chunks (não só o último) chega ao toast de sucesso.
+    expect(toastSuccess).toHaveBeenCalledWith(expect.stringContaining("501"));
+    expect(result.current.phase.kind).toBe("idle");
+  });
+});
+
+describe("useDocumentUpload — falha parcial multi-chunk revalida cache", () => {
+  it("revalida e reporta o parcial quando um chunk falha após outros entrarem", async () => {
+    // 501 docs → 2 chunks; o 2º falha. O 1º (500) já entrou: revalida para que
+    // apareçam, e reporta o parcial (só o último chunk revalidaria no servidor).
+    const rows = Array.from({ length: 501 }, (_, i) => ({ text_col: `linha ${i}` }));
+    checkDuplicates.mockResolvedValue({ duplicates: [], duplicatesWithResponses: 0 });
+    uploadDocuments
+      .mockResolvedValueOnce({ count: 500 })
+      .mockResolvedValueOnce({ error: "boom" });
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    feedCsv(rows, ["text_col"]);
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+    act(() =>
+      result.current.setMapping({ text: "text_col", title: "", external_id: "" })
+    );
+
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+
+    expect(uploadDocuments).toHaveBeenCalledTimes(2);
+    expect(revalidateProjectDocuments).toHaveBeenCalledWith("p1");
+    expect(toastError).toHaveBeenCalledWith(expect.stringContaining("500"));
+    expect(result.current.phase.kind).toBe("mapping");
+  });
+
+  it("não revalida quando a falha ocorre no primeiro chunk (nada inserido)", async () => {
+    checkDuplicates.mockResolvedValue({ duplicates: [], duplicatesWithResponses: 0 });
+    uploadDocuments.mockResolvedValue({ error: "boom" });
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    await primeMapping(result);
+
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+
+    expect(revalidateProjectDocuments).not.toHaveBeenCalled();
+    expect(result.current.phase.kind).toBe("mapping");
+  });
+
+  it("revalidação que REJEITA no catch não trava a UI em 'uploading'", async () => {
+    // Parcial → catch → revalida. Se a Server Action rejeitar (falha de
+    // transporte), o setPhase(returnTo) ainda precisa rodar: UI volta a 'mapping'.
+    const rows = Array.from({ length: 501 }, (_, i) => ({ text_col: `linha ${i}` }));
+    checkDuplicates.mockResolvedValue({ duplicates: [], duplicatesWithResponses: 0 });
+    uploadDocuments
+      .mockResolvedValueOnce({ count: 500 })
+      .mockResolvedValueOnce({ error: "boom" });
+    revalidateProjectDocuments.mockRejectedValueOnce(new Error("revalidate down"));
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    feedCsv(rows, ["text_col"]);
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+    act(() =>
+      result.current.setMapping({ text: "text_col", title: "", external_id: "" })
+    );
+
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+
+    expect(revalidateProjectDocuments).toHaveBeenCalledWith("p1");
+    // Crítico: não preso em 'uploading'/loading apesar da revalidação ter falhado.
+    expect(result.current.phase.kind).toBe("mapping");
+    expect(result.current.loading).toBe(false);
+  });
+});
+
+describe("useDocumentUpload — replace destrutivo falhando", () => {
+  it("replace_and_add+deleteResponses falhando revalida e avisa da remoção", async () => {
+    // Deletes/resets do replace podem já ter ocorrido mesmo sem inserção: mesmo
+    // com totalInserted===0, revalida e avisa (não "nada aconteceu").
+    checkDuplicates.mockResolvedValue({
+      duplicates: [{ csvIndex: 0, existingDocId: "d1", matchType: "external_id" }],
+      duplicatesWithResponses: 1,
+    });
+    uploadDocuments.mockResolvedValue({ error: "boom" });
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    await primeMapping(result);
+    await act(async () => {
+      await result.current.handleCheckAndUpload();
+    });
+    expect(result.current.phase.kind).toBe("analysis");
+
+    act(() => result.current.handleReplaceAndImport(true));
+
+    await waitFor(() =>
+      expect(revalidateProjectDocuments).toHaveBeenCalledWith("p1")
+    );
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(expect.stringContaining("removidas"))
+    );
+    await waitFor(() => expect(result.current.phase.kind).toBe("analysis"));
+  });
+});
+
+describe("useDocumentUpload — erros de parsing do CSV", () => {
+  it("erro fatal do Papa.parse aborta em 'idle' com toast contendo a causa", async () => {
+    parse.mockImplementation(
+      (_file: unknown, opts: { error: (e: Error) => void }) => {
+        opts.error(new Error("arquivo corrompido"));
+      }
+    );
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("arquivo corrompido")
+    );
+    expect(result.current.phase.kind).toBe("idle");
+  });
+
+  it("avisos de parsing (results.errors) seguem para 'mapping' reportando a contagem", async () => {
+    feedCsv([{ text_col: "ok" }], ["text_col"], [{ type: "Quotes" }]);
+
+    const { result } = renderHook(() => useDocumentUpload("p1"));
+    await act(async () => {
+      await result.current.handleFile(new File(["x"], "t.csv"));
+    });
+
+    expect(toastWarning).toHaveBeenCalledWith(expect.stringContaining("1"));
+    expect(result.current.phase.kind).toBe("mapping");
   });
 });

--- a/frontend/src/hooks/useDocumentUpload.ts
+++ b/frontend/src/hooks/useDocumentUpload.ts
@@ -5,11 +5,13 @@ import { toast } from "sonner";
 import {
   uploadDocuments,
   checkDuplicates,
+  revalidateProjectDocuments,
   type DuplicateMatch,
   type UploadDoc,
   type UploadOptions,
 } from "@/actions/documents";
 import { md5 } from "@/lib/hash";
+import { errorMessage } from "@/lib/utils";
 import {
   MAX_CHUNK_BYTES,
   MAX_HASH_CHECK_CONCURRENCY,
@@ -71,11 +73,26 @@ export function useDocumentUpload(projectId: string) {
     Papa.parse(file, {
       header: true,
       complete: (results) => {
+        // PapaParse é tolerante: popula `errors` em problemas recuperáveis
+        // (aspas, contagem de campos) mas ainda devolve linhas. Avisa e segue —
+        // linhas parciais costumam ser mapeáveis.
+        if (results.errors?.length) {
+          console.warn("[useDocumentUpload] Papa.parse avisos", results.errors);
+          toast.warning(
+            `CSV lido com ${results.errors.length} aviso(s) de parsing; confira as linhas afetadas.`
+          );
+        }
         const rows = results.data as Record<string, string>[];
         const columns = results.meta.fields || [];
         setCsv({ rows, columns });
         setMapping({ text: "", title: "", external_id: "" });
         setPhase({ kind: "mapping" });
+      },
+      // Erro fatal de leitura/parsing: aborta sem sair de `idle` (a dropzone
+      // continua visível para nova tentativa).
+      error: (err) => {
+        console.error("[useDocumentUpload] Papa.parse falhou", err);
+        toast.error(`Não foi possível ler o CSV: ${err.message}`);
       },
     });
   }, []);
@@ -96,14 +113,19 @@ export function useDocumentUpload(projectId: string) {
   const doUpload = async (
     docs: UploadDoc[],
     returnTo: UploadPhase,
-    options?: UploadOptions
+    options?: UploadOptions,
+    // Bytes UTF-8 por doc já medidos pelo chamador (handleCheckAndUpload mede uma
+    // vez no check de oversize); repassados a chunkByBytes para não re-encodar.
+    sizes?: number[]
   ) => {
     setPhase({ kind: "uploading", current: 0, total: docs.length });
 
+    // Hoisted out of the try so the catch can revalidate/report based on how many
+    // docs landed before a failure (count-based, como o caminho de sucesso).
+    let processed = 0;
+    let totalInserted = 0;
     try {
-      const chunks = chunkByBytes(docs);
-      let processed = 0;
-      let totalInserted = 0;
+      const chunks = chunkByBytes(docs, sizes);
       for (let ci = 0; ci < chunks.length; ci++) {
         const { items, startIndex } = chunks[ci];
         const endIndex = startIndex + items.length;
@@ -141,20 +163,61 @@ export function useDocumentUpload(projectId: string) {
         setPhase({ kind: "uploading", current: processed, total: docs.length });
       }
       const skipped = docs.length - totalInserted;
+      // Verbo ciente do modo: em replace_and_add, `count` conta duplicatas
+      // ATUALIZADAS (não inseridas), então "importados" sozinho superconta.
+      const savedVerb =
+        options?.mode === "replace_and_add"
+          ? "importado(s)/atualizado(s)"
+          : "importado(s)";
+      const allVerb =
+        options?.mode === "replace_and_add"
+          ? "importados/atualizados"
+          : "importados";
       toast.success(
         skipped > 0
-          ? `${totalInserted} documento(s) importado(s); ${skipped} ignorado(s) (já existiam no projeto ou repetidos no arquivo).`
-          : `${docs.length} documentos importados!`
+          ? `${totalInserted} documento(s) ${savedVerb}; ${skipped} ignorado(s) (já existiam no projeto ou repetidos no arquivo).`
+          : `${docs.length} documentos ${allVerb}!`
       );
       setCsv(null);
       setPhase({ kind: "idle" });
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "";
-      toast.error(
-        isPayloadTooLarge(msg)
-          ? PAYLOAD_TOO_LARGE_MESSAGE
-          : msg || "Erro ao importar documentos"
-      );
+      console.error("[useDocumentUpload] doUpload falhou", e);
+      const msg = errorMessage(e);
+      const destructiveReplace =
+        options?.mode === "replace_and_add" && !!options?.deleteResponses;
+      // Revalida sempre que o banco pode ter mudado: algo entrou (totalInserted > 0)
+      // ou um replace destrutivo já pode ter apagado responses/reviews mesmo sem
+      // inserção. Guarda: revalidateProjectDocuments é Server Action e pode rejeitar
+      // no transporte — sem o try, setPhase(returnTo) abaixo não rodaria (UI presa).
+      if (totalInserted > 0 || destructiveReplace) {
+        try {
+          await revalidateProjectDocuments(projectId);
+        } catch (revalErr) {
+          console.error("[useDocumentUpload] revalidate no catch falhou", revalErr);
+        }
+      }
+      if (totalInserted > 0) {
+        // Chunks 0..N-1 já foram commitados; só o último chunk revalidaria.
+        const importedVerb =
+          options?.mode === "replace_and_add"
+            ? "importados/atualizados"
+            : "importados";
+        toast.error(
+          isPayloadTooLarge(msg)
+            ? `${totalInserted}/${docs.length} ${importedVerb}. ${PAYLOAD_TOO_LARGE_MESSAGE}`
+            : `${totalInserted} de ${docs.length} documentos ${importedVerb} antes de uma falha${msg ? `: ${msg}` : ""}`
+        );
+      } else if (destructiveReplace) {
+        toast.error(
+          `A importação falhou, mas respostas/revisões dos documentos duplicados podem já ter sido removidas. Confira a lista.${msg ? ` (${msg})` : ""}`
+        );
+      } else {
+        toast.error(
+          isPayloadTooLarge(msg)
+            ? PAYLOAD_TOO_LARGE_MESSAGE
+            : msg || "Erro ao importar documentos"
+        );
+      }
       setPhase(returnTo);
     }
   };
@@ -166,10 +229,14 @@ export function useDocumentUpload(projectId: string) {
       return;
     }
 
+    // Mede os bytes UTF-8 uma única vez: reusado no check de oversize e repassado
+    // a chunkByBytes (via doUpload) para não re-encodar todo o array.
+    const sizes = docs.map((d) => utf8Bytes(d.text));
+
     // Fail early if a single doc exceeds the per-chunk byte budget — chunking can't rescue it.
-    const oversizeIdx = docs.findIndex((d) => utf8Bytes(d.text) > MAX_CHUNK_BYTES);
+    const oversizeIdx = sizes.findIndex((b) => b > MAX_CHUNK_BYTES);
     if (oversizeIdx !== -1) {
-      const sizeMb = (utf8Bytes(docs[oversizeIdx].text) / 1_000_000).toFixed(2);
+      const sizeMb = (sizes[oversizeIdx] / 1_000_000).toFixed(2);
       const limitMb = (MAX_CHUNK_BYTES / 1_000_000).toFixed(1);
       toast.error(
         `Documento na linha ${oversizeIdx + 1} tem ${sizeMb} MB, acima do limite de ${limitMb} MB por documento. Remova-o ou divida o texto antes de importar.`
@@ -209,7 +276,7 @@ export function useDocumentUpload(projectId: string) {
 
       if (allDuplicates.length === 0) {
         // No duplicates — upload directly; a failure returns to mapping.
-        await doUpload(docs, { kind: "mapping" });
+        await doUpload(docs, { kind: "mapping" }, undefined, sizes);
       } else {
         // Has duplicates — show analysis panel.
         const hasExternalIdMatch = allDuplicates.some(
@@ -226,7 +293,8 @@ export function useDocumentUpload(projectId: string) {
         });
       }
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "";
+      console.error("[useDocumentUpload] handleCheckAndUpload falhou", e);
+      const msg = errorMessage(e);
       toast.error(
         isPayloadTooLarge(msg)
           ? PAYLOAD_TOO_LARGE_MESSAGE

--- a/frontend/src/hooks/useDocumentUpload.ts
+++ b/frontend/src/hooks/useDocumentUpload.ts
@@ -202,10 +202,18 @@ export function useDocumentUpload(projectId: string) {
           options?.mode === "replace_and_add"
             ? "importados/atualizados"
             : "importados";
+        // Num replace destrutivo multi-chunk, este ramo (totalInserted > 0) e o
+        // ramo `else if (destructiveReplace)` não são exclusivos: um chunk
+        // anterior pode ter inserido enquanto o que falhou já apagou
+        // responses/reviews. O aviso de remoção precisa ser anexado aqui também,
+        // senão ficaria inalcançável justamente no cenário com perda de dados.
+        const destructiveWarn = destructiveReplace
+          ? " Respostas/revisões de documentos duplicados podem já ter sido removidas — confira a lista."
+          : "";
         toast.error(
           isPayloadTooLarge(msg)
-            ? `${totalInserted}/${docs.length} ${importedVerb}. ${PAYLOAD_TOO_LARGE_MESSAGE}`
-            : `${totalInserted} de ${docs.length} documentos ${importedVerb} antes de uma falha${msg ? `: ${msg}` : ""}`
+            ? `${totalInserted}/${docs.length} ${importedVerb}. ${PAYLOAD_TOO_LARGE_MESSAGE}${destructiveWarn}`
+            : `${totalInserted} de ${docs.length} documentos ${importedVerb} antes de uma falha${msg ? `: ${msg}` : ""}${destructiveWarn}`
         );
       } else if (destructiveReplace) {
         toast.error(

--- a/frontend/src/lib/upload-chunking.ts
+++ b/frontend/src/lib/upload-chunking.ts
@@ -21,15 +21,19 @@ export function isPayloadTooLarge(msg: string): boolean {
 // Generic over `{ text: string }` so the lib stays decoupled from UploadDoc.
 // `startIndex` is the position of each chunk's first item in the original
 // array — the caller uses it to re-base per-chunk indices (e.g. duplicateMap).
+// `sizes` (opcional) são os bytes UTF-8 por doc já medidos pelo chamador (o hook
+// mede uma vez para o check de oversize); evita re-encodar todo o array aqui.
+// Sem `sizes`, encoda sob demanda — mantém a API pura testável isoladamente.
 export function chunkByBytes<T extends { text: string }>(
-  docs: T[]
+  docs: T[],
+  sizes?: number[]
 ): { items: T[]; startIndex: number }[] {
   const chunks: { items: T[]; startIndex: number }[] = [];
   let current: T[] = [];
   let currentBytes = 0;
   let startIndex = 0;
   for (let i = 0; i < docs.length; i++) {
-    const itemBytes = utf8Bytes(docs[i].text);
+    const itemBytes = sizes ? sizes[i] : utf8Bytes(docs[i].text);
     if (
       current.length > 0 &&
       (currentBytes + itemBytes > MAX_CHUNK_BYTES ||

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,12 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+// Extrai a message de um erro desconhecido (Error ou string); "" caso contrário.
+// Fonte única compartilhada pelo hook de upload e pelas actions de schema.
+export function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : typeof e === "string" ? e : "";
+}
+
 // Normalizacao agressiva para comparar respostas de texto livre que sao
 // "iguais" para um humano mas diferem em bytes: acentos decompostos
 // (NFD vs NFC, comum em texto colado de PDF), maiusculas e espacos internos


### PR DESCRIPTION
## Contexto

O PR #279 (hardening do import de CSV) foi fechado **sem merge**: era um PR empilhado sobre a branch do #264 e, quando o #264 foi squash-mergeado e sua branch deletada, o #279 ficou órfão e o GitHub o auto-fechou. O trabalho dele nunca chegou à `main`.

Ao resgatar, descobri que a `main` **evoluiu o upload por outra via** (via #264/#263): já tem contagem por `count`, `mapWithConcurrency` (concorrência limitada no check de duplicatas) e `getDocumentText` com `maybeSingle`+error handling. Um rebase mecânico da linha do #279 brigaria com essa evolução paralela e poderia **perder melhorias da main**.

Por isso este PR foi **reconciliado**: parte da `main` atual e re-aplica só os deltas que faltavam, preservando o que a `main` já tinha de bom. O diff é limpo (7 arquivos) e o merge não tem conflito.

## O que foi re-aplicado (faltava na main)

**Correção**
- `checkDuplicates` propaga erro de cada query (external_id, hash, responses) em vez de engolir — antes um erro transitório virava "0 duplicatas".
- `revalidateProjectDocuments` como helper **best-effort** (try/catch interno) e incluindo a tag de progresso (a main revalidava só `documents` no upload); uma falha de revalidação não vira erro da action nem trava a UI.
- `doUpload`: recovery de **falha parcial** multi-chunk — revalida quando algo entrou (ou houve replace destrutivo), com **guarda** para o `setPhase(returnTo)` sempre rodar mesmo se a revalidação rejeitar; reporta o parcial real e avisa quando responses/reviews podem ter sido removidas.
- `replace_and_add`: deletes de reviews/responses e reset de assignments passam a **checar erro (fail-loud)** — antes silenciosos. Sequência segue não-atômica; atomicidade fica para o RPC (#284).
- `handleFile`: trata avisos e erro fatal do PapaParse.
- Verbo do toast ciente do modo ("importados/atualizados" em replace).

**Limpeza**
- `chunkByBytes` aceita `sizes` pré-medidos (mede uma vez no check de oversize).
- `errorMessage` unificado em `@/lib/utils` (schema.ts larga a cópia divergente).
- `exclude/restore/hardDelete` + os 3 sites de `uploadDocuments` chamam o helper de revalidação.

## Preservado da main (não perdido)

`getDocumentText` com `maybeSingle`+error handling (#263), `mapWithConcurrency` e a contagem por `count` (#264), e os testes de contagem já existentes.

## Verificação

- `npx tsc --noEmit` limpo
- `npx vitest run` — **722 testes passam**
- `npm run react-doctor:diff` — 100/100
- `git merge-tree origin/main HEAD` — merge limpo, sem conflito
- _Obs.: `npm run lint` está crashando neste worktree por um skew de versão do ESLint no `node_modules` (efeito do bump do dependabot #285); reproduz em arquivos não tocados (ex.: `DocumentUpload.tsx`). É ambiental, não deste PR — roda no checkout principal._

Refs #284, #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)