### PR TITLE
perf(react-doctor): performance Onda 5 — paralelizar awaits + index/set maps + supressões (#236)

### DIFF
--- a/frontend/src/actions/comparisons.ts
+++ b/frontend/src/actions/comparisons.ts
@@ -69,6 +69,9 @@ export async function retryPendingComparisons(projectId: string): Promise<{
     let assigned = 0;
     let stillNoPool = 0;
     for (const { documentId, coderIds } of backlog) {
+      // Sequencial intencional (ver comentário acima): cada atribuição enxerga
+      // a carga atualizada da anterior; paralelizar degradaria o balanceamento.
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop
       const result = await assignComparisonReviewer(
         admin,
         projectId,

--- a/frontend/src/actions/equivalences.ts
+++ b/frontend/src/actions/equivalences.ts
@@ -154,6 +154,11 @@ export async function unmarkEquivalencePair(
     .eq("project_id", projectId)
     .maybeSingle();
 
+  // Ordem obrigatória, não awaits independentes: o select acima captura
+  // document_id/field_name ANTES de a linha ser apagada. Paralelizar com o
+  // delete criaria uma race read-after-delete (row viria null e a limpeza de
+  // reviews abaixo não rodaria).
+  // react-doctor-disable-next-line react-doctor/server-sequential-independent-await
   const { error } = await supabase
     .from("response_equivalences")
     .delete()

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -1219,6 +1219,9 @@ export async function retryPendingArbitrations(
     let assigned = 0;
     let stillNoPool = 0;
     for (const g of groups.values()) {
+      // Sequencial intencional (ver comentário acima): cada assignArbitrator lê
+      // openCounts recalculado; paralelizar degradaria a distribuição.
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop
       const result = await assignArbitrator(
         projectId,
         g.documentId,

--- a/frontend/src/actions/reviews.ts
+++ b/frontend/src/actions/reviews.ts
@@ -28,9 +28,12 @@ export async function submitVerdict(
   // Identidade de trabalho no projeto (spec 002): conta vinculada revisa
   // como o membro canônico — reviewer_id, author_id e o sync do assignment
   // usam o id efetivo, casando com o onConflict do upsert.
-  const effectiveId = await getEffectiveMemberId(projectId);
-
-  const supabase = await createSupabaseServer();
+  // `getEffectiveMemberId` (admin client, cache()) e `createSupabaseServer`
+  // são independentes — rodam em paralelo.
+  const [effectiveId, supabase] = await Promise.all([
+    getEffectiveMemberId(projectId),
+    createSupabaseServer(),
+  ]);
 
   const { error } = await supabase.from("reviews").upsert(
     {
@@ -133,9 +136,11 @@ export async function markCompareDocReviewed(
   if (!user) throw new Error("Não autenticado");
 
   // Conta vinculada fecha o doc como o membro canônico (spec 002).
-  const effectiveId = await getEffectiveMemberId(projectId);
-
-  const supabase = await createSupabaseServer();
+  // Awaits independentes em paralelo.
+  const [effectiveId, supabase] = await Promise.all([
+    getEffectiveMemberId(projectId),
+    createSupabaseServer(),
+  ]);
 
   const { error } = await supabase
     .from("assignments")

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -467,6 +467,9 @@ async function runBackfill(projectId: string): Promise<BackfillStats> {
   };
   const responses: ResponseRow[] = [];
   for (let from = 0; ; from += RESPONSES_PAGE) {
+    // Paginação sequencial: a próxima página depende de a anterior ter retornado
+    // uma página cheia; não há como paralelizar sem saber o total de linhas.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
     const { data: page, error: pageErr } = await supabase
       .from("responses")
       .select("id, created_at, answer_field_hashes, version_inferred_from")

--- a/frontend/src/actions/suggestions.ts
+++ b/frontend/src/actions/suggestions.ts
@@ -121,11 +121,13 @@ export async function approveSchemaSuggestionWithEdits(
     return { error: "Apenas coordenadores podem aprovar sugestões de schema." };
   }
 
-  const supabase = await createSupabaseServer();
-
-  // Mesma proteção de resolveSchemaSuggestion: sugestão só vira "approved"
-  // depois que o schema persistiu de fato.
-  const saved = await saveSchemaFromGUI(projectId, editedFields);
+  // Criar o client e persistir o schema são independentes — rodam em paralelo.
+  // Mesma proteção de resolveSchemaSuggestion: a sugestão só vira "approved"
+  // depois que o schema persistiu de fato (o update abaixo aguarda ambos).
+  const [supabase, saved] = await Promise.all([
+    createSupabaseServer(),
+    saveSchemaFromGUI(projectId, editedFields),
+  ]);
   if (saved.error) return { error: saved.error };
 
   const { data: updated, error } = await supabase

--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -53,6 +53,11 @@ function DateFieldRenderer({
   const [parts, setParts] = useState<DateParts>(() =>
     parseDatePartsForUI(externalForUI),
   );
+  // `lastExternal` É lido no render (na comparação `externalForUI !== lastExternal`
+  // abaixo) — é o padrão oficial React de "previous render", não state só-de-handler.
+  // A regra classifica errado; useRef quebraria o padrão (set-durante-render
+  // precisa de useState para reagendar o render).
+  // react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers
   const [lastExternal, setLastExternal] = useState(externalForUI);
 
   // React's official "Storing information from previous renders" pattern

--- a/frontend/src/components/shared/RunLlmButton.tsx
+++ b/frontend/src/components/shared/RunLlmButton.tsx
@@ -42,6 +42,11 @@ export function RunLlmButton({
       const poll = async () => {
         if (cancelledRef.current) return;
         try {
+          // O guard de cancelamento abaixo roda DEPOIS do await de propósito: o
+          // usuário pode cancelar enquanto a request de status está em voo, então
+          // re-checamos `cancelledRef` após a rede retornar. Mover o await para
+          // baixo do guard anularia essa semântica de cancelamento.
+          // react-doctor-disable-next-line react-doctor/async-defer-await
           const status = await fetchFastAPI<{
             status: string;
             errors: string[];

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -114,6 +114,10 @@ export function EditFieldDialog({
 
   // Reset state when dialog opens with a different field or suggestion
   const resetKey = `${fieldName}::${pendingSuggestion?.id ?? ""}`;
+  // `prevKey` É lido no render (comparação `resetKey !== prevKey` abaixo) — é o
+  // padrão oficial React de "adjusting state on a prop change", não state
+  // só-de-handler. A regra classifica errado; useRef quebraria o padrão.
+  // react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers
   const [prevKey, setPrevKey] = useState(resetKey);
   if (resetKey !== prevKey) {
     setPrevKey(resetKey);

--- a/frontend/src/components/stats/SuggestFieldDialog.tsx
+++ b/frontend/src/components/stats/SuggestFieldDialog.tsx
@@ -50,6 +50,10 @@ export function SuggestFieldDialog({
   const [reason, setReason] = useState("");
   const [isSaving, startSave] = useTransition();
 
+  // `prevFieldName` É lido no render (comparação `fieldName !== prevFieldName`
+  // abaixo) — padrão oficial React de "adjusting state on a prop change", não
+  // state só-de-handler. A regra classifica errado; useRef quebraria o padrão.
+  // react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers
   const [prevFieldName, setPrevFieldName] = useState(fieldName);
   if (fieldName !== prevFieldName) {
     setPrevFieldName(fieldName);

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -230,6 +230,9 @@ export function distributeDocs(
 
   for (const docId of shuffleWithRng(eligibleDocIds, rng)) {
     const preservedOnDoc = docAssignedUsers[docId] || [];
+    // Set para lookup O(1) no filtro do while (preservedOnDoc é constante no
+    // escopo deste docId).
+    const preservedSet = new Set(preservedOnDoc);
     const newOnDoc = new Set<string>();
     let need = researchersPerDoc - preservedOnDoc.length;
 
@@ -239,7 +242,7 @@ export function distributeDocs(
         (p) =>
           remaining[p.id] > 0 &&
           !newOnDoc.has(p.id) &&
-          !preservedOnDoc.includes(p.id) &&
+          !preservedSet.has(p.id) &&
           !preservedPairs.has(`${docId}:${p.id}`),
       );
       if (!candidates.length) break;

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -200,6 +200,11 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
   }
 
   const names = new Set<string>();
+  // Índice incremental name -> primeiro campo com esse nome já visto. Substitui
+  // o `earlier.find()` O(n²) na checagem de condition por um lookup O(1).
+  // Preserva a primeira ocorrência (só insere se ausente) para casar com a
+  // semântica de `earlier.find` em schemas com nomes duplicados.
+  const fieldByName = new Map<string, PydanticField>();
   for (let i = 0; i < fields.length; i++) {
     const f = fields[i];
     const label = `Campo ${i + 1}`;
@@ -217,6 +222,7 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
       errors.push(`${label}: nome "${f.name}" duplicado`);
     }
     names.add(f.name);
+    if (!fieldByName.has(f.name)) fieldByName.set(f.name, f);
 
     if (!f.description.trim()) {
       errors.push(`${label}: descrição não pode ser vazia`);
@@ -269,8 +275,12 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
       } else if (trigger === f.name) {
         errors.push(`${label}: condição não pode referenciar o próprio campo`);
       } else {
-        const earlier = fields.slice(0, i);
-        const triggerField = earlier.find((g) => g.name === trigger);
+        const triggerField = fieldByName.get(trigger);
+        // Set das opções do gatilho construído uma vez e reusado nos dois
+        // branches (equals/not_equals e in/not_in) para lookups O(1).
+        const triggerOptionSet = triggerField?.options
+          ? new Set(triggerField.options)
+          : null;
         if (!triggerField) {
           errors.push(
             `${label}: campo gatilho "${trigger}" inexistente ou posterior ao campo condicional`,
@@ -281,9 +291,9 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
               ? f.condition.equals
               : f.condition.not_equals;
           if (
-            triggerField.options &&
+            triggerOptionSet &&
             typeof val === "string" &&
-            !triggerField.options.includes(val)
+            !triggerOptionSet.has(val)
           ) {
             errors.push(
               `${label}: valor "${val}" não está nas opções de "${trigger}"`,
@@ -294,8 +304,7 @@ export function validateGUIFields(fields: PydanticField[]): string[] {
             "in" in f.condition ? f.condition.in : f.condition.not_in;
           if (!Array.isArray(vals) || vals.length === 0) {
             errors.push(`${label}: lista de valores da condição vazia`);
-          } else if (triggerField.options) {
-            const triggerOptionSet = new Set(triggerField.options);
+          } else if (triggerOptionSet) {
             for (const v of vals) {
               if (typeof v === "string" && !triggerOptionSet.has(v)) {
                 errors.push(
@@ -334,15 +343,24 @@ export function findConditionConflicts(
     const c = f.condition;
     if (!c || c.field !== triggerFieldName) continue;
 
+    // Os `.includes` abaixo checam UM valor (`removedOption`) contra a lista de
+    // opções da própria condition do campo, uma vez por iteração — não há scan
+    // repetido de array estável, então um Set não acelera nada (FP da regra).
     let conditionKey: ConditionConflict["conditionKey"] | null = null;
     if ("equals" in c && c.equals === removedOption) conditionKey = "equals";
     else if ("not_equals" in c && c.not_equals === removedOption)
       conditionKey = "not_equals";
-    else if ("in" in c && Array.isArray(c.in) && c.in.includes(removedOption))
+    else if (
+      "in" in c &&
+      Array.isArray(c.in) &&
+      // react-doctor-disable-next-line react-doctor/js-set-map-lookups
+      c.in.includes(removedOption)
+    )
       conditionKey = "in";
     else if (
       "not_in" in c &&
       Array.isArray(c.not_in) &&
+      // react-doctor-disable-next-line react-doctor/js-set-map-lookups
       c.not_in.includes(removedOption)
     )
       conditionKey = "not_in";

--- a/frontend/src/lib/upload-chunking.ts
+++ b/frontend/src/lib/upload-chunking.ts
@@ -70,6 +70,10 @@ export async function mapWithConcurrency<T, R>(
   const worker = async () => {
     while (next < items.length) {
       const i = next++;
+      // O await em loop é o núcleo deste helper de concorrência limitada: cada
+      // worker processa itens em série; o paralelismo vem dos N workers. O
+      // Promise.all que a regra sugeriria é justamente o que estamos limitando.
+      // react-doctor-disable-next-line react-doctor/async-await-in-loop
       results[i] = await fn(items[i], i);
     }
   };


### PR DESCRIPTION
## Contexto

Onda 5 da campanha **Zerar react-doctor** (épico #239), eixo **Performance** (issue #236). O texto do issue estava parcialmente stale: ao rodar `npm run react-doctor` fresco, várias regras já tinham caído nas Ondas 3-4 (`async-parallel`, `js-length-check-first`, `rerender-lazy-ref-init`) e o `dirtyDocs` do CodingPage já fora resolvido por `useDirtyDocs` (useRef) — o carve-out do issue ficou **moot**.

Triagem honesta dos 14 flags remanescentes: **~6 fixes genuínos** + **~8 falsos-positivos / padrões intencionais** suprimidos com justificativa inline (decisão acordada: `react-doctor-disable-next-line` + comentário, conforme a convenção já usada em `useDocumentUpload.ts`).

## Fixes genuínos

- **`server-sequential-independent-await`** — `Promise.all` em awaits independentes:
  - `reviews.submitVerdict` / `reviews.markCompareDocReviewed`: `getEffectiveMemberId` (admin client, `cache()`) ∥ `createSupabaseServer`.
  - `suggestions.approveSchemaSuggestionWithEdits`: `createSupabaseServer` ∥ `saveSchemaFromGUI` (o `update` que usa o client continua sequencial, depois de ambos).
- **`js-index-maps`** — `validateSchema`: `earlier.find()` O(n²) → `Map<name,field>` incremental (insere só a 1ª ocorrência → resultado idêntico, inclusive em schemas com nomes duplicados).
- **`js-set-map-lookups`** — `lottery-utils`: `Set` para `preservedOnDoc` no filtro do `while`; `validateSchema`: um único `triggerOptionSet` reusado nos branches `equals`/`not_equals` e `in`/`not_in`.

## Supressões documentadas (FP / intencional)

- **`async-await-in-loop` ×4** — loops sequenciais propositais (já comentados no código): balanceamento de carga (`comparisons`, `field-reviews`), paginação (`schema`), helper de concorrência limitada (`upload-chunking`).
- **`server-sequential-independent-await`** — `equivalences.unmarkEquivalencePair`: ordem **obrigatória** (o `select` captura `document_id`/`field_name` antes do `delete`; paralelizar = race read-after-delete).
- **`async-defer-await`** — `RunLlmButton`: o guard de cancelamento roda **depois** do await de rede de propósito.
- **`rerender-state-only-in-handlers` ×3** — padrão oficial React "previous render / adjust-on-prop-change" (`FieldRenderer`, `EditFieldDialog`, `SuggestFieldDialog`): o state **é lido no render** (na comparação); `useRef` quebraria o padrão (cf. MEMORY #281).
- **`js-set-map-lookups` ×2** — `findConditionConflicts`: checagem única por iteração, `Set` não acelera.

## Verificação

- `npm run react-doctor`: **nenhuma** regra de Performance reportada; score **65 → 67**.
- `npm run typecheck`: limpo.
- `npx vitest run`: **817/817** (inclui `schema-utils`, `lottery-utils`, actions e coding).
- `npm run lint` (eslint standalone) quebra por incompatibilidade **ESLint 10 × eslint-plugin-react** na fase de load de regra — **pré-existente** (reproduz em arquivo intocado) e alheio a esta mudança; o gate de merge é o `next build`/Vercel.

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)