### PR TITLE
fix(coding): reconcilia condicionais órfãs na leitura + robustece scroll [follow-up #252]

### DIFF
--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -6,6 +6,8 @@ import { revalidatePath, revalidateTag } from "next/cache";
 
 const TAG_PROFILE = Object.freeze({ expire: 300 });
 import { createHash } from "crypto";
+import { dropHiddenConditionals } from "@/lib/conditional";
+import type { PydanticField } from "@/lib/types";
 
 export interface DocumentRow {
   external_id?: string;
@@ -458,7 +460,16 @@ export async function getDocumentForCoding(
         clean[field.name] = val;
       }
     }
-    return { document: doc, existingAnswers: clean, existingJustifications: (response?.justifications as Record<string, unknown>) ?? null };
+    // Remove condicionais órfãs (cuja condição não é satisfeita pelo próprio
+    // `clean`) — espelha a sanitização de escrita do `saveResponse` na fronteira
+    // de leitura, para um documento orfanado por mudança de schema pós-codificação
+    // não reaparecer pré-preenchido no editor (ver #252). Avalia sobre o conjunto
+    // COMPLETO de campos, pois uma condição pode referenciar qualquer campo.
+    const existingAnswers = dropHiddenConditionals(
+      project.pydantic_fields as PydanticField[],
+      clean,
+    );
+    return { document: doc, existingAnswers, existingJustifications: (response?.justifications as Record<string, unknown>) ?? null };
   }
 
   return { document: doc, existingAnswers: rawAnswers, existingJustifications: (response?.justifications as Record<string, unknown>) ?? null };

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -3,7 +3,7 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getEffectiveMemberId } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
-import { isFieldVisible } from "@/lib/conditional";
+import { dropHiddenConditionals } from "@/lib/conditional";
 import { isCodingComplete } from "@/lib/coding-completeness";
 import { createAutoReviewIfDiverges } from "@/lib/auto-review";
 import { createAutoComparisonIfDiverges } from "@/lib/auto-comparison";
@@ -77,13 +77,9 @@ export async function saveResponse(
 
     // Drop values of fields whose visibility condition is not satisfied —
     // prevents orphaned answers from earlier trigger values ending up in the
-    // persisted payload.
-    const sanitizedAnswers: Record<string, unknown> = { ...answers };
-    for (const f of fields) {
-      if (f.condition && !isFieldVisible(f, sanitizedAnswers)) {
-        delete sanitizedAnswers[f.name];
-      }
-    }
+    // persisted payload. Ponto-fixo compartilhado com o clean de leitura
+    // (getDocumentForCoding / code/page.tsx) — ver #252.
+    const sanitizedAnswers = dropHiddenConditionals(fields, answers);
 
     const roundIdToPersist =
       project?.round_strategy === "manual"

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -3,6 +3,7 @@ import { createSupabaseServer } from "@/lib/supabase/server";
 import { getAuthUser, getEffectiveMemberId } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { CodingPage } from "@/components/coding/CodingPage";
+import { dropHiddenConditionals } from "@/lib/conditional";
 import type {
   Document,
   Assignment,
@@ -184,7 +185,8 @@ export default async function CodePage({
     );
   });
 
-  const fields = ((project?.pydantic_fields || []) as PydanticField[]).filter(
+  const allFields = (project?.pydantic_fields || []) as PydanticField[];
+  const fields = allFields.filter(
     (f) => f.target !== "llm_only" && f.target !== "none",
   );
   const fieldOptionSet = new Map<string, Set<string>>();
@@ -214,7 +216,11 @@ export default async function CodePage({
         clean[field.name] = val;
       }
     }
-    existingAnswers[d.id] = clean;
+    // Remove condicionais órfãs na fronteira de leitura — mesma primitiva do
+    // saveResponse; evita que um documento orfanado por mudança de schema
+    // pós-codificação reapareça pré-preenchido no editor (ver #252). Conjunto
+    // COMPLETO de campos: uma condição pode referenciar qualquer campo.
+    existingAnswers[d.id] = dropHiddenConditionals(allFields, clean);
     if (r.justifications) {
       existingJustifications[d.id] = r.justifications;
     }

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -140,13 +140,16 @@ function SortableQuestion({
 export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false, onReorder }: QuestionsPanelProps) {
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
-  // Rastreia quais campos estavam visíveis no render anterior para detectar
-  // condicionais que acabaram de aparecer. Lazy-init (null → semeado abaixo)
-  // para não realocar um Set a cada render.
+  // Conjunto de nomes visíveis no render anterior — detecta condicionais que
+  // acabaram de aparecer. `null` até o 1º effect (semeado lá dentro, nunca no
+  // corpo do render — escrita de ref durante o render não é concurrent-safe).
   const prevVisibleNamesRef = useRef<Set<string> | null>(null);
-  // Guarda a prop `fields` do render anterior. Troca de schema/reorder também
-  // muda `visibleNames`, mas não deve disparar scroll — só resposta do usuário.
-  const prevFieldsRef = useRef(fields);
+  // Assinatura order-independent do conjunto de TODOS os campos. Só muda quando
+  // um campo é adicionado/removido (mudança de schema). Reorder e o load
+  // assíncrono de `fieldOrder` reordenam mas não mudam o conjunto, então não
+  // suprimem um scroll legítimo (ver #252); a comparação por identidade da prop
+  // `fields` suprimia-os por engano.
+  const prevAllNamesKeyRef = useRef<string | null>(null);
 
   const visibleFields = useMemo(
     () =>
@@ -159,12 +162,10 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     () => new Set(visibleFields.map((f) => f.name)),
     [visibleFields],
   );
-
-  // Semeia o set anterior com o atual no 1º render: no mount `prev === current`,
-  // logo nenhuma condicional conta como "recém-visível" e não há scroll.
-  if (prevVisibleNamesRef.current === null) {
-    prevVisibleNamesRef.current = visibleNames;
-  }
+  const allNamesKey = useMemo(
+    () => fields.map((f) => f.name).sort().join(","),
+    [fields],
+  );
 
   // A limpeza de respostas órfãs de condicionais que ficaram invisíveis vive no
   // pai (`CodingPage`), aplicada no updater de `answers` ao mudar uma resposta
@@ -175,12 +176,16 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
   // pergunta fora da viewport. Detecta o campo condicional que passou de
   // invisível para visível e rola suavemente até ele.
   useEffect(() => {
-    const prev = prevVisibleNamesRef.current ?? new Set<string>();
+    const firstRun = prevVisibleNamesRef.current === null;
+    const prev = prevVisibleNamesRef.current ?? visibleNames;
     prevVisibleNamesRef.current = visibleNames;
-    const fieldsChanged = prevFieldsRef.current !== fields;
-    prevFieldsRef.current = fields;
+    const structuralChange =
+      prevAllNamesKeyRef.current !== null &&
+      prevAllNamesKeyRef.current !== allNamesKey;
+    prevAllNamesKeyRef.current = allNamesKey;
 
-    if (fieldsChanged) return; // troca de schema/reorder, não resposta do usuário
+    if (firstRun) return; // mount: semeia os refs e não rola
+    if (structuralChange) return; // add/remove de campo (schema), não resposta
     if (readOnly) return;
 
     const newIdx = visibleFields.findIndex(

--- a/frontend/src/lib/__tests__/conditional.test.ts
+++ b/frontend/src/lib/__tests__/conditional.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { clearHiddenConditionalAnswers } from "@/lib/conditional";
+import {
+  clearHiddenConditionalAnswers,
+  dropHiddenConditionals,
+} from "@/lib/conditional";
 import type { PydanticField } from "@/lib/types";
 
 // Helper: monta um PydanticField com defaults mínimos.
@@ -208,5 +211,53 @@ describe("clearHiddenConditionalAnswers", () => {
     const result = clearHiddenConditionalAnswers(fields, { x: "1", y: "2" });
     expect(result.x).toBeNull();
     expect(result.y).toBe("2");
+  });
+});
+
+// Variante de fronteira (leitura/escrita persistida): mesma lógica de ponto-fixo
+// que `clearHiddenConditionalAnswers`, mas OMITE a chave em vez de setá-la `null`
+// — alinhada à sanitização do `saveResponse`. Ver #252.
+describe("dropHiddenConditionals", () => {
+  it("omite (delete) a chave de uma condicional que ficou invisível", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const result = dropHiddenConditionals(fields, { q1: "não", q2: "a" });
+    expect("q2" in result).toBe(false); // chave ausente, não null
+    expect(result.q1).toBe("não");
+  });
+
+  it("preserva a condicional ainda visível (identidade quando nada muda)", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const answers = { q1: "sim", q2: "a" };
+    const result = dropHiddenConditionals(fields, answers);
+    expect(result).toBe(answers); // mesma referência
+    expect(result.q2).toBe("a");
+  });
+
+  it("aplica ponto-fixo em cascata, omitindo as chaves", () => {
+    const fields = [
+      field({ name: "a" }),
+      field({ name: "b", condition: { field: "a", equals: "sim" } }),
+      field({ name: "c", condition: { field: "b", equals: "sim" } }),
+    ];
+    const result = dropHiddenConditionals(fields, { a: "não", b: "sim", c: "x" });
+    expect("b" in result).toBe(false);
+    expect("c" in result).toBe(false);
+    expect(result.a).toBe("não");
+  });
+
+  it("não muta o objeto de entrada", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const answers = { q1: "não", q2: "a" };
+    dropHiddenConditionals(fields, answers);
+    expect(answers.q2).toBe("a"); // entrada intacta
   });
 });

--- a/frontend/src/lib/__tests__/conditional.test.ts
+++ b/frontend/src/lib/__tests__/conditional.test.ts
@@ -260,4 +260,47 @@ describe("dropHiddenConditionals", () => {
     dropHiddenConditionals(fields, answers);
     expect(answers.q2).toBe("a"); // entrada intacta
   });
+
+  // Paridade com o `delete` incondicional do `saveResponse` antigo: uma chave de
+  // condicional oculta deve ser omitida mesmo quando o valor é vazio (`null`/`""`),
+  // senão chaves órfãs vazias sobrevivem no payload persistido / no pré-preenchimento.
+  it("omite a chave de uma condicional oculta com valor vazio (string vazia)", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const result = dropHiddenConditionals(fields, { q1: "não", q2: "" });
+    expect("q2" in result).toBe(false);
+    expect(result.q1).toBe("não");
+  });
+
+  it("omite a chave de uma condicional oculta com valor null", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const result = dropHiddenConditionals(fields, { q1: "não", q2: null });
+    expect("q2" in result).toBe(false);
+  });
+
+  it("preserva a chave vazia de uma condicional ainda VISÍVEL", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    // q2 visível (gatilho satisfeito) mas ainda não respondido (""): a chave fica.
+    const result = dropHiddenConditionals(fields, { q1: "sim", q2: "" });
+    expect("q2" in result).toBe(true);
+    expect(result.q2).toBe("");
+  });
+
+  it("não omite condicional cuja chave está ausente do objeto", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    const answers = { q1: "não" }; // q2 nunca respondido
+    const result = dropHiddenConditionals(fields, answers);
+    expect(result).toBe(answers); // nada a omitir → mesma referência
+  });
 });

--- a/frontend/src/lib/conditional.ts
+++ b/frontend/src/lib/conditional.ts
@@ -71,30 +71,69 @@ export function isFieldVisible(
   return evaluateCondition(field.condition, answers);
 }
 
-// Zera as respostas de campos condicionais que não estão mais visíveis. Aplica
-// ponto-fixo: limpar uma condicional pode esconder outra que dependia dela. Não
-// muta a entrada — clona apenas na primeira mudança real (copy-on-write) e
-// retorna o MESMO objeto quando nada muda, preservando a identidade referencial
-// que o React usa para evitar re-renders.
-export function clearHiddenConditionalAnswers(
+// Núcleo compartilhado: nomes de campos condicionais que estão ocultos E têm
+// valor não-vazio, calculados em ponto-fixo (limpar uma condicional pode
+// esconder outra que dependia dela). Trabalha sobre uma view copy-on-write
+// (clona só na primeira limpeza), marcando cada órfão como `null` para
+// reavaliar a visibilidade em cascata — `null` e chave ausente são
+// equivalentes para `isFieldVisible`, então o resultado independe de a fronteira
+// querer zerar ou omitir. Cada campo é zerado no máximo uma vez (um valor já
+// `null` falha o guard), o que garante terminação em ≤N passes. Não muta a
+// entrada.
+function hiddenConditionalNames(
   fields: PydanticField[],
   answers: Record<string, unknown>,
-): Record<string, unknown> {
-  let next = answers;
+): Set<string> {
+  const hidden = new Set<string>();
+  let view = answers;
   let changed = true;
   while (changed) {
     changed = false;
     for (const f of fields) {
       if (!f.condition) continue;
-      if (isFieldVisible(f, next)) continue;
-      const v = next[f.name];
+      if (hidden.has(f.name)) continue;
+      if (isFieldVisible(f, view)) continue;
+      const v = view[f.name];
       if (v !== undefined && v !== null && v !== "") {
-        if (next === answers) next = { ...answers };
-        next[f.name] = null;
+        if (view === answers) view = { ...answers };
+        view[f.name] = null;
+        hidden.add(f.name);
         changed = true;
       }
     }
   }
+  return hidden;
+}
+
+// Cliente (estado vivo de codificação): zera as respostas de condicionais
+// ocultas para `null`. Retorna o MESMO objeto quando nada muda, preservando a
+// identidade referencial que o React usa para evitar re-renders.
+export function clearHiddenConditionalAnswers(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+): Record<string, unknown> {
+  const hidden = hiddenConditionalNames(fields, answers);
+  if (hidden.size === 0) return answers;
+  const next = { ...answers };
+  for (const name of hidden) next[name] = null;
+  return next;
+}
+
+// Fronteira (leitura/escrita de respostas persistidas): OMITE as chaves de
+// condicionais ocultas — mesma semântica de `delete` que o `saveResponse` usa.
+// Centraliza a invariante "respostas não contêm valor de condicional oculta"
+// numa primitiva só, aplicada tanto no clean de leitura quanto na sanitização
+// de escrita (ver #252). Avaliar visibilidade sobre o conjunto COMPLETO de
+// campos (não filtrado por `target`), pois uma condição pode referenciar
+// qualquer campo. Retorna o MESMO objeto quando nada muda.
+export function dropHiddenConditionals(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+): Record<string, unknown> {
+  const hidden = hiddenConditionalNames(fields, answers);
+  if (hidden.size === 0) return answers;
+  const next = { ...answers };
+  for (const name of hidden) delete next[name];
   return next;
 }
 

--- a/frontend/src/lib/conditional.ts
+++ b/frontend/src/lib/conditional.ts
@@ -71,69 +71,83 @@ export function isFieldVisible(
   return evaluateCondition(field.condition, answers);
 }
 
-// Núcleo compartilhado: nomes de campos condicionais que estão ocultos E têm
-// valor não-vazio, calculados em ponto-fixo (limpar uma condicional pode
-// esconder outra que dependia dela). Trabalha sobre uma view copy-on-write
-// (clona só na primeira limpeza), marcando cada órfão como `null` para
-// reavaliar a visibilidade em cascata — `null` e chave ausente são
-// equivalentes para `isFieldVisible`, então o resultado independe de a fronteira
-// querer zerar ou omitir. Cada campo é zerado no máximo uma vez (um valor já
-// `null` falha o guard), o que garante terminação em ≤N passes. Não muta a
-// entrada.
-function hiddenConditionalNames(
+// Núcleo compartilhado do ponto-fixo: limpar uma condicional pode esconder
+// outra que dependia dela, então iteramos até estabilizar. Trabalha sobre uma
+// view copy-on-write (clona só na primeira limpeza), marcando cada órfão com
+// valor SIGNIFICATIVO como `null` para reavaliar a visibilidade em cascata —
+// `null` e chave ausente são equivalentes para `isFieldVisible`. O guard de
+// valor não-vazio é essencial para a cascata: zerar um `""`/`null` não muda a
+// visibilidade downstream (inclusive para `exists`), e limitar a limpeza a
+// valores significativos garante terminação em ≤N passes (cada campo entra em
+// `cleared` no máximo uma vez). Não muta a entrada. Retorna a `view` resolvida
+// (com os órfãos significativos zerados) e o conjunto `cleared` de nomes que
+// foram efetivamente zerados.
+function resolveHiddenConditionals(
   fields: PydanticField[],
   answers: Record<string, unknown>,
-): Set<string> {
-  const hidden = new Set<string>();
+): { view: Record<string, unknown>; cleared: Set<string> } {
+  const cleared = new Set<string>();
   let view = answers;
   let changed = true;
   while (changed) {
     changed = false;
     for (const f of fields) {
       if (!f.condition) continue;
-      if (hidden.has(f.name)) continue;
+      if (cleared.has(f.name)) continue;
       if (isFieldVisible(f, view)) continue;
       const v = view[f.name];
       if (v !== undefined && v !== null && v !== "") {
         if (view === answers) view = { ...answers };
         view[f.name] = null;
-        hidden.add(f.name);
+        cleared.add(f.name);
         changed = true;
       }
     }
   }
-  return hidden;
+  return { view, cleared };
 }
 
 // Cliente (estado vivo de codificação): zera as respostas de condicionais
-// ocultas para `null`. Retorna o MESMO objeto quando nada muda, preservando a
-// identidade referencial que o React usa para evitar re-renders.
+// ocultas para `null`. Só toca campos com valor significativo (o conjunto
+// `cleared` do ponto-fixo), então retorna o MESMO objeto quando nada muda,
+// preservando a identidade referencial que o React usa para evitar re-renders.
 export function clearHiddenConditionalAnswers(
   fields: PydanticField[],
   answers: Record<string, unknown>,
 ): Record<string, unknown> {
-  const hidden = hiddenConditionalNames(fields, answers);
-  if (hidden.size === 0) return answers;
+  const { cleared } = resolveHiddenConditionals(fields, answers);
+  if (cleared.size === 0) return answers;
   const next = { ...answers };
-  for (const name of hidden) next[name] = null;
+  for (const name of cleared) next[name] = null;
   return next;
 }
 
-// Fronteira (leitura/escrita de respostas persistidas): OMITE as chaves de
-// condicionais ocultas — mesma semântica de `delete` que o `saveResponse` usa.
-// Centraliza a invariante "respostas não contêm valor de condicional oculta"
-// numa primitiva só, aplicada tanto no clean de leitura quanto na sanitização
-// de escrita (ver #252). Avaliar visibilidade sobre o conjunto COMPLETO de
-// campos (não filtrado por `target`), pois uma condição pode referenciar
-// qualquer campo. Retorna o MESMO objeto quando nada muda.
+// Fronteira (leitura/escrita de respostas persistidas): OMITE a chave de TODA
+// condicional finalmente oculta — inclusive valores vazios (`null`/`""`) —, o
+// que reproduz exatamente o `delete` incondicional que o `saveResponse` fazia
+// antes do refactor e garante a invariante "respostas não contêm chave de
+// condicional oculta". Centraliza essa invariante numa primitiva só, aplicada
+// tanto no clean de leitura quanto na sanitização de escrita (ver #252).
+// Avaliar visibilidade sobre o conjunto COMPLETO de campos (não filtrado por
+// `target`), pois uma condição pode referenciar qualquer campo. Retorna o
+// MESMO objeto quando nada há a omitir.
 export function dropHiddenConditionals(
   fields: PydanticField[],
   answers: Record<string, unknown>,
 ): Record<string, unknown> {
-  const hidden = hiddenConditionalNames(fields, answers);
-  if (hidden.size === 0) return answers;
+  const { view } = resolveHiddenConditionals(fields, answers);
+  // Reavalia sobre a view resolvida do ponto-fixo: uma chave presente cujo
+  // campo condicional segue oculto é órfã, independente de o valor ser vazio.
+  const orphans: string[] = [];
+  for (const f of fields) {
+    if (!f.condition) continue;
+    if (!(f.name in answers)) continue;
+    if (isFieldVisible(f, view)) continue;
+    orphans.push(f.name);
+  }
+  if (orphans.length === 0) return answers;
   const next = { ...answers };
-  for (const name of hidden) delete next[name];
+  for (const name of orphans) delete next[name];
   return next;
 }
 


### PR DESCRIPTION
Follow-up da revisão profunda do #273. Endereça os achados de comportamento e os itens de polish que ficaram fora daquele PR (que era escopo "react-doctor, comportamento preservado").

## Contexto

A revisão apontou que remover a reconciliação de órfãos no mount do `QuestionsPanel` não é um no-op quando uma **condição é adicionada/alterada no schema após a codificação**: o clean de load (`getDocumentForCoding` e `analyze/code/page.tsx`) sanitizava só por **opções**, sem `isFieldVisible`, então um valor de condicional órfão sobrevivia no estado vivo e reaparecia pré-preenchido ao re-disparar a condição (e podia ser re-salvo enviesado). Persistência (`saveResponse`) e comparação (`compare-divergence`) já estavam protegidas — o furo era a fronteira de leitura.

## Mudanças

**#1 + #5 (fronteira de leitura + altitude).** Extrai em `lib/conditional.ts` o núcleo de ponto-fixo compartilhado (`hiddenConditionalNames`, copy-on-write) e exponho duas variantes:
- `clearHiddenConditionalAnswers` (cliente, seta `null` — comportamento vivo, intacto);
- `dropHiddenConditionals` (fronteira, **omite a chave** — igual ao `saveResponse`).

Aplico `dropHiddenConditionals` nas duas fronteiras de leitura (avaliando sobre o `pydantic_fields` **completo**, pois uma condição pode referenciar qualquer campo) e refatoro `saveResponse` para reusar a mesma primitiva. A invariante "respostas não contêm valor de condicional oculta" passa a viver num lugar só, aplicada na leitura e na escrita.

**#3 (scroll).** Troco o guard de supressão por identidade da prop `fields` por uma assinatura order-independent do conjunto de nomes (`allNamesKey`). Reorder e o load assíncrono de `fieldOrder` reordenam mas não mudam o conjunto, então não suprimem mais um scroll legítimo; só add/remove de campo (schema) suprime.

**#4 (concurrent-safety).** Removo a escrita de ref durante o render (o seed de `prevVisibleNamesRef`); passa a semear dentro do effect no 1º run.

## Testes

- `clearHiddenConditionalAnswers`: +9 casos cobrindo `not_equals`/`in`/`not_in`/`exists`, o flip não-monotônico do `exists`, campo aninhado, cascata mista e terminação (entraram no #273 e já estão em main).
- `dropHiddenConditionals`: +4 casos (omite chave, preserva visível, cascata, não muta).

## Verificação

- `tsc --noEmit` limpo; `eslint` e `lint:types` sem novos problemas nos arquivos tocados (débito de `lint:types` é pré-existente/grandfathered).
- Vitest: suíte completa verde (708).
- react-doctor (`--scope changed --base origin/main --blocking error`): sem diagnóstico; `QuestionsPanel` segue 0.

Repro manual do #1: codificar um doc com um campo sem condição respondido → adicionar ao schema uma condição que o esconda → reabrir (assigned e browse) e, ao re-disparar a condição, o campo aparece **em branco** (não pré-preenchido com o valor stale).