### PR TITLE
refactor(coding): melhorias do review do PR 257 (8 itens)

### DIFF
--- a/frontend/src/components/coding/BrowseDocCoder.tsx
+++ b/frontend/src/components/coding/BrowseDocCoder.tsx
@@ -74,23 +74,29 @@ export function BrowseDocCoder({
   // o ref reinicia limpo a cada doc junto com o estado.
   const draftRef = useRef<CodingDraft>({ answers, notes });
 
+  // Durante um save em voo (`submitting`) a edição congela: o container já tirou
+  // o snapshot do rascunho que está salvando e, ao concluir, descarta o draftRef
+  // e navega. Sem este guard, teclas digitadas no meio do save atualizariam o
+  // draftRef tarde demais e seriam perdidas silenciosamente.
   const handleAnswer = useCallback(
     (fieldName: string, value: unknown) => {
+      if (submitting) return;
       const next = { ...draftRef.current.answers, [fieldName]: value };
       draftRef.current = { answers: next, notes: draftRef.current.notes };
       setAnswers(next);
       onDraftChange(draftRef.current);
     },
-    [onDraftChange],
+    [onDraftChange, submitting],
   );
 
   const handleNotesChange = useCallback(
     (next: string) => {
+      if (submitting) return;
       draftRef.current = { answers: draftRef.current.answers, notes: next };
       setNotes(next);
       onDraftChange(draftRef.current);
     },
-    [onDraftChange],
+    [onDraftChange, submitting],
   );
 
   const handleSubmit = useCallback(() => {

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -43,6 +43,8 @@ type DocSection =
       responseCount: number;
       onBack: () => void;
       onRandom: () => void;
+      /** Save em voo: desabilita Voltar/Sortear para evitar disparo duplo. */
+      submitting?: boolean;
       parecerUrl?: string;
       projectId: string;
       documentId: string;
@@ -270,6 +272,7 @@ function BrowseDocSection({
         size="icon"
         className="size-6 shrink-0"
         onClick={doc.onBack}
+        disabled={doc.submitting}
       >
         <ArrowLeft className="size-4" />
       </Button>
@@ -291,6 +294,7 @@ function BrowseDocSection({
           size="icon"
           className="size-6"
           onClick={doc.onRandom}
+          disabled={doc.submitting}
         >
           <Shuffle className="size-4" />
         </Button>

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -40,6 +40,25 @@ export type CodingSortMode = "default" | "recent";
 const EMPTY_CODED_AT: Record<string, string> = {};
 const EMPTY_JUSTIFICATIONS: Record<string, Record<string, unknown>> = {};
 
+/** Estado centralizado de falha + ação de retry do modo Explorar (lista e doc
+ *  compartilham a mesma marcação). */
+function RetryState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+      <p className="text-sm text-muted-foreground">{message}</p>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        Tentar novamente
+      </Button>
+    </div>
+  );
+}
+
 interface CodingPageProps {
   projectId: string;
   documents: (Document & { assignment?: Pick<Assignment, "id" | "status"> })[];
@@ -186,6 +205,10 @@ function CodingPageInner({
   // Rascunho atual do doc de browse, reportado pelo BrowseDocCoder; lido pelo
   // autosave-on-exit centralizado. Ref (não estado) para não entrar no render.
   const browseDraftRef = useRef<CodingDraft | null>(null);
+  // Guarda de reentrância dos saves de browse: impede que um duplo-clique em
+  // "Enviar"/"Voltar" dispare saveResponse/markResponded duas vezes antes do
+  // setSubmitting re-renderizar e desabilitar os botões.
+  const browseSavingRef = useRef(false);
 
   // Update URL query param without full navigation
   const updateDocParam = useCallback(
@@ -403,24 +426,30 @@ function CodingPageInner({
   const handleBrowseSubmit = useCallback(
     async ({ answers, notes }: CodingDraft) => {
       if (!browseDocId || Object.keys(answers).length === 0) return;
+      if (browseSavingRef.current) return;
+      browseSavingRef.current = true;
       setSubmitting(true);
-      const result = await saveResponse(projectId, browseDocId, answers, {
-        notes,
-      });
-      setSubmitting(false);
-      if (result.success) {
-        markClean(browseDocId);
-        toast.success("Respostas salvas!");
-        markResponded(browseDocId, "submit");
-        browseDraftRef.current = null;
-        // Zera o ?doc= ANTES de invalidar: com browseDocId já null, o hook não
-        // refetcha o doc que estamos deixando (evita refetch/flicker). A
-        // invalidação garante que reabri-lo na sessão reflita o que foi salvo
-        // (sem isto, o seed ficaria stale).
-        updateDocParam(null);
-        invalidateBrowseDoc(browseDocId);
-      } else {
-        toast.error(result.error || "Erro ao salvar respostas");
+      try {
+        const result = await saveResponse(projectId, browseDocId, answers, {
+          notes,
+        });
+        if (result.success) {
+          markClean(browseDocId);
+          toast.success("Respostas salvas!");
+          markResponded(browseDocId, "submit");
+          browseDraftRef.current = null;
+          // Zera o ?doc= ANTES de invalidar: com browseDocId já null, o hook não
+          // refetcha o doc que estamos deixando (evita refetch/flicker). A
+          // invalidação garante que reabri-lo na sessão reflita o que foi salvo
+          // (sem isto, o seed ficaria stale).
+          updateDocParam(null);
+          invalidateBrowseDoc(browseDocId);
+        } else {
+          toast.error(result.error || "Erro ao salvar respostas");
+        }
+      } finally {
+        setSubmitting(false);
+        browseSavingRef.current = false;
       }
     },
     [
@@ -439,23 +468,29 @@ function CodingPageInner({
     // Com rascunho sujo, aguarda o autosave ANTES de navegar: se falhar, mantém
     // o doc aberto e o rascunho intacto (em vez de descartá-lo otimisticamente).
     if (docId && dirtyDocs.has(docId) && browseDraftRef.current) {
+      if (browseSavingRef.current) return;
+      browseSavingRef.current = true;
       const { answers, notes } = browseDraftRef.current;
       setSubmitting(true);
-      const result = await saveResponse(projectId, docId, answers, {
-        notes,
-        isAutoSave: true,
-      });
-      setSubmitting(false);
-      if (!result.success) {
-        toast.error(
-          result.error ||
-            "Não foi possível salvar. Suas alterações não foram perdidas.",
-        );
-        return;
+      try {
+        const result = await saveResponse(projectId, docId, answers, {
+          notes,
+          isAutoSave: true,
+        });
+        if (!result.success) {
+          toast.error(
+            result.error ||
+              "Não foi possível salvar. Suas alterações não foram perdidas.",
+          );
+          return;
+        }
+        markClean(docId);
+        markResponded(docId, "autosave");
+        saved = true;
+      } finally {
+        setSubmitting(false);
+        browseSavingRef.current = false;
       }
-      markClean(docId);
-      markResponded(docId, "autosave");
-      saved = true;
     }
     browseDraftRef.current = null;
     // Zera o ?doc= ANTES de invalidar (mesmo motivo do handleBrowseSubmit: evita
@@ -555,6 +590,7 @@ function CodingPageInner({
                     responseCount: browseDocInfo?.responseCount ?? 0,
                     onBack: handleBrowseBack,
                     onRandom: handleBrowseRandom,
+                    submitting,
                     parecerUrl: browseParecerUrl,
                     projectId,
                     documentId: browseDocId,
@@ -648,18 +684,10 @@ function CodingPageInner({
       {mode === "browse" && (
         <>
           {browseError ? (
-            <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
-              <p className="text-sm text-muted-foreground">
-                Não foi possível carregar os documentos.
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={retryBrowseDocuments}
-              >
-                Tentar novamente
-              </Button>
-            </div>
+            <RetryState
+              message="Não foi possível carregar os documentos."
+              onRetry={retryBrowseDocuments}
+            />
           ) : browseLoading ? (
             <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
               Carregando documentos…
@@ -691,18 +719,10 @@ function CodingPageInner({
           ) : (
             // browseDoc === null → o fetch do doc falhou (erro de transporte ou
             // documento ausente). Oferece retry em vez de afirmar "não encontrado".
-            <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
-              <p className="text-sm text-muted-foreground">
-                Não foi possível carregar o documento.
-              </p>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => invalidateBrowseDoc(browseDocId)}
-              >
-                Tentar novamente
-              </Button>
-            </div>
+            <RetryState
+              message="Não foi possível carregar o documento."
+              onRetry={() => invalidateBrowseDoc(browseDocId)}
+            />
           )}
         </>
       )}

--- a/frontend/src/components/coding/__tests__/BrowseDocCoder.test.tsx
+++ b/frontend/src/components/coding/__tests__/BrowseDocCoder.test.tsx
@@ -138,6 +138,26 @@ describe("BrowseDocCoder", () => {
     });
   });
 
+  it("congela a edição enquanto submitting (não perde teclas durante o save em voo)", async () => {
+    const onDraftChange = vi.fn();
+    render(
+      <BrowseDocCoder
+        {...baseProps}
+        submitting
+        doc={makeDoc()}
+        onSubmit={vi.fn()}
+        onDraftChange={onDraftChange}
+      />,
+    );
+    await userEvent.click(screen.getByText("set-q1"));
+    await userEvent.click(screen.getByText("set-notes"));
+    // Com um save em voo, as edições são ignoradas: nada reportado para cima e o
+    // estado exibido permanece no seed (o container já salvou o snapshot).
+    expect(onDraftChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("answers").textContent).toBe('{"q0":"x"}');
+    expect(screen.getByTestId("notes").textContent).toBe("nota0");
+  });
+
   it("envia com as respostas e notas atuais", async () => {
     const onSubmit = vi.fn();
     render(

--- a/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, waitFor, cleanup, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import type { PydanticField, Document } from "@/lib/types";
@@ -330,6 +330,77 @@ describe("CodingPage — modo Explorar (integração)", () => {
     expect(autosaveProps.current.getPayload()).toBeNull();
     // O doc não foi re-buscado no retorno (cache não invalidado).
     expect(getDocumentForCoding).toHaveBeenCalledTimes(1);
+  });
+
+  it("nº3: duplo-clique em Enviar não duplica saveResponse", async () => {
+    getDocumentsForBrowse.mockResolvedValue([browseDoc("d1")]);
+    getDocumentForCoding.mockResolvedValue(codingResult("d1", null));
+    let resolveSave: (v: { success: boolean }) => void = () => {};
+    saveResponse.mockReturnValue(
+      new Promise<{ success: boolean }>((r) => {
+        resolveSave = r;
+      }),
+    );
+
+    render(
+      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+    );
+
+    await userEvent.click(await screen.findByText("pick-d1"));
+    await waitFor(() =>
+      expect(screen.getByTestId("qp-answers").textContent).toBe("{}"),
+    );
+    await userEvent.click(screen.getByText("qp-set")); // q1=sim (rascunho não vazio)
+
+    // Dois cliques antes do save em voo resolver: a guarda de reentrância barra
+    // o segundo, então saveResponse roda só uma vez.
+    await userEvent.click(screen.getByText("qp-enviar"));
+    await userEvent.click(screen.getByText("qp-enviar"));
+    expect(saveResponse).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSave({ success: true });
+    });
+    // Fluxo de sucesso conclui: volta ao picker.
+    await screen.findByText("pick-d1");
+  });
+
+  it("nº6: erro ao carregar a lista mostra RetryState e refaz o fetch", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getDocumentsForBrowse.mockRejectedValueOnce(new Error("falha de rede"));
+
+    render(
+      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+    );
+
+    expect(
+      await screen.findByText("Não foi possível carregar os documentos."),
+    ).toBeTruthy();
+
+    getDocumentsForBrowse.mockResolvedValueOnce([browseDoc("d1")]);
+    await userEvent.click(screen.getByText("Tentar novamente"));
+    expect(await screen.findByText("pick-d1")).toBeTruthy();
+  });
+
+  it("nº6: falha ao carregar o doc mostra RetryState e permite tentar de novo", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    getDocumentsForBrowse.mockResolvedValue([browseDoc("d1")]);
+    getDocumentForCoding.mockRejectedValueOnce(new Error("falha de rede"));
+
+    render(
+      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+    );
+
+    await userEvent.click(await screen.findByText("pick-d1"));
+    expect(
+      await screen.findByText("Não foi possível carregar o documento."),
+    ).toBeTruthy();
+
+    getDocumentForCoding.mockResolvedValueOnce(codingResult("d1", { q1: "ok" }));
+    await userEvent.click(screen.getByText("Tentar novamente"));
+    await waitFor(() =>
+      expect(screen.getByTestId("qp-answers").textContent).toBe('{"q1":"ok"}'),
+    );
   });
 
   it("nº5: trocar de doc limpa o dirty do anterior (sem vazamento)", async () => {

--- a/frontend/src/hooks/__tests__/useBrowseDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useBrowseDocuments.test.ts
@@ -116,6 +116,54 @@ describe("useBrowseDocuments", () => {
     ).toBeUndefined();
   });
 
+  it("markResponded antes da lista resolver é aplicado quando a base chega (race de deep-link)", async () => {
+    let resolveList: (v: BrowseDocument[]) => void = () => {};
+    mockGet.mockReturnValue(
+      new Promise<BrowseDocument[]>((r) => {
+        resolveList = r;
+      }),
+    );
+    const { result } = renderHook(() => useBrowseDocuments("p1", true));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.documents).toBeNull();
+
+    // Usuário envia rápido (deep-link) ANTES da lista chegar: a intenção fica
+    // pendente sem depender da base já carregada.
+    act(() => result.current.markResponded("d1", "submit"));
+    expect(result.current.documents).toBeNull();
+
+    // Lista chega depois, com a contagem do servidor pré-save.
+    await act(async () => {
+      resolveList([doc("d1", { responseCount: 2 }), doc("d2")]);
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const d1 = result.current.documents?.find((d) => d.id === "d1");
+    expect(d1?.userAlreadyResponded).toBe(true);
+    expect(d1?.responseCount).toBe(3);
+    const d2 = result.current.documents?.find((d) => d.id === "d2");
+    expect(d2?.userAlreadyResponded).toBe(false);
+    expect(d2?.responseCount).toBe(0);
+  });
+
+  it("bump de submit sobrevive a um autosave posterior no mesmo doc", async () => {
+    mockGet.mockResolvedValue([doc("d1", { responseCount: 2 })]);
+    const { result } = renderHook(() => useBrowseDocuments("p1", true));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.markResponded("d1", "submit"));
+    expect(
+      result.current.documents?.find((d) => d.id === "d1")?.responseCount,
+    ).toBe(3);
+
+    // autosave posterior não deve zerar o bump já aplicado.
+    act(() => result.current.markResponded("d1", "autosave"));
+    expect(
+      result.current.documents?.find((d) => d.id === "d1")?.responseCount,
+    ).toBe(3);
+  });
+
   it("toggle enabled true→false→true: refetch só 1x e preserva overrides", async () => {
     mockGet.mockResolvedValue([doc("d1", { responseCount: 1 })]);
     const { result, rerender } = renderHook(

--- a/frontend/src/hooks/useBrowseDocuments.ts
+++ b/frontend/src/hooks/useBrowseDocuments.ts
@@ -44,8 +44,12 @@ export function useBrowseDocuments(
     retry: retryResource,
   } = useCachedResource(projectId, fetcher, { enabled });
 
+  // Override guarda a INTENÇÃO (respondido; e se houve bump de contagem), não o
+  // valor absoluto. Assim `markResponded` não precisa ler a lista já carregada —
+  // o merge abaixo aplica a intenção sobre a base de forma idempotente quando a
+  // base chega (corrige a race de deep-link em que a lista ainda não resolveu).
   const [overrides, setOverrides] = useState<
-    Record<string, { userAlreadyResponded: boolean; responseCount: number }>
+    Record<string, { responded: true; bumped: boolean }>
   >({});
 
   const retry = useCallback(() => {
@@ -57,26 +61,34 @@ export function useBrowseDocuments(
     if (!base) return null;
     return base.map((d) => {
       const o = overrides[d.id];
-      return o ? { ...d, ...o } : d;
+      if (!o) return d;
+      return {
+        ...d,
+        userAlreadyResponded: true,
+        // +1 só quando o override pediu bump E a base ainda não contava este
+        // pesquisador. Recomputado de `base` a cada render → nunca acumula.
+        responseCount:
+          o.bumped && !d.userAlreadyResponded
+            ? d.responseCount + 1
+            : d.responseCount,
+      };
     });
   }, [base, overrides]);
 
-  // Lê o estado mesclado atual (base + overrides anteriores) pela closure: o
-  // callback recria quando `documents` muda, então a contagem nunca é dobrada.
+  // Registra a intenção sem ler `documents`: funciona mesmo com a lista ainda
+  // não resolvida. O bump é ADITIVO (uma vez "submit", permanece bumpado) para
+  // não se perder se um "autosave" posterior reescrever o mesmo doc.
   const markResponded = useCallback(
     (docId: string, intent: "submit" | "autosave") => {
-      const cur = documents?.find((d) => d.id === docId);
-      if (!cur) return;
-      const responseCount =
-        intent === "submit" && !cur.userAlreadyResponded
-          ? cur.responseCount + 1
-          : cur.responseCount;
       setOverrides((prev) => ({
         ...prev,
-        [docId]: { userAlreadyResponded: true, responseCount },
+        [docId]: {
+          responded: true,
+          bumped: (prev[docId]?.bumped ?? false) || intent === "submit",
+        },
       }));
     },
-    [documents],
+    [],
   );
 
   return { documents, loading, error, retry, markResponded };

--- a/frontend/src/hooks/useCachedResource.ts
+++ b/frontend/src/hooks/useCachedResource.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * Núcleo de cache-por-chave compartilhado pelos lazy-loaders do app
@@ -88,8 +88,17 @@ export function useCachedResource<T>(
   const [store, setStore] = useState<CacheStore<T>>({ entries: {}, order: [] });
   const [errors, setErrors] = useState<Record<string, true>>({});
 
+  // `needsFetch` é a única condição que dispara o effect: chave habilitada,
+  // ainda não cacheada e sem erro registrado. Como é um BOOLEANO derivado, o
+  // effect só reage quando ela vira true (precisa buscar) — e não a cada
+  // mutação do `store`/`errors`, evitando a antiga subscrição ao cache inteiro.
+  // Ao `invalidate`/`retry` a chave sai do cache, `needsFetch` volta a true e o
+  // effect refaz o fetch.
+  const needsFetch =
+    enabled && !!key && !(key in store.entries) && !errors[key];
+
   useEffect(() => {
-    if (!enabled || !key || key in store.entries || errors[key]) return;
+    if (!needsFetch || !key) return;
     let cancelled = false;
     fetcher(key)
       .then((value) => {
@@ -104,7 +113,7 @@ export function useCachedResource<T>(
     return () => {
       cancelled = true;
     };
-  }, [enabled, key, store, errors, fetcher, maxEntries]);
+  }, [needsFetch, key, fetcher, maxEntries]);
 
   const invalidate = useCallback((k: string) => {
     setStore((prev) => removeKey(prev, k));
@@ -113,18 +122,13 @@ export function useCachedResource<T>(
 
   // Limpa cache+erro da chave CORRENTE para que o effect refaça o fetch.
   const retry = useCallback(() => {
-    if (!key) return;
-    setStore((prev) => removeKey(prev, key));
-    setErrors((prev) => deleteKey(prev, key));
-  }, [key]);
+    if (key) invalidate(key);
+  }, [key, invalidate]);
 
-  const data = useMemo(
-    () => (enabled && key && key in store.entries ? store.entries[key] : undefined),
-    [enabled, key, store],
-  );
+  const data =
+    enabled && key && key in store.entries ? store.entries[key] : undefined;
   const error = enabled && !!key && !!errors[key];
-  const loading =
-    enabled && !!key && !(key in store.entries) && !errors[key];
+  const loading = needsFetch;
 
   return { data, loading, error, invalidate, retry };
 }

--- a/frontend/src/hooks/useDocumentText.ts
+++ b/frontend/src/hooks/useDocumentText.ts
@@ -6,6 +6,14 @@ import { useCachedResource } from "./useCachedResource";
 
 const NOT_FOUND = "(Documento não encontrado)";
 
+/** Teto do cache de texto. Os consumidores (`CommentsSplitView`, `MyVerdictsView`)
+ *  percorrem um conjunto ABERTO de documentos um a um; sem teto, o `text` integral
+ *  de todo doc visitado ficaria retido pelo tempo de vida do componente (mesmo
+ *  risco de heap que motivou o teto em `useDocumentForCoding`). O teto cobre o
+ *  ir-e-voltar imediato entre docs vizinhos; reabrir um doc despejado refaz o
+ *  fetch (texto imutável, sem custo de staleness). */
+const MAX_CACHED_TEXTS = 10;
+
 /**
  * Lazy-load do texto de um documento, com cache por id e flag `loading`.
  *
@@ -35,6 +43,8 @@ export function useDocumentText(
     [projectId],
   );
 
-  const { data, loading } = useCachedResource(documentId, fetcher);
+  const { data, loading } = useCachedResource(documentId, fetcher, {
+    maxEntries: MAX_CACHED_TEXTS,
+  });
   return { text: data, loading };
 }


### PR DESCRIPTION
**Stacked sobre o #257** (base = `refactor/coding-browse-react-doctor`). Endereça os **8 itens** do code-review high do PR 257 — 3 de correctness de borda + 5 de cleanup — sem regressão. O diff mostra só as melhorias; mergear o #257 primeiro reduz este PR ao delta.

## Correctness

1. **Teclas perdidas no autosave do "Voltar"** (`BrowseDocCoder`): a edição congela enquanto `submitting` (`handleAnswer`/`handleNotesChange` com guard) — teclas digitadas durante o save em voo não são mais descartadas.
2. **Race de deep-link no `markResponded`** (`useBrowseDocuments`): o override passou a registrar a *intenção* (`{responded, bumped}`) sem ler a lista já carregada; o merge aplica idempotentemente sobre a base quando ela chega. O bump de `submit` é aditivo (sobrevive a um `autosave` posterior).
3. **Duplo-clique duplica save** (`CodingPage` + `CodingHeader`): guarda de reentrância (`browseSavingRef`) em `handleBrowseSubmit`/`handleBrowseBack` + botões Voltar/Sortear desabilitados durante o save.

## Cleanup

4. **`useCachedResource`**: effect passa a depender do booleano derivado `needsFetch`, não dos objetos `store`/`errors` inteiros (altitude certa, sem subscrição ao cache).
5. **`useCachedResource`**: `data` inline (remove `useMemo` que não trazia estabilidade).
6. **`CodingPage`**: extraído `RetryState` local — elimina o bloco erro+retry duplicado.
7. **`useCachedResource`**: `retry` delega a `invalidate` (sem corpo duplicado).
8. **`useDocumentText`**: teto de cache `MAX_CACHED_TEXTS=10` — evita reter o texto integral de todo doc visitado por sessão (consumido por `CommentsSplitView` e `MyVerdictsView`).

## Validação

- `tsc --noEmit`, `eslint` e `react-doctor:diff` limpos (0 errors/diagnósticos novos).
- **598/598** testes verdes (55 arquivos), incluindo **+6 casos novos**: race de deep-link, bump aditivo, edição congelada, duplo-clique sem duplicar `saveResponse`, `RetryState` nos dois estados.
- ⚠️ Verify manual E2E pendente (precisa auth + dados): Explorar — deep-link `?doc=<não-atribuído>` + envio rápido (valida #2); editar + "Voltar" com rede lenta + tentar digitar/duplo-clicar (valida #1/#3); erro de carregamento → "Tentar novamente" (valida #6).

Decorre do code-review high do #257.