### PR TITLE
feat(compare): equivalência em campos single (NI ≡ N/A ≡ "não informado") [#247]

### DIFF
--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -211,8 +211,9 @@ export function AgreementGroup({
           <div className="rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1.5 text-[11px] leading-tight text-muted-foreground">
             <p>
               <Link2 className="mr-1 inline size-3" />
-              Texto livre: marque os cards equivalentes e indique qual fica
-              como <strong>gabarito</strong> (a resposta que será registrada).
+              Marque os cards equivalentes (ex.: NI ≡ N/A ≡ &ldquo;não
+              informado&rdquo;) e indique qual fica como{" "}
+              <strong>gabarito</strong> (a resposta que será registrada).
             </p>
           </div>
         )}

--- a/frontend/src/components/compare/useCompareFieldData.ts
+++ b/frontend/src/components/compare/useCompareFieldData.ts
@@ -2,7 +2,6 @@
 
 import { useMemo } from "react";
 import { normalizeForComparison } from "@/lib/utils";
-import { isFreeTextField } from "@/lib/compare-divergence";
 import { buildResponseGroupKeys } from "@/lib/equivalence";
 import type { PydanticField } from "@/lib/types";
 import type {
@@ -89,8 +88,13 @@ export function useCompareFieldData({
     return equivalencesByDocField[currentDoc.id]?.[currentFieldName] ?? [];
   }, [equivalencesByDocField, currentDoc, currentFieldName]);
 
+  // Equivalência (fundir respostas distintas como iguais) vale para qualquer
+  // campo NÃO-multi: texto, data e single (com ou sem opções). Todos renderizam
+  // via AgreementGroup, cujos cards são selecionáveis. multi usa MultiOptionReview
+  // (checkboxes), sem cards de equivalência. Antes restringia a free-text, o que
+  // deixava de fora single-com-opções (ex.: NI ≡ N/A ≡ "não informado") — #247.
   const allowEquivalence = useMemo(() => {
-    return !!currentField && isFreeTextField(currentField);
+    return !!currentField && currentField.type !== "multi";
   }, [currentField]);
 
   const answerGroups = useMemo(() => {

--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
   computeDivergentFieldNames,
-  isFreeTextField,
   isDocComplete,
   findNextPendingDocIndex,
   resolveCompareStatus,
@@ -19,37 +18,6 @@ function field(overrides: Partial<PydanticField>): PydanticField {
     ...overrides,
   };
 }
-
-describe("isFreeTextField", () => {
-  it("true for type=text", () => {
-    expect(isFreeTextField(field({ type: "text" }))).toBe(true);
-  });
-
-  it("true for type=date", () => {
-    expect(isFreeTextField(field({ type: "date" }))).toBe(true);
-  });
-
-  it("true for type=single without options", () => {
-    expect(isFreeTextField(field({ type: "single", options: null }))).toBe(
-      true,
-    );
-    expect(isFreeTextField(field({ type: "single", options: [] }))).toBe(true);
-  });
-
-  it("false for type=single with options", () => {
-    expect(
-      isFreeTextField(field({ type: "single", options: ["a", "b"] })),
-    ).toBe(false);
-  });
-
-  it("false for type=multi (always has options conceptually)", () => {
-    expect(isFreeTextField(field({ type: "multi", options: ["a"] }))).toBe(
-      false,
-    );
-    // Even multi with empty options is not "free text" for fusion purposes
-    expect(isFreeTextField(field({ type: "multi", options: [] }))).toBe(false);
-  });
-});
 
 describe("computeDivergentFieldNames", () => {
   it("skips fields with target llm_only / human_only / none", () => {

--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -124,6 +124,50 @@ describe("computeDivergentFieldNames", () => {
     ).toEqual(["a"]);
   });
 
+  it("single-com-opções: opções diferentes são divergentes sem pares", () => {
+    const fields = [
+      field({ name: "s", type: "single", options: ["NI", "N/A", "Sim"] }),
+    ];
+    const responses = [
+      { id: "1", answers: { s: "NI" } },
+      { id: "2", answers: { s: "N/A" } },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual(["s"]);
+  });
+
+  it("single-com-opções: par fundindo NI ≡ N/A remove a divergência (#247, ponto 5)", () => {
+    const fields = [
+      field({ name: "s", type: "single", options: ["NI", "N/A", "Sim"] }),
+    ];
+    const responses = [
+      { id: "1", answers: { s: "NI" } },
+      { id: "2", answers: { s: "N/A" } },
+    ];
+    const equivalencesByField = new Map<string, EquivalencePair[]>([
+      ["s", [{ response_a_id: "1", response_b_id: "2" }]],
+    ]);
+    expect(
+      computeDivergentFieldNames(fields, responses, equivalencesByField),
+    ).toEqual([]);
+  });
+
+  it("single-com-opções: par cobrindo só parte das opções deixa divergência", () => {
+    const fields = [
+      field({ name: "s", type: "single", options: ["NI", "N/A", "Sim"] }),
+    ];
+    const responses = [
+      { id: "1", answers: { s: "NI" } },
+      { id: "2", answers: { s: "N/A" } },
+      { id: "3", answers: { s: "Sim" } },
+    ];
+    const equivalencesByField = new Map<string, EquivalencePair[]>([
+      ["s", [{ response_a_id: "1", response_b_id: "2" }]],
+    ]);
+    expect(
+      computeDivergentFieldNames(fields, responses, equivalencesByField),
+    ).toEqual(["s"]);
+  });
+
   it("multi: differing selections are divergent", () => {
     const fields = [
       field({ name: "tags", type: "multi", options: ["x", "y", "z"] }),

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -3,16 +3,6 @@ import { isFieldVisible } from "@/lib/conditional";
 import { buildResponseGroupKeys, type EquivalencePair } from "@/lib/equivalence";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
-// A field is free-text when there is no fixed option set —
-// equivalence makes sense only here. Multi/single-with-options have
-// canonical answer keys already.
-export function isFreeTextField(field: PydanticField): boolean {
-  if (field.type === "text" || field.type === "date") return true;
-  if (field.type === "single" && (!field.options || field.options.length === 0))
-    return true;
-  return false;
-}
-
 interface ResponseLike {
   id: string;
   answers: Record<string, unknown> | null | undefined;

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -90,29 +90,24 @@ export function computeDivergentFieldNames(
       continue;
     }
 
-    // Scalar / free-text path. For free-text we run union-find over both
-    // explicit pairs and same-normalized-answer edges, so responses with
-    // identical text always land in the same group regardless of pairs.
-    if (isFreeTextField(field)) {
-      const pairs = equivalencesByField?.get(field.name) ?? [];
-      const items = applicable.map((r) => ({
-        id: r.id,
-        answer: (r.answers as Record<string, unknown>)?.[field.name],
-      }));
-      const groupKeys = buildResponseGroupKeys(items, pairs, (r) =>
-        normalizeForComparison(r.answer),
-      );
-      const keys = new Set<string>();
-      for (const r of applicable) keys.add(groupKeys.get(r.id) ?? r.id);
-      if (keys.size > 1) divergent.push(field.name);
-      continue;
-    }
-
+    // Non-multi path: free-text, date e single (com ou sem opções). Union-find
+    // sobre pares de equivalência explícitos + arestas de mesma-resposta-
+    // normalizada: respostas com a mesma resposta normalizada caem sempre no
+    // mesmo grupo, e o revisor pode fundir respostas distintas — ex.: NI ≡ N/A ≡
+    // "não informado" num single de opções (issue #247, ponto 5). Sem pares,
+    // é equivalente a agrupar por resposta normalizada (comportamento antigo do
+    // ramo scalar). multi tem seu próprio caminho (set de opções) acima, pois
+    // sua UI de revisão (MultiOptionReview) não tem cards de equivalência.
+    const pairs = equivalencesByField?.get(field.name) ?? [];
+    const items = applicable.map((r) => ({
+      id: r.id,
+      answer: (r.answers as Record<string, unknown>)?.[field.name],
+    }));
+    const groupKeys = buildResponseGroupKeys(items, pairs, (r) =>
+      normalizeForComparison(r.answer),
+    );
     const keys = new Set<string>();
-    for (const r of applicable) {
-      const raw = (r.answers as Record<string, unknown>)?.[field.name];
-      keys.add(normalizeForComparison(raw));
-    }
+    for (const r of applicable) keys.add(groupKeys.get(r.id) ?? r.id);
     if (keys.size > 1) divergent.push(field.name);
   }
 

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -4,7 +4,6 @@ import type { createSupabaseServer } from "@/lib/supabase/server";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import {
   computeDivergentFieldNames,
-  isFreeTextField,
   resolveCompareStatus,
 } from "@/lib/compare-divergence";
 import {
@@ -157,5 +156,3 @@ export async function syncCompareAssignment(
       .eq("id", assignment.id);
   }
 }
-
-export { isFreeTextField };


### PR DESCRIPTION
## Contexto

Parte da issue #247 (ponto 5b). Divergências triviais em campos de **opção** — NI vs N/A vs "não informado" num single-choice — não podiam ser marcadas como equivalentes. A fusão por equivalência só valia para texto livre, então essas divergências ficavam presas na fila.

## Mudança

- **`compare-divergence.ts`**: unifica o ramo free-text com o scalar (single-com-opções) num único caminho não-`multi` que usa `buildResponseGroupKeys` + equivalências. **Sem pares, é idêntico** ao agrupamento por resposta normalizada (comportamento antigo do ramo scalar preservado — todos os testes existentes passam). `multi` mantém o caminho próprio (set de opções), pois sua UI (`MultiOptionReview`) não tem cards de equivalência.
- **`useCompareFieldData.ts`**: `allowEquivalence` passa a valer para qualquer campo **não-multi** (single/text/date), não só free-text — todos renderizam via `AgreementGroup` com cards selecionáveis.
- **`compare-sync.ts`**: nenhuma mudança — já passa `equivalencesByField` a `computeDivergentFieldNames`, então a materialização do assignment acompanha sem drift (mesmo princípio do #168).
- Texto da dica generalizado (não é mais só "texto livre").

Combina com o botão "Todas são similares" (PR #290): em single-com-opções agora também aparece o fluxo de equivalência + o atalho de 1 clique.

## Testes

- `compare-divergence.test.ts`: single-com-opções divergente sem pares; par fundindo NI ≡ N/A zera a divergência; par parcial deixa divergência. Mais os 39 testes pré-existentes (free-text, multi, staleness) — todos verdes.
- Suítes divergence + equivalence + components/compare — 65 passam. `typecheck` e `react-doctor --diff` limpos.

Parte de #247. ⚠️ Toca a detecção de divergência (núcleo da fila) — revisar com atenção, embora o comportamento sem pares seja comprovadamente idêntico.