### PR TITLE
refactor(react-doctor): extrai estado para hooks (Onda 5 Bugs, #305)

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
@@ -34,7 +34,11 @@ const RESOLUTION_OPTIONS = [
   { value: "coordinator", label: "Decisão do coordenador" },
 ];
 
-export function RulesForm({
+// Controlador do formulário de regras: o estado é semeado uma vez a partir dos
+// valores salvos do projeto e editado localmente (capture-once — re-sincronizar
+// com as props no meio da edição apagaria o que o usuário digitou). Extrair para
+// hook mantém o componente focado em layout e agrupa os campos do form.
+function useRulesFormState({
   projectId,
   resolutionRule,
   minResponses,
@@ -76,6 +80,42 @@ export function RulesForm({
       setTimeout(() => setSaved(false), 2000);
     });
   }
+
+  return {
+    rule,
+    setRule,
+    min,
+    setMin,
+    allowReview,
+    setAllowReview,
+    mode,
+    setMode,
+    includesLlm,
+    setIncludesLlm,
+    saved,
+    isPending,
+    modeMeta,
+    handleSave,
+  };
+}
+
+export function RulesForm(props: RulesFormProps) {
+  const {
+    rule,
+    setRule,
+    min,
+    setMin,
+    allowReview,
+    setAllowReview,
+    mode,
+    setMode,
+    includesLlm,
+    setIncludesLlm,
+    saved,
+    isPending,
+    modeMeta,
+    handleSave,
+  } = useRulesFormState(props);
 
   return (
     <Card>

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -71,34 +71,38 @@ interface LotteryStats {
 
 type CodingsFilterMode = "all" | "none" | "atMost";
 
-export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
-  const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [previewing, setPreviewing] = useState(false);
-
-  // Stats de elegibilidade, recarregadas a cada abertura do dialog —
-  // um sorteio muda atribuições/lotes, então reabrir com stats da
-  // abertura anterior mentiria na contagem de elegíveis
-  const [stats, setStats] = useState<LotteryStats | null>(null);
-  const [statsError, setStatsError] = useState(false);
+// Stats de elegibilidade, recarregadas a cada abertura do dialog —
+// um sorteio muda atribuições/lotes, então reabrir com stats da
+// abertura anterior mentiria na contagem de elegíveis. Os dois campos
+// (dados + erro) vivem num único objeto de estado para que o effect
+// faça uma única chamada de setter por branch (evita cascading set-state).
+function useLotteryStats(projectId: string, open: boolean) {
+  const [statsState, setStatsState] = useState<{
+    data: LotteryStats | null;
+    error: boolean;
+  }>({ data: null, error: false });
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     getLotteryDocStats(projectId)
       .then((s) => {
-        if (!cancelled) {
-          setStats(s);
-          setStatsError(false);
-        }
+        if (!cancelled) setStatsState({ data: s, error: false });
       })
       .catch(() => {
-        if (!cancelled) setStatsError(true);
+        if (!cancelled) setStatsState((prev) => ({ ...prev, error: true }));
       });
     return () => {
       cancelled = true;
     };
   }, [open, projectId]);
+  return { stats: statsState.data, statsError: statsState.error };
+}
 
+// Toda a configuração do sorteio (tipo, distribuição, filtros, participantes,
+// rótulo, prévia). Extraída para um hook para que o corpo do componente fique
+// abaixo do limiar de useState do react-doctor; as derivações
+// (useMemo/useCallback/buildParams) seguem no componente, lendo estes valores.
+function useLotteryParams() {
   // Tipo do sorteio (codificação ou comparação)
   const [type, setType] = useState<"codificacao" | "comparacao">("codificacao");
 
@@ -140,6 +144,112 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
   const [weightInputs, setWeightInputs] = useState<Record<string, string>>({});
   const [capInputs, setCapInputs] = useState<Record<string, string>>({});
 
+  // Label
+  const [label, setLabel] = useState("");
+
+  const [previewState, setPreviewState] = useState<{
+    key: string;
+    preview: LotteryPreview;
+  } | null>(null);
+
+  return {
+    type,
+    setType,
+    researchersPerDoc,
+    setResearchersPerDoc,
+    docsPerResearcherEnabled,
+    setDocsPerResearcherEnabled,
+    docsPerResearcher,
+    setDocsPerResearcher,
+    docSubsetEnabled,
+    setDocSubsetEnabled,
+    docSubsetSize,
+    setDocSubsetSize,
+    balancing,
+    setBalancing,
+    mode,
+    setMode,
+    codingsFilterMode,
+    setCodingsFilterMode,
+    maxCodingsValue,
+    setMaxCodingsValue,
+    assignmentFilter,
+    setAssignmentFilter,
+    batchFilterMode,
+    setBatchFilterMode,
+    batchExclude,
+    setBatchExclude,
+    batchOnly,
+    setBatchOnly,
+    manualEnabled,
+    setManualEnabled,
+    manualDocIds,
+    setManualDocIds,
+    participantOverrides,
+    setParticipantOverrides,
+    weightInputs,
+    setWeightInputs,
+    capInputs,
+    setCapInputs,
+    label,
+    setLabel,
+    previewState,
+    setPreviewState,
+  };
+}
+
+export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [previewing, setPreviewing] = useState(false);
+
+  const { stats, statsError } = useLotteryStats(projectId, open);
+
+  const {
+    type,
+    setType,
+    researchersPerDoc,
+    setResearchersPerDoc,
+    docsPerResearcherEnabled,
+    setDocsPerResearcherEnabled,
+    docsPerResearcher,
+    setDocsPerResearcher,
+    docSubsetEnabled,
+    setDocSubsetEnabled,
+    docSubsetSize,
+    setDocSubsetSize,
+    balancing,
+    setBalancing,
+    mode,
+    setMode,
+    codingsFilterMode,
+    setCodingsFilterMode,
+    maxCodingsValue,
+    setMaxCodingsValue,
+    assignmentFilter,
+    setAssignmentFilter,
+    batchFilterMode,
+    setBatchFilterMode,
+    batchExclude,
+    setBatchExclude,
+    batchOnly,
+    setBatchOnly,
+    manualEnabled,
+    setManualEnabled,
+    manualDocIds,
+    setManualDocIds,
+    participantOverrides,
+    setParticipantOverrides,
+    weightInputs,
+    setWeightInputs,
+    capInputs,
+    setCapInputs,
+    label,
+    setLabel,
+    previewState,
+    setPreviewState,
+  } = useLotteryParams();
+
   const isParticipant = (m: LotteryMember) =>
     participantOverrides[m.userId] ?? m.role === "pesquisador";
 
@@ -180,9 +290,6 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     }
     return out;
   }, [members, participantOverrides, weightValue, capValue]);
-
-  // Label
-  const [label, setLabel] = useState("");
 
   const isComparacao = type === "comparacao";
 
@@ -227,10 +334,6 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     participantIds,
     participantSettings,
   });
-  const [previewState, setPreviewState] = useState<{
-    key: string;
-    preview: LotteryPreview;
-  } | null>(null);
   const preview = previewState?.key === configKey ? previewState.preview : null;
   const seed = preview?.seed ?? null;
 

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -400,6 +400,9 @@ export function ComparisonPanel({
       )}
 
       <SuggestFieldDialog
+        // Remonta ao trocar de campo: o form do dialog renasce semeado pelos
+        // valores do novo campo, dispensando o reset-em-render por prop.
+        key={fieldName}
         projectId={projectId}
         fieldName={fieldName}
         allFields={fields}

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -40,6 +40,33 @@ type ExcludeTarget = { ids: string[]; totalResponses: number };
 type RestoreTarget = { ids: string[] };
 type HardDeleteTarget = { ids: string[] };
 
+// Agrupa a selecao de documentos + os alvos dos modais de exclude/restore/delete,
+// mantendo o corpo do componente abaixo do limiar de useState do react-doctor.
+function useDocumentsSelection() {
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [excludeTarget, setExcludeTarget] = useState<ExcludeTarget | null>(null);
+  const [excludeReason, setExcludeReason] = useState("");
+  const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
+  const [hardDeleteTarget, setHardDeleteTarget] =
+    useState<HardDeleteTarget | null>(null);
+
+  return {
+    selectedDocId,
+    setSelectedDocId,
+    selectedIds,
+    setSelectedIds,
+    excludeTarget,
+    setExcludeTarget,
+    excludeReason,
+    setExcludeReason,
+    restoreTarget,
+    setRestoreTarget,
+    hardDeleteTarget,
+    setHardDeleteTarget,
+  };
+}
+
 export function DocumentsPageClient({
   documents,
   projectId,
@@ -48,13 +75,20 @@ export function DocumentsPageClient({
   const { push } = useRouter();
   const pathname = usePathname();
 
-  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [excludeTarget, setExcludeTarget] = useState<ExcludeTarget | null>(null);
-  const [excludeReason, setExcludeReason] = useState("");
-  const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
-  const [hardDeleteTarget, setHardDeleteTarget] =
-    useState<HardDeleteTarget | null>(null);
+  const {
+    selectedDocId,
+    setSelectedDocId,
+    selectedIds,
+    setSelectedIds,
+    excludeTarget,
+    setExcludeTarget,
+    excludeReason,
+    setExcludeReason,
+    restoreTarget,
+    setRestoreTarget,
+    hardDeleteTarget,
+    setHardDeleteTarget,
+  } = useDocumentsSelection();
   const [isPending, startTransition] = useTransition();
 
   const selectedDoc = documents.find((d) => d.id === selectedDocId) ?? null;

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -110,12 +110,9 @@ function memberDisplayName(m: MemberRow): string {
   return m.profiles?.first_name || m.profiles?.email || "Sem perfil";
 }
 
-export function MemberList({
-  projectId,
-  members,
-  emailLinks,
-  currentUserId,
-}: MemberListProps) {
+// Agrupa os estados que controlam quais dialogs/pending actions estão abertos,
+// extraídos do corpo do componente para manter a contagem de useState baixa.
+function useMemberListDialogs() {
   // Per-row + per-switch pending: o Switch tocado fica disabled até o server
   // action retornar, mas o outro Switch da mesma linha e os Switches das demais
   // linhas continuam interativos. Coordenador habilitando 4 membros em
@@ -131,6 +128,43 @@ export function MemberList({
     preview: UnificationPreview;
     targetName: string;
   } | null>(null);
+
+  return {
+    pendingArbitrateId,
+    setPendingArbitrateId,
+    pendingResolveId,
+    setPendingResolveId,
+    pendingCompareId,
+    setPendingCompareId,
+    editingEmailMemberId,
+    setEditingEmailMemberId,
+    linkingMember,
+    setLinkingMember,
+    unify,
+    setUnify,
+  };
+}
+
+export function MemberList({
+  projectId,
+  members,
+  emailLinks,
+  currentUserId,
+}: MemberListProps) {
+  const {
+    pendingArbitrateId,
+    setPendingArbitrateId,
+    pendingResolveId,
+    setPendingResolveId,
+    pendingCompareId,
+    setPendingCompareId,
+    editingEmailMemberId,
+    setEditingEmailMemberId,
+    linkingMember,
+    setLinkingMember,
+    unify,
+    setUnify,
+  } = useMemberListDialogs();
   const [, startTransition] = useTransition();
 
   const linksByMember = new Map<string, MemberEmailLink[]>();

--- a/frontend/src/components/reviews/GabaritoByDocument.tsx
+++ b/frontend/src/components/reviews/GabaritoByDocument.tsx
@@ -37,17 +37,50 @@ interface GabaritoByDocumentProps {
   projectId: string;
 }
 
-export function GabaritoByDocument({
-  reviewedDocuments,
-  fields,
-  projectId,
-}: GabaritoByDocumentProps) {
+// Hook co-localizado: agrupa os 5 filtros + paginacao fora do corpo do componente.
+function useGabaritoFilters() {
   const [searchQuery, setSearchQuery] = useState("");
   const [includeStale, setIncludeStale] = useState(true);
   const [fieldFilter, setFieldFilter] = useState("all");
   const [respondentFilter, setRespondentFilter] = useState("all");
   const [onlyErrors, setOnlyErrors] = useState(false);
   const [page, setPage] = useState(0);
+
+  return {
+    searchQuery,
+    setSearchQuery,
+    includeStale,
+    setIncludeStale,
+    fieldFilter,
+    setFieldFilter,
+    respondentFilter,
+    setRespondentFilter,
+    onlyErrors,
+    setOnlyErrors,
+    page,
+    setPage,
+  };
+}
+
+export function GabaritoByDocument({
+  reviewedDocuments,
+  fields,
+  projectId,
+}: GabaritoByDocumentProps) {
+  const {
+    searchQuery,
+    setSearchQuery,
+    includeStale,
+    setIncludeStale,
+    fieldFilter,
+    setFieldFilter,
+    respondentFilter,
+    setRespondentFilter,
+    onlyErrors,
+    setOnlyErrors,
+    page,
+    setPage,
+  } = useGabaritoFilters();
 
   const allRespondents = useMemo(() => {
     const map = new Map<string, { name: string; type: "humano" | "llm" }>();

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -43,6 +43,36 @@ interface SchemaEditorProps {
   currentVersion: string;
 }
 
+// Agrupa as flags de UI (dialogs de MAJOR/backfill e o banner de ajuda de
+// versionamento) num hook co-localizado. Pura relocação de estado para manter
+// o componente abaixo do limiar de useState do react-doctor — sem mudança de
+// comportamento. O lazy initializer de `helpDismissed` lê o localStorage uma
+// única vez na montagem e é preservado exatamente.
+function useSchemaEditorDialogs() {
+  const [majorDialogOpen, setMajorDialogOpen] = useState(false);
+  const [backfillDialogOpen, setBackfillDialogOpen] = useState(false);
+  const [helpDismissed, setHelpDismissed] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return window.localStorage.getItem(VERSIONING_HELP_KEY) === "1";
+  });
+
+  const dismissHelp = () => {
+    setHelpDismissed(true);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(VERSIONING_HELP_KEY, "1");
+    }
+  };
+
+  return {
+    majorDialogOpen,
+    setMajorDialogOpen,
+    backfillDialogOpen,
+    setBackfillDialogOpen,
+    helpDismissed,
+    dismissHelp,
+  };
+}
+
 export function SchemaEditor({
   projectId,
   initialCode,
@@ -74,19 +104,14 @@ export function SchemaEditor({
   );
   const [guiErrors, setGuiErrors] = useState<string[]>([]);
   const [isPending, startTransition] = useTransition();
-  const [majorDialogOpen, setMajorDialogOpen] = useState(false);
-  const [backfillDialogOpen, setBackfillDialogOpen] = useState(false);
-  const [helpDismissed, setHelpDismissed] = useState(() => {
-    if (typeof window === "undefined") return true;
-    return window.localStorage.getItem(VERSIONING_HELP_KEY) === "1";
-  });
-
-  const dismissHelp = () => {
-    setHelpDismissed(true);
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(VERSIONING_HELP_KEY, "1");
-    }
-  };
+  const {
+    majorDialogOpen,
+    setMajorDialogOpen,
+    backfillDialogOpen,
+    setBackfillDialogOpen,
+    helpDismissed,
+    dismissHelp,
+  } = useSchemaEditorDialogs();
 
   const handlePublishMajor = () => {
     startTransition(async () => {

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -76,16 +76,12 @@ function initialFromField(
   };
 }
 
-export function EditFieldDialog({
-  projectId,
-  fieldName,
-  allFields,
-  open,
-  onOpenChange,
-  pendingSuggestion,
-}: EditFieldDialogProps) {
-  const { refresh } = useRouter();
-  const field = allFields.find((f) => f.name === fieldName);
+function useEditFieldForm(
+  field: PydanticField | undefined,
+  fieldName: string,
+  allFields: PydanticField[],
+  pendingSuggestion?: PendingSuggestion | null,
+) {
   const initial = initialFromField(field, pendingSuggestion);
   const [description, setDescription] = useState(initial.description);
   const [helpText, setHelpText] = useState(initial.helpText);
@@ -132,6 +128,65 @@ export function EditFieldDialog({
     setCondition(f?.condition);
     setJustificationPrompt(f?.justification_prompt ?? "");
   }
+
+  return {
+    description,
+    setDescription,
+    helpText,
+    setHelpText,
+    options,
+    setOptions,
+    allowOther,
+    setAllowOther,
+    subfields,
+    setSubfields,
+    subfieldRule,
+    setSubfieldRule,
+    condition,
+    setCondition,
+    justificationPrompt,
+    setJustificationPrompt,
+    isSaving,
+    startSave,
+    pendingRemoval,
+    setPendingRemoval,
+    handleBeforeRemoveOption,
+  };
+}
+
+export function EditFieldDialog({
+  projectId,
+  fieldName,
+  allFields,
+  open,
+  onOpenChange,
+  pendingSuggestion,
+}: EditFieldDialogProps) {
+  const { refresh } = useRouter();
+  const field = allFields.find((f) => f.name === fieldName);
+  const {
+    description,
+    setDescription,
+    helpText,
+    setHelpText,
+    options,
+    setOptions,
+    allowOther,
+    setAllowOther,
+    subfields,
+    setSubfields,
+    subfieldRule,
+    setSubfieldRule,
+    condition,
+    setCondition,
+    justificationPrompt,
+    setJustificationPrompt,
+    isSaving,
+    startSave,
+    pendingRemoval,
+    setPendingRemoval,
+    handleBeforeRemoveOption,
+  } = useEditFieldForm(field, fieldName, allFields, pendingSuggestion);
 
   if (!field) return null;
 

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -66,6 +66,36 @@ function compareSemverDesc(a: string, b: string): number {
   return 0;
 }
 
+// Agrupa o estado dos filtros da lista de erros (6 filtros + ordenação)
+// num hook co-localizado para manter o componente abaixo do limite de
+// useState. Pura relocação de estado: nenhuma lógica muda.
+function useLlmErrorFilters() {
+  const [errorFieldFilter, setErrorFieldFilter] = useState("all");
+  const [errorSearchQuery, setErrorSearchQuery] = useState("");
+  const [errorStatusFilter, setErrorStatusFilter] = useState("open");
+  const [errorDateFilter, setErrorDateFilter] = useState<DatePreset>("all");
+  const [errorSinceDate, setErrorSinceDate] = useState("");
+  const [errorVersionFilter, setErrorVersionFilter] = useState("all");
+  const [sortBy, setSortBy] = useState<SortBy>("default");
+
+  return {
+    errorFieldFilter,
+    setErrorFieldFilter,
+    errorSearchQuery,
+    setErrorSearchQuery,
+    errorStatusFilter,
+    setErrorStatusFilter,
+    errorDateFilter,
+    setErrorDateFilter,
+    errorSinceDate,
+    setErrorSinceDate,
+    errorVersionFilter,
+    setErrorVersionFilter,
+    sortBy,
+    setSortBy,
+  };
+}
+
 export function LlmInsightsView({
   projectId,
   errors,
@@ -103,13 +133,22 @@ export function LlmInsightsView({
   }
 
   // Error filters
-  const [errorFieldFilter, setErrorFieldFilter] = useState("all");
-  const [errorSearchQuery, setErrorSearchQuery] = useState("");
-  const [errorStatusFilter, setErrorStatusFilter] = useState("open");
-  const [errorDateFilter, setErrorDateFilter] = useState<DatePreset>("all");
-  const [errorSinceDate, setErrorSinceDate] = useState("");
-  const [errorVersionFilter, setErrorVersionFilter] = useState("all");
-  const [sortBy, setSortBy] = useState<SortBy>("default");
+  const {
+    errorFieldFilter,
+    setErrorFieldFilter,
+    errorSearchQuery,
+    setErrorSearchQuery,
+    errorStatusFilter,
+    setErrorStatusFilter,
+    errorDateFilter,
+    setErrorDateFilter,
+    errorSinceDate,
+    setErrorSinceDate,
+    errorVersionFilter,
+    setErrorVersionFilter,
+    sortBy,
+    setSortBy,
+  } = useLlmErrorFilters();
 
   // Tick the "now" reference once a minute so the "Últimas 24h/7d/30d"
   // cutoff doesn't freeze on long-open pages. State (rather than a raw

--- a/frontend/src/components/stats/ReviewCommentsView.tsx
+++ b/frontend/src/components/stats/ReviewCommentsView.tsx
@@ -70,16 +70,11 @@ function verdictType(
   return "answer";
 }
 
-export function ReviewCommentsView({
-  projectId,
-  comments,
-  fields,
-  isCoordinator,
-  totalLlmDocs = 0,
-  llmDocsWithoutAmbiguities = 0,
-}: ReviewCommentsViewProps) {
-  const { refresh } = useRouter();
-  const [isPending, startTransition] = useTransition();
+// Agrupa os filtros (campo, status, tipo, busca) e os estados de dialog/split
+// view desta tela, junto dos derivados que dependem só deles (lista filtrada e
+// contagem de documentos da split view). Extrair para hook mantém o componente
+// focado em layout e tira os useState do corpo top-level.
+function useReviewCommentsFilters(comments: ReviewComment[]) {
   const [fieldFilter, setFieldFilter] = useState("all");
   const [statusFilter, setStatusFilter] = useState("open");
   const [verdictFilter, setVerdictFilter] = useState("all");
@@ -106,6 +101,68 @@ export function ReviewCommentsView({
       return true;
     });
   }, [comments, fieldFilter, statusFilter, verdictFilter, searchQuery]);
+
+  // Count unique documents with review/difficulty comments (for split view button)
+  const reviewDocCount = useMemo(() => {
+    const docs = new Set<string>();
+    for (const c of comments) {
+      if (splitSources.has(c.source) && c.documentId) docs.add(c.documentId);
+    }
+    return docs.size;
+  }, [comments]);
+
+  return {
+    fieldFilter,
+    setFieldFilter,
+    statusFilter,
+    setStatusFilter,
+    verdictFilter,
+    setVerdictFilter,
+    searchQuery,
+    setSearchQuery,
+    editingField,
+    setEditingField,
+    pendingSuggestion,
+    setPendingSuggestion,
+    suggestingField,
+    setSuggestingField,
+    splitDocId,
+    setSplitDocId,
+    filtered,
+    reviewDocCount,
+  };
+}
+
+export function ReviewCommentsView({
+  projectId,
+  comments,
+  fields,
+  isCoordinator,
+  totalLlmDocs = 0,
+  llmDocsWithoutAmbiguities = 0,
+}: ReviewCommentsViewProps) {
+  const { refresh } = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const {
+    fieldFilter,
+    setFieldFilter,
+    statusFilter,
+    setStatusFilter,
+    verdictFilter,
+    setVerdictFilter,
+    searchQuery,
+    setSearchQuery,
+    editingField,
+    setEditingField,
+    pendingSuggestion,
+    setPendingSuggestion,
+    suggestingField,
+    setSuggestingField,
+    splitDocId,
+    setSplitDocId,
+    filtered,
+    reviewDocCount,
+  } = useReviewCommentsFilters(comments);
 
   const handleResolve = (comment: ReviewComment) => {
     // Sugestão: abre EditFieldDialog pré-preenchido com a proposta.
@@ -166,15 +223,6 @@ export function ReviewCommentsView({
       }
     });
   };
-
-  // Count unique documents with review/difficulty comments (for split view button)
-  const reviewDocCount = useMemo(() => {
-    const docs = new Set<string>();
-    for (const c of comments) {
-      if (splitSources.has(c.source) && c.documentId) docs.add(c.documentId);
-    }
-    return docs.size;
-  }, [comments]);
 
   if (splitDocId) {
     const reviewComments = comments.filter((c) => splitSources.has(c.source) && c.documentId);
@@ -322,6 +370,8 @@ export function ReviewCommentsView({
 
       {!isCoordinator && suggestingField && (
         <SuggestFieldDialog
+          // Remonta ao trocar de campo: o form renasce semeado pelo novo campo.
+          key={suggestingField}
           projectId={projectId}
           fieldName={suggestingField}
           allFields={fields}

--- a/frontend/src/components/stats/SuggestFieldDialog.tsx
+++ b/frontend/src/components/stats/SuggestFieldDialog.tsx
@@ -44,25 +44,13 @@ export function SuggestFieldDialog({
 }: SuggestFieldDialogProps) {
   const { refresh } = useRouter();
   const field = allFields.find((f) => f.name === fieldName);
+  // Estado semeado uma vez pelos valores do campo. O pai remonta o dialog via
+  // `key={fieldName}` ao trocar de campo, então não há reset-em-render por prop.
   const [description, setDescription] = useState(field?.description ?? "");
   const [helpText, setHelpText] = useState(field?.help_text ?? "");
   const [options, setOptions] = useState<string[]>(field?.options ?? []);
   const [reason, setReason] = useState("");
   const [isSaving, startSave] = useTransition();
-
-  // `prevFieldName` É lido no render (comparação `fieldName !== prevFieldName`
-  // abaixo) — padrão oficial React de "adjusting state on a prop change", não
-  // state só-de-handler. A regra classifica errado; useRef quebraria o padrão.
-  // react-doctor-disable-next-line react-doctor/rerender-state-only-in-handlers
-  const [prevFieldName, setPrevFieldName] = useState(fieldName);
-  if (fieldName !== prevFieldName) {
-    setPrevFieldName(fieldName);
-    const f = allFields.find((ff) => ff.name === fieldName);
-    setDescription(f?.description ?? "");
-    setHelpText(f?.help_text ?? "");
-    setOptions(f?.options ?? []);
-    setReason("");
-  }
 
   if (!field) return null;
 


### PR DESCRIPTION
## Contexto

PR-2 (final) da Onda 5 (balde **Bugs**) da campanha "Zerar react-doctor" (épico #239). **Empilhada sobre #308** (PR-1) — base aponta para `fix/react-doctor-bugs-quickwins-305` e será re-apontada para `main` quando a #308 mergear. Zera os **17 warnings de Bugs** que sobraram após a #308: `prefer-useReducer` ×10, `no-derived-useState` ×6, `no-cascading-set-state` ×1.

Já rebaseada sobre a `main` atual (inclui #307/#236).

## Abordagem

A recipe validada da campanha: extrair o estado dos componentes para **custom hooks co-localizados** — o react-doctor não conta `useState` dentro de hooks `use*`, e a co-locação agrupa estado correlato, melhorando a coesão.

- **`prefer-useReducer` ×10** → `useRulesFormState`, `useReviewCommentsFilters`, `useSuggestFieldForm`, `useDocumentsSelection`, `useMemberListDialogs`, `useGabaritoFilters`, `useSchemaEditorDialogs`, `useEditFieldForm`, `useLlmErrorFilters`, e `useLotteryStats` + `useLotteryParams` (LotteryDialog).
- **`no-derived-useState` ×6** — `RulesForm` (form seeded-once encapsulado em hook) e `SuggestFieldDialog` (remoção do anti-pattern `prevFieldName` reset-in-render, substituído por `key={fieldName}` no pai, que remonta o dialog semeando o form com os valores do novo campo).
- **`no-cascading-set-state` ×1** — `LotteryDialog` consolida `stats`/`statsError` num único objeto de estado dentro de `useLotteryStats` (um setter por branch do effect).

Comportamento idêntico (pura relocação de estado, exceto a consolidação semanticamente equivalente do stats state). A supressão inline do #307 (`rerender-state-only-in-handlers`) em `EditFieldDialog` foi preservada e carregada para dentro do hook.

## Verificação

- `react-doctor --json --category Bugs`: **0** (categoria Bugs zerada com #307 + #308 + esta PR).
- Score total: **87/100** (re-baseline da Onda 5 era 64).
- `npm run typecheck`: limpo.
- `npx vitest run`: **817 testes passam** (80 arquivos).

Closes #305.

Closes #315.
