### PR TITLE
feat(compare): botão "Nenhuma correta" + resposta nova [#247]

### DIFF
--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { ProgressDots } from "../coding/ProgressDots";
 import { AgreementGroup, type FieldEquivalencePair } from "./AgreementGroup";
 import { MultiOptionReview } from "./MultiOptionReview";
+import { CustomAnswerInput } from "./CustomAnswerInput";
 import { KeyboardHints } from "./KeyboardHints";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -238,6 +239,16 @@ export function ComparisonPanel({
                 >
                   [S] Pular
                 </Button>
+                {/*
+                  "Nenhuma correta" + input de resposta nova (issue #247, ponto
+                  4). Keyed por doc|campo: navegar remonta e reseta o estado
+                  interno (aberto/valor) sem reset-em-effect — react-doctor só
+                  aceita key={identidade} para reset-on-prop-change.
+                */}
+                <CustomAnswerInput
+                  key={`${documentId}|${fieldName}`}
+                  onSubmit={(value) => onVerdict(value)}
+                />
               </div>
             )}
 

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -244,9 +244,23 @@ export function ComparisonPanel({
                   4). Keyed por doc|campo: navegar remonta e reseta o estado
                   interno (aberto/valor) sem reset-em-effect — react-doctor só
                   aceita key={identidade} para reset-on-prop-change.
+
+                  currentValue: no bloco !isMulti, um veredito de texto sem
+                  chosenResponseId que não seja marcador especial é, por
+                  construção, uma resposta custom (voto sempre carrega
+                  chosenResponseId). Passá-lo destaca o botão e re-semeia o
+                  input ao revisitar o campo — paridade com Ambíguo/Pular.
                 */}
                 <CustomAnswerInput
                   key={`${documentId}|${fieldName}`}
+                  currentValue={
+                    existingVerdict &&
+                    existingVerdict.verdict !== "ambiguo" &&
+                    existingVerdict.verdict !== "pular" &&
+                    !existingVerdict.chosenResponseId
+                      ? existingVerdict.verdict
+                      : null
+                  }
                   onSubmit={(value) => onVerdict(value)}
                 />
               </div>

--- a/frontend/src/components/compare/CustomAnswerInput.tsx
+++ b/frontend/src/components/compare/CustomAnswerInput.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface CustomAnswerInputProps {
+  // Chamado com o valor digitado quando o revisor confirma a resposta nova.
+  // O pai grava como verdict SEM chosenResponseId — nenhuma resposta existente
+  // é o gabarito.
+  onSubmit: (value: string) => void;
+}
+
+// "Nenhuma correta" (issue #247, ponto 4): quando todas as respostas dos
+// codificadores/LLM estão erradas (ex.: o robô inventou uma data que não existe
+// na nota técnica), o revisor digita o valor correto.
+//
+// O estado (aberto + valor) vive aqui, e o pai remonta este componente via
+// key={doc|campo}: navegar reseta o estado sozinho, sem reset-em-effect — o
+// react-doctor só aceita key={identidade} para reset-on-prop-change.
+export function CustomAnswerInput({ onSubmit }: CustomAnswerInputProps) {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+
+  const submit = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSubmit(trimmed);
+    setOpen(false);
+    setValue("");
+  };
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className={cn(open && "border-brand bg-brand/10 text-brand")}
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+      >
+        Nenhuma correta
+      </Button>
+      {open && (
+        <div className="mt-1 flex basis-full items-center gap-2 rounded-md border border-brand/30 bg-brand/5 px-2.5 py-2">
+          <Input
+            autoFocus
+            placeholder="Resposta correta…"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                submit();
+              }
+            }}
+            className="min-w-[180px] flex-1 text-sm"
+          />
+          <Button size="sm" disabled={!value.trim()} onClick={submit}>
+            Confirmar resposta nova
+          </Button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/compare/CustomAnswerInput.tsx
+++ b/frontend/src/components/compare/CustomAnswerInput.tsx
@@ -10,6 +10,10 @@ interface CustomAnswerInputProps {
   // O pai grava como verdict SEM chosenResponseId — nenhuma resposta existente
   // é o gabarito.
   onSubmit: (value: string) => void;
+  // Veredito de "resposta nova" já salvo para este doc|campo (ou null). Quando
+  // presente, o botão fica destacado e o input reabre pré-preenchido — paridade
+  // com Ambíguo/Pular, que refletem o veredito atual ao revisitar o campo.
+  currentValue?: string | null;
 }
 
 // "Nenhuma correta" (issue #247, ponto 4): quando todas as respostas dos
@@ -18,17 +22,25 @@ interface CustomAnswerInputProps {
 //
 // O estado (aberto + valor) vive aqui, e o pai remonta este componente via
 // key={doc|campo}: navegar reseta o estado sozinho, sem reset-em-effect — o
-// react-doctor só aceita key={identidade} para reset-on-prop-change.
-export function CustomAnswerInput({ onSubmit }: CustomAnswerInputProps) {
+// react-doctor só aceita key={identidade} para reset-on-prop-change. A
+// remontagem também re-semeia `value` a partir de `currentValue`, então o
+// veredito salvo reaparece ao voltar ao campo sem precisar de useEffect.
+export function CustomAnswerInput({
+  onSubmit,
+  currentValue = null,
+}: CustomAnswerInputProps) {
   const [open, setOpen] = useState(false);
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState(currentValue ?? "");
+  const isActive = currentValue != null;
 
   const submit = () => {
     const trimmed = value.trim();
     if (!trimmed) return;
     onSubmit(trimmed);
     setOpen(false);
-    setValue("");
+    // Mantém o valor confirmado (não limpa): reabrir o input no mesmo campo
+    // mostra a resposta recém-salva, consistente com o destaque do botão.
+    setValue(trimmed);
   };
 
   return (
@@ -36,7 +48,7 @@ export function CustomAnswerInput({ onSubmit }: CustomAnswerInputProps) {
       <Button
         variant="outline"
         size="sm"
-        className={cn(open && "border-brand bg-brand/10 text-brand")}
+        className={cn((open || isActive) && "border-brand bg-brand/10 text-brand")}
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
       >

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Filhos que tocam Server Actions / dialogs ficam fora do escopo: este teste
+// cobre só o fluxo de "resposta nova" (issue #247, ponto 4).
+vi.mock("@/components/shared/AddNoteButton", () => ({
+  AddNoteButton: () => <button type="button">Anotar</button>,
+}));
+vi.mock("@/components/stats/SuggestFieldDialog", () => ({
+  SuggestFieldDialog: () => null,
+}));
+
+import { ComparisonPanel } from "@/components/compare/ComparisonPanel";
+import type { PydanticField } from "@/lib/types";
+
+afterEach(cleanup);
+
+const FIELD: PydanticField = {
+  name: "data_parecer",
+  type: "date",
+  description: "Data do parecer",
+} as PydanticField;
+
+function renderPanel(
+  props: Partial<Parameters<typeof ComparisonPanel>[0]> = {},
+) {
+  const onVerdict = vi.fn();
+  render(
+    <ComparisonPanel
+      projectId="p1"
+      documentId="d1"
+      documentTitle="Nota técnica 1"
+      fieldName="data_parecer"
+      fieldDescription="Data do parecer"
+      fieldType="date"
+      fieldOptions={null}
+      fields={[FIELD]}
+      fieldIndex={0}
+      totalFields={1}
+      responses={[
+        {
+          id: "r-llm",
+          respondent_type: "llm",
+          respondent_name: "Robô",
+          answer: "2021-05-10",
+          is_latest: true,
+          isFieldStale: false,
+        },
+      ]}
+      existingVerdict={null}
+      reviewed={[false]}
+      isDivergent={true}
+      isDocComplete={false}
+      hasNextDoc={false}
+      onNextDoc={vi.fn()}
+      onFieldNavigate={vi.fn()}
+      onVerdict={onVerdict}
+      onMarkReviewed={vi.fn()}
+      comment=""
+      onCommentChange={vi.fn()}
+      commentCount={0}
+      suggestionCount={0}
+      allowEquivalence={false}
+      equivalences={[]}
+      onConfirmEquivalent={vi.fn(async () => {})}
+      onUnmarkEquivalencePair={vi.fn(async () => {})}
+      currentUserId="u1"
+      canManageAnyPair={false}
+      {...props}
+    />,
+  );
+  return { onVerdict };
+}
+
+describe("ComparisonPanel — resposta nova (issue #247, ponto 4)", () => {
+  it("o input de resposta nova fica oculto até clicar em 'Nenhuma correta'", () => {
+    renderPanel();
+    expect(screen.queryByPlaceholderText("Resposta correta…")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: /nenhuma correta/i }),
+    ).toBeTruthy();
+  });
+
+  it("confirma o valor digitado como verdict SEM chosenResponseId", async () => {
+    const user = userEvent.setup();
+    const { onVerdict } = renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /nenhuma correta/i }));
+    const input = screen.getByPlaceholderText("Resposta correta…");
+    await user.type(input, "sem data no parecer");
+    await user.click(
+      screen.getByRole("button", { name: /confirmar resposta nova/i }),
+    );
+
+    expect(onVerdict).toHaveBeenCalledTimes(1);
+    // 2º argumento (chosenResponseId) ausente: nenhuma resposta existente é o
+    // gabarito — é um valor novo do revisor.
+    expect(onVerdict).toHaveBeenCalledWith("sem data no parecer");
+    expect(onVerdict.mock.calls[0][1]).toBeUndefined();
+  });
+
+  it("Enter no input também confirma; valor em branco não dispara", async () => {
+    const user = userEvent.setup();
+    const { onVerdict } = renderPanel();
+
+    await user.click(screen.getByRole("button", { name: /nenhuma correta/i }));
+    const input = screen.getByPlaceholderText("Resposta correta…");
+
+    // só espaços → não confirma
+    await user.type(input, "   {Enter}");
+    expect(onVerdict).not.toHaveBeenCalled();
+
+    await user.clear(input);
+    await user.type(input, "8 meses{Enter}");
+    expect(onVerdict).toHaveBeenCalledWith("8 meses");
+  });
+});

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
@@ -116,4 +116,54 @@ describe("ComparisonPanel — resposta nova (issue #247, ponto 4)", () => {
     await user.type(input, "8 meses{Enter}");
     expect(onVerdict).toHaveBeenCalledWith("8 meses");
   });
+
+  it("ao revisitar um campo com resposta nova salva, o botão fica destacado e reabre pré-preenchido", async () => {
+    const user = userEvent.setup();
+    // Veredito custom: texto livre SEM chosenResponseId e que não é marcador.
+    renderPanel({
+      existingVerdict: {
+        verdict: "sem data no parecer",
+        chosenResponseId: null,
+        comment: null,
+      },
+    });
+
+    const button = screen.getByRole("button", { name: /nenhuma correta/i });
+    // Destaque de estado ativo, paridade com Ambíguo/Pular.
+    expect(button.className).toContain("border-brand");
+
+    // Reabre já preenchido com o valor salvo (sem precisar redigitar).
+    await user.click(button);
+    const input = screen.getByPlaceholderText(
+      "Resposta correta…",
+    ) as HTMLInputElement;
+    expect(input.value).toBe("sem data no parecer");
+  });
+
+  it("não destaca o botão quando o veredito é um voto (tem chosenResponseId)", () => {
+    // Voto numa resposta existente: verdict de texto, mas com chosenResponseId.
+    renderPanel({
+      existingVerdict: {
+        verdict: "2021-05-10",
+        chosenResponseId: "r-llm",
+        comment: null,
+      },
+    });
+    expect(
+      screen.getByRole("button", { name: /nenhuma correta/i }).className,
+    ).not.toContain("border-brand");
+  });
+
+  it("não destaca o botão quando o veredito é um marcador especial (ambiguo)", () => {
+    renderPanel({
+      existingVerdict: {
+        verdict: "ambiguo",
+        chosenResponseId: null,
+        comment: null,
+      },
+    });
+    expect(
+      screen.getByRole("button", { name: /nenhuma correta/i }).className,
+    ).not.toContain("border-brand");
+  });
 });


### PR DESCRIPTION
## Contexto

Parte da issue #247 (ponto 4). Quando **todas** as respostas dos codificadores/LLM estão erradas — o exemplo da issue é o robô inventar uma data que não existe na nota técnica — o revisor não tinha como registrar o valor correto. As opções eram só votar num grupo existente, marcar **Ambíguo** ou **Pular**.

## Mudança

Novo botão **"Nenhuma correta"** ao lado de Ambíguo/Pular (campos `single`/`text`/`date`). Ao clicar, revela um campo de texto; o valor digitado é salvo como verdict **sem** `chosenResponseId` — nenhuma resposta existente vira gabarito. `submitVerdict` já suportava `chosenResponseId` opcional, então não há mudança de schema nem de Server Action.

Multi (verdict é JSON de opções) fica de fora nesta iteração.

### Nota de implementação

O controle vive num subcomponente `CustomAnswerInput` keyed por `doc|campo`: a navegação remonta e reseta o estado interno (aberto/valor) sem `useEffect` de reset — o padrão que o react-doctor exige para reset-on-prop-change (ver memória do projeto). Como efeito colateral, `ComparisonPanel` encolheu abaixo do limiar de "componente longo".

## Testes

- `ComparisonPanel.customAnswer.test.tsx` (novo): input oculto até clicar; confirma valor digitado chamando `onVerdict(valor)` sem `chosenResponseId`; Enter confirma; valor em branco não dispara.
- Suíte `components/compare` — 26 passam.
- `react-doctor --diff` — "No issues found".

Parte de #247 (demais pontos em PRs separados).