### PR TITLE
feat(compare): botão "Todas são similares" (texto livre, 1 clique) [#247]

### DIFF
--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -186,6 +186,25 @@ export function AgreementGroup({
     });
   }
 
+  // "Todas são similares" (issue #247, ponto 5): funde TODOS os grupos de uma
+  // vez, em vez de o revisor marcar par a par. O gabarito é o maior grupo —
+  // `groups` já vem ordenado desc por nº de respostas, então `groups[0]` é a
+  // resposta mais comum. Quem quiser outro gabarito usa o fluxo manual de
+  // seleção abaixo.
+  function handleConfirmAll() {
+    if (!onConfirmEquivalent) return;
+    if (groups.length < 2) return;
+    const gabaritoGroup = groups[0];
+    const gabaritoResponseId = gabaritoGroup.responses[0].id;
+    const responseIds = groups.map((g) => g.responses[0].id);
+    const verdictDisplay = gabaritoGroup.displayAnswer;
+    startTransition(async () => {
+      await onConfirmEquivalent(responseIds, gabaritoResponseId, verdictDisplay);
+      setSelectionOrder([]);
+      setGabaritoOverride(null);
+    });
+  }
+
   function handleUnmark(pairId: string) {
     if (!onUnmarkPair) return;
     startTransition(async () => {
@@ -208,12 +227,23 @@ export function AgreementGroup({
     <TooltipProvider delayDuration={200}>
       <div className="space-y-1.5">
         {allowEquivalence && groups.length > 1 && (
-          <div className="rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1.5 text-[11px] leading-tight text-muted-foreground">
-            <p>
+          <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1.5 text-[11px] leading-tight text-muted-foreground">
+            <p className="min-w-0 flex-1">
               <Link2 className="mr-1 inline size-3" />
               Texto livre: marque os cards equivalentes e indique qual fica
               como <strong>gabarito</strong> (a resposta que será registrada).
             </p>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-7 shrink-0 gap-1"
+              disabled={isSubmitting}
+              onClick={handleConfirmAll}
+              title="Funde todas as respostas como equivalentes; a mais comum vira o gabarito"
+            >
+              <Link2 className="size-3.5" />
+              Todas são similares
+            </Button>
           </div>
         )}
 

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -187,13 +187,27 @@ export function AgreementGroup({
   }
 
   // "Todas são similares" (issue #247, ponto 5): funde TODOS os grupos de uma
-  // vez, em vez de o revisor marcar par a par. O gabarito é o maior grupo —
-  // `groups` já vem ordenado desc por nº de respostas, então `groups[0]` é a
-  // resposta mais comum. Quem quiser outro gabarito usa o fluxo manual de
-  // seleção abaixo.
+  // vez, em vez de o revisor marcar par a par. `groups` já vem ordenado desc
+  // por nº de respostas, então `groups[0]` é a resposta mais comum.
+  //
+  // Só funde em 1 clique quando há maioria CLARA — `groups[0]` tem
+  // estritamente mais respostas que o segundo grupo, logo o gabarito é
+  // inequívoco. Quando há empate no topo (ex.: divergências 1×1 como
+  // "8 meses" vs "0 ano e 08 meses"), não existe "resposta mais comum": eleger
+  // `groups[0]` seria escolher o gabarito pela ordem do array, sem o revisor
+  // ver nem poder corrigir. Nesse caso pré-selecionamos todos os grupos e
+  // caímos no fluxo de confirmação manual abaixo, onde o gabarito fica visível
+  // e pode ser sobrescrito antes de aplicar.
   function handleConfirmAll() {
     if (!onConfirmEquivalent) return;
     if (groups.length < 2) return;
+    const hasClearMajority =
+      groups[0].responses.length > groups[1].responses.length;
+    if (!hasClearMajority) {
+      setSelectionOrder(groups.map((g) => g.groupKey));
+      setGabaritoOverride(null);
+      return;
+    }
     const gabaritoGroup = groups[0];
     const gabaritoResponseId = gabaritoGroup.responses[0].id;
     const responseIds = groups.map((g) => g.responses[0].id);
@@ -239,7 +253,7 @@ export function AgreementGroup({
               className="h-7 shrink-0 gap-1"
               disabled={isSubmitting}
               onClick={handleConfirmAll}
-              title="Funde todas as respostas como equivalentes; a mais comum vira o gabarito"
+              title="Funde todas as respostas como equivalentes; a mais comum vira o gabarito. Em caso de empate, você confirma o gabarito antes de aplicar."
             >
               <Link2 className="size-3.5" />
               Todas são similares

--- a/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
+++ b/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AgreementGroup } from "@/components/compare/AgreementGroup";
+
+afterEach(cleanup);
+
+type Resp = Parameters<typeof AgreementGroup>[0]["responses"][number];
+
+function resp(over: Partial<Resp> & { id: string; answer: unknown }): Resp {
+  return {
+    respondent_type: "humano",
+    respondent_name: "Anon",
+    is_latest: true,
+    isFieldStale: false,
+    ...over,
+  } as Resp;
+}
+
+function renderGroup(
+  props: Partial<Parameters<typeof AgreementGroup>[0]> = {},
+) {
+  const onConfirmEquivalent =
+    vi.fn<
+      (
+        responseIds: string[],
+        gabaritoId: string,
+        verdictDisplay: string,
+      ) => Promise<void>
+    >(async () => {});
+  const onVote = vi.fn();
+  render(
+    <AgreementGroup
+      responses={[
+        resp({ id: "ni-1", respondent_name: "Ana", answer: "NI" }),
+        resp({ id: "ni-2", respondent_name: "Bia", answer: "NI" }),
+        resp({ id: "na-1", respondent_name: "Caio", answer: "N/A" }),
+        resp({
+          id: "info-1",
+          respondent_name: "Dora",
+          answer: "não informado",
+        }),
+      ]}
+      existingVerdict={null}
+      onVote={onVote}
+      allowEquivalence={true}
+      equivalences={[]}
+      onConfirmEquivalent={onConfirmEquivalent}
+      onUnmarkPair={vi.fn(async () => {})}
+      currentUserId="u1"
+      canManageAnyPair={false}
+      {...props}
+    />,
+  );
+  return { onConfirmEquivalent, onVote };
+}
+
+describe("AgreementGroup — 'Todas são similares' (issue #247, ponto 5)", () => {
+  it("funde todos os grupos num clique; o maior grupo (NI) vira gabarito", async () => {
+    const user = userEvent.setup();
+    const { onConfirmEquivalent } = renderGroup();
+
+    await user.click(
+      screen.getByRole("button", { name: /todas são similares/i }),
+    );
+
+    await waitFor(() => expect(onConfirmEquivalent).toHaveBeenCalledTimes(1));
+    const [responseIds, gabaritoId, verdictDisplay] =
+      onConfirmEquivalent.mock.calls[0];
+    // um representante por grupo distinto (NI, N/A, não informado)
+    expect(responseIds).toHaveLength(3);
+    // gabarito = primeiro do maior grupo (NI tem 2 respostas)
+    expect(gabaritoId).toBe("ni-1");
+    expect(verdictDisplay).toBe("NI");
+    expect(responseIds).toContain("ni-1");
+    expect(responseIds).toContain("na-1");
+    expect(responseIds).toContain("info-1");
+  });
+
+  it("não mostra o botão quando há um único grupo (nada a fundir)", () => {
+    renderGroup({
+      responses: [
+        resp({ id: "a", respondent_name: "Ana", answer: "NI" }),
+        resp({ id: "b", respondent_name: "Bia", answer: "NI" }),
+      ],
+    });
+    expect(
+      screen.queryByRole("button", { name: /todas são similares/i }),
+    ).toBeNull();
+  });
+
+  it("não mostra o botão quando allowEquivalence é falso (campo de opção)", () => {
+    renderGroup({ allowEquivalence: false });
+    expect(
+      screen.queryByRole("button", { name: /todas são similares/i }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
+++ b/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
@@ -79,6 +79,36 @@ describe("AgreementGroup — 'Todas são similares' (issue #247, ponto 5)", () =
     expect(responseIds).toContain("info-1");
   });
 
+  it("sem maioria clara (empate 1×1), não funde cego: abre a confirmação manual do gabarito", async () => {
+    const user = userEvent.setup();
+    const { onConfirmEquivalent } = renderGroup({
+      responses: [
+        resp({ id: "a", respondent_name: "Ana", answer: "NI" }),
+        resp({ id: "b", respondent_name: "Bia", answer: "8 meses" }),
+      ],
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /todas são similares/i }),
+    );
+
+    // Empate no topo: não pode registrar um gabarito arbitrário sem o revisor
+    // ver. Em vez de fundir, pré-seleciona tudo e mostra a barra de confirmação.
+    expect(onConfirmEquivalent).not.toHaveBeenCalled();
+    const confirmBtn = await screen.findByRole("button", {
+      name: /confirmar .*equivalentes/i,
+    });
+
+    // O revisor confirma (aceitando o gabarito default = primeiro grupo).
+    await user.click(confirmBtn);
+    await waitFor(() => expect(onConfirmEquivalent).toHaveBeenCalledTimes(1));
+    const [responseIds, gabaritoId] = onConfirmEquivalent.mock.calls[0];
+    expect(responseIds).toHaveLength(2);
+    expect(responseIds).toContain("a");
+    expect(responseIds).toContain("b");
+    expect(gabaritoId).toBe("a");
+  });
+
   it("não mostra o botão quando há um único grupo (nada a fundir)", () => {
     renderGroup({
       responses: [


### PR DESCRIPTION
## Contexto

Parte da issue #247 (ponto 5). Divergências triviais entre respostas de **texto livre** — NI vs "não informado" vs N/A, ou "0 ano e 08 meses" vs "8 meses" — exigiam que o revisor marcasse os cards equivalentes **par a par** antes de confirmar um gabarito.

## Mudança

Botão **"Todas são similares"** no cabeçalho da seção de equivalência: funde **todos** os grupos de uma vez. O gabarito é o maior grupo (a resposta mais comum — `groups` já vem ordenado desc por nº de respostas). Quem quiser outro gabarito segue usando a seleção manual existente.

Aparece só em campos de **texto livre** (`allowEquivalence`) com 2+ grupos distintos. Reaproveita `confirmEquivalentVerdict` — sem mudança de schema ou Server Action.

Equivalência em **campos de opção** (NI ≡ N/A em single/multi) é o ponto 5b, que vem em PR separado (mais invasivo).

## Testes

- `AgreementGroup.markAll.test.tsx` (novo): funde 3 grupos num clique com o maior (NI, 2 respostas) como gabarito; botão oculto com 1 grupo só; botão oculto quando `allowEquivalence` é falso.
- Suíte `components/compare` — 26 passam. `typecheck` e `react-doctor --diff` limpos.

Parte de #247.