### PR TITLE
docs(claude): remove proibição absoluta de push direto na main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Para aplicar migrations pendentes: `npx supabase db push`
 
 ## Deploy
 
-Deploy e automatico a partir de merge no branch `main`. Frontend: em migracao Vercel → Fly.io (app `gui-analise-sistematica-frontend`); enquanto o cutover de dominio nao ocorre, Vercel ainda e a producao. Backend: Fly.io (app `gui-analise-sistematica-api`) via workflow quando ha mudanca em `backend/**`. A partir de 2026-04-20, **sempre criar branch + PR** em vez de push direto na main. Fluxo:
+Deploy e automatico a partir de merge no branch `main`. Frontend: em migracao Vercel → Fly.io (app `gui-analise-sistematica-frontend`); enquanto o cutover de dominio nao ocorre, Vercel ainda e a producao. Backend: Fly.io (app `gui-analise-sistematica-api`) via workflow quando ha mudanca em `backend/**`. A partir de 2026-04-20, **preferir branch + PR** ao push direto na main. Fluxo recomendado:
 
 1. **Criar git worktree isolado** para a tarefa (ver secao "Workspace isolado" abaixo) — nao trabalhar no diretorio principal
 2. Criar branch descritiva (`feat/...`, `fix/...`, `perf/...`) na worktree

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ Deploy e automatico a partir de merge no branch `main`. Frontend: em migracao Ve
 5. Deixar o usuario revisar o PR
 6. Remover a worktree apos o merge
 
-Nunca fazer push direto para `main`. Merge do PR pode ser feito pelo Claude quando o usuario pedir explicitamente.
+Merge do PR pode ser feito pelo Claude quando o usuario pedir explicitamente.
 
 ## Workspace isolado (worktree)
 


### PR DESCRIPTION
Remove a frase "Nunca fazer push direto para `main`." da seção Deploy do `CLAUDE.md`.

O fluxo **branch + PR** continua descrito (passos 1–6) como prática padrão, e a cláusula "merge do PR sob pedido explícito" permanece. Decisão do dono do repositório para reduzir a fricção de push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)