### PR TITLE
fix(secret-scan): allowlist das chaves públicas em frontend/fly.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+# Config do gitleaks (lida por padrao em .gitleaks.toml na raiz, tanto pela
+# action em .github/workflows/secret-scan.yml quanto pelo hook de pre-commit).
+#
+# Estende as regras default do gitleaks e libera falsos-positivos conhecidos.
+[extend]
+useDefault = true
+
+# As build args em frontend/fly.toml carregam a publishable/anon key do Supabase
+# (prefixo sb_publishable_) e a publishable key do Clerk (prefixo pk_test_ /
+# pk_live_). Ambas sao NEXT_PUBLIC_* — embutidas no bundle do browser em build
+# time e publicas por definicao; vao para o cliente de qualquer forma. A regra
+# generic-api-key do gitleaks as pega por entropia, mas nao sao segredos.
+# Allowlist por prefixo (nao por caminho) para nao cegar o scanner ao arquivo
+# inteiro — um segredo real ali continua sendo detectado.
+[allowlist]
+description = "Chaves publicas por design (Supabase publishable/anon, Clerk publishable)"
+regexes = [
+  '''sb_publishable_[A-Za-z0-9_-]+''',
+  '''pk_(test|live)_[A-Za-z0-9_-]+''',
+]


### PR DESCRIPTION
## Contexto

O merge do #172 (deploy do frontend no Fly) trouxe `frontend/fly.toml` com duas `NEXT_PUBLIC_*` nas `build.args`:

- `NEXT_PUBLIC_SUPABASE_ANON_KEY` (`sb_publishable_…`)
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` (`pk_test_…`)

São **chaves públicas por design** — embutidas no bundle do browser em build time, vão para o cliente de qualquer forma. Mas a regra `generic-api-key` do gitleaks as pega por **entropia** e deixou o `secret-scan` vermelho no push da `main` ([run](https://github.com/bdcdo/dataframeitGUI/actions/runs/28383174044)).

## Mudança

Adiciona `.gitleaks.toml` na raiz (local lido por padrão tanto pela action quanto pelo hook de pre-commit), estendendo as regras default (`useDefault = true`) e liberando os falsos-positivos **por prefixo de chave pública**, não por caminho:

```toml
regexes = [
  '''sb_publishable_[A-Za-z0-9_-]+''',
  '''pk_(test|live)_[A-Za-z0-9_-]+''',
]
```

Allowlist por prefixo (e não por `paths = ["frontend/fly.toml"]`) é mais seguro: identifica a classe "chave pública" onde quer que apareça, sem cegar o scanner para o arquivo inteiro — um `service_role`/secret real em `fly.toml` continua sendo detectado.

## Validação

Testei os regexes contra os valores reais das chaves: ambas casam (seriam allowlisted) e um `service_role` fictício **não** casa (continua sendo pego). O gitleaks não roda nesta PR sobre `fly.toml` porque o diff só adiciona `.gitleaks.toml`; o efeito aparece na próxima vez que `frontend/fly.toml` for tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)