### PR TITLE
fix(security): endurece allowlist AST e corrige regressões do #197

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 
 from config import settings
 from routes.llm_routes import router as llm_router
+from routes.pydantic_routes import router as pydantic_router
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +94,7 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 
 
 app.include_router(llm_router, prefix="/api/llm", tags=["llm"])
+app.include_router(pydantic_router, prefix="/api/pydantic", tags=["pydantic"])
 
 
 @app.get("/health")

--- a/backend/routes/pydantic_routes.py
+++ b/backend/routes/pydantic_routes.py
@@ -1,0 +1,59 @@
+"""Recuperação de campos a partir do `pydantic_code` armazenado.
+
+Diferente do endpoint `POST /api/pydantic/validate` removido no #197 (que
+recebia código Pydantic arbitrário do cliente — o vetor do #163), este endpoint
+recebe apenas um `project_id`: o backend lê `projects.pydantic_code` via service
+key e roda `compile_pydantic` (allowlist AST, sem exec). O cliente não consegue
+injetar código, então não há vetor de RCE. Existe para repopular o editor visual
+quando um projeto legado tem `pydantic_code` mas `pydantic_fields` vazio, e dá a
+`compile_pydantic` um chamador de produção (round-trip da regra (b) do CLAUDE.md).
+
+NOTA: quando a auth JWT de rotas (#195) estiver mergeada, este router deve herdar
+a mesma proteção das demais rotas — hoje o backend confia no boundary de rede,
+igual a `/api/llm/*`.
+"""
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from services.pydantic_compiler import compile_pydantic
+from services.supabase_client import get_supabase
+
+router = APIRouter()
+
+
+class RecoverRequest(BaseModel):
+    project_id: str
+
+
+class PydanticFieldOut(BaseModel):
+    name: str
+    type: str
+    options: list[str] | None
+    description: str
+
+
+class RecoverResponse(BaseModel):
+    valid: bool
+    fields: list[dict]
+    model_name: str | None
+    errors: list[str]
+
+
+@router.post("/recover-fields", response_model=RecoverResponse)
+async def recover_fields(req: RecoverRequest) -> dict:
+    sb = get_supabase()
+    result = (
+        sb.table("projects")
+        .select("pydantic_code")
+        .eq("id", req.project_id)
+        .single()
+        .execute()
+    )
+    if not result.data:
+        raise HTTPException(status_code=404, detail="Projeto não encontrado")
+    code = result.data.get("pydantic_code")
+    if not code:
+        raise HTTPException(
+            status_code=404, detail="Projeto não possui código Pydantic armazenado"
+        )
+    return compile_pydantic(code)

--- a/backend/routes/pydantic_routes.py
+++ b/backend/routes/pydantic_routes.py
@@ -25,13 +25,6 @@ class RecoverRequest(BaseModel):
     project_id: str
 
 
-class PydanticFieldOut(BaseModel):
-    name: str
-    type: str
-    options: list[str] | None
-    description: str
-
-
 class RecoverResponse(BaseModel):
     valid: bool
     fields: list[dict]
@@ -42,14 +35,18 @@ class RecoverResponse(BaseModel):
 @router.post("/recover-fields", response_model=RecoverResponse)
 async def recover_fields(req: RecoverRequest) -> dict:
     sb = get_supabase()
+    # maybe_single (não single): single() lança APIError quando nenhuma linha
+    # casa, o que viraria 500 opaco em vez do 404 abaixo. maybe_single retorna
+    # data=None para projeto inexistente, deixando o guard responder 404 claro
+    # (mesmo padrão de llm_runner.get_job_status).
     result = (
         sb.table("projects")
         .select("pydantic_code")
         .eq("id", req.project_id)
-        .single()
+        .maybe_single()
         .execute()
     )
-    if not result.data:
+    if not result or not result.data:
         raise HTTPException(status_code=404, detail="Projeto não encontrado")
     code = result.data.get("pydantic_code")
     if not code:

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -80,6 +80,12 @@ def _extract_pydantic_location(exc: Exception, tb: str) -> tuple[int | None, int
     """Best-effort line/column inside pydantic_code where the error originated."""
     if isinstance(exc, SyntaxError) and exc.filename in (None, "<pydantic_schema>"):
         return exc.lineno, exc.offset
+    # build_model_from_code envolve erros de sintaxe num SchemaError e carrega
+    # lineno/offset nele (o `compile`/exec antigo expunha um SyntaxError direto,
+    # caminho que não existe mais). getattr evita acoplar o import do SchemaError.
+    lineno = getattr(exc, "lineno", None)
+    if isinstance(lineno, int):
+        return lineno, getattr(exc, "offset", None)
     m = re.search(r'File "<pydantic_schema>", line (\d+)', tb)
     if m:
         return int(m.group(1)), None

--- a/backend/services/pydantic_compiler.py
+++ b/backend/services/pydantic_compiler.py
@@ -11,7 +11,7 @@ lambda, comprehension ou decorador é aceito.
 import ast
 import hashlib
 import typing
-from typing import Annotated, Any, Literal, Optional, Union, get_args, get_origin
+from typing import Literal, Optional, get_args, get_origin
 
 
 def compile_pydantic(code: str) -> dict:
@@ -226,12 +226,32 @@ def _sanitize_condition(raw: object) -> dict | None:
 # --------------------------------------------------------------------------
 
 class SchemaError(ValueError):
-    """Código de schema rejeitado pela allowlist ou inválido."""
+    """Código de schema rejeitado pela allowlist ou inválido.
+
+    Carrega ``lineno``/``offset`` quando a origem do erro tem posição conhecida
+    (ex.: ``SyntaxError`` do ``ast.parse``), para que o runner consiga apontar a
+    linha do schema ao coordenador (ver ``llm_runner._extract_pydantic_location``).
+    ``None`` quando a posição não é localizável (ex.: violação de allowlist sobre
+    um nó sem linha relevante).
+    """
+
+    def __init__(
+        self, *args: object, lineno: int | None = None, offset: int | None = None
+    ):
+        super().__init__(*args)
+        self.lineno = lineno
+        self.offset = offset
 
 
 # Imports tolerados no topo do schema. Nada além de pydantic/typing é
 # necessário para definir os modelos; qualquer outro import é rejeitado.
 _ALLOWED_IMPORT_MODULES = {"pydantic", "typing", "typing_extensions", "__future__"}
+
+# Tamanho máximo do código de schema. O código é gerado pela GUI
+# (`generatePydanticCode`) e nunca chega perto disso; o limite só existe como
+# defense-in-depth para barrar um `projects.pydantic_code` patológico antes de
+# `ast.parse`, evitando custo de parsing/recursão sobre entrada gigante.
+_MAX_CODE_LENGTH = 64 * 1024
 
 # Escalares aceitos como anotação de campo.
 _SCALAR_TYPES: dict[str, type] = {
@@ -273,41 +293,70 @@ _FORBIDDEN_NODES = (
     ast.Import,  # `import x` — ImportFrom permitido só p/ módulos do allowlist
 )
 
-# Profundidade máxima de aninhamento de anotações de tipo. Anotações legítimas
-# (Optional[list[Literal[...]]]) ficam muito abaixo disso; o limite só existe
-# para transformar um aninhamento patológico num SchemaError claro em vez de
-# RecursionError.
+# Profundidade máxima de aninhamento de anotações de tipo. A anotação mais
+# profunda que `generatePydanticCode` emite é `list[Literal[...]]` (profundidade
+# ~2); 20 é folgado de propósito. O limite só existe para transformar um
+# aninhamento patológico num SchemaError claro em vez de RecursionError.
 _MAX_TYPE_DEPTH = 20
 
 
 def build_model_from_code(code: str):
     """Parseia, valida e reconstrói a classe Pydantic raiz — sem executar nada.
 
-    O código aceito é o subconjunto que ``generatePydanticCode`` (frontend)
-    emite, mais variações equivalentes: classes ``BaseModel`` com campos
-    anotados por escalares (str/int/float/bool), ``Literal[...]``,
-    ``list[Literal[...]]``, ``Optional[...]``, união ``X | None``, ``dict``,
-    ``tuple`` e ``BaseModel`` aninhado; valores de ``Field(...)`` e defaults
-    são literais (avaliados por ``ast.literal_eval``, que não chama funções).
-    Imports são restritos a pydantic/typing. Qualquer outra construção
-    (import arbitrário, chamada que não ``Field``, acesso a atributo, dunder
-    estrito, lambda, comprehension, decorador) é rejeitada por
-    ``_reject_dangerous``. A edição manual do código foi descontinuada na UI;
-    o código existe apenas como fonte de verdade gerada pela GUI, mas a
-    allowlist é mantida como defense-in-depth sobre ``projects.pydantic_code``.
+    Aceita **exatamente** a grammar que ``generatePydanticCode`` (frontend)
+    emite — o único produtor legítimo de ``projects.pydantic_code`` desde que a
+    edição manual foi descontinuada na UI (#197):
 
-    Retorna a classe (equivalente ao antigo find_root_model do namespace
-    exec'd) ou None se nenhum BaseModel for definido. Levanta SchemaError em
-    código inválido ou que viole a allowlist.
+    - imports só de ``pydantic``/``typing``;
+    - classes ``BaseModel`` com herança única;
+    - anotações ``str`` (e demais escalares de ``_SCALAR_TYPES``),
+      ``Literal[...]``, ``list[Literal[...]]``, ``Optional[...]`` e ``BaseModel``
+      aninhado;
+    - ``Field(...)`` com valores literais (``ast.literal_eval``, que não chama
+      funções) — incluindo ``json_schema_extra={...}``.
+
+    Tudo fora disso — ``Annotated[...]``, ``dict``/``tuple``/``Union[...]``,
+    união ``X | None``, herança múltipla, import arbitrário, chamada que não
+    ``Field``, acesso a atributo, dunder estrito, lambda, comprehension,
+    decorador — é rejeitado com ``SchemaError`` (defense-in-depth). A allowlist
+    é deliberadamente estreita: casa só o seu produtor, sem suportar Pydantic
+    arbitrário.
+
+    Retorna a classe raiz (ver ``find_root_model``) ou ``None`` se nenhum
+    ``BaseModel`` for definido. Levanta ``SchemaError`` (sempre — nunca um
+    ``ValueError``/``TypeError`` cru) em código inválido ou que viole a
+    allowlist.
     """
+    if len(code) > _MAX_CODE_LENGTH:
+        raise SchemaError("Código de schema excede o tamanho máximo permitido")
     try:
-        tree = ast.parse(code)
+        tree = ast.parse(code, filename="<pydantic_schema>")
     except SyntaxError as e:
-        raise SchemaError(f"Código inválido: {e}") from e
+        raise SchemaError(f"Código inválido: {e}", lineno=e.lineno, offset=e.offset) from e
 
     _reject_dangerous(tree)
-    namespace = _build_models(tree)
+    # _build_models/_resolve_type só devem levantar SchemaError; qualquer
+    # exceção inesperada (ex.: TypeError de typing, ValueError de unpack) é
+    # encapsulada para honrar o contrato e dar mensagem coerente ao usuário.
+    try:
+        namespace = _build_models(tree)
+    except SchemaError:
+        raise
+    except Exception as e:  # noqa: BLE001 — converte para o tipo de erro do contrato
+        raise SchemaError(str(e) or type(e).__name__) from e
     return find_root_model(namespace)
+
+
+def _is_strict_dunder(name: str) -> bool:
+    """True para identificadores que começam E terminam com "__".
+
+    Nomes legítimos com "__" interno (ex.: my__field) ou de borda (a classe
+    aninhada _doc__fields gerada de um campo terminando em "_") são liberados;
+    só os dunders estritos (__import__, __class__, __subclasses__, ...) são
+    atributos mágicos/builtins perigosos. Espelha o `isStrictDunder` do
+    frontend (schema-utils.ts).
+    """
+    return name.startswith("__") and name.endswith("__")
 
 
 def _reject_dangerous(tree: ast.AST) -> None:
@@ -320,25 +369,29 @@ def _reject_dangerous(tree: ast.AST) -> None:
         if isinstance(node, ast.ImportFrom):
             if node.module not in _ALLOWED_IMPORT_MODULES:
                 raise SchemaError(f"Import não permitido: {node.module}")
-        if isinstance(node, ast.ClassDef) and node.decorator_list:
-            raise SchemaError("Decoradores não são permitidos em classes do schema")
+        if isinstance(node, ast.ClassDef):
+            if node.decorator_list:
+                raise SchemaError("Decoradores não são permitidos em classes do schema")
+            # Nome da classe não é um ast.Name (é str), então não passa pela
+            # checagem de Name abaixo — valida aqui (ex.: class __reduce__(...)).
+            if _is_strict_dunder(node.name):
+                raise SchemaError(f"Nome de classe não permitido: {node.name}")
         # Única chamada permitida é Field(...). Bloqueia open/eval/__import__/etc.
         if isinstance(node, ast.Call):
             if not (isinstance(node.func, ast.Name) and node.func.id == "Field"):
                 raise SchemaError("Apenas Field(...) pode ser chamado no schema")
-        # Bloqueia dunders estritos (__import__, __class__, __subclasses__, ...).
-        # Nomes de campo legítimos com "__" interno (ex.: my__field) ou de
-        # borda (a classe aninhada _doc__fields gerada de um campo terminando
-        # em "_") são liberados; só identificadores que começam E terminam com
-        # "__" são atributos mágicos/builtins perigosos.
-        if (
-            isinstance(node, ast.Name)
-            and node.id.startswith("__")
-            and node.id.endswith("__")
-        ):
+            # Nomes de kwarg também são str, não ast.Name; um dunder estrito
+            # como Field(__class__=...) ou json_schema_extra de chave dunder
+            # passaria despercebido sem esta checagem.
+            for kw in node.keywords:
+                if kw.arg is not None and _is_strict_dunder(kw.arg):
+                    raise SchemaError(f"Argumento não permitido em Field(...): {kw.arg}")
+        # Bloqueia dunders estritos escritos como identificador (ast.Name).
+        if isinstance(node, ast.Name) and _is_strict_dunder(node.id):
             raise SchemaError(f"Identificador não permitido: {node.id}")
-        # Só BitOr (X | None) é aceito como operação binária (em anotações).
-        if isinstance(node, ast.BinOp) and not isinstance(node.op, ast.BitOr):
+        # Nenhuma operação binária é válida no schema gerado (Optional[...] é
+        # usado no lugar de `X | None`). Rejeita todas.
+        if isinstance(node, ast.BinOp):
             raise SchemaError("Operação não permitida no schema")
 
 
@@ -350,14 +403,19 @@ def _build_models(tree: ast.Module) -> dict:
     """
     class_defs = [n for n in tree.body if isinstance(n, ast.ClassDef)]
     names = {cd.name for cd in class_defs}
+    # Dependências computadas uma única vez por classe (cada `_class_dependencies`
+    # faz `ast.walk` das anotações); o loop abaixo só testa pertinência contra o
+    # conjunto já construído, mantido incrementalmente — O(N) walks, não O(N²).
+    deps_by_name = {cd.name: _class_dependencies(cd, names) for cd in class_defs}
     built: dict = {}
+    built_names: set[str] = set()
     pending = list(class_defs)
     while pending:
         progressed = False
         for cd in list(pending):
-            deps = _class_dependencies(cd, names)
-            if deps <= set(built):
+            if deps_by_name[cd.name] <= built_names:
                 built[cd.name] = _build_one_class(cd, built)
+                built_names.add(cd.name)
                 pending.remove(cd)
                 progressed = True
         if not progressed:
@@ -383,18 +441,22 @@ def _class_dependencies(cd: ast.ClassDef, local_names: set[str]) -> set[str]:
 def _build_one_class(cd: ast.ClassDef, built: dict):
     from pydantic import BaseModel, create_model
 
-    base = None
-    for b in cd.bases:
-        if not isinstance(b, ast.Name):
-            raise SchemaError(f"Base de classe inválida em {cd.name}")
-        if b.id == "BaseModel":
-            base = BaseModel
-        elif b.id in built:
-            base = built[b.id]
-        else:
-            raise SchemaError(f"Base desconhecida em {cd.name}: {b.id}")
-    if base is None:
-        raise SchemaError(f"Classe {cd.name} não herda de BaseModel")
+    # O gerador só emite herança única de BaseModel (ou de uma classe aninhada).
+    # Herança múltipla não é suportada e antes era colapsada em silêncio para a
+    # última base, descartando campos — agora é rejeitada explicitamente.
+    if len(cd.bases) != 1:
+        raise SchemaError(
+            f"Classe {cd.name} deve herdar de exatamente uma base (BaseModel)"
+        )
+    b = cd.bases[0]
+    if not isinstance(b, ast.Name):
+        raise SchemaError(f"Base de classe inválida em {cd.name}")
+    if b.id == "BaseModel":
+        base = BaseModel
+    elif b.id in built:
+        base = built[b.id]
+    else:
+        raise SchemaError(f"Base desconhecida em {cd.name}: {b.id}")
 
     field_defs: dict = {}
     for stmt in cd.body:
@@ -416,17 +478,19 @@ def _build_one_class(cd: ast.ClassDef, built: dict):
     return create_model(cd.name, __base__=base, **field_defs)
 
 
-def _subscript_slice(node: ast.Subscript) -> ast.AST:
-    # Em Python 3.9+ o slice é a expressão direta (Index foi removido).
-    return node.slice
-
-
 def _slice_elements(sl: ast.AST) -> list[ast.AST]:
     return list(sl.elts) if isinstance(sl, ast.Tuple) else [sl]
 
 
 def _resolve_type(node: ast.AST, built: dict, depth: int = 0):
-    """Converte um nó de anotação de tipo num objeto de tipo real (sem eval)."""
+    """Converte um nó de anotação de tipo num objeto de tipo real (sem eval).
+
+    Suporta apenas a grammar do gerador: escalares (``_SCALAR_TYPES``), classes
+    aninhadas, ``Literal[...]``, ``list[...]`` e ``Optional[...]``. Construtores
+    como ``Annotated``/``dict``/``tuple``/``Union`` (e união ``X | None``, já
+    barrada em ``_reject_dangerous``) não são emitidos pelo gerador e viram
+    ``SchemaError`` limpo.
+    """
     if depth > _MAX_TYPE_DEPTH:
         raise SchemaError("Anotação de tipo aninhada demais")
     if isinstance(node, ast.Name):
@@ -434,8 +498,6 @@ def _resolve_type(node: ast.AST, built: dict, depth: int = 0):
             return _SCALAR_TYPES[node.id]
         if node.id in built:
             return built[node.id]
-        if node.id == "Any":
-            return Any
         raise SchemaError(f"Tipo não suportado: {node.id}")
 
     if isinstance(node, ast.Constant):
@@ -443,17 +505,11 @@ def _resolve_type(node: ast.AST, built: dict, depth: int = 0):
             return type(None)
         raise SchemaError(f"Anotação inválida: {node.value!r}")
 
-    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
-        return Union[
-            _resolve_type(node.left, built, depth + 1),
-            _resolve_type(node.right, built, depth + 1),
-        ]
-
     if isinstance(node, ast.Subscript):
         if not isinstance(node.value, ast.Name):
             raise SchemaError("Construtor de tipo inválido")
         ctor = node.value.id
-        sl = _subscript_slice(node)
+        sl = node.slice  # Python 3.9+: o slice é a expressão direta.
         if ctor == "Literal":
             values = tuple(_literal_value(e) for e in _slice_elements(sl))
             return Literal[values]
@@ -461,25 +517,6 @@ def _resolve_type(node: ast.AST, built: dict, depth: int = 0):
             return list[_resolve_type(_single_arg(sl), built, depth + 1)]
         if ctor == "Optional":
             return Optional[_resolve_type(_single_arg(sl), built, depth + 1)]
-        if ctor == "Union":
-            return Union[
-                tuple(_resolve_type(e, built, depth + 1) for e in _slice_elements(sl))
-            ]
-        if ctor == "Annotated":
-            elts = _slice_elements(sl)
-            inner = _resolve_type(elts[0], built, depth + 1)
-            meta = [_safe_literal(e) for e in elts[1:]]
-            return Annotated[tuple([inner, *meta])]
-        if ctor in ("dict", "Dict"):
-            k, v = _slice_elements(sl)
-            return dict[
-                _resolve_type(k, built, depth + 1),
-                _resolve_type(v, built, depth + 1),
-            ]
-        if ctor in ("tuple", "Tuple"):
-            return tuple[
-                tuple(_resolve_type(e, built, depth + 1) for e in _slice_elements(sl))
-            ]
         raise SchemaError(f"Construtor de tipo não suportado: {ctor}")
 
     raise SchemaError(f"Anotação de tipo inválida: {type(node).__name__}")
@@ -505,8 +542,9 @@ def _build_field(value: ast.AST | None):
     if value is None:
         return ...  # campo sem default → required
     if isinstance(value, ast.Call):
-        # _reject_dangerous já garantiu func == Field
-        args = [_field_default(a) for a in value.args]
+        # _reject_dangerous já garantiu func == Field. _safe_literal trata
+        # `...` (literal_eval retorna Ellipsis), então não há caso especial.
+        args = [_safe_literal(a) for a in value.args]
         kwargs: dict = {}
         for kw in value.keywords:
             if kw.arg is None:
@@ -515,12 +553,6 @@ def _build_field(value: ast.AST | None):
         return Field(*args, **kwargs)
     # Default literal direto (ex.: `x: int = 5`)
     return Field(default=_safe_literal(value))
-
-
-def _field_default(node: ast.AST):
-    if isinstance(node, ast.Constant) and node.value is ...:
-        return ...
-    return _safe_literal(node)
 
 
 def _safe_literal(node: ast.AST):

--- a/backend/tests/test_llm_error_location.py
+++ b/backend/tests/test_llm_error_location.py
@@ -1,5 +1,8 @@
 """Unit tests for _extract_pydantic_location in services.llm_runner."""
+import traceback
+
 from services.llm_runner import _extract_pydantic_location
+from services.pydantic_compiler import build_model_from_code
 
 
 def test_syntax_error_returns_line_and_column():
@@ -32,5 +35,38 @@ def test_unrelated_traceback_returns_none():
         "ValueError: unrelated\n"
     )
     line, col = _extract_pydantic_location(ValueError("x"), fake_tb)
+    assert line is None
+    assert col is None
+
+
+def test_real_build_syntax_error_carries_line():
+    # Caminho REAL pós-#197: build_model_from_code envolve o SyntaxError do
+    # ast.parse num SchemaError com lineno/offset. Sem isso, error_line ficava
+    # NULL para todo erro de schema (a regressão que este teste cobre).
+    code = (
+        "from pydantic import BaseModel, Field\n"
+        "class Analysis(BaseModel):\n"
+        "    x: str = Field(description=)\n"  # syntax error na linha 3
+    )
+    try:
+        build_model_from_code(code)
+        raise AssertionError("esperava SchemaError")
+    except Exception as e:  # noqa: BLE001 — capturamos para inspecionar a posição
+        line, col = _extract_pydantic_location(e, traceback.format_exc())
+    assert line == 3
+
+
+def test_real_build_allowlist_violation_has_no_spurious_line():
+    # Violação de allowlist (sem posição mapeável) não inventa linha: (None, None).
+    code = (
+        "import os\n"
+        "class Analysis(BaseModel):\n"
+        "    x: str = Field()\n"
+    )
+    try:
+        build_model_from_code(code)
+        raise AssertionError("esperava SchemaError")
+    except Exception as e:  # noqa: BLE001
+        line, col = _extract_pydantic_location(e, traceback.format_exc())
     assert line is None
     assert col is None

--- a/backend/tests/test_pydantic_compiler_ast.py
+++ b/backend/tests/test_pydantic_compiler_ast.py
@@ -120,16 +120,17 @@ class Analysis(BaseModel):
     assert inst.doc.part_b is None
 
 
-def test_union_pipe_syntax_supported():
-    # Edição manual pode usar `str | None` em vez de Optional[str].
+def test_union_pipe_syntax_rejected():
+    # Após o estreitamento à grammar do gerador, `X | None` não é suportado (o
+    # gerador usa Optional[...]). Deve ser rejeitado de forma limpa, não aceito.
     code = '''from pydantic import BaseModel, Field
 
 class Analysis(BaseModel):
     x: str | None = Field(default=None, description="X")
 '''
     result = compile_pydantic(code)
-    assert result["valid"], result["errors"]
-    assert result["fields"][0]["name"] == "x"
+    assert result["valid"] is False
+    assert result["errors"]
 
 
 def test_top_level_literal_assignment_allowed_but_no_model():
@@ -198,3 +199,131 @@ def test_deeply_nested_annotation_rejected_with_message():
     result = compile_pydantic(code)
     assert result["valid"] is False
     assert any("aninhada" in e for e in result["errors"])
+
+
+# ------------- estreitamento à grammar do gerador (hardening #197) -----------
+
+
+@pytest.mark.parametrize(
+    "annotation",
+    [
+        'Annotated[str, Field(description="d")]',  # forma canônica do Annotated
+        "Annotated[str]",  # Annotated de 1 elemento (antes: TypeError cru)
+        "dict[str, str]",
+        "dict[str]",  # antes: ValueError cru de unpack
+        "tuple[str, int]",
+        "Union[str, int]",
+    ],
+)
+def test_unsupported_type_constructors_rejected_cleanly(annotation):
+    # Construtores que o gerador nunca emite são rejeitados com SchemaError
+    # (nunca ValueError/TypeError cru) — build_model_from_code honra o contrato.
+    code = (
+        "from pydantic import BaseModel, Field\n"
+        "from typing import Annotated, Union\n"
+        "class Analysis(BaseModel):\n"
+        f'    x: {annotation} = Field(description="X")\n'
+    )
+    result = compile_pydantic(code)
+    assert result["valid"] is False
+    assert result["errors"]
+
+
+def test_build_raises_only_schema_error_on_bad_constructor():
+    # Contrato: build_model_from_code levanta SchemaError, não ValueError/TypeError.
+    from services.pydantic_compiler import SchemaError
+
+    code = (
+        "from pydantic import BaseModel, Field\n"
+        "class Analysis(BaseModel):\n"
+        '    x: dict[str] = Field(description="X")\n'
+    )
+    with pytest.raises(SchemaError):
+        build_model_from_code(code)
+
+
+def test_multiple_inheritance_rejected_not_silently_collapsed():
+    # Antes: herança múltipla colapsava para a última base, descartando campos
+    # do mixin em silêncio. Agora é rejeitada explicitamente.
+    code = '''from pydantic import BaseModel, Field
+
+class Mixin(BaseModel):
+    m: str = Field(description="m")
+
+class Analysis(Mixin, BaseModel):
+    x: str = Field(description="x")
+'''
+    result = compile_pydantic(code)
+    assert result["valid"] is False
+    assert result["errors"]
+
+
+def test_strict_dunder_class_name_rejected():
+    # Nome de classe dunder (ast.ClassDef.name, não ast.Name) é barrado.
+    code = '''from pydantic import BaseModel, Field
+
+class __reduce__(BaseModel):
+    x: int = Field(default=1)
+
+class Analysis(BaseModel):
+    x: int = Field(default=1)
+'''
+    result = compile_pydantic(code)
+    assert result["valid"] is False
+    assert result["errors"]
+
+
+def test_strict_dunder_field_kwarg_rejected():
+    # Nome de kwarg de Field dunder (kw.arg é str, não ast.Name) é barrado.
+    code = '''from pydantic import BaseModel, Field
+
+class Analysis(BaseModel):
+    x: int = Field(__class__=1, default=1)
+'''
+    result = compile_pydantic(code)
+    assert result["valid"] is False
+    assert result["errors"]
+
+
+@pytest.mark.parametrize("name", ["__", "___", "____"])
+def test_all_underscore_field_names_rejected(name):
+    # `__`/`___`/`____` começam E terminam com "__" → dunder estrito, rejeitado.
+    # (Alinhado ao isStrictDunder do frontend, que antes divergia para __/___.)
+    code = (
+        "from pydantic import BaseModel, Field\n"
+        "class Analysis(BaseModel):\n"
+        f'    {name}: str = Field(description="X")\n'
+    )
+    result = compile_pydantic(code)
+    assert result["valid"] is False
+    assert result["errors"]
+
+
+def test_oversized_code_rejected():
+    from services.pydantic_compiler import SchemaError, _MAX_CODE_LENGTH
+
+    code = "x = 1\n" * (_MAX_CODE_LENGTH // 2)
+    assert len(code) > _MAX_CODE_LENGTH
+    with pytest.raises(SchemaError):
+        build_model_from_code(code)
+
+
+def test_type_depth_boundary():
+    # Fixa a fronteira de _MAX_TYPE_DEPTH: até o limite compila; acima rejeita.
+    from services.pydantic_compiler import _MAX_TYPE_DEPTH
+
+    def code_for(depth):
+        ann = "list[" * depth + "str" + "]" * depth
+        return (
+            "from pydantic import BaseModel, Field\n"
+            "class Analysis(BaseModel):\n"
+            f'    x: {ann} = Field(description="X")\n'
+        )
+
+    # Profundidade no limite é aceita (str na base conta como nível extra,
+    # então usamos _MAX_TYPE_DEPTH wrappers de list).
+    ok = compile_pydantic(code_for(_MAX_TYPE_DEPTH - 1))
+    assert ok["valid"], ok["errors"]
+    too_deep = compile_pydantic(code_for(_MAX_TYPE_DEPTH + 5))
+    assert too_deep["valid"] is False
+    assert any("aninhada" in e for e in too_deep["errors"])

--- a/backend/tests/test_pydantic_routes.py
+++ b/backend/tests/test_pydantic_routes.py
@@ -1,0 +1,78 @@
+"""Testes do endpoint POST /api/pydantic/recover-fields."""
+import pytest
+from fastapi.testclient import TestClient
+
+import routes.pydantic_routes as pr
+from main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class _FakeQuery:
+    """Encadeia table/select/eq/maybe_single/execute como o supabase-py."""
+
+    def __init__(self, response: object) -> None:
+        self._response = response
+
+    def select(self, *a, **k):
+        return self
+
+    def eq(self, *a, **k):
+        return self
+
+    def maybe_single(self):
+        return self
+
+    def execute(self):
+        return self._response
+
+
+class _FakeSupabase:
+    def __init__(self, response: object) -> None:
+        self._response = response
+
+    def table(self, *a, **k):
+        return _FakeQuery(self._response)
+
+
+class _Response:
+    def __init__(self, data: object) -> None:
+        self.data = data
+
+
+def _patch_supabase(monkeypatch, response: object) -> None:
+    monkeypatch.setattr(pr, "get_supabase", lambda: _FakeSupabase(response))
+
+
+def test_recover_fields_404_quando_projeto_nao_existe(client, monkeypatch):
+    # maybe_single retorna data=None para projeto inexistente — o guard deve
+    # responder 404 claro, não 500 (a regressão que o single() causava).
+    _patch_supabase(monkeypatch, _Response(None))
+    r = client.post("/api/pydantic/recover-fields", json={"project_id": "nope"})
+    assert r.status_code == 404
+    assert r.json()["detail"] == "Projeto não encontrado"
+
+
+def test_recover_fields_404_quando_sem_codigo(client, monkeypatch):
+    _patch_supabase(monkeypatch, _Response({"pydantic_code": None}))
+    r = client.post("/api/pydantic/recover-fields", json={"project_id": "p1"})
+    assert r.status_code == 404
+    assert "código Pydantic" in r.json()["detail"]
+
+
+def test_recover_fields_reconstroi_campos_do_codigo_armazenado(client, monkeypatch):
+    code = (
+        "from pydantic import BaseModel, Field\n"
+        "class Analysis(BaseModel):\n"
+        '    x: str = Field(description="X")\n'
+    )
+    _patch_supabase(monkeypatch, _Response({"pydantic_code": code}))
+    r = client.post("/api/pydantic/recover-fields", json={"project_id": "p1"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["valid"] is True
+    assert body["model_name"] == "Analysis"
+    assert [f["name"] for f in body["fields"]] == ["x"]

--- a/frontend/src/actions/__tests__/schema.test.ts
+++ b/frontend/src/actions/__tests__/schema.test.ts
@@ -16,6 +16,8 @@ import {
 let writeCalls: WriteCall[];
 let serverTableResults: TableResults | undefined;
 
+const fetchMock = vi.hoisted(() => vi.fn());
+
 vi.mock("next/cache", () => ({
   revalidatePath: () => {},
   revalidateTag: () => {},
@@ -24,7 +26,7 @@ vi.mock("@/lib/auth", () => ({
   getAuthUser: async () => ({ id: "userCoord" }),
 }));
 vi.mock("@/lib/api", () => ({
-  fetchFastAPI: async () => ({ valid: true, fields: [], model_name: null, errors: [] }),
+  fetchFastAPI: fetchMock,
 }));
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServer: async () =>
@@ -36,6 +38,7 @@ import {
   savePrompt,
   publishMajorVersion,
   saveLlmConfig,
+  recoverFieldsFromStoredCode,
 } from "../schema";
 
 const FIELD: PydanticField = {
@@ -58,6 +61,13 @@ const PROJECT_SELECT: TableResult = {
 beforeEach(() => {
   writeCalls = [];
   serverTableResults = undefined;
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({
+    valid: true,
+    fields: [],
+    model_name: null,
+    errors: [],
+  });
 });
 
 describe("saveSchemaFromGUI", () => {
@@ -116,6 +126,56 @@ describe("saveSchemaFromGUI", () => {
     expect(r.error).toMatch(/histórico.*log boom/);
     // O update de projects aconteceu antes da falha do log.
     expect(writeCalls.some((c) => c.table === "projects" && c.op === "update")).toBe(true);
+  });
+
+  it("guarda anti-wipe: 0 campos sobre schema não-vazio é recusado sem tocar projects", async () => {
+    // Projeto já tem 1 campo; salvar com [] apagaria o schema → recusa.
+    serverTableResults = {
+      projects: [{ data: { ...PROJECT_SELECT.data, pydantic_fields: [FIELD] } }],
+    };
+
+    const r = await saveSchemaFromGUI("p1", []);
+    expect(r.error).toMatch(/0 campos|apagaria/i);
+    expect(writeCalls.some((c) => c.table === "projects" && c.op === "update")).toBe(false);
+  });
+
+  it("permite salvar [] quando o schema já estava vazio", async () => {
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [{ id: "p1" }] }],
+    };
+    const r = await saveSchemaFromGUI("p1", []);
+    expect(r.error).toBeUndefined();
+  });
+});
+
+describe("recoverFieldsFromStoredCode", () => {
+  it("retorna os campos reconstruídos pelo backend a partir do código armazenado", async () => {
+    fetchMock.mockResolvedValueOnce({
+      valid: true,
+      fields: [FIELD],
+      model_name: "Analysis",
+      errors: [],
+    });
+    const r = await recoverFieldsFromStoredCode("p1");
+    expect(r.error).toBeUndefined();
+    expect(r.fields).toEqual([FIELD]);
+    // Envia project_id, nunca código do cliente.
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/pydantic/recover-fields",
+      expect.objectContaining({ method: "POST", body: JSON.stringify({ project_id: "p1" }) }),
+    );
+  });
+
+  it("propaga erro quando o backend não consegue reconstruir", async () => {
+    fetchMock.mockResolvedValueOnce({
+      valid: false,
+      fields: [],
+      model_name: null,
+      errors: ["código inválido"],
+    });
+    const r = await recoverFieldsFromStoredCode("p1");
+    expect(r.fields).toBeUndefined();
+    expect(r.error).toBe("código inválido");
   });
 });
 

--- a/frontend/src/actions/__tests__/schema.test.ts
+++ b/frontend/src/actions/__tests__/schema.test.ts
@@ -131,7 +131,7 @@ describe("saveSchemaFromGUI", () => {
   it("guarda anti-wipe: 0 campos sobre schema não-vazio é recusado sem tocar projects", async () => {
     // Projeto já tem 1 campo; salvar com [] apagaria o schema → recusa.
     serverTableResults = {
-      projects: [{ data: { ...PROJECT_SELECT.data, pydantic_fields: [FIELD] } }],
+      projects: [{ data: { ...(PROJECT_SELECT.data as Record<string, unknown>), pydantic_fields: [FIELD] } }],
     };
 
     const r = await saveSchemaFromGUI("p1", []);

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -14,7 +14,39 @@ import {
   type ChangeType,
 } from "@/lib/schema-utils";
 import { updateOrThrow } from "@/lib/supabase/rls-guard";
+import { fetchFastAPI } from "@/lib/api";
 import crypto from "crypto";
+
+interface RecoverResponse {
+  valid: boolean;
+  fields: PydanticField[];
+  model_name: string | null;
+  errors: string[];
+}
+
+// Repopula os campos a partir do `pydantic_code` ARMAZENADO do projeto (lido no
+// backend via service key, não enviado pelo cliente — logo sem vetor do #163).
+// Usado quando um projeto legado tem código mas o editor visual abre vazio.
+export async function recoverFieldsFromStoredCode(
+  projectId: string,
+): Promise<{ fields?: PydanticField[]; error?: string }> {
+  try {
+    const result = await fetchFastAPI<RecoverResponse>(
+      "/api/pydantic/recover-fields",
+      { method: "POST", body: JSON.stringify({ project_id: projectId }) },
+    );
+    if (!result.valid) {
+      return {
+        error:
+          result.errors[0] ||
+          "Não foi possível reconstruir os campos a partir do código armazenado.",
+      };
+    }
+    return { fields: result.fields };
+  } catch (e) {
+    return { error: errorMessage(e, "Erro ao recuperar campos do código") };
+  }
+}
 
 // As actions deste arquivo retornam { error } em vez de lançar: o Next mascara
 // a message de erros lançados em Server Actions em produção (o client recebe
@@ -117,6 +149,18 @@ export async function saveSchemaFromGUI(
     .single();
 
   const oldFields = (project?.pydantic_fields as PydanticField[]) || [];
+
+  // Guarda anti-wipe: nunca sobrescrever um schema existente com 0 campos. Sem
+  // isto, abrir um projeto cujo editor visual ficou vazio (ex.: legado com
+  // pydantic_code mas pydantic_fields não carregado) e clicar "Salvar"
+  // regeneraria `class Analysis(BaseModel): pass`, apagando schema + campos em
+  // silêncio. Um schema realmente vazio só é salvável quando já estava vazio.
+  if (fields.length === 0 && oldFields.length > 0) {
+    return {
+      error:
+        "Salvar com 0 campos apagaria o schema atual. Adicione ao menos um campo, ou use 'Recuperar do código' se o editor abriu vazio.",
+    };
+  }
 
   const current = {
     major: project?.schema_version_major ?? 0,

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -19,6 +19,7 @@ import {
   saveSchemaFromGUI,
   publishMajorVersion,
   backfillSchemaVersionHistory,
+  recoverFieldsFromStoredCode,
 } from "@/actions/schema";
 import { validateGUIFields, generatePydanticCode } from "@/lib/schema-utils";
 import { toast } from "sonner";
@@ -55,7 +56,13 @@ export function SchemaEditor({
   // o estado inicial é sempre "gui".
   const [mode, setMode] = useState<"gui" | "code">("gui");
   const [fields, setFields] = useState<PydanticField[]>(initialFields || []);
-  const [code, setCode] = useState(initialCode || "");
+  // O código é uma visualização DERIVADA dos campos, não estado próprio. Para um
+  // projeto sem campos mas com código armazenado (legado), mostra o código
+  // original até que os campos sejam recuperados (ver banner de recuperação).
+  const code = useMemo(
+    () => (fields.length > 0 ? generatePydanticCode(fields) : initialCode || ""),
+    [fields, initialCode],
+  );
   const [guiErrors, setGuiErrors] = useState<string[]>([]);
   const [isPending, startTransition] = useTransition();
   const [majorDialogOpen, setMajorDialogOpen] = useState(false);
@@ -120,14 +127,30 @@ export function SchemaEditor({
   // O modo "código" é só visualização da fonte de verdade. Alternar não
   // recompila nada: os campos já estão no estado e o código é gerado deles.
 
-  const switchToCode = () => {
-    setCode(generatePydanticCode(fields));
-    setMode("code");
-  };
+  const switchToCode = () => setMode("code");
 
   const switchToGUI = () => {
     setGuiErrors([]);
     setMode("gui");
+  };
+
+  // --- Recuperação de campos a partir do código armazenado (projeto legado) ---
+  // Quando o projeto tem pydantic_code mas nenhum campo carregado, o editor
+  // abriria vazio e um "Salvar" apagaria o schema (barrado pela guarda em
+  // saveSchemaFromGUI). Recuperar reconstrói os campos a partir do código.
+  const canRecover =
+    !initialFields?.length && !!initialCode && fields.length === 0;
+
+  const handleRecover = () => {
+    startTransition(async () => {
+      const r = await recoverFieldsFromStoredCode(projectId);
+      if (r.error) {
+        toast.error(r.error);
+        return;
+      }
+      setFields(r.fields || []);
+      toast.success(`${r.fields?.length ?? 0} campos recuperados do código`);
+    });
   };
 
   // --- Salvar ---
@@ -154,11 +177,8 @@ export function SchemaEditor({
   };
 
   // --- Info para badges ---
-  const currentFields = fields;
-  const fieldCount = currentFields.length;
-  const llmOnlyCount = currentFields.filter(
-    (f) => f.target === "llm_only"
-  ).length;
+  const fieldCount = fields.length;
+  const llmOnlyCount = fields.filter((f) => f.target === "llm_only").length;
 
   return (
     <div className="flex h-[calc(100vh-148px)] flex-col">
@@ -258,6 +278,27 @@ export function SchemaEditor({
             title="Dispensar"
           >
             <X className="size-3" />
+          </Button>
+        </div>
+      )}
+
+      {canRecover && (
+        <div className="flex items-start gap-2 border-b bg-amber-500/10 px-4 py-2 text-xs">
+          <Info className="mt-0.5 size-3.5 shrink-0 text-amber-600" />
+          <div className="flex-1 text-muted-foreground">
+            <strong className="text-foreground">Editor visual vazio.</strong>{" "}
+            Este projeto tem código Pydantic armazenado, mas nenhum campo
+            carregado no editor. Salvar agora apagaria o schema — recupere os
+            campos a partir do código.
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 shrink-0 text-xs"
+            onClick={handleRecover}
+            disabled={isPending}
+          >
+            Recuperar do código
           </Button>
         </div>
       )}

--- a/frontend/src/lib/__tests__/schema-utils-conditions.test.ts
+++ b/frontend/src/lib/__tests__/schema-utils-conditions.test.ts
@@ -183,4 +183,17 @@ describe("validateGUIFields — nomes dunder", () => {
       'Campo 1: subcampo "__init__" não pode começar e terminar com "__" (reservado pelo Python)',
     );
   });
+
+  // Antes a regex /^__.*__$/ exigia ≥4 chars e NÃO casava "__"/"___", que o
+  // backend (startswith E endswith "__") rejeita — divergência que gerava
+  // código recusado no run. isStrictDunder espelha o backend.
+  it.each(["__", "___", "____"])(
+    "rejeita nome só de underscores %s (alinhado ao backend)",
+    (name) => {
+      const fields = [baseField({ name, type: "text", description: "x" })];
+      expect(validateGUIFields(fields)).toContain(
+        `Campo 1: nome "${name}" não pode começar e terminar com "__" (reservado pelo Python)`,
+      );
+    },
+  );
 });

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -183,7 +183,13 @@ const PYTHON_IDENTIFIER = /^[a-z_][a-z0-9_]*$/;
 // pela allowlist do compilador backend; barrar aqui dá feedback imediato em
 // vez de gerar código que o `llm_runner` recusaria. "__" interno (my__field)
 // é permitido.
-const STRICT_DUNDER = /^__.*__$/;
+//
+// Espelha EXATAMENTE o `_is_strict_dunder` do backend (startswith E endswith
+// "__"). A regex antiga `/^__.*__$/` exigia ≥4 chars e divergia: aceitava "__"
+// e "___" no front, mas o backend os rejeitava — gerando código que o run
+// recusaria. Usar startsWith/endsWith elimina a divergência.
+const isStrictDunder = (name: string): boolean =>
+  name.startsWith("__") && name.endsWith("__");
 
 export function validateGUIFields(fields: PydanticField[]): string[] {
   const errors: string[] = [];
@@ -202,7 +208,7 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
       errors.push(
         `${label}: nome inválido "${f.name}" (use letras minúsculas, números e _)`
       );
-    } else if (STRICT_DUNDER.test(f.name)) {
+    } else if (isStrictDunder(f.name)) {
       errors.push(
         `${label}: nome "${f.name}" não pode começar e terminar com "__" (reservado pelo Python)`
       );
@@ -224,7 +230,7 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
           errors.push(
             `${label}: subcampo ${j + 1} tem chave inválida "${sf.key}"`
           );
-        } else if (STRICT_DUNDER.test(sf.key)) {
+        } else if (isStrictDunder(sf.key)) {
           errors.push(
             `${label}: subcampo "${sf.key}" não pode começar e terminar com "__" (reservado pelo Python)`
           );


### PR DESCRIPTION
Empilhado sobre o #197 (base = `fix/pydantic-ast-allowlist`). Resolve os achados da revisão high daquele PR. Premissa central: como a edição manual do schema foi descontinuada (form-only), o `generatePydanticCode` é o **único produtor** de `pydantic_code` — então o allowlist é **estreitado exatamente à grammar dele** (rejeição limpa do resto) em vez de tentar suportar Pydantic arbitrário.

## Correções (mapeadas aos achados da revisão)

**Backend — `services/pydantic_compiler.py`**
- **#4 (Annotated) / #9 (contrato) / generalidade especulativa:** `_resolve_type` estreitado a `str`/escalares/`Literal`/`list`/`Optional`/classe aninhada. Removidos os ramos `Annotated`/`dict`/`tuple`/`Union`/`BitOr` — nunca emitidos pelo gerador e antes meio-quebrados (`Annotated[X, Field()]` rejeitava com mensagem errada; `dict[str]` lançava `ValueError` cru). `build_model_from_code` agora encapsula qualquer `ValueError`/`TypeError` em `SchemaError` (contrato).
- **#5 (herança múltipla):** rejeitada explicitamente — antes colapsava em silêncio para a última base, descartando campos do mixin.
- **#6 (guard de dunder):** cobre nome de classe (`ClassDef.name`) e nome de kwarg de `Field` (`kw.arg`), não só `ast.Name`.
- **#2 (error_line):** `ast.parse(filename="<pydantic_schema>")` + `lineno`/`offset` carregados no `SchemaError`.
- **DoS:** cap de tamanho (`_MAX_CODE_LENGTH`).
- **Limpezas:** remove `_field_default` (`literal_eval` já trata `Ellipsis`) e `_subscript_slice`; `_build_models` O(N²)→O(N); `_MAX_TYPE_DEPTH` documentado; docstring honesta.

**Backend — `services/llm_runner.py`**
- **#2 (cont.):** `_extract_pydantic_location` lê o `lineno` do `SchemaError` — `error_line`/`column` voltam a ser populados (antes viravam NULL para todo erro de schema).

**Backend — `routes/pydantic_routes.py` + `main.py`**
- **#10 (compile_pydantic morto) + recuperação:** novo `POST /api/pydantic/recover-fields` que recebe **`project_id`** (não código do cliente), lê o `pydantic_code` armazenado e roda `compile_pydantic`. Dá a `compile_pydantic` um chamador de produção (round-trip da regra (b) do CLAUDE.md) e repopula o editor de projeto legado. **Não reabre o #163** — sem `exec`; o código vem do DB, não do cliente. (Quando a auth JWT de rotas do #195 mergear, este router deve herdá-la, igual a `/api/llm/*`.)

**Frontend**
- **#7 (divergência dunder):** `schema-utils.ts` passa a usar `startsWith && endsWith` (`isStrictDunder`), espelhando o backend — a regex `/^__.*__$/` divergia em `__`/`___`.
- **#3 (wipe no save):** guarda anti-wipe em `saveSchemaFromGUI` (recusa 0 campos sobre schema não-vazio) + action `recoverFieldsFromStoredCode` + banner "Recuperar do código" no `SchemaEditor`.
- **Limpeza:** `code` vira visualização derivada (`useMemo`); remove estado morto (`currentFields`, `code`/`setCode`).

## Testes
- Backend: rejeições limpas (`Annotated`/`dict`/`tuple`/`Union`, herança múltipla, dunder classe/kwarg, `__`/`___`), cap de tamanho, fronteira de `_MAX_TYPE_DEPTH`, error-location pelo caminho **real**, contrato `SchemaError`-only.
- Frontend: dunder `__`/`___`, guarda anti-wipe, recovery.
- **Backend 143 + frontend 391 verdes; `ruff` limpo; `tsc` limpo nos arquivos alterados.**

## ⚠️ Antes de deployar — auditoria/migração de dados (Grupo 0)
O allowlist ficou estritamente mais restrito que o antigo `exec()`. Projetos cujo `pydantic_code` foi salvo via o antigo editor de código com construto fora da grammar quebrariam na próxima rodada de LLM. Rodar o **script de auditoria** (read-only) sobre produção antes do deploy; se houver projeto fora da grammar, regenerar o `pydantic_code` a partir dos `pydantic_fields`. Scripts entregues à parte (não versionados, `pipeline-processos/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)