### PR TITLE
fix(ci): deploy do frontend usa token Fly app-scoped

### DIFF
--- a/.github/workflows/frontend-fly-deploy.yml
+++ b/.github/workflows/frontend-fly-deploy.yml
@@ -23,4 +23,7 @@ jobs:
       - run: flyctl deploy --remote-only -a gui-analise-sistematica-frontend
         working-directory: frontend
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          # Token app-scoped DESTE app (gui-analise-sistematica-frontend). O
+          # FLY_API_TOKEN compartilhado com o backend tem escopo do app da API
+          # e dava `unauthorized` aqui — tokens de deploy do Fly sao por app.
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_FRONTEND }}


### PR DESCRIPTION
> [!IMPORTANT]
> **🚧 Bloqueado — não mergear ainda.** O secret `FLY_API_TOKEN_FRONTEND` (token app-scoped do frontend) precisa existir **antes** do merge; sem ele o deploy falha por token vazio. Mantido em **Draft** de propósito até o secret ser criado. Rastreado pela #300; comando na seção "Pré-requisito" abaixo.

## Contexto

Após o merge do #172, o workflow `Deploy frontend (Fly.io)` falhou no push da `main` com `Error: unauthorized` ([run](https://github.com/bdcdo/dataframeitGUI/actions/runs/28383174601)). A config do `fly.toml` é válida e o `FLY_API_TOKEN` está presente — o problema é **escopo**: tokens de deploy do Fly são **por app**, e o `FLY_API_TOKEN` que o repo já tinha foi criado para o app do **backend** (`gui-analise-sistematica-api`). Ele não autoriza deploy do `gui-analise-sistematica-frontend`.

## Mudança

Opção de **menor privilégio** (alinhada à constituição): cada app tem seu próprio token. O workflow do frontend passa a ler um secret novo, `FLY_API_TOKEN_FRONTEND`.

## Pré-requisito para mergear

O secret `FLY_API_TOKEN_FRONTEND` precisa existir no repo antes do merge, contendo um token app-scoped do frontend:

```bash
fly tokens create deploy -a gui-analise-sistematica-frontend -n "gh-actions-frontend-deploy" \
  | gh secret set FLY_API_TOKEN_FRONTEND --repo bdcdo/dataframeitGUI
```

Sem o secret, o próximo deploy falha por token vazio. Com ele, o push em `frontend/**` volta a deployar automaticamente.

Refs #300, #172, #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)