### PR TITLE
fix(migrations): remove policy duplicada da 001 (destrava supabase start do zero)

### DIFF
--- a/frontend/supabase/migrations/001_initial_schema.sql
+++ b/frontend/supabase/migrations/001_initial_schema.sql
@@ -61,9 +61,9 @@ CREATE POLICY "Coordinators manage members" ON project_members FOR ALL USING (
     SELECT project_id FROM project_members WHERE user_id = auth.uid() AND role = 'coordenador'
   )
 );
-CREATE POLICY "Creator inserts members" ON project_members FOR INSERT WITH CHECK (
-  project_id IN (SELECT id FROM projects WHERE created_by = auth.uid())
-);
+-- A policy "Creator inserts members" é criada na migration 002 (e redefinida
+-- depois em clerk_uid_rls/master_users), não aqui: duplicá-la nesta migration
+-- quebrava o boot do zero com SQLSTATE 42710.
 
 -- projects RLS (após project_members existir)
 ALTER TABLE projects ENABLE ROW LEVEL SECURITY;

--- a/frontend/supabase/migrations/002_creator_inserts_members.sql
+++ b/frontend/supabase/migrations/002_creator_inserts_members.sql
@@ -1,4 +1,10 @@
--- Fix chicken-and-egg: allow project creator to insert members
+-- Fix chicken-and-egg: allow project creator to insert members.
+-- Idempotente: a policy também é criada em 001_initial_schema.sql (a 001 foi
+-- editada depois para incluí-la), então em banco fresh (supabase start / db
+-- reset) esta migration colidiria com SQLSTATE 42710. O DROP IF EXISTS antes do
+-- CREATE segue o padrão das demais migrations de policy e mantém o boot do zero
+-- funcionando, sem efeito no remoto (já aplicada incrementalmente).
+DROP POLICY IF EXISTS "Creator inserts members" ON project_members;
 CREATE POLICY "Creator inserts members" ON project_members FOR INSERT WITH CHECK (
   project_id IN (SELECT id FROM projects WHERE created_by = auth.uid())
 );

--- a/frontend/supabase/migrations/002_creator_inserts_members.sql
+++ b/frontend/supabase/migrations/002_creator_inserts_members.sql
@@ -1,9 +1,9 @@
 -- Fix chicken-and-egg: allow project creator to insert members.
--- Idempotente: a policy também é criada em 001_initial_schema.sql (a 001 foi
--- editada depois para incluí-la), então em banco fresh (supabase start / db
--- reset) esta migration colidiria com SQLSTATE 42710. O DROP IF EXISTS antes do
--- CREATE segue o padrão das demais migrations de policy e mantém o boot do zero
--- funcionando, sem efeito no remoto (já aplicada incrementalmente).
+-- Cria a policy "Creator inserts members" pela primeira vez (a duplicata que
+-- existia na 001 foi removida — era o drift que quebrava o boot do zero com
+-- SQLSTATE 42710; migrations de RLS posteriores, clerk_uid_rls/master_users,
+-- a redefinem). O DROP IF EXISTS antes do CREATE é defensivo/idempotente, no
+-- padrão das demais migrations de policy; no remoto não tem efeito (já aplicada).
 DROP POLICY IF EXISTS "Creator inserts members" ON project_members;
 CREATE POLICY "Creator inserts members" ON project_members FOR INSERT WITH CHECK (
   project_id IN (SELECT id FROM projects WHERE created_by = auth.uid())


### PR DESCRIPTION
## Contexto

`npx supabase start` / `db reset` do zero falhava ao aplicar `002_creator_inserts_members.sql` com `policy "Creator inserts members" already exists (SQLSTATE 42710)`, derrubando os containers e impedindo a inicialização local/CI a partir de um banco limpo.

Causa-raiz: **drift de migration**. A policy `"Creator inserts members"` estava duplicada — criada em `001_initial_schema.sql:64` (incluída numa edição posterior do schema inicial) **e** em `002`, sem `DROP` antes. Em banco aplicado incrementalmente (remoto) não há colisão; do zero, a `001` cria a policy e a `002` bate nela.

Descoberto ao validar o teste SQL do #293 (precisei de um contorno manual na `002` para subir o local).

## O que muda

Ataca a causa-raiz em vez de só contornar o sintoma:

- **`001`**: remove o `CREATE POLICY "Creator inserts members"` duplicado (a 001 não é o lugar dela). Comentário no lugar aponta para a `002`.
- **`002`**: mantém o `DROP POLICY IF EXISTS` + `CREATE` como criação inicial limpa e idempotente da policy (no padrão das demais migrations de RLS do projeto). A definição efetiva é redefinida depois em `clerk_uid_rls`/`master_users` — todas já idempotentes.

**Sem efeito no remoto**: a `001` já foi aplicada na sua versão original (sem a policy) e a `002` já está no histórico; nada re-roda. O estado final da policy (vindo da `master_users`) é inalterado.

## Testes (banco fresh)

- `supabase db reset` do zero: **exit 0**, todas as migrations aplicadas, sem `42710`.
- `supabase/tests/atomic_replace_rpcs.test.sql` via psql: **7/7 OK** (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)