### PR TITLE
fix(actions): atomicidade transacional via RPC no sorteio e no upload (#181, #284)

### DIFF
--- a/frontend/src/actions/__tests__/documents.test.ts
+++ b/frontend/src/actions/__tests__/documents.test.ts
@@ -9,12 +9,16 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 // consome o 1o item.
 import {
   makeSupabaseMock,
+  type TableResult,
   type TableResults,
   type WriteCall,
+  type RpcCall,
 } from "./supabase-mock";
 
 let writeCalls: WriteCall[];
+let rpcCalls: RpcCall[];
 let serverTableResults: TableResults | undefined;
+let serverRpcResults: Record<string, TableResult> | undefined;
 
 vi.mock("next/cache", () => ({
   revalidatePath: () => {},
@@ -26,12 +30,19 @@ vi.mock("@/lib/auth", () => ({
 }));
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServer: async () =>
-    makeSupabaseMock({ tableResults: serverTableResults, writeCalls }),
+    makeSupabaseMock({
+      tableResults: serverTableResults,
+      writeCalls,
+      rpcCalls,
+      rpcResults: serverRpcResults,
+    }),
 }));
 
 beforeEach(() => {
   writeCalls = [];
+  rpcCalls = [];
   serverTableResults = undefined;
+  serverRpcResults = undefined;
 });
 
 async function loadUpload() {
@@ -170,18 +181,67 @@ describe("uploadDocuments — contagem em add_new_only", () => {
   });
 });
 
-describe("uploadDocuments — replace_and_add propaga erro de UPDATE", () => {
-  it("retorna error quando o UPDATE viola o indice unico (23505)", async () => {
-    // 1a query em documents = o UPDATE do duplicado, que falha com 23505.
-    serverTableResults = {
-      documents: [
-        {
-          error: {
-            message: "duplicate key value violates unique constraint",
-            code: "23505",
-          },
-        },
+describe("uploadDocuments — replace_and_add delega à RPC transacional", () => {
+  // O caminho replace_and_add deixou de fazer 5 chamadas PostgREST separadas
+  // (delete reviews/responses + reset assignments + update duplicados + insert)
+  // e passou a chamar a RPC replace_and_add_documents, que roda os 5 passos numa
+  // transação (issue #284 — falha parcial não apaga respostas/revisões). O
+  // pré-filtro read-only de external_id (SELECT em documents) continua no TS.
+  function rpcArgs(): Record<string, unknown> {
+    const call = rpcCalls.find((c) => c.fn === "replace_and_add_documents");
+    return (call?.args as Record<string, unknown>) ?? {};
+  }
+
+  it("chama a RPC com dup + novo e não emite writes diretos", async () => {
+    // O filtro do novo doc consulta documents (SELECT, sem conflito ativo).
+    serverTableResults = { documents: [{ data: [] }] };
+    const uploadDocuments = await loadUpload();
+
+    const r = await uploadDocuments(
+      "proj-1",
+      [
+        { external_id: "DOC-1", text: "casa por hash com doc existente" },
+        { external_id: "DOC-2", text: "novo" },
       ],
+      false,
+      {
+        mode: "replace_and_add",
+        deleteResponses: true,
+        duplicateMap: [
+          { csvIndex: 0, existingDocId: "id-1", matchType: "text_hash" },
+        ],
+      },
+    );
+
+    expect(r.error).toBeUndefined();
+    expect(r.count).toBe(2);
+    expect(r.skipped).toBe(0);
+
+    // Uma única RPC com o payload transacional; nenhum delete/update/insert solto.
+    expect(rpcCalls).toHaveLength(1);
+    expect(writeCalls).toHaveLength(0);
+
+    const args = rpcArgs();
+    expect(args.p_existing_doc_ids).toEqual(["id-1"]);
+    expect(args.p_delete_responses).toBe(true);
+    expect(args.p_duplicate_updates).toHaveLength(1);
+    expect((args.p_duplicate_updates as { id: string }[])[0].id).toBe("id-1");
+    expect((args.p_duplicate_updates as { text_hash: string }[])[0].text_hash)
+      .toBeTruthy();
+    expect(args.p_new_documents).toHaveLength(1);
+    expect((args.p_new_documents as { external_id: string }[])[0].external_id)
+      .toBe("DOC-2");
+  });
+
+  it("propaga o erro da RPC (ex.: 23505) sem fallout parcial", async () => {
+    // newDocs vazio (o único doc é duplicado) -> sem SELECT de filtro; só a RPC.
+    serverRpcResults = {
+      replace_and_add_documents: {
+        error: {
+          message: "duplicate key value violates unique constraint",
+          code: "23505",
+        },
+      },
     };
     const uploadDocuments = await loadUpload();
 
@@ -191,6 +251,7 @@ describe("uploadDocuments — replace_and_add propaga erro de UPDATE", () => {
       false,
       {
         mode: "replace_and_add",
+        deleteResponses: true,
         duplicateMap: [
           { csvIndex: 0, existingDocId: "id-1", matchType: "text_hash" },
         ],
@@ -198,10 +259,9 @@ describe("uploadDocuments — replace_and_add propaga erro de UPDATE", () => {
     );
 
     expect(r.error).toContain("duplicate key");
-    // O INSERT nao deve acontecer apos o erro do UPDATE.
-    expect(
-      writeCalls.some((c) => c.table === "documents" && c.op === "insert"),
-    ).toBe(false);
+    // Nenhuma escrita direta — a atomicidade (rollback) é responsabilidade da RPC.
+    expect(writeCalls).toHaveLength(0);
+    expect(rpcCalls).toHaveLength(1);
   });
 });
 

--- a/frontend/src/actions/__tests__/supabase-mock.ts
+++ b/frontend/src/actions/__tests__/supabase-mock.ts
@@ -15,6 +15,11 @@ export type WriteCall = {
   payload: unknown;
 };
 
+export type RpcCall = {
+  fn: string;
+  args: unknown;
+};
+
 export type TableResult = {
   data?: unknown;
   error?: { message: string; code?: string } | null;
@@ -27,9 +32,25 @@ export function makeSupabaseMock(opts?: {
   tableResults?: TableResults;
   defaultResult?: TableResult;
   writeCalls?: WriteCall[];
+  rpcCalls?: RpcCall[];
+  rpcResults?: Record<string, TableResult>;
 }) {
-  const { tableResults, defaultResult, writeCalls } = opts ?? {};
+  const { tableResults, defaultResult, writeCalls, rpcCalls, rpcResults } =
+    opts ?? {};
   return {
+    // rpc(): registra a chamada e resolve { data, error } como o thenable das
+    // queries. Resultado por função em `rpcResults`; sem entrada, sucesso vazio.
+    rpc: (fn: string, args: unknown) => {
+      rpcCalls?.push({ fn, args });
+      const result = rpcResults?.[fn];
+      return {
+        then: (resolve: (v: unknown) => unknown) =>
+          resolve({
+            data: result?.data ?? null,
+            error: result?.error ?? null,
+          }),
+      };
+    },
     from: (table: string) => {
       const builder: Record<string, unknown> = {};
       for (const m of [

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -495,37 +495,23 @@ export async function smartRandomize(params: LotteryParams) {
     );
   }
 
-  // Pendentes do tipo só são descartadas no modo substituir.
-  // Delete + inserts não são atômicos (sem transação via PostgREST) —
-  // os erros são verificados e expostos, mas uma falha entre o delete e
-  // os inserts ainda perde pendentes; transação via RPC é follow-up.
-  if (params.mode === "replace") {
-    const { error: deleteError } = await supabase
-      .from("assignments")
-      .delete()
-      .eq("project_id", params.projectId)
-      .eq("status", "pendente")
-      .eq("type", assignmentType);
-    if (deleteError) {
-      throw new Error(`Erro ao descartar atribuições pendentes: ${deleteError.message}`);
-    }
-  }
-
-  const chunkSize = 100;
-  for (let i = 0; i < newAssignments.length; i += chunkSize) {
-    const chunk = newAssignments.slice(i, i + chunkSize).map((a) => ({
-      project_id: params.projectId,
-      document_id: a.document_id,
-      user_id: a.user_id,
-      batch_id: batch.id,
-      type: assignmentType,
-    }));
-    const { error: insertError } = await supabase.from("assignments").insert(chunk);
-    if (insertError) {
-      throw new Error(
-        `Erro ao gravar as atribuições (${i} de ${newAssignments.length} inseridas): ${insertError.message}`
-      );
-    }
+  // Descarte das pendentes (modo substituir) + gravação das novas numa
+  // transação única via RPC (issue #181): uma falha entre o delete e o insert
+  // não perde mais as pendentes. SECURITY INVOKER — a RLS do coordenador vale
+  // dentro da função. Dispensa o chunk de 100 (era limite de payload PostgREST).
+  const assignmentRows = newAssignments.map((a) => ({
+    document_id: a.document_id,
+    user_id: a.user_id,
+  }));
+  const { error: rpcError } = await supabase.rpc("apply_lottery_assignments", {
+    p_project_id: params.projectId,
+    p_type: assignmentType,
+    p_batch_id: batch.id,
+    p_assignments: assignmentRows,
+    p_replace: params.mode === "replace",
+  });
+  if (rpcError) {
+    throw new Error(`Erro ao gravar as atribuições do sorteio: ${rpcError.message}`);
   }
 
   // Persiste o peso/limite usado por participante (decisão: editar no diálogo,

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -243,76 +243,50 @@ export async function uploadDocuments(
     // Update existing duplicates + insert new ones
     const existingDocIds = duplicateMap.map((d) => d.existingDocId);
 
-    if (options?.deleteResponses && existingDocIds.length > 0) {
-      // Delete reviews first (FK chosen_response_id -> responses without CASCADE)
-      await supabase
-        .from("reviews")
-        .delete()
-        .eq("project_id", projectId)
-        .in("document_id", existingDocIds);
-
-      // Then delete responses
-      await supabase
-        .from("responses")
-        .delete()
-        .eq("project_id", projectId)
-        .in("document_id", existingDocIds);
-
-      // Reset assignments to 'pendente'
-      await supabase
-        .from("assignments")
-        .update({ status: "pendente" })
-        .eq("project_id", projectId)
-        .in("document_id", existingDocIds);
-    }
-
-    // Batch update duplicate documents (avoid N+1)
-    if (duplicateMap.length > 0) {
-      // Checa o erro de cada update: setar external_id num doc casado por
-      // text_hash pode colidir com outro doc ativo e violar o indice unico
-      // parcial (23505). Sem isso o erro seria resolvido e ignorado em silencio
-      // (o doc nao seria atualizado mas contaria como processado).
-      const updateResults = await Promise.all(
-        duplicateMap.map((dup) => {
-          const doc = documents[dup.csvIndex];
-          return supabase
-            .from("documents")
-            .update({
-              text: doc.text,
-              title: doc.title || null,
-              external_id: doc.external_id || null,
-              text_hash: md5(doc.text),
-              metadata: doc.metadata || null,
-            })
-            .eq("id", dup.existingDocId);
-        })
-      );
-      const failedUpdate = updateResults.find((r) => r.error);
-      if (failedUpdate?.error) return { error: failedUpdate.error.message };
-    }
-
-    // Insert new (non-duplicate) documents
-    const newDocs = documents.filter((_, i) => !duplicateIndices.has(i));
-    let skipped = 0;
-    if (newDocs.length > 0) {
-      const baseRows = newDocs.map((doc) => ({
-        project_id: projectId,
-        external_id: doc.external_id || null,
-        title: doc.title || null,
+    // Payload de atualização dos duplicados (text_hash precomputado, igual ao
+    // INSERT abaixo). Setar external_id num doc casado por text_hash pode colidir
+    // com outro doc ativo e violar o indice unico parcial (23505) — dentro da
+    // transação isso faz ROLLBACK de tudo, em vez de deixar estado parcial.
+    const duplicateUpdates = duplicateMap.map((dup) => {
+      const doc = documents[dup.csvIndex];
+      return {
+        id: dup.existingDocId,
         text: doc.text,
+        title: doc.title || null,
+        external_id: doc.external_id || null,
         text_hash: md5(doc.text),
         metadata: doc.metadata || null,
-      }));
-      // Defesa contra o indice unico (duplicateMap stale / repeticao no lote).
-      const { rows, skippedExisting, skippedInBatch } =
-        await filterActiveExternalIdConflicts(supabase, projectId, baseRows);
-      skipped = skippedExisting + skippedInBatch;
+      };
+    });
 
-      if (rows.length > 0) {
-        const { error } = await supabase.from("documents").insert(rows);
-        if (error) return { error: error.message };
-      }
-    }
+    // Novos (não-duplicados) + defesa read-only contra o indice unico parcial
+    // (duplicateMap stale / repeticao no lote). O filtro roda no TS por ser só
+    // leitura; o rollback atômico continua dentro da RPC.
+    const newDocs = documents.filter((_, i) => !duplicateIndices.has(i));
+    const baseRows = newDocs.map((doc) => ({
+      external_id: doc.external_id || null,
+      title: doc.title || null,
+      text: doc.text,
+      text_hash: md5(doc.text),
+      metadata: doc.metadata || null,
+    }));
+    const { rows, skippedExisting, skippedInBatch } =
+      await filterActiveExternalIdConflicts(supabase, projectId, baseRows);
+    const skipped = skippedExisting + skippedInBatch;
+
+    // Transação única (issue #284): delete reviews/responses + reset assignments
+    // + update duplicados + insert novos. Falha em qualquer passo faz ROLLBACK
+    // de tudo — respostas/revisões não ficam apagadas sem o upload concluir.
+    // SECURITY INVOKER: a RLS do coordenador (braço coordinator_or_creator nas
+    // policies de responses/reviews) continua valendo dentro da função.
+    const { error } = await supabase.rpc("replace_and_add_documents", {
+      p_project_id: projectId,
+      p_existing_doc_ids: existingDocIds,
+      p_delete_responses: !!options?.deleteResponses,
+      p_duplicate_updates: duplicateUpdates,
+      p_new_documents: rows,
+    });
+    if (error) return { error: error.message };
 
     if (revalidate) {
       revalidatePath(`/projects/${projectId}/config/documents`);

--- a/frontend/supabase/migrations/20260629120000_atomic_replace_rpcs.sql
+++ b/frontend/supabase/migrations/20260629120000_atomic_replace_rpcs.sql
@@ -10,13 +10,17 @@
 --
 -- Ambas as funções rodam como SECURITY INVOKER (não DEFINER): chamadas pelo
 -- client autenticado (lib/supabase/server.ts), o JWT do Clerk continua no
--- contexto, então (a) as RLS policies de coordenador continuam valendo dentro
--- da função e (b) os triggers enforce_*_column_guard (que fazem bypass quando
--- clerk_uid() é NULL = service-role) NÃO são desligados — ao contrário do que
--- aconteceria com SECURITY DEFINER + service_role. Direção alinhada às issues
--- de segurança #137 (reduzir uso do admin client), #134 (RLS consistente) e
--- #243 (column guards). search_path = '' por higiene (tudo qualificado com
--- public.). GRANT só a authenticated (sem REVOKE especial — não precisa).
+-- contexto, então a RLS de coordenador (braço coordinator_or_creator nas
+-- policies de documents/assignments/responses/reviews) continua sendo avaliada
+-- dentro da função. Sob SECURITY DEFINER + service_role isso se perderia: a
+-- função rodaria como owner/service_role, que BYPASSA a RLS, e clerk_uid()
+-- ficaria NULL — exatamente o anti-padrão que a #137 (reduzir uso do admin
+-- client) audita. Note que estas quatro tabelas NÃO têm triggers
+-- enforce_*_column_guard (esses existem só em projects/project_comments/
+-- schema_change_log); aqui o que protege a escrita é puramente a RLS. Direção
+-- alinhada às issues de segurança #137, #134 (RLS consistente) e #243 (column
+-- guards). search_path = '' por higiene (tudo qualificado com public.). GRANT
+-- só a authenticated (sem REVOKE especial — não precisa).
 
 -- ========== #181: sorteio ==========
 -- Quando p_replace é true, descarta as pendentes do tipo antes de inserir; o
@@ -113,7 +117,9 @@ BEGIN
     FROM jsonb_to_recordset(p_duplicate_updates)
       AS u(id uuid, "text" text, title text, external_id text,
            text_hash text, metadata jsonb)
-    WHERE d.id = u.id;
+    WHERE d.id = u.id
+      AND d.project_id = p_project_id;  -- defense-in-depth: escopa ao projeto,
+                                        -- coerente com os DELETE/INSERT acima
   END IF;
 
   IF p_new_documents IS NOT NULL

--- a/frontend/supabase/migrations/20260629120000_atomic_replace_rpcs.sql
+++ b/frontend/supabase/migrations/20260629120000_atomic_replace_rpcs.sql
@@ -1,0 +1,136 @@
+-- RPCs transacionais para fechar a janela de não-atomicidade de duas escritas
+-- multi-passo que hoje rodam como chamadas PostgREST separadas (sem transação):
+--
+--   #181  smartRandomize (sorteio, modo "substituir"): DELETE das pendentes +
+--         INSERT das novas. Falha entre os dois perde as pendentes.
+--   #284  uploadDocuments (replace_and_add com deleteResponses): DELETE reviews
+--         + DELETE responses + UPDATE assignments + UPDATE duplicados + INSERT
+--         novos. Falha no INSERT deixava respostas/revisões já apagadas, sem
+--         rollback — perda de dado humano irreversível.
+--
+-- Ambas as funções rodam como SECURITY INVOKER (não DEFINER): chamadas pelo
+-- client autenticado (lib/supabase/server.ts), o JWT do Clerk continua no
+-- contexto, então (a) as RLS policies de coordenador continuam valendo dentro
+-- da função e (b) os triggers enforce_*_column_guard (que fazem bypass quando
+-- clerk_uid() é NULL = service-role) NÃO são desligados — ao contrário do que
+-- aconteceria com SECURITY DEFINER + service_role. Direção alinhada às issues
+-- de segurança #137 (reduzir uso do admin client), #134 (RLS consistente) e
+-- #243 (column guards). search_path = '' por higiene (tudo qualificado com
+-- public.). GRANT só a authenticated (sem REVOKE especial — não precisa).
+
+-- ========== #181: sorteio ==========
+-- Quando p_replace é true, descarta as pendentes do tipo antes de inserir; o
+-- DELETE+INSERT numa transação só resolve tanto a janela de perda quanto a
+-- colisão com UNIQUE(document_id, user_id, type) (que impede inverter a ordem).
+-- p_assignments é um array de objetos { document_id, user_id }. Dispensa o
+-- chunking de 100 do lado TS (aquilo era limite de payload PostgREST, não SQL).
+CREATE OR REPLACE FUNCTION public.apply_lottery_assignments(
+  p_project_id uuid,
+  p_type text,
+  p_batch_id uuid,
+  p_assignments jsonb,
+  p_replace boolean
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_inserted integer;
+BEGIN
+  IF p_replace THEN
+    DELETE FROM public.assignments
+    WHERE project_id = p_project_id
+      AND status = 'pendente'
+      AND type = p_type;
+  END IF;
+
+  INSERT INTO public.assignments (project_id, document_id, user_id, batch_id, type)
+  SELECT p_project_id,
+         (e->>'document_id')::uuid,
+         (e->>'user_id')::uuid,
+         p_batch_id,
+         p_type
+  FROM jsonb_array_elements(p_assignments) AS e;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  RETURN v_inserted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.apply_lottery_assignments(uuid, text, uuid, jsonb, boolean)
+  TO authenticated;
+
+-- ========== #284: upload replace_and_add ==========
+-- Os 5 passos numa transação implícita: erro em qualquer um faz ROLLBACK de
+-- tudo. O pré-filtro de conflito de external_id (filterActiveExternalIdConflicts)
+-- continua no TS por ser read-only — p_new_documents já chega filtrado.
+--   p_duplicate_updates: array de { id, text, title, external_id, text_hash, metadata }
+--   p_new_documents:     array de { external_id, title, text, text_hash, metadata }
+-- text_hash chega precomputado (md5) do TS, para paridade exata com o caminho
+-- antigo. Retorna o número de documentos novos inseridos.
+CREATE OR REPLACE FUNCTION public.replace_and_add_documents(
+  p_project_id uuid,
+  p_existing_doc_ids uuid[],
+  p_delete_responses boolean,
+  p_duplicate_updates jsonb,
+  p_new_documents jsonb
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_inserted integer := 0;
+BEGIN
+  IF p_delete_responses
+     AND p_existing_doc_ids IS NOT NULL
+     AND array_length(p_existing_doc_ids, 1) > 0 THEN
+    -- reviews antes (FK chosen_response_id -> responses sem CASCADE)
+    DELETE FROM public.reviews
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids);
+
+    DELETE FROM public.responses
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids);
+
+    UPDATE public.assignments
+    SET status = 'pendente'
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids);
+  END IF;
+
+  IF p_duplicate_updates IS NOT NULL
+     AND jsonb_array_length(p_duplicate_updates) > 0 THEN
+    UPDATE public.documents d
+    SET text = u."text",
+        title = u.title,
+        external_id = u.external_id,
+        text_hash = u.text_hash,
+        metadata = u.metadata
+    FROM jsonb_to_recordset(p_duplicate_updates)
+      AS u(id uuid, "text" text, title text, external_id text,
+           text_hash text, metadata jsonb)
+    WHERE d.id = u.id;
+  END IF;
+
+  IF p_new_documents IS NOT NULL
+     AND jsonb_array_length(p_new_documents) > 0 THEN
+    INSERT INTO public.documents
+      (project_id, external_id, title, text, text_hash, metadata)
+    SELECT p_project_id, n.external_id, n.title, n."text", n.text_hash, n.metadata
+    FROM jsonb_to_recordset(p_new_documents)
+      AS n(external_id text, title text, "text" text,
+           text_hash text, metadata jsonb);
+    GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  END IF;
+
+  RETURN v_inserted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.replace_and_add_documents(uuid, uuid[], boolean, jsonb, jsonb)
+  TO authenticated;

--- a/frontend/supabase/tests/atomic_replace_rpcs.test.sql
+++ b/frontend/supabase/tests/atomic_replace_rpcs.test.sql
@@ -6,10 +6,12 @@
 -- Sucesso = nenhuma exceção e os NOTICE "OK ..." no final. Qualquer FALHOU aborta.
 --
 -- Roda inteiro dentro de BEGIN ... ROLLBACK: não altera dados locais. Prova a
--- ATOMICIDADE (a chamada à função é um statement atômico — erro no INSERT
--- reverte os DELETEs/UPDATEs anteriores da mesma chamada). Executa como owner,
--- então NÃO testa RLS (isso fica nas policies + rls-guard.test.ts); o objeto
--- aqui é a transação. Sem dependência de profiles/auth.users: os FKs
+-- ATOMICIDADE (a chamada à função é um statement atômico — erro no INSERT ou no
+-- UPDATE reverte os DELETEs/UPDATEs anteriores da mesma chamada). A maioria dos
+-- blocos roda como owner (o objeto é a transação); o bloco "RLS" abaixo troca
+-- para o role `authenticated` com um JWT forjado para provar que, sob SECURITY
+-- INVOKER, a RLS continua filtrando dentro da função (um não-coordenador não
+-- apaga dados via a RPC). Sem dependência de profiles/auth.users: os FKs
 -- created_by / respondent_id / reviewer_id / user_id são todos nuláveis.
 
 BEGIN;
@@ -32,6 +34,45 @@ INSERT INTO public.reviews (id, project_id, document_id, field_name, verdict) VA
 
 INSERT INTO public.assignments (id, project_id, document_id, status, type) VALUES
   ('66666666-6666-6666-6666-666666666666', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'concluido', 'codificacao');
+
+-- ----- RLS: authenticated não-coordenador não apaga dados via a RPC -----
+-- A decisão central do PR é SECURITY INVOKER justamente para manter a RLS valendo
+-- dentro da transação. Aqui forjamos um JWT com um supabase_uid que não é membro
+-- de projeto algum (logo não é coordenador/criador/master) e trocamos para o role
+-- `authenticated`. Os braços das policies de responses/reviews (respondent_id /
+-- reviewer_id IN member_identity OR coordinator_or_creator OR is_master) não
+-- batem -> o DELETE da RPC enxerga 0 linhas e não apaga nada. Sem inserts no
+-- payload (o foco é o DELETE; um INSERT exigiria WITH CHECK e mascararia o teste).
+--
+-- Em produção o role `authenticated` tem DML nestas tabelas (o app opera via
+-- PostgREST autenticado); o supabase local não concede por padrão. Concede aqui
+-- (revertido no ROLLBACK) para isolar a camada sob teste — a RLS, não o GRANT.
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON public.responses, public.reviews, public.assignments, public.documents
+  TO authenticated;
+SELECT set_config('request.jwt.claims',
+  '{"supabase_uid":"99999999-9999-9999-9999-999999999999"}', true);
+SET LOCAL ROLE authenticated;
+SELECT public.replace_and_add_documents(
+  '11111111-1111-1111-1111-111111111111'::uuid,
+  ARRAY['22222222-2222-2222-2222-222222222222'::uuid],
+  true,          -- tenta apagar responses/reviews + reset assignments
+  '[]'::jsonb,
+  '[]'::jsonb
+);
+RESET ROLE;
+
+DO $$
+DECLARE n_resp int; n_rev int; a_status text;
+BEGIN
+  SELECT count(*) INTO n_resp   FROM public.responses   WHERE id = '44444444-4444-4444-4444-444444444444';
+  SELECT count(*) INTO n_rev    FROM public.reviews     WHERE id = '55555555-5555-5555-5555-555555555555';
+  SELECT status   INTO a_status FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666666';
+  IF n_resp <> 1 THEN RAISE EXCEPTION 'FALHOU RLS: response apagada por nao-coordenador via RPC (n=%)', n_resp; END IF;
+  IF n_rev  <> 1 THEN RAISE EXCEPTION 'FALHOU RLS: review apagada por nao-coordenador via RPC (n=%)', n_rev; END IF;
+  IF a_status <> 'concluido' THEN RAISE EXCEPTION 'FALHOU RLS: assignment resetado por nao-coordenador via RPC (status=%)', a_status; END IF;
+  RAISE NOTICE 'OK RLS: authenticated nao-coordenador nao apagou responses/reviews/assignments via a RPC';
+END $$;
 
 -- ----- #284: falha no INSERT reverte os deletes/reset da mesma chamada -----
 DO $$
@@ -60,6 +101,48 @@ BEGIN
   IF n_rev  <> 1   THEN RAISE EXCEPTION 'FALHOU #284: review apagada sem rollback (n=%)', n_rev; END IF;
   IF a_status <> 'concluido' THEN RAISE EXCEPTION 'FALHOU #284: assignment resetado sem rollback (status=%)', a_status; END IF;
   RAISE NOTICE 'OK #284: responses/reviews/assignments preservados apos falha (rollback atomico)';
+END $$;
+
+-- ----- #284: caminho feliz atualiza um doc duplicado (passo UPDATE) -----
+-- Sem deletes nem inserts: só o UPDATE dos duplicados, que antes não tinha
+-- cobertura. Atualiza D1 (text + external_id) e confere que pegou.
+DO $$
+DECLARE v_text text; v_ext text;
+BEGIN
+  PERFORM public.replace_and_add_documents(
+    '11111111-1111-1111-1111-111111111111'::uuid,
+    ARRAY[]::uuid[],
+    false,           -- sem deletes
+    '[{"id":"22222222-2222-2222-2222-222222222222","text":"d1 atualizado","title":"D1 upd","external_id":"DUP-UPD","text_hash":"h-d1-upd","metadata":null}]'::jsonb,
+    '[]'::jsonb      -- sem inserts
+  );
+  SELECT text, external_id INTO v_text, v_ext
+    FROM public.documents WHERE id = '22222222-2222-2222-2222-222222222222';
+  IF v_text <> 'd1 atualizado' THEN RAISE EXCEPTION 'FALHOU: UPDATE nao alterou text (text=%)', v_text; END IF;
+  IF v_ext  <> 'DUP-UPD'       THEN RAISE EXCEPTION 'FALHOU: UPDATE nao alterou external_id (ext=%)', v_ext; END IF;
+  RAISE NOTICE 'OK #284: passo UPDATE atualizou o doc duplicado';
+END $$;
+
+-- ----- #284: falha no UPDATE (colisao de external_id) tambem reverte deletes -----
+-- D1 recebe external_id 'EXISTING', já ativo em D2 -> viola o índice único
+-- parcial DENTRO do passo UPDATE. Como há delete_responses=true, o DELETE roda
+-- antes; a exceção deve reverter inclusive esse DELETE (atomicidade no UPDATE).
+DO $$
+DECLARE n_resp int;
+BEGIN
+  PERFORM public.replace_and_add_documents(
+    '11111111-1111-1111-1111-111111111111'::uuid,
+    ARRAY['22222222-2222-2222-2222-222222222222'::uuid],
+    true,            -- apaga responses/reviews antes do UPDATE
+    '[{"id":"22222222-2222-2222-2222-222222222222","text":"colide","title":"x","external_id":"EXISTING","text_hash":"h-x","metadata":null}]'::jsonb,
+    '[]'::jsonb
+  );
+  RAISE EXCEPTION 'TESTE FALHOU: o UPDATE deveria ter abortado com unique_violation';
+EXCEPTION
+  WHEN unique_violation THEN
+    SELECT count(*) INTO n_resp FROM public.responses WHERE id = '44444444-4444-4444-4444-444444444444';
+    IF n_resp <> 1 THEN RAISE EXCEPTION 'FALHOU #284: response apagada sem rollback na falha do UPDATE (n=%)', n_resp; END IF;
+    RAISE NOTICE 'OK #284: falha no UPDATE reverteu o DELETE anterior (rollback atomico)';
 END $$;
 
 -- ----- #284: caminho feliz aplica deletes + insere o novo doc -----

--- a/frontend/supabase/tests/atomic_replace_rpcs.test.sql
+++ b/frontend/supabase/tests/atomic_replace_rpcs.test.sql
@@ -1,0 +1,100 @@
+-- Verificação de atomicidade das RPCs transacionais (issues #181 e #284).
+--
+-- Como rodar (após `npx supabase start` e `npx supabase db reset`):
+--   psql "$(npx supabase status -o env | grep DB_URL | cut -d= -f2- | tr -d '\"')" \
+--     -v ON_ERROR_STOP=1 -f supabase/tests/atomic_replace_rpcs.test.sql
+-- Sucesso = nenhuma exceção e os NOTICE "OK ..." no final. Qualquer FALHOU aborta.
+--
+-- Roda inteiro dentro de BEGIN ... ROLLBACK: não altera dados locais. Prova a
+-- ATOMICIDADE (a chamada à função é um statement atômico — erro no INSERT
+-- reverte os DELETEs/UPDATEs anteriores da mesma chamada). Executa como owner,
+-- então NÃO testa RLS (isso fica nas policies + rls-guard.test.ts); o objeto
+-- aqui é a transação. Sem dependência de profiles/auth.users: os FKs
+-- created_by / respondent_id / reviewer_id / user_id são todos nuláveis.
+
+BEGIN;
+
+-- ----- Fixtures -----
+INSERT INTO public.projects (id, name) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'proj atomic test');
+
+-- D1 = doc alvo do "replace"; D2 = doc ativo cujo external_id 'EXISTING' será
+-- colidido pelo INSERT do caminho de falha.
+INSERT INTO public.documents (id, project_id, external_id, title, text, text_hash) VALUES
+  ('22222222-2222-2222-2222-222222222222', '11111111-1111-1111-1111-111111111111', NULL,       'D1 alvo',  'texto d1', 'h-d1'),
+  ('33333333-3333-3333-3333-333333333333', '11111111-1111-1111-1111-111111111111', 'EXISTING', 'D2 ativo', 'texto d2', 'h-d2');
+
+INSERT INTO public.responses (id, project_id, document_id, respondent_type, answers) VALUES
+  ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'humano', '{"campo":"x"}');
+
+INSERT INTO public.reviews (id, project_id, document_id, field_name, verdict) VALUES
+  ('55555555-5555-5555-5555-555555555555', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'campo', 'concordo');
+
+INSERT INTO public.assignments (id, project_id, document_id, status, type) VALUES
+  ('66666666-6666-6666-6666-666666666666', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'concluido', 'codificacao');
+
+-- ----- #284: falha no INSERT reverte os deletes/reset da mesma chamada -----
+DO $$
+BEGIN
+  PERFORM public.replace_and_add_documents(
+    '11111111-1111-1111-1111-111111111111'::uuid,
+    ARRAY['22222222-2222-2222-2222-222222222222'::uuid],
+    true,            -- delete responses/reviews + reset assignments
+    '[]'::jsonb,     -- sem dup updates
+    -- novo doc com external_id 'EXISTING' (já ativo) -> viola o índice parcial
+    '[{"external_id":"EXISTING","title":"colide","text":"y","text_hash":"h-new","metadata":null}]'::jsonb
+  );
+  RAISE EXCEPTION 'TESTE FALHOU: a RPC deveria ter abortado com unique_violation';
+EXCEPTION
+  WHEN unique_violation THEN
+    RAISE NOTICE 'OK: RPC abortou com unique_violation (esperado)';
+END $$;
+
+DO $$
+DECLARE n_resp int; n_rev int; a_status text;
+BEGIN
+  SELECT count(*) INTO n_resp   FROM public.responses   WHERE id = '44444444-4444-4444-4444-444444444444';
+  SELECT count(*) INTO n_rev    FROM public.reviews     WHERE id = '55555555-5555-5555-5555-555555555555';
+  SELECT status   INTO a_status FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666666';
+  IF n_resp <> 1   THEN RAISE EXCEPTION 'FALHOU #284: response apagada sem rollback (n=%)', n_resp; END IF;
+  IF n_rev  <> 1   THEN RAISE EXCEPTION 'FALHOU #284: review apagada sem rollback (n=%)', n_rev; END IF;
+  IF a_status <> 'concluido' THEN RAISE EXCEPTION 'FALHOU #284: assignment resetado sem rollback (status=%)', a_status; END IF;
+  RAISE NOTICE 'OK #284: responses/reviews/assignments preservados apos falha (rollback atomico)';
+END $$;
+
+-- ----- #284: caminho feliz aplica deletes + insere o novo doc -----
+DO $$
+DECLARE n_new int; n_resp int;
+BEGIN
+  PERFORM public.replace_and_add_documents(
+    '11111111-1111-1111-1111-111111111111'::uuid,
+    ARRAY['22222222-2222-2222-2222-222222222222'::uuid],
+    true, '[]'::jsonb,
+    '[{"external_id":"NEW-OK","title":"novo","text":"z","text_hash":"h-ok","metadata":null}]'::jsonb
+  );
+  SELECT count(*) INTO n_new  FROM public.documents WHERE project_id = '11111111-1111-1111-1111-111111111111' AND external_id = 'NEW-OK';
+  SELECT count(*) INTO n_resp FROM public.responses WHERE id = '44444444-4444-4444-4444-444444444444';
+  IF n_new  <> 1 THEN RAISE EXCEPTION 'FALHOU: novo doc nao inserido no caminho feliz (n=%)', n_new; END IF;
+  IF n_resp <> 0 THEN RAISE EXCEPTION 'FALHOU: deleteResponses nao apagou a response no caminho feliz (n=%)', n_resp; END IF;
+  RAISE NOTICE 'OK #284: caminho feliz inseriu o novo doc e aplicou os deletes';
+END $$;
+
+-- ----- #181: apply_lottery_assignments(replace) descarta pendentes do tipo + insere -----
+DO $$
+DECLARE n_pend int;
+BEGIN
+  -- Pendente antiga (em D2) que deve ser descartada pelo modo replace.
+  INSERT INTO public.assignments (project_id, document_id, status, type)
+    VALUES ('11111111-1111-1111-1111-111111111111', '33333333-3333-3333-3333-333333333333', 'pendente', 'codificacao');
+  PERFORM public.apply_lottery_assignments(
+    '11111111-1111-1111-1111-111111111111'::uuid, 'codificacao', NULL,
+    '[{"document_id":"22222222-2222-2222-2222-222222222222","user_id":null}]'::jsonb,
+    true
+  );
+  SELECT count(*) INTO n_pend FROM public.assignments
+    WHERE project_id = '11111111-1111-1111-1111-111111111111' AND type = 'codificacao' AND status = 'pendente';
+  IF n_pend <> 1 THEN RAISE EXCEPTION 'FALHOU #181: esperava 1 pendente (a nova), achei %', n_pend; END IF;
+  RAISE NOTICE 'OK #181: replace descartou a pendente antiga e inseriu a nova atomicamente';
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
## Contexto

Duas issues de `tech-debt` descrevem o **mesmo bug arquitetural** em dois lugares: escritas multi-passo no PostgREST que não rodam em transação, deixando estado parcial quando um passo intermediário falha.

- **#181 — `smartRandomize` (sorteio, modo substituir):** `DELETE` das pendentes + `INSERT` em chunks de 100. Falha entre os dois perde as pendentes (regeneráveis, mas ruim).
- **#284 — `uploadDocuments` (`replace_and_add` com `deleteResponses`):** `DELETE reviews` → `DELETE responses` → `UPDATE assignments → pendente` → `UPDATE` duplicados → `INSERT` novos. Falha no `INSERT` deixava **respostas e revisões já codificadas apagadas, sem rollback** — perda de dado humano irreversível.

Resolvidas juntas (PR único) porque compartilham diagnóstico, remédio e as decisões de design.

## O que muda

Ambos os fluxos passam a chamar funções Postgres transacionais via `supabase.rpc()` (migration `20260629120000_atomic_replace_rpcs.sql`):

- **`apply_lottery_assignments(..., p_replace)`** — no modo substituir, `DELETE` das pendentes + `INSERT` numa transação só. Isso também resolve a colisão com `UNIQUE(document_id, user_id, type)` que impede simplesmente inverter a ordem. Dispensa o chunk de 100 (era limite de payload PostgREST, não de SQL).
- **`replace_and_add_documents(...)`** — os 5 passos numa transação implícita; erro em qualquer um faz `ROLLBACK` de tudo.

### Decisão de segurança: `SECURITY INVOKER` (não `DEFINER`)

As funções rodam como `SECURITY INVOKER`, chamadas pelo client autenticado (`lib/supabase/server.ts`). O JWT do Clerk continua no contexto, então:

a RLS do coordenador (braço `coordinator_or_creator` nas policies de `documents`/`assignments`/`responses`/`reviews`) continua valendo dentro da função. Sob `SECURITY DEFINER` + service_role isso se perderia: a função rodaria como owner/service_role, que **bypassa a RLS**, e `clerk_uid()` ficaria NULL.

> **Correção (review):** uma versão anterior desta seção também justificava INVOKER por "não desligar os triggers `enforce_*_column_guard`". Isso não se aplica: esses triggers existem **só** em `projects`/`project_comments`/`schema_change_log`, **não** nas quatro tabelas que estas RPCs tocam. A proteção dessas escritas é puramente a RLS — a decisão por INVOKER segue correta por esse motivo.

Direção alinhada às issues de segurança abertas **#137** (reduzir uso do admin client), **#134** (RLS consistente) e **#243** (column guards). `unify_project_members` (DEFINER + service_role) é o padrão antigo que a #137 audita — deliberadamente não copiado aqui.

### Detalhes preservados

- O pré-filtro read-only de `external_id` (`filterActiveExternalIdConflicts`) continua no TS; só as escritas entram na transação.
- Contratos de retorno intactos: `{ count, preserved }` (sorteio) e `{ count, skipped }` (upload).
- **Caveat conhecido (não corrigido aqui):** `DocumentUpload.tsx` fatia o upload por ~3,5MB e chama a action por chunk. A RPC dá atomicidade **por chamada**; atomicidade cross-chunk continua não garantida. Aceitável — os deletes destrutivos são escopados aos duplicados de cada chunk.

## Testes

- `documents.test.ts` vira teste de **delegação**: o caminho `replace_and_add` agora emite uma única `rpc(...)` com o payload correto e nenhum write solto (o mock ganhou suporte a `.rpc()`). Suíte: **711 testes verdes**, `tsc` limpo, `react-doctor` 100/100.
- `supabase/tests/atomic_replace_rpcs.test.sql` prova o **rollback contra Postgres real**: ao forçar `unique_violation` no `INSERT`, `responses`/`reviews`/`assignments` sobrevivem (executado e verde nesta entrega).

## Verificação manual sugerida

- Sorteio em modo "substituir" com muitas atribuições.
- Upload `replace_and_add` com `deleteResponses` sobre docs que já têm respostas — conferir `count`/`skipped` e que uma falha não destrói dado.

Closes #181
Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)
