### PR TITLE
test(e2e): destrava smoke do coordenador serializando o smoke do dashboard (#198)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,13 +48,16 @@ O Playwright sobe o dev server automaticamente. Cada papel cuja credencial
 não estiver definida em `.env.e2e` tem o teste **pulado** (não falha), então
 CI sem o tenant de teste configurado continua verde.
 
-O smoke do dashboard (`dashboard.smoke.spec.ts`) roda os papéis em **série**
-(`test.describe.configure({ mode: "serial" })`). A instância de **desenvolvimento**
-do Clerk tem limites de uso estritos; rodar os papéis em paralelo gera um burst
-de `signIn`/`signOut`/`currentUser` que dispara rate-limit (`fetch failed` no
-backend do Clerk) e torna o smoke flaky — foi a causa raiz da #198 (não era
-credencial nem o sync Clerk↔Supabase). Por isso o E2E permanece **manual**
-(rodado localmente/staging), sem workflow de CI dedicado.
+O smoke do dashboard (`dashboard.smoke.spec.ts`) roda os papéis **em ordem**,
+num único worker (`test.describe.configure({ mode: "default" })`, que
+sobrescreve o `fullyParallel` da config só para este arquivo). A instância de
+**desenvolvimento** do Clerk tem limites de uso estritos; rodar os papéis em
+paralelo gera um burst de `signIn`/`signOut`/`currentUser` que dispara
+rate-limit (`fetch failed` no backend do Clerk) e torna o smoke flaky — foi a
+causa raiz da #198 (não era credencial nem o sync Clerk↔Supabase). Usamos
+`default` em vez de `serial` porque os papéis são testes isolados: queremos só
+controlar o ritmo, sem que a falha de um papel pule os demais. Por isso o E2E
+permanece **manual** (rodado localmente/staging), sem workflow de CI dedicado.
 
 ### Smoke manual de login (mitigação)
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -48,6 +48,27 @@ O Playwright sobe o dev server automaticamente. Cada papel cuja credencial
 não estiver definida em `.env.e2e` tem o teste **pulado** (não falha), então
 CI sem o tenant de teste configurado continua verde.
 
+O smoke do dashboard (`dashboard.smoke.spec.ts`) roda os papéis em **série**
+(`test.describe.configure({ mode: "serial" })`). A instância de **desenvolvimento**
+do Clerk tem limites de uso estritos; rodar os papéis em paralelo gera um burst
+de `signIn`/`signOut`/`currentUser` que dispara rate-limit (`fetch failed` no
+backend do Clerk) e torna o smoke flaky — foi a causa raiz da #198 (não era
+credencial nem o sync Clerk↔Supabase). Por isso o E2E permanece **manual**
+(rodado localmente/staging), sem workflow de CI dedicado.
+
+### Smoke manual de login (mitigação)
+
+Como o E2E não roda no CI, antes de promover mudanças que toquem o boundary de
+auth (Clerk, middleware `proxy.ts`, `lib/auth.ts`, `lib/clerk-sync.ts`), faça um
+smoke manual de login no preview/produção:
+
+1. **Coordenador** — login com a conta de coordenador → confirmar que cai em
+   `/dashboard` com "Meus Projetos" (sem voltar para `/auth/login`).
+2. **Membro** — login com a conta de pesquisador → mesmo check.
+3. Em caso de loop login↔dashboard, abrir `/api/debug-token` autenticado e
+   conferir `metadataSupabaseUid`, `tokenSupabaseUid`, `uidMatch` e
+   `supabaseProbe` para localizar o elo quebrado (metadata, claim do JWT ou RLS).
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/frontend/e2e/dashboard.smoke.spec.ts
+++ b/frontend/e2e/dashboard.smoke.spec.ts
@@ -11,13 +11,20 @@ import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
 // dispositivo" da instância, que bloqueia a estratégia password em contexto
 // headless — cada contexto Playwright é um dispositivo novo.
 
-// Roda os papéis em SÉRIE (não em paralelo). Cada signIn/signOut/currentUser
-// bate na instância de DEV do Clerk, que tem limites de uso estritos; rodar os
-// papéis em paralelo gera um burst que dispara rate-limit / `fetch failed` no
-// backend do Clerk e torna o smoke flaky (issue #198 — a falha não era
-// credencial nem o sync Clerk↔Supabase, ambos íntegros). Em série o ritmo fica
-// abaixo do limite.
-test.describe.configure({ mode: "serial" });
+// Roda os papéis EM ORDEM, num único worker (não em paralelo). Cada
+// signIn/signOut/currentUser bate na instância de DEV do Clerk, que tem limites
+// de uso estritos; rodar os papéis em paralelo gera um burst que dispara
+// rate-limit / `fetch failed` no backend do Clerk e torna o smoke flaky (issue
+// #198 — a falha não era credencial nem o sync Clerk↔Supabase, ambos íntegros).
+// Em ordem o ritmo fica abaixo do limite.
+//
+// Usamos `mode: "default"` (não `"serial"`) de propósito: ele sobrescreve o
+// `fullyParallel` do playwright.config.ts para este arquivo, rodando os papéis
+// sequencialmente, mas — ao contrário do `serial` — uma falha num papel NÃO
+// pula os demais e os retries são independentes. Os papéis são testes isolados
+// (cada um com seu próprio login), então não há dependência entre eles que
+// justifique o fail-fast do `serial`; só queremos controlar o ritmo.
+test.describe.configure({ mode: "default" });
 
 const roles = [
   { role: "coordenador", emailEnv: "E2E_COORDINATOR_EMAIL" },

--- a/frontend/e2e/dashboard.smoke.spec.ts
+++ b/frontend/e2e/dashboard.smoke.spec.ts
@@ -10,6 +10,15 @@ import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
 // CLERK_SECRET_KEY): dispensa senha e não esbarra na verificação de "novo
 // dispositivo" da instância, que bloqueia a estratégia password em contexto
 // headless — cada contexto Playwright é um dispositivo novo.
+
+// Roda os papéis em SÉRIE (não em paralelo). Cada signIn/signOut/currentUser
+// bate na instância de DEV do Clerk, que tem limites de uso estritos; rodar os
+// papéis em paralelo gera um burst que dispara rate-limit / `fetch failed` no
+// backend do Clerk e torna o smoke flaky (issue #198 — a falha não era
+// credencial nem o sync Clerk↔Supabase, ambos íntegros). Em série o ritmo fica
+// abaixo do limite.
+test.describe.configure({ mode: "serial" });
+
 const roles = [
   { role: "coordenador", emailEnv: "E2E_COORDINATOR_EMAIL" },
   { role: "membro", emailEnv: "E2E_MEMBER_EMAIL" },
@@ -28,14 +37,33 @@ for (const { role, emailEnv } of roles) {
     await page.goto("/auth/login");
     await clerk.signIn({ page, emailAddress: identifier! });
 
+    // Espera a sessão Clerk ficar ativa no cliente antes de navegar. O signIn
+    // resolve quando a sessão existe client-side, mas o cookie de sessão pode
+    // não ter propagado para a navegação server-side imediatamente seguinte —
+    // aí `currentUser()` no guard de /dashboard não vê a sessão e manda de
+    // volta ao login (a race do #198).
+    await page.waitForFunction(
+      () =>
+        (window as unknown as { Clerk?: { session?: { status?: string } } })
+          .Clerk?.session?.status === "active",
+      { timeout: 15_000 },
+    );
+
     try {
       await page.goto("/dashboard");
       await expect(
         page.getByRole("heading", { name: "Meus Projetos" }),
       ).toBeVisible();
     } finally {
-      // Garante que a sessão é encerrada mesmo se a asserção falhar.
-      await clerk.signOut({ page });
+      // Encerra a sessão mesmo se a asserção falhar. clerk.signOut faz
+      // page.evaluate sobre window.Clerk e pode pendurar se a página não
+      // estiver no estado esperado (ver nota em lottery.smoke.spec.ts); limita
+      // a 5s para não estourar o timeout do teste e mascarar a causa real — o
+      // contexto isolado do Playwright já descarta os cookies entre testes.
+      await Promise.race([
+        clerk.signOut({ page }).catch(() => {}),
+        page.waitForTimeout(5_000),
+      ]);
     }
   });
 }


### PR DESCRIPTION
## Contexto

O smoke E2E `frontend/e2e/dashboard.smoke.spec.ts` falhava de forma flaky no papel **coordenador** — após `clerk.signIn`, a navegação para `/dashboard` redirecionava de volta para `/auth/login` (a quebra reportada na #198).

## Diagnóstico empírico

Reproduzi a falha localmente e investiguei o caminho de auth. As **duas hipóteses da issue foram descartadas**:

- **Credencial/ambiente do test-user:** sondei o coordenador (`coordenador2+clerk_test@example.com`) no Supabase e no Clerk. Tudo íntegro e coerente — `profiles` existe e ativado, `clerk_user_mapping` presente, `publicMetadata.supabase_uid` no Clerk idêntico ao mapping/profile, conta não banida/locked.
- **Sync sob demanda Clerk↔Supabase:** como `publicMetadata.supabase_uid` já existe, `resolveSupabaseUidFromClerk` pega o caminho rápido (`auth.ts:25-28`) e **nunca chama o sync** — logo ele não pode lançar para este usuário.

**Causa raiz:** a suíte roda os papéis em **paralelo** (`fullyParallel: true`). O burst de `signIn`/`signOut`/`currentUser` bate na instância de **desenvolvimento** do Clerk, que tem limites de uso estritos, disparando `ClerkAPIResponseError: fetch failed` no `currentUser()` do guard de `/dashboard` (`auth.ts:20`, fora de try/catch). O stack trace no log do dev server confirma:

```
ClerkAPIResponseError (errors: [{ 'unexpected_error', 'fetch failed' }])
    at async resolveSupabaseUidFromClerk (src/lib/auth.ts:20:16)  ← const user = await currentUser();
    at async DashboardPage (src/app/(app)/dashboard/page.tsx:13:16)
```

Numa rodada limpa e **serial**, o coordenador passa de forma consistente. O `clerk.signOut` no `finally` ainda agravava: ele faz `page.evaluate` sobre `window.Clerk` e pendura quando a página não está no estado esperado (problema já anotado em `lottery.smoke.spec.ts`), virando timeout de 30s que mascarava a causa real.

## Mudanças (só teste + docs)

- **Serializa** `dashboard.smoke.spec.ts` com `test.describe.configure({ mode: "serial" })` — mantém o ritmo abaixo do limite do Clerk dev.
- **Espera a sessão Clerk ficar ativa** antes de navegar — fecha a race entre `signIn` (resolve client-side) e o cookie de sessão propagar para a navegação server-side seguinte.
- **Limita `clerk.signOut` a 5s** via `Promise.race`, para não estourar o timeout e mascarar o erro real (o contexto isolado do Playwright já descarta cookies entre testes).
- **README:** documenta o porquê do serial e adiciona um **checklist de smoke manual de login** (coordenador + membro). O E2E **permanece manual**, sem novo workflow de CI, conforme decidido.

## Validação

- `dashboard.smoke.spec.ts`: **3 rodadas seguidas verdes** (coordenador + membro; master pulado por falta de `E2E_MASTER_EMAIL`).
- `npm run typecheck`: limpo.
- `npm run lint` está quebrado em `origin/main` (ESLint 10.5.0 incompatível com `eslint-plugin-react`, crash em arquivos não tocados) — **pré-existente**, não introduzido aqui.

## Notas / follow-ups possíveis (fora de escopo)

- `currentUser()` em `auth.ts:20` está fora de try/catch — um `fetch failed` transitório quebra o render do dashboard. Não alterei para manter o PR focado e evitar risco de loop/silent-failure; fica como observação.
- Os outros smokes (`lottery`, `config-guard`) não são serializados e podem sofrer do mesmo burst do Clerk dev — candidatos ao mesmo tratamento se voltarem a flakear.

Closes #198