### PR TITLE
feat(cutover): Parte A do cutover de domínio dataframeit.com.br (#194)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,35 +57,42 @@ A partir daí, cada commit é varrido em busca de segredos antes de entrarem no 
 
 ## Deploy (Produção)
 
+Produção roda inteiramente no **Fly.io** (`gru`), com deploy **automático por CI** a partir de merge na `main`: `backend/**` dispara `fly-deploy.yml` (app `gui-analise-sistematica-api`) e `frontend/**` dispara `frontend-fly-deploy.yml` (app `gui-analise-sistematica-frontend`). Domínio: `dataframeit.com.br`.
+
 ### 1. Supabase Cloud
 
 1. Criar projeto em [supabase.com](https://supabase.com)
-2. Rodar `frontend/supabase/migrations/001_initial_schema.sql` no SQL Editor
-3. Em Auth → Settings: habilitar email/password, setar Site URL para o domínio Vercel
+2. Aplicar as migrations de `frontend/supabase/migrations/` (`npx supabase db push`)
+3. Auth é via **Clerk** (não o Auth nativo do Supabase); o RLS valida o JWT do Clerk
 4. Anotar: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY`
 
-### 2. Backend (Fly.io)
+### 2. Backend (Fly.io — `gui-analise-sistematica-api`)
+
+Config em `backend/fly.toml`. Secrets de runtime via `fly secrets set` (nunca no toml):
 
 ```bash
 cd backend
-fly apps create gui-analise-conteudo-api
 fly secrets set SUPABASE_URL=https://xxx.supabase.co \
   SUPABASE_SERVICE_KEY=your-key \
-  CORS_ORIGINS='["https://seu-dominio.vercel.app"]'
-fly deploy
+  CLERK_JWKS_URL='https://<slug>.clerk.accounts.dev/.well-known/jwks.json' \
+  -a gui-analise-sistematica-api
+# CORS_ORIGINS fica em [env] no fly.toml (origens permitidas, JSON array).
+fly deploy -c fly.toml -a gui-analise-sistematica-api   # fallback; o normal é via CI
 ```
 
-Verificar: `curl https://gui-analise-conteudo-api.fly.dev/health`
+Verificar: `curl https://gui-analise-sistematica-api.fly.dev/health`
 
-### 3. Frontend (Vercel)
+### 3. Frontend (Fly.io — `gui-analise-sistematica-frontend`)
+
+Config em `frontend/fly.toml`. As `NEXT_PUBLIC_*` ficam em `[build.args]` (embutidas no bundle em build time, todas públicas por design); os secrets de runtime (`CLERK_SECRET_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `CLERK_WEBHOOK_SECRET`) via `fly secrets set`:
 
 ```bash
 cd frontend
-vercel link
-vercel env add NEXT_PUBLIC_SUPABASE_URL     # https://xxx.supabase.co
-vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY
-vercel env add NEXT_PUBLIC_API_URL           # https://gui-analise-conteudo-api.fly.dev
-vercel --prod
+fly secrets set CLERK_SECRET_KEY=sk_... \
+  SUPABASE_SERVICE_ROLE_KEY=your-key \
+  CLERK_WEBHOOK_SECRET=whsec_... \
+  -a gui-analise-sistematica-frontend
+fly deploy -c fly.toml -a gui-analise-sistematica-frontend   # fallback; o normal é via CI
 ```
 
 ### Variáveis de ambiente
@@ -94,10 +101,15 @@ vercel --prod
 |----------|------|-----------|
 | `SUPABASE_URL` | Backend (Fly.io) | URL do projeto Supabase |
 | `SUPABASE_SERVICE_KEY` | Backend (Fly.io) | Service role key |
-| `CORS_ORIGINS` | Backend (Fly.io) | JSON array de origens permitidas |
-| `NEXT_PUBLIC_SUPABASE_URL` | Frontend (Vercel) | URL do projeto Supabase |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Frontend (Vercel) | Anon/public key |
-| `NEXT_PUBLIC_API_URL` | Frontend (Vercel) | URL do backend no Fly.io |
+| `CLERK_JWKS_URL` | Backend (Fly.io) | URL do JWKS do Clerk (verificação RS256 do JWT) |
+| `CORS_ORIGINS` | Backend (`fly.toml [env]`) | JSON array de origens permitidas |
+| `NEXT_PUBLIC_SUPABASE_URL` | Frontend (`fly.toml [build.args]`) | URL do projeto Supabase |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Frontend (`fly.toml [build.args]`) | Anon/publishable key |
+| `NEXT_PUBLIC_API_URL` | Frontend (`fly.toml [build.args]`) | URL do backend no Fly.io |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Frontend (`fly.toml [build.args]`) | Publishable key do Clerk |
+| `CLERK_SECRET_KEY` | Frontend (Fly secret) | Secret key do Clerk |
+| `SUPABASE_SERVICE_ROLE_KEY` | Frontend (Fly secret) | Service role (server actions) |
+| `CLERK_WEBHOOK_SECRET` | Frontend (Fly secret) | Signing secret do webhook do Clerk |
 
 ## Estrutura do Projeto
 

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -38,4 +38,4 @@ kill_timeout = "5m"
 
 [env]
   PORT = "8000"
-  CORS_ORIGINS = '["https://ac.brunodcdo.com.br", "http://localhost:3000"]'
+  CORS_ORIGINS = '["https://dataframeit.com.br", "https://gui-analise-sistematica-frontend.fly.dev", "https://ac.brunodcdo.com.br", "http://localhost:3000"]'

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -19,16 +19,19 @@ primary_region = "gru"
     NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL = "/dashboard"
 
 [deploy]
-  strategy = "bluegreen"
+  # Rolling (nao bluegreen): com min_machines_running = 1 e always-on, rolling
+  # reinicia a unica maquina no lugar. Tradeoff aceito (#194 A3): blip curto
+  # possivel no deploy, em troca de manter o frontend sempre ligado.
+  strategy = "rolling"
 
 [http_service]
   internal_port = 3000
   force_https = true
-  # Frontend e stateless (nao roda jobs em background como o backend), entao
-  # pode escalar a zero quando ocioso. Cold start do Next standalone e leve.
-  auto_stop_machines = "stop"
-  auto_start_machines = true
-  min_machines_running = 0
+  # Always-on (#194 A3): como dominio de producao, o frontend nao escala a
+  # zero — evita cold start na primeira request e espelha o backend. auto_stop
+  # = "off" + min = 1 garantem ao menos uma maquina sempre rodando.
+  auto_stop_machines = "off"
+  min_machines_running = 1
 
   [[http_service.checks]]
     grace_period = "10s"

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,4 +1,12 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+// Cutover de dominio (#194): o dominio antigo na Vercel passa a apontar para o
+// frontend no Fly; aqui redirecionamos 308 (preserva metodo + corpo) para o
+// dominio canonico, preservando path + query. Inerte ate o DNS de LEGACY_HOST
+// apontar para o Fly, entao e seguro deployar cedo.
+const LEGACY_HOST = "ac.brunodcdo.com.br";
+const CANONICAL_HOST = "dataframeit.com.br";
 
 const isPublicRoute = createRouteMatcher([
   "/auth/(.*)",
@@ -7,6 +15,12 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export default clerkMiddleware(async (auth, request) => {
+  if (request.headers.get("host") === LEGACY_HOST) {
+    return NextResponse.redirect(
+      `https://${CANONICAL_HOST}${request.nextUrl.pathname}${request.nextUrl.search}`,
+      308,
+    );
+  }
   if (!isPublicRoute(request)) {
     await auth.protect();
   }

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "regions": ["gru1"]
-}


### PR DESCRIPTION
## Contexto

**Parte A do #194** — o código do cutover de domínio para `dataframeit.com.br` (frontend no Fly, redirect do antigo, aposentar Vercel). Todas as mudanças são **inertes até o DNS apontar para o Fly**, então é seguro mergear cedo. As Partes B (CLI: certs, DNS) e C (manual: Clerk, registrar) vêm depois, conduzidas via runbook.

> [!NOTE]
> Pré-requisito da Parte B é o #300 (token Fly do frontend / PR #298) — sem ele o CI não deploya o frontend. Este PR (Parte A) é independente e pode mergear antes.

## O que muda

- **A1 `backend/fly.toml`** — `CORS_ORIGINS` ganha `https://dataframeit.com.br` + `https://gui-analise-sistematica-frontend.fly.dev`, mantendo `ac.brunodcdo.com.br` na transição. Fecha o gap de CORS do #172: `fetchFastAPI` é chamado do browser em `LlmConfigurePane.tsx`/`RunLlmButton.tsx`.
- **A2 `frontend/src/proxy.ts`** — redirect **308** de `ac.brunodcdo.com.br` → `dataframeit.com.br`, preservando path+query, no topo do callback do `clerkMiddleware` (antes do `auth.protect()`). Inerte até o DNS antigo apontar para o Fly.
- **A3 `frontend/fly.toml`** — **always-on + rolling**: `strategy bluegreen→rolling`, `auto_stop_machines stop→off`, `min_machines_running 0→1`, remove `auto_start_machines` redundante. Tradeoff aceito: blip curto possível no deploy (1 máquina + rolling).
- **A4 aposentar Vercel no código** — remove `frontend/vercel.json` (só fixava região de build `gru1`; risco negligível) e reescreve a seção "Deploy (Produção)" do `README.md`: frontend no Fly via `[build.args]`, corrige o nome stale `gui-analise-conteudo-api`→`gui-analise-sistematica-api`, deploy por CI, tabela de env vars atualizada (Vercel→Fly).

## Verificação

Mudanças inertes até o DNS; a verificação ponta a ponta (health, CORS, redirect, login + job de LLM no domínio novo) roda na Parte B/C do runbook. `tsc` confirma `proxy.ts` limpo.

Refs #194, #172, #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)