### PR TITLE
refactor(coding): melhorias do review do #297 reaplicadas sobre o split do #280

### DIFF
--- a/frontend/src/components/coding/BrowseCodingView.tsx
+++ b/frontend/src/components/coding/BrowseCodingView.tsx
@@ -31,6 +31,25 @@ interface BrowseCodingViewProps {
   onDraftChange: (draft: CodingDraft) => void;
 }
 
+/** Estado centralizado de falha + ação de retry do modo Explorar (lista e doc
+ *  compartilham a mesma marcação). */
+function RetryState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
+      <p className="text-sm text-muted-foreground">{message}</p>
+      <Button variant="outline" size="sm" onClick={onRetry}>
+        Tentar novamente
+      </Button>
+    </div>
+  );
+}
+
 /** Corpo do modo Explorar: lista (picker) ou coder do doc selecionado. */
 export function BrowseCodingView({
   browseLoading,
@@ -55,14 +74,10 @@ export function BrowseCodingView({
 }: BrowseCodingViewProps) {
   if (browseError) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
-        <p className="text-sm text-muted-foreground">
-          Não foi possível carregar os documentos.
-        </p>
-        <Button variant="outline" size="sm" onClick={onRetry}>
-          Tentar novamente
-        </Button>
-      </div>
+      <RetryState
+        message="Não foi possível carregar os documentos."
+        onRetry={onRetry}
+      />
     );
   }
   if (browseLoading) {
@@ -88,14 +103,10 @@ export function BrowseCodingView({
     // browseDoc === null → o fetch do doc falhou (erro de transporte ou
     // documento ausente). Oferece retry em vez de afirmar "não encontrado".
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-3 text-center">
-        <p className="text-sm text-muted-foreground">
-          Não foi possível carregar o documento.
-        </p>
-        <Button variant="outline" size="sm" onClick={onRetryDoc}>
-          Tentar novamente
-        </Button>
-      </div>
+      <RetryState
+        message="Não foi possível carregar o documento."
+        onRetry={onRetryDoc}
+      />
     );
   }
   return (

--- a/frontend/src/components/coding/BrowseDocCoder.tsx
+++ b/frontend/src/components/coding/BrowseDocCoder.tsx
@@ -75,8 +75,13 @@ export function BrowseDocCoder({
   // o ref reinicia limpo a cada doc junto com o estado.
   const draftRef = useRef<CodingDraft>({ answers, notes });
 
+  // Durante um save em voo (`submitting`) a edição congela: o container já tirou
+  // o snapshot do rascunho que está salvando e, ao concluir, descarta o draftRef
+  // e navega. Sem este guard, teclas digitadas no meio do save atualizariam o
+  // draftRef tarde demais e seriam perdidas silenciosamente.
   const handleAnswer = useCallback(
     (fieldName: string, value: unknown) => {
+      if (submitting) return;
       // Ao mudar uma resposta, limpa as condicionais que ficaram órfãs —
       // mesma invariante do modo Atribuídos (`CodingPage.handleAnswer`, #252).
       const next = clearHiddenConditionalAnswers(fields, {
@@ -87,16 +92,17 @@ export function BrowseDocCoder({
       setAnswers(next);
       onDraftChange(draftRef.current);
     },
-    [onDraftChange, fields],
+    [onDraftChange, submitting, fields],
   );
 
   const handleNotesChange = useCallback(
     (next: string) => {
+      if (submitting) return;
       draftRef.current = { answers: draftRef.current.answers, notes: next };
       setNotes(next);
       onDraftChange(draftRef.current);
     },
-    [onDraftChange],
+    [onDraftChange, submitting],
   );
 
   const handleSubmit = useCallback(() => {

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -43,6 +43,8 @@ type DocSection =
       responseCount: number;
       onBack: () => void;
       onRandom: () => void;
+      /** Save em voo: desabilita Voltar/Sortear para evitar disparo duplo. */
+      submitting?: boolean;
       parecerUrl?: string;
       projectId: string;
       documentId: string;
@@ -270,6 +272,7 @@ function BrowseDocSection({
         size="icon"
         className="size-6 shrink-0"
         onClick={doc.onBack}
+        disabled={doc.submitting}
       >
         <ArrowLeft className="size-4" />
       </Button>
@@ -291,6 +294,7 @@ function BrowseDocSection({
           size="icon"
           className="size-6"
           onClick={doc.onRandom}
+          disabled={doc.submitting}
         >
           <Shuffle className="size-4" />
         </Button>

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -243,6 +243,7 @@ function CodingPageInner({
                   responseCount: browse.browseDocInfo?.responseCount ?? 0,
                   onBack: browse.handleBrowseBack,
                   onRandom: browse.handleBrowseRandom,
+                  submitting,
                   parecerUrl: browseParecerUrl,
                   projectId,
                   documentId: browse.browseDocId,

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -296,7 +296,18 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         </p>
       </div>
 
-      <div className="flex-1 overflow-y-auto p-4 space-y-2.5">
+      <div
+        // Durante um save em voo a edição congela (os handlers a montante
+        // descartam as teclas). Sem pista visual o usuário digitaria no vazio;
+        // aqui o bloco fica esmaecido e sem resposta a mouse — `aria-busy`
+        // anuncia o estado a leitores de tela. O teclado segue barrado pelos
+        // guards a montante (`FieldRenderer` não aceita `disabled`).
+        aria-busy={submitting}
+        className={cn(
+          "flex-1 overflow-y-auto p-4 space-y-2.5",
+          submitting && "pointer-events-none opacity-60",
+        )}
+      >
         {dragEnabled ? (
           <DndContext
             sensors={sensors}
@@ -325,6 +336,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
               <Textarea
                 value={notes}
                 onChange={(e) => onNotesChange(e.target.value)}
+                disabled={submitting || readOnly}
                 placeholder="Anotações, dúvidas ou sugestões sobre este documento..."
                 className="mt-2 text-sm min-h-[80px] resize-y"
               />

--- a/frontend/src/components/coding/__tests__/BrowseDocCoder.test.tsx
+++ b/frontend/src/components/coding/__tests__/BrowseDocCoder.test.tsx
@@ -138,6 +138,26 @@ describe("BrowseDocCoder", () => {
     });
   });
 
+  it("congela a edição enquanto submitting (não perde teclas durante o save em voo)", async () => {
+    const onDraftChange = vi.fn();
+    render(
+      <BrowseDocCoder
+        {...baseProps}
+        submitting
+        doc={makeDoc()}
+        onSubmit={vi.fn()}
+        onDraftChange={onDraftChange}
+      />,
+    );
+    await userEvent.click(screen.getByText("set-q1"));
+    await userEvent.click(screen.getByText("set-notes"));
+    // Com um save em voo, as edições são ignoradas: nada reportado para cima e o
+    // estado exibido permanece no seed (o container já salvou o snapshot).
+    expect(onDraftChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("answers").textContent).toBe('{"q0":"x"}');
+    expect(screen.getByTestId("notes").textContent).toBe("nota0");
+  });
+
   it("envia com as respostas e notas atuais", async () => {
     const onSubmit = vi.fn();
     render(

--- a/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
@@ -190,4 +190,52 @@ describe("useAssignedCoding", () => {
       notes: "",
     });
   });
+
+  it("duplo-clique em Enviar não duplica saveResponse (guarda de reentrância)", async () => {
+    let resolveSave: (v: { success: boolean }) => void = () => {};
+    mockSave.mockReturnValue(
+      new Promise<{ success: boolean }>((r) => {
+        resolveSave = r;
+      }),
+    );
+    const { view } = setup({ existingAnswers: { d1: { q1: "sim" } } });
+
+    // Dois envios antes do primeiro save em voo resolver: o segundo é barrado
+    // pela guarda de reentrância, então saveResponse roda só uma vez.
+    const p1 = view.result.current.handleSubmit();
+    const p2 = view.result.current.handleSubmit();
+    expect(mockSave).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSave({ success: true });
+      await Promise.all([p1, p2]);
+    });
+    expect(mockSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("congela a edição enquanto submitting (não perde teclas no save em voo)", async () => {
+    let resolveSave: (v: { success: boolean }) => void = () => {};
+    mockSave.mockReturnValue(
+      new Promise<{ success: boolean }>((r) => {
+        resolveSave = r;
+      }),
+    );
+    const { view, params } = setup({ existingAnswers: { d1: { q1: "sim" } } });
+
+    // Save em voo → savingRef.current === true.
+    const p = view.result.current.handleSubmit();
+    expect(mockSave).toHaveBeenCalledTimes(1);
+
+    // Edições durante o save são ignoradas: nada muda e markDirty não é chamado.
+    act(() => view.result.current.handleAnswer("q2", "tarde demais"));
+    act(() => view.result.current.handleNotesChange("nota tardia"));
+    expect(view.result.current.docAnswers).toEqual({ q1: "sim" });
+    expect(view.result.current.docNotes).toBe("");
+    expect(params.markDirty).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveSave({ success: true });
+      await p;
+    });
+  });
 });

--- a/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
@@ -101,9 +101,37 @@ describe("useBrowseCoding", () => {
 
     expect(mockSave).toHaveBeenCalledWith("p1", "b1", { q: "sim" }, { notes: "n" });
     expect(params.markClean).toHaveBeenCalledWith("b1");
-    expect(markResponded).toHaveBeenCalledWith("b1", "submit");
+    expect(markResponded).toHaveBeenCalledWith("b1");
     expect(invalidate).toHaveBeenCalledWith("b1");
     expect(params.updateDocParam).toHaveBeenCalledWith(null);
+  });
+
+  it("nº3: duplo-clique em Enviar não duplica saveResponse (guarda de reentrância)", async () => {
+    let resolveSave: (v: { success: boolean }) => void = () => {};
+    mockSave.mockReturnValue(
+      new Promise<{ success: boolean }>((r) => {
+        resolveSave = r;
+      }),
+    );
+    const { view } = setup("b1");
+
+    // Dois envios antes do primeiro save em voo resolver: o segundo é barrado
+    // pela guarda de reentrância, então saveResponse roda só uma vez.
+    const p1 = view.result.current.handleBrowseSubmit({
+      answers: { q: "sim" },
+      notes: "",
+    });
+    const p2 = view.result.current.handleBrowseSubmit({
+      answers: { q: "sim" },
+      notes: "",
+    });
+    expect(mockSave).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSave({ success: true });
+      await Promise.all([p1, p2]);
+    });
+    expect(mockSave).toHaveBeenCalledTimes(1);
   });
 
   it("getPayload reflete o rascunho reportado", () => {
@@ -117,7 +145,7 @@ describe("useBrowseCoding", () => {
     });
   });
 
-  it("back autosalva o doc sujo (intent autosave), invalida e limpa", async () => {
+  it("back autosalva o doc sujo, marca respondido, invalida e limpa", async () => {
     const dirty = new Set<string>();
     const { view, params } = setup("b1", dirty);
     act(() => view.result.current.handleDraftChange({ answers: { q: "x" }, notes: "nota" })); // marca sujo
@@ -130,7 +158,7 @@ describe("useBrowseCoding", () => {
       { q: "x" },
       { notes: "nota", isAutoSave: true },
     );
-    expect(markResponded).toHaveBeenCalledWith("b1", "autosave");
+    expect(markResponded).toHaveBeenCalledWith("b1");
     expect(invalidate).toHaveBeenCalledWith("b1");
     expect(params.updateDocParam).toHaveBeenCalledWith(null);
   });

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -156,25 +156,33 @@ export function useAssignedCoding({
   const handleSubmit = useCallback(async () => {
     if (!currentDoc || Object.keys(docAnswers).length === 0) return;
     setSubmitting(true);
-    const result = await saveResponse(projectId, currentDoc.id, docAnswers, {
-      notes: docNotes,
-    });
-    setSubmitting(false);
-    if (result.success) {
-      markClean(currentDoc.id);
-      toast.success("Respostas salvas!");
-      if (docIndex < sortedDocuments.length - 1) {
-        const nextIndex = docIndex + 1;
-        dispatch({ type: "index", index: nextIndex });
-        // Mantem a URL em sincronia com o doc exibido — sem isso, um refresh
-        // apos enviar cai no doc recem-enviado (que no modo "recent" pula para
-        // o topo da lista), nao no proximo.
-        updateDocParam(sortedDocuments[nextIndex]?.id ?? null);
+    try {
+      const result = await saveResponse(projectId, currentDoc.id, docAnswers, {
+        notes: docNotes,
+      });
+      if (result.success) {
+        markClean(currentDoc.id);
+        toast.success("Respostas salvas!");
+        if (docIndex < sortedDocuments.length - 1) {
+          const nextIndex = docIndex + 1;
+          dispatch({ type: "index", index: nextIndex });
+          // Mantem a URL em sincronia com o doc exibido — sem isso, um refresh
+          // apos enviar cai no doc recem-enviado (que no modo "recent" pula para
+          // o topo da lista), nao no proximo.
+          updateDocParam(sortedDocuments[nextIndex]?.id ?? null);
+        } else {
+          dispatch({ type: "allDone", value: true });
+        }
       } else {
-        dispatch({ type: "allDone", value: true });
+        toast.error(result.error || "Erro ao salvar respostas");
       }
-    } else {
-      toast.error(result.error || "Erro ao salvar respostas");
+    } finally {
+      // `saveResponse` é Server Action: uma rejeição de transporte (offline /
+      // erro de RPC) rejeita a promessa em vez de devolver `{success:false}`.
+      // O `finally` garante que `submitting` não fique preso `true` — como é
+      // estado único compartilhado com o modo Explorar, isso congelaria a
+      // edição lá (guards do `BrowseDocCoder`) até um reload.
+      setSubmitting(false);
     }
   }, [
     currentDoc,

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useReducer } from "react";
+import { useCallback, useMemo, useReducer, useRef } from "react";
 import { saveResponse } from "@/actions/responses";
 import { sortByRecent } from "@/lib/coding-sort";
 import { autosaveDirtyDoc } from "@/lib/coding-autosave";
@@ -133,8 +133,19 @@ export function useAssignedCoding({
   );
   const docNotes = allNotes[currentDoc?.id] ?? "";
 
+  // Guarda de reentrância dos saves: liga ANTES do `await saveResponse` e desliga
+  // no `finally`. Espelha o `browseSavingRef` do modo Explorar, mas serve a dois
+  // propósitos com um só ref síncrono: (1) impede que um duplo-clique em "Enviar"
+  // dispare `saveResponse`/`toast` duas vezes antes do re-render desabilitar o
+  // botão; (2) congela a edição enquanto o save está em voo — o container já tirou
+  // o snapshot das respostas que está salvando e, ao concluir, navega para o
+  // próximo doc; sem o guard, teclas digitadas durante o save editariam o doc já
+  // salvo com o snapshot antigo e seriam descartadas na navegação.
+  const savingRef = useRef(false);
+
   const handleAnswer = useCallback(
     (fieldName: string, value: unknown) => {
+      if (savingRef.current) return;
       const docId = currentDoc?.id;
       if (!docId) return;
       dispatch({ type: "answer", docId, field: fieldName, value, fields });
@@ -145,6 +156,7 @@ export function useAssignedCoding({
 
   const handleNotesChange = useCallback(
     (notes: string) => {
+      if (savingRef.current) return;
       const docId = currentDoc?.id;
       if (!docId) return;
       dispatch({ type: "notes", docId, notes });
@@ -155,6 +167,8 @@ export function useAssignedCoding({
 
   const handleSubmit = useCallback(async () => {
     if (!currentDoc || Object.keys(docAnswers).length === 0) return;
+    if (savingRef.current) return;
+    savingRef.current = true;
     setSubmitting(true);
     try {
       const result = await saveResponse(projectId, currentDoc.id, docAnswers, {
@@ -179,10 +193,11 @@ export function useAssignedCoding({
     } finally {
       // `saveResponse` é Server Action: uma rejeição de transporte (offline /
       // erro de RPC) rejeita a promessa em vez de devolver `{success:false}`.
-      // O `finally` garante que `submitting` não fique preso `true` — como é
-      // estado único compartilhado com o modo Explorar, isso congelaria a
-      // edição lá (guards do `BrowseDocCoder`) até um reload.
+      // O `finally` garante que `submitting`/o ref não fiquem presos `true` —
+      // como `submitting` é estado único compartilhado com o modo Explorar, isso
+      // congelaria a edição lá (guards do `BrowseDocCoder`) até um reload.
       setSubmitting(false);
+      savingRef.current = false;
     }
   }, [
     currentDoc,

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -30,9 +30,9 @@ interface UseBrowseCodingParams {
  * keyed `BrowseDocCoder`; este hook só guarda o rascunho num ref para o
  * autosave-on-exit centralizado (#28).
  *
- * Cumpre os contratos da #257: `markResponded(id, "submit"|"autosave")`,
- * `invalidate(id)` após salvar (anti-staleness do cache de doc) e exposição de
- * `error`/`retry` da lista.
+ * Cumpre os contratos da #257: `markResponded(id)` (update otimista do contador
+ * pós-save), `invalidate(id)` após salvar (anti-staleness do cache de doc) e
+ * exposição de `error`/`retry` da lista.
  */
 export function useBrowseCoding({
   projectId,
@@ -68,6 +68,10 @@ export function useBrowseCoding({
   // Rascunho atual reportado pelo BrowseDocCoder; lido pelo autosave-on-exit.
   // Ref (não estado) para não entrar no render.
   const browseDraftRef = useRef<CodingDraft | null>(null);
+  // Guarda de reentrância dos saves de browse: impede que um duplo-clique em
+  // "Enviar"/"Voltar" dispare saveResponse/markResponded duas vezes antes do
+  // setSubmitting re-renderizar e desabilitar os botões.
+  const browseSavingRef = useRef(false);
 
   const browseDocInfo = browseDocId
     ? browseDocuments?.find((d) => d.id === browseDocId) ?? null
@@ -107,24 +111,34 @@ export function useBrowseCoding({
   const handleBrowseSubmit = useCallback(
     async ({ answers, notes }: CodingDraft) => {
       if (!browseDocId || Object.keys(answers).length === 0) return;
+      if (browseSavingRef.current) return;
+      browseSavingRef.current = true;
       setSubmitting(true);
-      const result = await saveResponse(projectId, browseDocId, answers, {
-        notes,
-      });
-      setSubmitting(false);
-      if (result.success) {
-        markClean(browseDocId);
-        toast.success("Respostas salvas!");
-        markResponded(browseDocId, "submit");
-        browseDraftRef.current = null;
-        // Zera o ?doc= ANTES de invalidar: com browseDocId já null o hook não
-        // refetcha o doc que estamos deixando (evita refetch/flicker). A
-        // invalidação garante que reabri-lo na sessão reflita o que foi salvo
-        // (sem isto, o seed ficaria stale).
-        updateDocParam(null);
-        invalidateBrowseDoc(browseDocId);
-      } else {
-        toast.error(result.error || "Erro ao salvar respostas");
+      try {
+        const result = await saveResponse(projectId, browseDocId, answers, {
+          notes,
+        });
+        if (result.success) {
+          markClean(browseDocId);
+          toast.success("Respostas salvas!");
+          markResponded(browseDocId);
+          browseDraftRef.current = null;
+          // Zera o ?doc= ANTES de invalidar: com browseDocId já null o hook não
+          // refetcha o doc que estamos deixando (evita refetch/flicker). A
+          // invalidação garante que reabri-lo na sessão reflita o que foi salvo
+          // (sem isto, o seed ficaria stale).
+          updateDocParam(null);
+          invalidateBrowseDoc(browseDocId);
+        } else {
+          toast.error(result.error || "Erro ao salvar respostas");
+        }
+      } finally {
+        // `saveResponse` é Server Action: uma rejeição de transporte (offline /
+        // erro de RPC) rejeita a promessa em vez de devolver `{success:false}`.
+        // O `finally` garante que `submitting`/o ref não fiquem presos (o que
+        // congelaria a edição até reload).
+        setSubmitting(false);
+        browseSavingRef.current = false;
       }
     },
     [
@@ -139,28 +153,37 @@ export function useBrowseCoding({
   );
 
   const handleBrowseBack = useCallback(async () => {
+    // Guarda de reentrância no topo: cobre tanto o caminho com autosave quanto o
+    // caminho limpo (sem rascunho sujo). Sem ela, um "Voltar" durante um submit
+    // em voo zeraria a URL/rascunho no meio do save.
+    if (browseSavingRef.current) return;
     const docId = browseDocId;
     let saved = false;
     // Com rascunho sujo, aguarda o autosave ANTES de navegar: se falhar, mantém
     // o doc aberto e o rascunho intacto (em vez de descartá-lo otimisticamente).
     if (docId && isDirty(docId) && browseDraftRef.current) {
+      browseSavingRef.current = true;
       const { answers, notes } = browseDraftRef.current;
       setSubmitting(true);
-      const result = await saveResponse(projectId, docId, answers, {
-        notes,
-        isAutoSave: true,
-      });
-      setSubmitting(false);
-      if (!result.success) {
-        toast.error(
-          result.error ||
-            "Não foi possível salvar. Suas alterações não foram perdidas.",
-        );
-        return;
+      try {
+        const result = await saveResponse(projectId, docId, answers, {
+          notes,
+          isAutoSave: true,
+        });
+        if (!result.success) {
+          toast.error(
+            result.error ||
+              "Não foi possível salvar. Suas alterações não foram perdidas.",
+          );
+          return;
+        }
+        markClean(docId);
+        markResponded(docId);
+        saved = true;
+      } finally {
+        setSubmitting(false);
+        browseSavingRef.current = false;
       }
-      markClean(docId);
-      markResponded(docId, "autosave");
-      saved = true;
     }
     browseDraftRef.current = null;
     // Zera o ?doc= ANTES de invalidar (mesmo motivo do submit: evita

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
@@ -43,6 +43,7 @@ function renderPanel(
         {
           id: "r-llm",
           respondent_type: "llm",
+          respondent_id: null,
           respondent_name: "Robô",
           answer: "2021-05-10",
           is_latest: true,

--- a/frontend/src/hooks/__tests__/useBrowseDocuments.test.ts
+++ b/frontend/src/hooks/__tests__/useBrowseDocuments.test.ts
@@ -47,31 +47,33 @@ describe("useBrowseDocuments", () => {
     expect(mockGet).not.toHaveBeenCalled();
   });
 
-  it('markResponded("submit") incrementa o contador uma vez e marca respondido', async () => {
+  it("markResponded incrementa o contador uma vez e marca respondido", async () => {
     mockGet.mockResolvedValue([doc("d1", { responseCount: 2 }), doc("d2")]);
     const { result } = renderHook(() => useBrowseDocuments("p1", true));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    act(() => result.current.markResponded("d1", "submit"));
+    act(() => result.current.markResponded("d1"));
     let d1 = result.current.documents?.find((d) => d.id === "d1");
     expect(d1?.userAlreadyResponded).toBe(true);
     expect(d1?.responseCount).toBe(3);
 
     // Idempotente: segunda chamada não incrementa de novo (já respondido).
-    act(() => result.current.markResponded("d1", "submit"));
+    act(() => result.current.markResponded("d1"));
     d1 = result.current.documents?.find((d) => d.id === "d1");
     expect(d1?.responseCount).toBe(3);
   });
 
-  it('markResponded("autosave") marca respondido sem mexer no contador', async () => {
+  it("markResponded numa primeira resposta (ex.: autosave via Voltar) incrementa o contador", async () => {
+    // O servidor conta respondentes distintos sem filtrar is_partial, então a
+    // primeira resposta — venha de submit ou de autosave — entra na contagem.
     mockGet.mockResolvedValue([doc("d1", { responseCount: 5 })]);
     const { result } = renderHook(() => useBrowseDocuments("p1", true));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    act(() => result.current.markResponded("d1", "autosave"));
+    act(() => result.current.markResponded("d1"));
     const d1 = result.current.documents?.find((d) => d.id === "d1");
     expect(d1?.userAlreadyResponded).toBe(true);
-    expect(d1?.responseCount).toBe(5);
+    expect(d1?.responseCount).toBe(6);
   });
 
   it("em erro expõe error=true e NÃO cacheia lista vazia; retry refaz o fetch", async () => {
@@ -92,14 +94,14 @@ describe("useBrowseDocuments", () => {
     expect(result.current.error).toBe(false);
   });
 
-  it('markResponded("submit") não bumpa contador de doc já respondido', async () => {
+  it("markResponded não bumpa contador de doc já respondido", async () => {
     mockGet.mockResolvedValue([
       doc("d1", { responseCount: 4, userAlreadyResponded: true }),
     ]);
     const { result } = renderHook(() => useBrowseDocuments("p1", true));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    act(() => result.current.markResponded("d1", "submit"));
+    act(() => result.current.markResponded("d1"));
     const d1 = result.current.documents?.find((d) => d.id === "d1");
     expect(d1?.responseCount).toBe(4);
   });
@@ -109,11 +111,59 @@ describe("useBrowseDocuments", () => {
     const { result } = renderHook(() => useBrowseDocuments("p1", true));
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    act(() => result.current.markResponded("fantasma", "submit"));
+    act(() => result.current.markResponded("fantasma"));
     expect(result.current.documents?.map((d) => d.id)).toEqual(["d1"]);
     expect(
       result.current.documents?.find((d) => d.id === "fantasma"),
     ).toBeUndefined();
+  });
+
+  it("markResponded antes da lista resolver é aplicado quando a base chega (race de deep-link)", async () => {
+    let resolveList: (v: BrowseDocument[]) => void = () => {};
+    mockGet.mockReturnValue(
+      new Promise<BrowseDocument[]>((r) => {
+        resolveList = r;
+      }),
+    );
+    const { result } = renderHook(() => useBrowseDocuments("p1", true));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.documents).toBeNull();
+
+    // Usuário envia rápido (deep-link) ANTES da lista chegar: a intenção fica
+    // pendente sem depender da base já carregada.
+    act(() => result.current.markResponded("d1"));
+    expect(result.current.documents).toBeNull();
+
+    // Lista chega depois, com a contagem do servidor pré-save.
+    await act(async () => {
+      resolveList([doc("d1", { responseCount: 2 }), doc("d2")]);
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const d1 = result.current.documents?.find((d) => d.id === "d1");
+    expect(d1?.userAlreadyResponded).toBe(true);
+    expect(d1?.responseCount).toBe(3);
+    const d2 = result.current.documents?.find((d) => d.id === "d2");
+    expect(d2?.userAlreadyResponded).toBe(false);
+    expect(d2?.responseCount).toBe(0);
+  });
+
+  it("markResponded repetido no mesmo doc não acumula a contagem", async () => {
+    mockGet.mockResolvedValue([doc("d1", { responseCount: 2 })]);
+    const { result } = renderHook(() => useBrowseDocuments("p1", true));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.markResponded("d1"));
+    expect(
+      result.current.documents?.find((d) => d.id === "d1")?.responseCount,
+    ).toBe(3);
+
+    // Reaplicar (ex.: submit seguido de autosave no mesmo doc) é idempotente.
+    act(() => result.current.markResponded("d1"));
+    expect(
+      result.current.documents?.find((d) => d.id === "d1")?.responseCount,
+    ).toBe(3);
   });
 
   it("toggle enabled true→false→true: refetch só 1x e preserva overrides", async () => {
@@ -123,7 +173,7 @@ describe("useBrowseDocuments", () => {
       { initialProps: { on: true } },
     );
     await waitFor(() => expect(result.current.loading).toBe(false));
-    act(() => result.current.markResponded("d1", "submit"));
+    act(() => result.current.markResponded("d1"));
     expect(
       result.current.documents?.find((d) => d.id === "d1")?.responseCount,
     ).toBe(2);

--- a/frontend/src/hooks/useBrowseDocuments.ts
+++ b/frontend/src/hooks/useBrowseDocuments.ts
@@ -13,14 +13,14 @@ import { useCachedResource } from "./useCachedResource";
  * então o genérico expõe `error=true` SEM cachear (não mascara como "projeto sem
  * documentos"); `retry()` limpa o erro/cache e refaz o fetch.
  *
- * `markResponded` aplica os updates otimistas pós-envio sobre uma camada local
- * de `overrides` (atualizada em handler, nunca em effect): marca o doc como
- * respondido e — só no intent `"submit"` (envio de resposta nova) e quando o
- * doc ainda não constava como respondido — incrementa `responseCount` uma única
- * vez. O intent `"autosave"` (saída via "Voltar") marca respondido sem mexer no
- * contador. Espelha exatamente a lógica anterior de `handleBrowseSubmit` (bump)
- * e `handleBrowseBack` (sem bump). O `retry()` também zera os `overrides`: um
- * refetch traz dados frescos do servidor, e overrides antigos os clobbeariam.
+ * `markResponded` aplica o update otimista pós-envio sobre uma camada local de
+ * `overrides` (atualizada em handler, nunca em effect): marca o doc como
+ * respondido por este pesquisador e — quando o doc ainda não o contava —
+ * incrementa `responseCount` uma única vez. Vale para submit e para autosave
+ * (saída via "Voltar"): ambos persistem uma resposta que `getDocumentsForBrowse`
+ * conta (respondentes distintos, sem filtrar `is_partial`). O `retry()` também
+ * zera os `overrides`: um refetch traz dados frescos do servidor, e overrides
+ * antigos os clobbeariam.
  */
 export function useBrowseDocuments(
   projectId: string,
@@ -30,7 +30,7 @@ export function useBrowseDocuments(
   loading: boolean;
   error: boolean;
   retry: () => void;
-  markResponded: (docId: string, intent: "submit" | "autosave") => void;
+  markResponded: (docId: string) => void;
 } {
   const fetcher = useCallback(
     (id: string): Promise<BrowseDocument[]> => getDocumentsForBrowse(id),
@@ -44,9 +44,11 @@ export function useBrowseDocuments(
     retry: retryResource,
   } = useCachedResource(projectId, fetcher, { enabled });
 
-  const [overrides, setOverrides] = useState<
-    Record<string, { userAlreadyResponded: boolean; responseCount: number }>
-  >({});
+  // Override guarda só a INTENÇÃO "este pesquisador respondeu", não o valor
+  // absoluto. Assim `markResponded` não precisa ler a lista já carregada — o
+  // merge abaixo aplica a intenção sobre a base de forma idempotente quando a
+  // base chega (corrige a race de deep-link em que a lista ainda não resolveu).
+  const [overrides, setOverrides] = useState<Record<string, true>>({});
 
   const retry = useCallback(() => {
     retryResource();
@@ -56,28 +58,27 @@ export function useBrowseDocuments(
   const documents = useMemo(() => {
     if (!base) return null;
     return base.map((d) => {
-      const o = overrides[d.id];
-      return o ? { ...d, ...o } : d;
+      if (!overrides[d.id]) return d;
+      return {
+        ...d,
+        userAlreadyResponded: true,
+        // +1 só quando a base ainda não contava este pesquisador. Submit e
+        // autosave persistem ambos uma resposta contável (`getDocumentsForBrowse`
+        // conta respondentes distintos sem filtrar `is_partial`), então ambos
+        // bumpam a primeira resposta deste pesquisador. Recomputado de `base` a
+        // cada render e gateado por `userAlreadyResponded` → nunca acumula.
+        responseCount: d.userAlreadyResponded
+          ? d.responseCount
+          : d.responseCount + 1,
+      };
     });
   }, [base, overrides]);
 
-  // Lê o estado mesclado atual (base + overrides anteriores) pela closure: o
-  // callback recria quando `documents` muda, então a contagem nunca é dobrada.
-  const markResponded = useCallback(
-    (docId: string, intent: "submit" | "autosave") => {
-      const cur = documents?.find((d) => d.id === docId);
-      if (!cur) return;
-      const responseCount =
-        intent === "submit" && !cur.userAlreadyResponded
-          ? cur.responseCount + 1
-          : cur.responseCount;
-      setOverrides((prev) => ({
-        ...prev,
-        [docId]: { userAlreadyResponded: true, responseCount },
-      }));
-    },
-    [documents],
-  );
+  // Registra a intenção sem ler `documents`: funciona mesmo com a lista ainda
+  // não resolvida. Idempotente — reaplicar é no-op.
+  const markResponded = useCallback((docId: string) => {
+    setOverrides((prev) => (prev[docId] ? prev : { ...prev, [docId]: true }));
+  }, []);
 
   return { documents, loading, error, retry, markResponded };
 }

--- a/frontend/src/hooks/useCachedResource.ts
+++ b/frontend/src/hooks/useCachedResource.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 /**
  * Núcleo de cache-por-chave compartilhado pelos lazy-loaders do app
@@ -88,8 +88,17 @@ export function useCachedResource<T>(
   const [store, setStore] = useState<CacheStore<T>>({ entries: {}, order: [] });
   const [errors, setErrors] = useState<Record<string, true>>({});
 
+  // `needsFetch` é a única condição que dispara o effect: chave habilitada,
+  // ainda não cacheada e sem erro registrado. Como é um BOOLEANO derivado, o
+  // effect só reage quando ela vira true (precisa buscar) — e não a cada
+  // mutação do `store`/`errors`, evitando a antiga subscrição ao cache inteiro.
+  // Ao `invalidate`/`retry` a chave sai do cache, `needsFetch` volta a true e o
+  // effect refaz o fetch.
+  const needsFetch =
+    enabled && !!key && !(key in store.entries) && !errors[key];
+
   useEffect(() => {
-    if (!enabled || !key || key in store.entries || errors[key]) return;
+    if (!needsFetch || !key) return;
     let cancelled = false;
     fetcher(key)
       .then((value) => {
@@ -104,7 +113,7 @@ export function useCachedResource<T>(
     return () => {
       cancelled = true;
     };
-  }, [enabled, key, store, errors, fetcher, maxEntries]);
+  }, [needsFetch, key, fetcher, maxEntries]);
 
   const invalidate = useCallback((k: string) => {
     setStore((prev) => removeKey(prev, k));
@@ -113,18 +122,13 @@ export function useCachedResource<T>(
 
   // Limpa cache+erro da chave CORRENTE para que o effect refaça o fetch.
   const retry = useCallback(() => {
-    if (!key) return;
-    setStore((prev) => removeKey(prev, key));
-    setErrors((prev) => deleteKey(prev, key));
-  }, [key]);
+    if (key) invalidate(key);
+  }, [key, invalidate]);
 
-  const data = useMemo(
-    () => (enabled && key && key in store.entries ? store.entries[key] : undefined),
-    [enabled, key, store],
-  );
+  const data =
+    enabled && key && key in store.entries ? store.entries[key] : undefined;
   const error = enabled && !!key && !!errors[key];
-  const loading =
-    enabled && !!key && !(key in store.entries) && !errors[key];
+  const loading = needsFetch;
 
   return { data, loading, error, invalidate, retry };
 }


### PR DESCRIPTION
**Supersede o #297.** O #297 ficou estruturalmente stale: foi feito sobre o `CodingPage` consolidado, **antes** do #280 extrair os handlers para `useBrowseCoding`/`useAssignedCoding`. Rebaseá-lo cru sobre main reverteria o #280. Este PR **reaplica as 8 melhorias do #297 sobre a estrutura atual de main** e endereça os **3 achados do code-review** do #297.

## Melhorias do #257/#297 reaplicadas
- **BrowseDocCoder**: guards `if (submitting) return` em `handleAnswer`/`handleNotesChange` (teclas não se perdem durante o save em voo), preservando o `clearHiddenConditionalAnswers` do follow-up #252.
- **useBrowseDocuments**: override passa a guardar só a intenção "respondido", aplicada idempotentemente sobre a base — corrige a race de deep-link em `markResponded` (registrar envio antes da lista resolver).
- **useBrowseCoding**: `browseSavingRef` como guarda de reentrância em `handleBrowseSubmit`/`handleBrowseBack` (duplo-clique não duplica `saveResponse`) + `try/finally`.
- **CodingHeader**: prop `submitting` desabilita Voltar/Sortear durante o save.
- **useCachedResource**: effect depende do booleano derivado `needsFetch`; `data` inline; `retry` delega a `invalidate`.
- **BrowseCodingView**: extrai `RetryState` local (dedup do bloco erro+retry da lista e do doc).
- *Item #8 do #297 (teto no `useDocumentText` via `useCachedResource`) **descartado**: main manteve o `useDocumentText` bespoke deliberadamente (o erro sticky do genérico quebra o auto-retry-on-renavegação), então não se aplica.*

## Achados do code-review do #297 corrigidos
1. **(médio)** `try/finally` no `handleSubmit` de Atribuídos (`useAssignedCoding`): uma rejeição de transporte do Server Action não deixa mais `submitting` preso — como o estado é compartilhado com o Explorar, isso congelaria a edição lá até um reload.
2. Pista visual no `QuestionsPanel`: container esmaecido + `aria-busy` + `Textarea` disabled durante o save (o `FieldRenderer` não aceita `disabled`).
3. Guarda de reentrância no **topo** de `handleBrowseBack` (cobre também o caminho não-sujo).
4. `markResponded` perde o parâmetro `intent`: submit e autosave bumpam ambos a primeira resposta (`getDocumentsForBrowse` conta respondentes sem filtrar `is_partial`), corrigindo a sub-contagem do autosave.

## Validação
- `tsc --noEmit` limpo **nos arquivos deste PR**; `react-doctor` 100/100 nas linhas alteradas.
- **804/804** testes verdes, incluindo casos novos: edição congelada durante submitting, duplo-clique sem duplicar `saveResponse`, autosave bumpando a 1ª resposta.

> ℹ️ **Fix não relacionado dobrado (commit separado):** a ponta de `main` (#291) estava vermelha no `tsc` — `compare/__tests__/ComparisonPanel.customAnswer.test.tsx` ficou sem `respondent_id` (tornado obrigatório em `ComparisonResponse`). Adicionei `respondent_id: null` num commit à parte (`fix(compare): ...`) só para o typecheck do CI ficar verde. `tsc --noEmit` agora passa no projeto inteiro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
