### PR TITLE
feat(compare): sinaliza quem não preencheu o campo [#247]

### DIFF
--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -34,6 +34,7 @@ interface ComparisonResponse {
   id: string;
   respondent_type: "humano" | "llm";
   respondent_name: string;
+  respondent_id: string | null;
   answer: unknown;
   justification?: string;
   is_latest: boolean;
@@ -143,14 +144,36 @@ export function ComparisonPanel({
   // "Não preencheu este campo" (issue #247, ponto 3): respostas sem valor para
   // o campo atual ficam fora dos cards (que só mostram quem respondeu), o que
   // fazia parecer que "só o robô respondeu". Listamos quem deixou o campo em
-  // branco para o revisor entender a ausência. Filtramos por `!isFieldStale`:
-  // assim só contam respondentes cujo schema TINHA este campo e ainda assim não
-  // o preencheram — não respondentes de um schema antigo onde o campo nem
-  // existia (esses são ruído de versão, não uma omissão real).
-  const unanswered = useMemo(
-    () => responses.filter((r) => r.answer === undefined && !r.isFieldStale),
-    [responses],
-  );
+  // branco para o revisor entender a ausência. Três filtros:
+  //  - `answer === undefined`: o campo está vazio (complementar ao `!== undefined`
+  //    que os cards/stats usam para contar quem respondeu);
+  //  - `!isFieldStale`: só contam respondentes cujo schema TINHA este campo e
+  //    ainda assim não o preencheram — não respondentes de um schema antigo onde
+  //    o campo nem existia (ruído de versão, não uma omissão real);
+  //  - `respondent_type === "humano"`: a issue é sobre humanos sumindo da tela; um
+  //    LLM pode omitir um campo legitimamente (ex.: condicional não satisfeita),
+  //    então "Robô não preencheu" seria ruído.
+  // Deduplicamos por `respondent_id ?? id` — mesma chave que a contagem da página
+  // (page.tsx) — para que um respondente com duas respostas qualificadas em branco
+  // (dados legados / re-codificação) conte e apareça uma vez só, sem fundir
+  // anônimos distintos (respondent_id null cai no id, que é único por linha).
+  const unanswered = useMemo(() => {
+    const seen = new Set<string>();
+    const out: { name: string }[] = [];
+    for (const r of responses) {
+      if (
+        r.answer !== undefined ||
+        r.isFieldStale ||
+        r.respondent_type !== "humano"
+      )
+        continue;
+      const key = r.respondent_id ?? r.id;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      out.push({ name: r.respondent_name });
+    }
+    return out;
+  }, [responses]);
 
   return (
     <div className="flex h-full flex-col">
@@ -229,7 +252,7 @@ export function ComparisonPanel({
             {unanswered.length === 1
               ? "1 respondente não preencheu este campo"
               : `${unanswered.length} respondentes não preencheram este campo`}
-            : {unanswered.map((r) => r.respondent_name).join(", ")}
+            : {unanswered.map((r) => r.name).join(", ")}
           </div>
         )}
 

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -140,6 +140,18 @@ export function ComparisonPanel({
 
   const feedbackBadge = commentCount + suggestionCount;
 
+  // "Não preencheu este campo" (issue #247, ponto 3): respostas sem valor para
+  // o campo atual ficam fora dos cards (que só mostram quem respondeu), o que
+  // fazia parecer que "só o robô respondeu". Listamos quem deixou o campo em
+  // branco para o revisor entender a ausência. Filtramos por `!isFieldStale`:
+  // assim só contam respondentes cujo schema TINHA este campo e ainda assim não
+  // o preencheram — não respondentes de um schema antigo onde o campo nem
+  // existia (esses são ruído de versão, não uma omissão real).
+  const unanswered = useMemo(
+    () => responses.filter((r) => r.answer === undefined && !r.isFieldStale),
+    [responses],
+  );
+
   return (
     <div className="flex h-full flex-col">
       <div className="shrink-0 border-b px-4 py-1.5">
@@ -210,6 +222,15 @@ export function ComparisonPanel({
             currentUserId={currentUserId}
             canManageAnyPair={canManageAnyPair}
           />
+        )}
+
+        {unanswered.length > 0 && (
+          <div className="mt-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1.5 text-[11px] leading-tight text-muted-foreground">
+            {unanswered.length === 1
+              ? "1 respondente não preencheu este campo"
+              : `${unanswered.length} respondentes não preencheram este campo`}
+            : {unanswered.map((r) => r.respondent_name).join(", ")}
+          </div>
         )}
 
         {isDivergent ? (

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -60,6 +60,7 @@ function resp(
     id,
     respondent_type: type,
     respondent_name: name,
+    respondent_id: id,
     answers,
     justifications: null,
     is_latest: true,

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -153,6 +153,7 @@ function resp(
     id,
     respondent_type: type,
     respondent_name: name,
+    respondent_id: id,
     answers,
     justifications: null,
     is_latest: true,

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
@@ -63,6 +63,7 @@ function resp(over: Partial<Resp> & { id: string }): Resp {
   return {
     respondent_type: "humano",
     respondent_name: "Anon",
+    respondent_id: null,
     answer: undefined,
     is_latest: true,
     isFieldStale: false,
@@ -86,6 +87,24 @@ describe("ComparisonPanel — não preencheu este campo (issue #247, ponto 3)", 
       resp({ id: "bia", respondent_name: "Bia", answer: undefined, isFieldStale: true }),
     ]);
     expect(screen.queryByText(/não preencheu este campo/i)).toBeNull();
+  });
+
+  it("não lista LLM que deixou o campo em branco (a issue é sobre humanos)", () => {
+    renderPanel([
+      resp({ id: "robo", respondent_type: "llm", respondent_name: "Robô", answer: undefined }),
+      resp({ id: "ana", respondent_name: "Ana", answer: "2021-05-10" }),
+    ]);
+    expect(screen.queryByText(/não preencheu este campo/i)).toBeNull();
+  });
+
+  it("deduplica o mesmo respondente com duas respostas em branco (respondent_id)", () => {
+    renderPanel([
+      resp({ id: "llm", respondent_type: "llm", respondent_name: "Robô", answer: "2021-05-10" }),
+      resp({ id: "ana1", respondent_id: "ana", respondent_name: "Ana", answer: undefined }),
+      resp({ id: "ana2", respondent_id: "ana", respondent_name: "Ana", answer: undefined }),
+    ]);
+    expect(screen.getByText(/1 respondente não preencheu este campo/i)).toBeTruthy();
+    expect(screen.getByText(/: Ana$/)).toBeTruthy();
   });
 
   it("pluraliza quando dois ou mais deixaram em branco", () => {

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("@/components/shared/AddNoteButton", () => ({
+  AddNoteButton: () => <button type="button">Anotar</button>,
+}));
+vi.mock("@/components/stats/SuggestFieldDialog", () => ({
+  SuggestFieldDialog: () => null,
+}));
+
+import { ComparisonPanel } from "@/components/compare/ComparisonPanel";
+import type { PydanticField } from "@/lib/types";
+
+afterEach(cleanup);
+
+const FIELD: PydanticField = {
+  name: "data_parecer",
+  type: "date",
+  description: "Data do parecer",
+} as PydanticField;
+
+type Resp = Parameters<typeof ComparisonPanel>[0]["responses"][number];
+
+function renderPanel(responses: Resp[]) {
+  render(
+    <ComparisonPanel
+      projectId="p1"
+      documentId="d1"
+      documentTitle="Nota técnica 1"
+      fieldName="data_parecer"
+      fieldDescription="Data do parecer"
+      fieldType="date"
+      fieldOptions={null}
+      fields={[FIELD]}
+      fieldIndex={0}
+      totalFields={1}
+      responses={responses}
+      existingVerdict={null}
+      reviewed={[false]}
+      isDivergent={true}
+      isDocComplete={false}
+      hasNextDoc={false}
+      onNextDoc={vi.fn()}
+      onFieldNavigate={vi.fn()}
+      onVerdict={vi.fn()}
+      onMarkReviewed={vi.fn()}
+      comment=""
+      onCommentChange={vi.fn()}
+      commentCount={0}
+      suggestionCount={0}
+      allowEquivalence={false}
+      equivalences={[]}
+      onConfirmEquivalent={vi.fn(async () => {})}
+      onUnmarkEquivalencePair={vi.fn(async () => {})}
+      currentUserId="u1"
+      canManageAnyPair={false}
+    />,
+  );
+}
+
+function resp(over: Partial<Resp> & { id: string }): Resp {
+  return {
+    respondent_type: "humano",
+    respondent_name: "Anon",
+    answer: undefined,
+    is_latest: true,
+    isFieldStale: false,
+    ...over,
+  } as Resp;
+}
+
+describe("ComparisonPanel — não preencheu este campo (issue #247, ponto 3)", () => {
+  it("lista o humano que deixou o campo em branco quando só o robô respondeu", () => {
+    renderPanel([
+      resp({ id: "llm", respondent_type: "llm", respondent_name: "Robô", answer: "2021-05-10" }),
+      resp({ id: "ana", respondent_name: "Ana", answer: undefined }),
+    ]);
+    expect(screen.getByText(/1 respondente não preencheu este campo/i)).toBeTruthy();
+    expect(screen.getByText(/Ana/)).toBeTruthy();
+  });
+
+  it("não conta respondente cujo schema antigo nem tinha o campo (isFieldStale)", () => {
+    renderPanel([
+      resp({ id: "llm", respondent_type: "llm", respondent_name: "Robô", answer: "2021-05-10" }),
+      resp({ id: "bia", respondent_name: "Bia", answer: undefined, isFieldStale: true }),
+    ]);
+    expect(screen.queryByText(/não preencheu este campo/i)).toBeNull();
+  });
+
+  it("pluraliza quando dois ou mais deixaram em branco", () => {
+    renderPanel([
+      resp({ id: "llm", respondent_type: "llm", respondent_name: "Robô", answer: "2021-05-10" }),
+      resp({ id: "ana", respondent_name: "Ana", answer: undefined }),
+      resp({ id: "caio", respondent_name: "Caio", answer: undefined }),
+    ]);
+    expect(
+      screen.getByText(/2 respondentes não preencheram este campo/i),
+    ).toBeTruthy();
+  });
+
+  it("não mostra nada quando todos preencheram", () => {
+    renderPanel([
+      resp({ id: "llm", respondent_type: "llm", respondent_name: "Robô", answer: "2021-05-10" }),
+      resp({ id: "ana", respondent_name: "Ana", answer: "2021-05-11" }),
+    ]);
+    expect(screen.queryByText(/não preencheu este campo/i)).toBeNull();
+  });
+});

--- a/frontend/src/components/compare/compare-types.ts
+++ b/frontend/src/components/compare/compare-types.ts
@@ -13,6 +13,7 @@ export interface CompareResponse {
   id: string;
   respondent_type: "humano" | "llm";
   respondent_name: string;
+  respondent_id: string | null;
   answers: Record<string, unknown>;
   justifications: Record<string, string> | null;
   is_latest: boolean;
@@ -36,6 +37,7 @@ export interface FieldResponse {
   id: string;
   respondent_type: "humano" | "llm";
   respondent_name: string;
+  respondent_id: string | null;
   answer: unknown;
   justification: string | undefined;
   is_latest: boolean;

--- a/frontend/src/components/compare/useCompareFieldData.ts
+++ b/frontend/src/components/compare/useCompareFieldData.ts
@@ -74,6 +74,7 @@ export function useCompareFieldData({
       id: r.id,
       respondent_type: r.respondent_type,
       respondent_name: r.respondent_name,
+      respondent_id: r.respondent_id,
       answer: Object.prototype.hasOwnProperty.call(r.answers, currentFieldName)
         ? r.answers[currentFieldName]
         : undefined,


### PR DESCRIPTION
## Contexto

Parte da issue #247 (ponto 3): "em algumas notas técnicas só aparece a versão do robô e não a do humano". Os cards de resposta mostram só quem respondeu o campo. Quando um humano codificou o documento mas deixou **este** campo em branco, ele some da tela e parece que só o robô respondeu.

## Mudança

O painel passa a listar, abaixo dos cards, os respondentes que deixaram o campo em branco: _"N respondente(s) não preencheu(eram) este campo: <nomes>"_.

Filtra por `!isFieldStale`: conta só quem **tinha** o campo no schema e ainda assim não preencheu — não respondentes de um schema antigo onde o campo nem existia (ruído de versão). Zero plumbing: deriva de `responses`, que já inclui as respostas com `answer === undefined`.

### Fora de escopo

A outra causa possível do ponto 3 — respostas humanas **rebaixadas** (`is_latest=false`, ex.: resíduo do dedup pré-#259) que somem inteiras da fila — é investigação de dados e precisa de uma leitura autorizada da produção. Não coberta aqui; sigo precisando de OK para medir.

## Testes

- `ComparisonPanel.unanswered.test.tsx` (novo): lista o humano que deixou em branco quando só o robô respondeu; **não** conta `isFieldStale`; pluraliza; nada quando todos preencheram.
- Suíte `components/compare` — 27 passam. `typecheck` e `react-doctor --diff` limpos.

Parte de #247.