### PR TITLE
fix(backend): repara build do wheel, ordena imports e MD5 não-cripto

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,12 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+# O backend e um app FastAPI flat (sem diretorio de pacote homonimo), entao o
+# hatchling nao consegue inferir o conteudo do wheel sozinho e aborta o build
+# (quebrava `uv run ruff`/`pytest`). Listar os modulos explicitamente resolve.
+[tool.hatch.build.targets.wheel]
+only-include = ["main.py", "config.py", "routes", "services"]
+
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,9 +20,9 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-# O backend e um app FastAPI flat (sem diretorio de pacote homonimo), entao o
-# hatchling nao consegue inferir o conteudo do wheel sozinho e aborta o build
-# (quebrava `uv run ruff`/`pytest`). Listar os modulos explicitamente resolve.
+# O backend é um app FastAPI flat (sem diretório de pacote homônimo), então o
+# hatchling não consegue inferir o conteúdo do wheel sozinho e aborta o build
+# (quebrava `uv run ruff`/`pytest`). Listar os módulos explicitamente resolve.
 [tool.hatch.build.targets.wheel]
 only-include = ["main.py", "config.py", "routes", "services"]
 

--- a/backend/routes/llm_routes.py
+++ b/backend/routes/llm_routes.py
@@ -1,5 +1,6 @@
 import uuid
 from typing import Literal
+
 from fastapi import APIRouter, BackgroundTasks
 from pydantic import BaseModel
 

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -4,6 +4,7 @@ LLM runner service — coordinates dataframeit execution.
 Security: o schema Pydantic do projeto é reconstruído a partir do AST validado
 (`build_model_from_code`), sem exec — ver services/pydantic_compiler.
 """
+
 import hashlib
 import logging
 import random
@@ -14,9 +15,10 @@ from collections import Counter
 from datetime import datetime, timedelta, timezone
 
 import pandas as pd
+
 from services.condition_evaluator import evaluate_condition, extract_field_conditions
-from services.supabase_client import get_supabase
 from services.pydantic_compiler import build_model_from_code
+from services.supabase_client import get_supabase
 
 logger = logging.getLogger(__name__)
 
@@ -58,9 +60,11 @@ def get_job_status(job_id: str) -> dict:
         sb = get_supabase()
         row = (
             sb.table("llm_runs")
-            .select("status, phase, progress, total, error_message, error_type, "
-                    "error_traceback, error_line, error_column, pydantic_code, "
-                    "processed_complete, processed_partial, processed_empty")
+            .select(
+                "status, phase, progress, total, error_message, error_type, "
+                "error_traceback, error_line, error_column, pydantic_code, "
+                "processed_complete, processed_partial, processed_empty"
+            )
             .eq("job_id", job_id)
             .maybe_single()
             .execute()
@@ -70,13 +74,24 @@ def get_job_status(job_id: str) -> dict:
             return _status_from_row(row)
     except Exception:
         logger.exception("Failed to fetch job status from llm_runs fallback")
-    return {"status": "error", "phase": "error", "progress": 0, "total": 0,
-            "errors": ["Job not found"], "eta_seconds": None,
-            "current_batch": 0, "total_batches": 0,
-            "processed_complete": 0, "processed_partial": 0, "processed_empty": 0}
+    return {
+        "status": "error",
+        "phase": "error",
+        "progress": 0,
+        "total": 0,
+        "errors": ["Job not found"],
+        "eta_seconds": None,
+        "current_batch": 0,
+        "total_batches": 0,
+        "processed_complete": 0,
+        "processed_partial": 0,
+        "processed_empty": 0,
+    }
 
 
-def _extract_pydantic_location(exc: Exception, tb: str) -> tuple[int | None, int | None]:
+def _extract_pydantic_location(
+    exc: Exception, tb: str
+) -> tuple[int | None, int | None]:
     """Best-effort line/column inside pydantic_code where the error originated."""
     if isinstance(exc, SyntaxError) and exc.filename in (None, "<pydantic_schema>"):
         return exc.lineno, exc.offset
@@ -100,17 +115,19 @@ def _persist_run_insert(sb, job_id: str, project_id: str, filter_mode: str) -> N
     enganou o usuário no passado. Melhor falhar a request do /run e mostrar o
     erro de cara em vez de seguir uma execução invisível.
     """
-    sb.table("llm_runs").insert({
-        "job_id": job_id,
-        "project_id": project_id,
-        "filter_mode": filter_mode,
-        "status": "running",
-        "phase": "loading",
-        # heartbeat inicial. O save loop renova a cada ~2s (ver
-        # _persist_run_progress); cleanup ativo (mark_stale_runs_as_error)
-        # marca como erro runs cujo heartbeat ficou velho.
-        "heartbeat_at": datetime.now(timezone.utc).isoformat(),
-    }).execute()
+    sb.table("llm_runs").insert(
+        {
+            "job_id": job_id,
+            "project_id": project_id,
+            "filter_mode": filter_mode,
+            "status": "running",
+            "phase": "loading",
+            # heartbeat inicial. O save loop renova a cada ~2s (ver
+            # _persist_run_progress); cleanup ativo (mark_stale_runs_as_error)
+            # marca como erro runs cujo heartbeat ficou velho.
+            "heartbeat_at": datetime.now(timezone.utc).isoformat(),
+        }
+    ).execute()
 
 
 def _persist_run_progress(sb, job_id: str, jobs_state: dict) -> None:
@@ -121,13 +138,15 @@ def _persist_run_progress(sb, job_id: str, jobs_state: dict) -> None:
     atualização de progresso falhou. O próximo tick tenta de novo.
     """
     try:
-        sb.table("llm_runs").update({
-            "processed_complete": jobs_state.get("processed_complete", 0),
-            "processed_partial": jobs_state.get("processed_partial", 0),
-            "processed_empty": jobs_state.get("processed_empty", 0),
-            "progress": jobs_state.get("progress", 0),
-            "heartbeat_at": datetime.now(timezone.utc).isoformat(),
-        }).eq("job_id", job_id).execute()
+        sb.table("llm_runs").update(
+            {
+                "processed_complete": jobs_state.get("processed_complete", 0),
+                "processed_partial": jobs_state.get("processed_partial", 0),
+                "processed_empty": jobs_state.get("processed_empty", 0),
+                "progress": jobs_state.get("progress", 0),
+                "heartbeat_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ).eq("job_id", job_id).execute()
     except Exception:
         logger.exception("Failed to UPDATE llm_runs progress for job %s", job_id)
 
@@ -167,12 +186,14 @@ def mark_stale_runs_as_error(sb, project_id: str) -> int:
     )
     res = (
         sb.table("llm_runs")
-        .update({
-            "status": "error",
-            "phase": "error",
-            "error_message": error_msg,
-            "completed_at": now.isoformat(),
-        })
+        .update(
+            {
+                "status": "error",
+                "phase": "error",
+                "error_message": error_msg,
+                "completed_at": now.isoformat(),
+            }
+        )
         .eq("project_id", project_id)
         .eq("status", "running")
         .or_(or_clause)
@@ -181,20 +202,20 @@ def mark_stale_runs_as_error(sb, project_id: str) -> int:
     return len(res.data or [])
 
 
-def _persist_run_snapshot(
-    sb, job_id: str, project: dict, doc_count: int
-) -> None:
+def _persist_run_snapshot(sb, job_id: str, project: dict, doc_count: int) -> None:
     """Backfill provider/model/pydantic snapshot after the project is loaded.
 
     Não engolir erro: se essa atualização falhar, a aba Execuções fica sem
     metadados da run e o usuário não consegue diagnosticar nada depois.
     """
-    sb.table("llm_runs").update({
-        "llm_provider": project.get("llm_provider"),
-        "llm_model": project.get("llm_model"),
-        "document_count": doc_count,
-        "pydantic_code": project.get("pydantic_code"),
-    }).eq("job_id", job_id).execute()
+    sb.table("llm_runs").update(
+        {
+            "llm_provider": project.get("llm_provider"),
+            "llm_model": project.get("llm_model"),
+            "document_count": doc_count,
+            "pydantic_code": project.get("pydantic_code"),
+        }
+    ).eq("job_id", job_id).execute()
 
 
 def _persist_run_completion(
@@ -653,11 +674,19 @@ def init_job(job_id: str, project_id: str, filter_mode: str) -> None:
     """
     sb = get_supabase()
     _jobs[job_id] = {
-        "status": "running", "phase": "loading", "progress": 0, "total": 0,
-        "errors": [], "started_at": time.time(), "eta_seconds": None,
-        "current_batch": 0, "total_batches": 0,
-        "error_traceback": None, "error_type": None,
-        "error_line": None, "error_column": None,
+        "status": "running",
+        "phase": "loading",
+        "progress": 0,
+        "total": 0,
+        "errors": [],
+        "started_at": time.time(),
+        "eta_seconds": None,
+        "current_batch": 0,
+        "total_batches": 0,
+        "error_traceback": None,
+        "error_type": None,
+        "error_line": None,
+        "error_column": None,
         "pydantic_code": None,
         # Counters atualizados durante a fase de saving para o frontend
         # mostrar feedback ao vivo de quantos documentos saíram completos /
@@ -699,7 +728,9 @@ async def run_llm(
         # Load project (only needed columns)
         project = (
             sb.table("projects")
-            .select("pydantic_code, prompt_template, llm_provider, llm_model, llm_kwargs, description, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch")
+            .select(
+                "pydantic_code, prompt_template, llm_provider, llm_model, llm_kwargs, description, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch"
+            )
             .eq("id", project_id)
             .single()
             .execute()
@@ -751,7 +782,9 @@ async def run_llm(
         docs = query.execute().data
 
         # Apply filtering
-        docs = _filter_docs(sb, docs, project_id, filter_mode, max_response_count, sample_size)
+        docs = _filter_docs(
+            sb, docs, project_id, filter_mode, max_response_count, sample_size
+        )
 
         _jobs[job_id]["total"] = len(docs)
         _jobs[job_id]["pydantic_code"] = pydantic_code
@@ -765,7 +798,9 @@ async def run_llm(
         # Compile Pydantic model
         model_class = _compile_model(pydantic_code)
         if not model_class:
-            raise RuntimeError("Nenhuma classe BaseModel encontrada no código Pydantic.")
+            raise RuntimeError(
+                "Nenhuma classe BaseModel encontrada no código Pydantic."
+            )
 
         # Filter out fields that should not be sent to the LLM
         # (target="none" hides from everyone; target="human_only" hides from LLM)
@@ -801,13 +836,17 @@ async def run_llm(
             except (TypeError, ValueError):
                 logger.warning(
                     "llm_kwargs['%s']=%r não é número, usando default %s",
-                    key, raw, default,
+                    key,
+                    raw,
+                    default,
                 )
                 return default
             if not 0 <= v <= 1:
                 logger.warning(
                     "llm_kwargs['%s']=%s fora de [0,1], usando default %s",
-                    key, v, default,
+                    key,
+                    v,
+                    default,
                 )
                 return default
             return v
@@ -816,12 +855,25 @@ async def run_llm(
         run_failure_threshold = _threshold("run_failure_threshold", 0.3)
 
         DATAFRAMEIT_PARAMS = {
-            "api_key", "max_retries", "base_delay", "max_delay", "track_tokens",
-            "use_search", "search_provider", "search_per_field", "max_results",
-            "search_depth", "search_groups", "save_trace", "resume",
-            "reprocess_columns", "status_column",
+            "api_key",
+            "max_retries",
+            "base_delay",
+            "max_delay",
+            "track_tokens",
+            "use_search",
+            "search_provider",
+            "search_per_field",
+            "max_results",
+            "search_depth",
+            "search_groups",
+            "save_trace",
+            "resume",
+            "reprocess_columns",
+            "status_column",
         }
-        model_kwargs = {k: v for k, v in llm_kwargs.items() if k not in DATAFRAMEIT_PARAMS}
+        model_kwargs = {
+            k: v for k, v in llm_kwargs.items() if k not in DATAFRAMEIT_PARAMS
+        }
         dfi_kwargs = {k: v for k, v in llm_kwargs.items() if k in DATAFRAMEIT_PARAMS}
 
         # Build DataFrame
@@ -829,10 +881,11 @@ async def run_llm(
 
         # Run dataframeit in batches for granular progress
         from dataframeit import dataframeit
+
         dfi_kwargs.pop("resume", None)
 
         batch_size = max(1, parallel_requests)
-        batches = [df.iloc[i:i + batch_size] for i in range(0, len(df), batch_size)]
+        batches = [df.iloc[i : i + batch_size] for i in range(0, len(df), batch_size)]
         _jobs[job_id].update(phase="processing", total_batches=len(batches))
 
         result_frames = []
@@ -924,7 +977,9 @@ async def run_llm(
             dfi_status = row.get("_dataframeit_status")
             dfi_error_raw = row.get("_error_details")
             dfi_error: str | None = (
-                str(dfi_error_raw) if dfi_error_raw is not None and pd.notna(dfi_error_raw) else None
+                str(dfi_error_raw)
+                if dfi_error_raw is not None and pd.notna(dfi_error_raw)
+                else None
             )
 
             answers, justifications = _extract_answers_from_row(row, model_class)
@@ -971,7 +1026,8 @@ async def run_llm(
             # está satisfeita mas que não vieram do LLM. Excluímos condicionais
             # não-satisfeitas porque ausência delas é legítima.
             active_expected = {
-                name for name in expected_llm_fields
+                name
+                for name in expected_llm_fields
                 if name not in field_conditions
                 or evaluate_condition(field_conditions[name], answers, name)
             }
@@ -1004,16 +1060,21 @@ async def run_llm(
             if is_partial or is_empty or dfi_error:
                 logger.warning(
                     "LLM row diag doc=%s status=%s error=%s pre_prune=%s post_prune=%s",
-                    doc_id, dfi_status, dfi_error,
-                    answers_pre_prune_keys, sorted(answers.keys()),
+                    doc_id,
+                    dfi_status,
+                    dfi_error,
+                    answers_pre_prune_keys,
+                    sorted(answers.keys()),
                 )
 
             if dfi_error:
                 # Agrupa por hash da mensagem (não prefixo) para o RuntimeError
                 # final. Truncar 120 chars agrupava erros distintos com prefixo
                 # igual.
+                # usedforsecurity=False: chave de cache/dedup, nao uso cripto.
                 key = hashlib.md5(
-                    dfi_error.encode("utf-8", errors="replace")
+                    dfi_error.encode("utf-8", errors="replace"),
+                    usedforsecurity=False,
                 ).hexdigest()[:16]
                 if key not in dfi_error_samples:
                     dfi_error_samples[key] = f"doc={doc_id}: {dfi_error}"
@@ -1032,7 +1093,10 @@ async def run_llm(
             # mesmo após scale-to-zero o llm_runs reflete o trabalho feito,
             # e que a UI consegue distinguir run viva de zumbi.
             now_ts = time.time()
-            if now_ts - _jobs[job_id]["last_progress_persist"] >= progress_persist_interval_s:
+            if (
+                now_ts - _jobs[job_id]["last_progress_persist"]
+                >= progress_persist_interval_s
+            ):
                 _persist_run_progress(sb, job_id, _jobs[job_id])
                 _jobs[job_id]["last_progress_persist"] = now_ts
 
@@ -1056,7 +1120,9 @@ async def run_llm(
             ).execute()
 
         # Update project hash
-        sb.table("projects").update({"pydantic_hash": pydantic_hash}).eq("id", project_id).execute()
+        sb.table("projects").update({"pydantic_hash": pydantic_hash}).eq(
+            "id", project_id
+        ).execute()
 
         # Check de run comprometida: se uma fração grande dos docs produziu
         # resposta parcial, a run é marcada como erro para ficar visível na UI
@@ -1076,9 +1142,7 @@ async def run_llm(
                 f"Respostas gravadas com is_latest=false."
             ]
             if error_examples:
-                sections.append(
-                    "Erros do provider: " + " || ".join(error_examples)
-                )
+                sections.append("Erros do provider: " + " || ".join(error_examples))
             sections.append(
                 "Exemplos de cobertura baixa: " + " || ".join(partial_warnings[:3])
             )

--- a/backend/services/supabase_client.py
+++ b/backend/services/supabase_client.py
@@ -1,4 +1,4 @@
-from supabase import create_client, Client
+from supabase import Client, create_client
 
 from config import settings
 

--- a/backend/tests/test_llm_postprocess.py
+++ b/backend/tests/test_llm_postprocess.py
@@ -4,6 +4,7 @@ Usa o evaluator local (``services.condition_evaluator``), que espelha a
 semântica do frontend. Ver comentário no módulo sobre divergências com
 ``dataframeit.conditional``.
 """
+
 from services.condition_evaluator import evaluate_condition
 
 
@@ -87,16 +88,12 @@ def test_not_in_with_absent_trigger_hides():
 def test_exists_true_with_empty_string_hides():
     """Empty string nao deve contar como "existe"."""
     conds = {"follow": {"field": "trigger", "exists": True}}
-    assert _postprocess({"trigger": "", "follow": "orphan"}, conds) == {
-        "trigger": ""
-    }
+    assert _postprocess({"trigger": "", "follow": "orphan"}, conds) == {"trigger": ""}
 
 
 def test_exists_true_with_empty_list_hides():
     conds = {"follow": {"field": "trigger", "exists": True}}
-    assert _postprocess({"trigger": [], "follow": "orphan"}, conds) == {
-        "trigger": []
-    }
+    assert _postprocess({"trigger": [], "follow": "orphan"}, conds) == {"trigger": []}
 
 
 def test_exists_false_with_empty_string_keeps():
@@ -113,15 +110,14 @@ def test_not_equals_with_present_trigger_normal_semantics():
         "trigger": "nao",
         "follow": "x",
     }
-    assert _postprocess({"trigger": "sim", "follow": "x"}, conds) == {
-        "trigger": "sim"
-    }
+    assert _postprocess({"trigger": "sim", "follow": "x"}, conds) == {"trigger": "sim"}
 
 
 def test_extract_field_conditions_from_compiled_model():
     """extract_field_conditions deve ler de json_schema_extra, nao do JSON."""
-    from pydantic import BaseModel, Field
     from typing import Literal, Optional
+
+    from pydantic import BaseModel, Field
 
     from services.condition_evaluator import extract_field_conditions
 

--- a/backend/tests/test_llm_runner_cleanup.py
+++ b/backend/tests/test_llm_runner_cleanup.py
@@ -6,6 +6,7 @@ silencioso quebraria o cleanup sem qualquer sinal — runs morreriam em
 'running' eternamente e o frontend religaria polling. Este teste fixa a
 sintaxe e o pipeline de chamadas.
 """
+
 import re
 from unittest.mock import MagicMock
 
@@ -77,7 +78,7 @@ def test_cleanup_heartbeat_cutoff_is_10_minutes():
     teste falhar após mudar o cutoff, atualize tambem
     frontend/src/actions/llm.ts:getRunningLlmJob.
     """
-    from datetime import datetime, timezone, timedelta
+    from datetime import datetime, timedelta, timezone
 
     sb = _build_sb_chain([])
     before = datetime.now(timezone.utc)

--- a/backend/tests/test_llm_runner_extract.py
+++ b/backend/tests/test_llm_runner_extract.py
@@ -5,9 +5,11 @@ em Python, entao um filtro ingenuo (`if val`) deixaria NaN passar como
 "preenchido" e a resposta seria salva com lixo. Esta funcao precisa rejeitar
 NaN explicitamente.
 """
+
 import math
 
 from pydantic import BaseModel
+
 from services.llm_runner import _extract_answers_from_row
 
 

--- a/backend/tests/test_pydantic_compiler_ast.py
+++ b/backend/tests/test_pydantic_compiler_ast.py
@@ -4,6 +4,7 @@ Garante que nenhum payload malicioso executa código (sem side-effect) e que a
 classe reconstruída via create_model é um BaseModel funcional — o que o
 llm_runner precisa para validar a saída do LLM.
 """
+
 import os
 
 import pytest
@@ -11,14 +12,14 @@ from pydantic import BaseModel, ValidationError
 
 from services.pydantic_compiler import build_model_from_code, compile_pydantic
 
-VALID = '''from pydantic import BaseModel, Field
+VALID = """from pydantic import BaseModel, Field
 from typing import Literal, Optional
 
 class Analysis(BaseModel):
     topic: Literal["a", "b"] = Field(description="Topic")
     tags: list[Literal["x", "y"]] = Field(description="Tags")
     note: Optional[str] = Field(default=None, description="Note")
-'''
+"""
 
 
 # ----------------------- payloads maliciosos -----------------------
@@ -31,26 +32,26 @@ MALICIOUS = [
     "import socket",
     'x = open("/etc/passwd").read()',
     '__import__("os").system("id")',
-    '''from pydantic import BaseModel, Field
+    """from pydantic import BaseModel, Field
 class A(BaseModel):
-    x: str = Field(default=eval("1+1"))''',
-    '''from pydantic import BaseModel, Field
+    x: str = Field(default=eval("1+1"))""",
+    """from pydantic import BaseModel, Field
 class A(BaseModel):
-    x: str = Field(default=__import__("os"))''',
-    '''from pydantic import BaseModel, Field
+    x: str = Field(default=__import__("os"))""",
+    """from pydantic import BaseModel, Field
 class A(BaseModel):
-    x: str = Field(default_factory=lambda: 1)''',
-    '''from pydantic import BaseModel, Field
+    x: str = Field(default_factory=lambda: 1)""",
+    """from pydantic import BaseModel, Field
 class A(BaseModel):
-    x: str = Field(description=().__class__.__name__)''',
+    x: str = Field(description=().__class__.__name__)""",
     "y = [i for i in range(3)]",
-    '''@staticmethod
+    """@staticmethod
 class A(BaseModel):
-    pass''',
-    '''from pydantic import BaseModel
+    pass""",
+    """from pydantic import BaseModel
 class A(BaseModel):
     def __init__(self):
-        __import__("os").system("id")''',
+        __import__("os").system("id")""",
 ]
 
 
@@ -65,10 +66,7 @@ def test_malicious_payload_rejected(code):
 def test_strix_poc_does_not_write_file(tmp_path):
     """O PoC do strix escrevia um arquivo via pathlib; aqui ele nem importa."""
     marker = tmp_path / "PWNED"
-    code = (
-        "import pathlib\n"
-        f"pathlib.Path({str(marker)!r}).write_text('owned')\n"
-    )
+    code = f"import pathlib\npathlib.Path({str(marker)!r}).write_text('owned')\n"
     result = compile_pydantic(code)
     assert result["valid"] is False
     assert not marker.exists()
@@ -104,7 +102,7 @@ def test_built_model_enforces_literal():
 
 
 def test_built_nested_model_roundtrips():
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 from typing import Optional
 
 class _doc_fields(BaseModel):
@@ -113,7 +111,7 @@ class _doc_fields(BaseModel):
 
 class Analysis(BaseModel):
     doc: _doc_fields = Field(description="Doc")
-'''
+"""
     model = build_model_from_code(code)
     inst = model(doc={"part_a": "x"})
     assert inst.doc.part_a == "x"
@@ -123,11 +121,11 @@ class Analysis(BaseModel):
 def test_union_pipe_syntax_rejected():
     # Após o estreitamento à grammar do gerador, `X | None` não é suportado (o
     # gerador usa Optional[...]). Deve ser rejeitado de forma limpa, não aceito.
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 
 class Analysis(BaseModel):
     x: str | None = Field(default=None, description="X")
-'''
+"""
     result = compile_pydantic(code)
     assert result["valid"] is False
     assert result["errors"]
@@ -151,11 +149,11 @@ def test_no_side_effect_global_sentinel():
 def test_field_name_with_internal_double_underscore_accepted():
     # Nome legítimo com "__" interno não pode ser barrado pela guarda de
     # dunder — só dunders estritos (começam E terminam com "__") são perigosos.
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 
 class Analysis(BaseModel):
     my__field: str = Field(description="X")
-'''
+"""
     result = compile_pydantic(code)
     assert result["valid"], result["errors"]
     assert result["fields"][0]["name"] == "my__field"
@@ -164,25 +162,25 @@ class Analysis(BaseModel):
 def test_nested_class_name_with_boundary_underscore_accepted():
     # O gerador nomeia a classe aninhada `_<campo>_fields`; um campo terminando
     # em "_" produz `_doc__fields` (com "__" interno), que deve compilar.
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 
 class _doc__fields(BaseModel):
     part_a: str = Field(description="A")
 
 class Analysis(BaseModel):
     doc_: _doc__fields = Field(description="Doc")
-'''
+"""
     result = compile_pydantic(code)
     assert result["valid"], result["errors"]
 
 
 def test_strict_dunder_field_name_rejected():
     # Dunder estrito continua barrado (defense-in-depth).
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 
 class Analysis(BaseModel):
     __class__: str = Field(description="X")
-'''
+"""
     result = compile_pydantic(code)
     assert result["valid"] is False
     assert result["errors"]
@@ -245,14 +243,14 @@ def test_build_raises_only_schema_error_on_bad_constructor():
 def test_multiple_inheritance_rejected_not_silently_collapsed():
     # Antes: herança múltipla colapsava para a última base, descartando campos
     # do mixin em silêncio. Agora é rejeitada explicitamente.
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 
 class Mixin(BaseModel):
     m: str = Field(description="m")
 
 class Analysis(Mixin, BaseModel):
     x: str = Field(description="x")
-'''
+"""
     result = compile_pydantic(code)
     assert result["valid"] is False
     assert result["errors"]
@@ -260,14 +258,14 @@ class Analysis(Mixin, BaseModel):
 
 def test_strict_dunder_class_name_rejected():
     # Nome de classe dunder (ast.ClassDef.name, não ast.Name) é barrado.
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 
 class __reduce__(BaseModel):
     x: int = Field(default=1)
 
 class Analysis(BaseModel):
     x: int = Field(default=1)
-'''
+"""
     result = compile_pydantic(code)
     assert result["valid"] is False
     assert result["errors"]
@@ -275,11 +273,11 @@ class Analysis(BaseModel):
 
 def test_strict_dunder_field_kwarg_rejected():
     # Nome de kwarg de Field dunder (kw.arg é str, não ast.Name) é barrado.
-    code = '''from pydantic import BaseModel, Field
+    code = """from pydantic import BaseModel, Field
 
 class Analysis(BaseModel):
     x: int = Field(__class__=1, default=1)
-'''
+"""
     result = compile_pydantic(code)
     assert result["valid"] is False
     assert result["errors"]
@@ -300,7 +298,7 @@ def test_all_underscore_field_names_rejected(name):
 
 
 def test_oversized_code_rejected():
-    from services.pydantic_compiler import SchemaError, _MAX_CODE_LENGTH
+    from services.pydantic_compiler import _MAX_CODE_LENGTH, SchemaError
 
     code = "x = 1\n" * (_MAX_CODE_LENGTH // 2)
     assert len(code) > _MAX_CODE_LENGTH


### PR DESCRIPTION
Três reparos de tooling do backend descobertos ao rodar a stack de qualidade manualmente — os git hooks não estavam rodando neste checkout (`core.hooksPath` apontava para um caminho morto; corrigido localmente).

## Mudanças

- **`backend/pyproject.toml`** — adiciona `[tool.hatch.build.targets.wheel] only-include`. O backend é um app FastAPI flat (sem diretório de pacote homônimo), então o hatchling abortava o build do wheel (`Unable to determine which files to ship`), quebrando `uv run ruff`/`pytest`. (Closes #311)
- **`services/llm_runner.py`** — `hashlib.md5(..., usedforsecurity=False)` na chave de cache de erros. Uso não-criptográfico (dedup de mensagens de erro); o flag sinaliza a intenção e satisfaz o semgrep **sem alterar o digest** (chave de cache idêntica). (Closes #312)
- **ruff `--fix` + format** — ordena imports (`I001`) e aplica `ruff format` nos arquivos tocados. Débito baseline do #260, aplicado file-scoped pelo gate de pre-commit.

## Nota de revisão

O diff grande em `llm_runner.py` (~193 linhas) e `test_pydantic_compiler_ast.py` (~66) é **quase todo formatação** — o `ruff format` (file-scoped) formatou esses arquivos pela primeira vez ao serem tocados, conforme o design do #260. A mudança lógica é pequena: o `usedforsecurity=False` (3 linhas) e a config do `pyproject`. Revisar com "hide whitespace" ajuda.

## Validação

```
uvx ruff@0.15.19 check .   # All checks passed
uv run python -c ...        # build do wheel sucede (era o bug do #311)
uv run --with pytest pytest -q   # 152 passed
semgrep --config p/python services/llm_runner.py   # 0 findings
```

Closes #311
Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)