### PR TITLE
fix(schema): IDs estáveis em listas editáveis (no-array-index-as-key) (#316)

### DIFF
--- a/frontend/src/components/schema/FieldCard.tsx
+++ b/frontend/src/components/schema/FieldCard.tsx
@@ -17,6 +17,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@/lib/utils";
 import { OptionsEditor } from "./OptionsEditor";
+import { useStableListIds } from "@/hooks/useStableListIds";
 import { ConditionEditor } from "./ConditionEditor";
 import { candidateTriggersFor } from "@/lib/conditional";
 import { RemoveOptionDialog } from "./RemoveOptionDialog";
@@ -73,6 +74,10 @@ export function FieldCard({
   const updateField = (patch: Partial<PydanticField>) => {
     onChange({ ...field, ...patch });
   };
+
+  // Keys estáveis para a lista editável de subcampos: o `key` do subfield é
+  // digitado pelo usuário (muda a cada tecla), logo não serve como React key.
+  const subfieldKeys = useStableListIds(field.subfields?.length ?? 0);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id });
@@ -406,7 +411,7 @@ export function FieldCard({
                       </div>
                     </div>
                     {field.subfields.map((sf, si) => (
-                      <div key={si} className="flex items-center gap-1.5">
+                      <div key={subfieldKeys.ids[si]} className="flex items-center gap-1.5">
                         <Input
                           value={sf.key}
                           onChange={(e) => {
@@ -446,6 +451,7 @@ export function FieldCard({
                           className="size-6 p-0"
                           onClick={() => {
                             const sfs = field.subfields!.filter((_, j) => j !== si);
+                            subfieldKeys.removeIdAt(si);
                             updateField({ subfields: sfs.length > 0 ? sfs : undefined, subfield_rule: sfs.length > 0 ? field.subfield_rule : undefined });
                           }}
                         >
@@ -459,6 +465,7 @@ export function FieldCard({
                       className="text-xs h-6"
                       onClick={() => {
                         const idx = field.subfields!.length + 1;
+                        subfieldKeys.appendId();
                         updateField({
                           subfields: [
                             ...field.subfields!,

--- a/frontend/src/components/schema/OptionsEditor.tsx
+++ b/frontend/src/components/schema/OptionsEditor.tsx
@@ -4,6 +4,7 @@ import { useRef, useEffect } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Plus, X } from "lucide-react";
+import { useStableListIds } from "@/hooks/useStableListIds";
 
 interface OptionsEditorProps {
   options: string[];
@@ -20,6 +21,7 @@ export function OptionsEditor({
 }: OptionsEditorProps) {
   const lastInputRef = useRef<HTMLInputElement>(null);
   const shouldFocusLast = useRef(false);
+  const { ids, removeIdAt, appendId } = useStableListIds(options.length);
 
   useEffect(() => {
     if (shouldFocusLast.current && lastInputRef.current) {
@@ -40,18 +42,20 @@ export function OptionsEditor({
       const ok = await onBeforeRemove(opt);
       if (!ok) return;
     }
+    removeIdAt(index);
     onChange(options.filter((_, i) => i !== index));
   };
 
   const addOption = () => {
     shouldFocusLast.current = true;
+    appendId();
     onChange([...options, ""]);
   };
 
   return (
     <div className="space-y-2">
       {options.map((opt, i) => (
-        <div key={i} className="flex items-center gap-2">
+        <div key={ids[i]} className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground w-4 text-right shrink-0">
             {i + 1}.
           </span>

--- a/frontend/src/components/schema/__tests__/OptionsEditor.test.tsx
+++ b/frontend/src/components/schema/__tests__/OptionsEditor.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { useState } from "react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { OptionsEditor } from "@/components/schema/OptionsEditor";
+
+afterEach(cleanup);
+
+// Wrapper controlado: o OptionsEditor é controlado (options vêm do pai), então
+// o teste precisa segurar o estado para reproduzir o fluxo real de edição.
+function ControlledEditor({ initial }: { initial: string[] }) {
+  const [options, setOptions] = useState(initial);
+  return <OptionsEditor options={options} onChange={setOptions} />;
+}
+
+function inputs() {
+  return screen.getAllByRole("textbox") as HTMLInputElement[];
+}
+
+describe("OptionsEditor — keys estáveis (no-array-index-as-key)", () => {
+  it("preserva a identidade do nó DOM ao remover uma opção do topo", async () => {
+    const user = userEvent.setup();
+    render(<ControlledEditor initial={["a", "b", "c"]} />);
+
+    // Guarda a referência do nó do input "b" (índice 1). Foco/cursor/seleção
+    // vivem nesse nó — preservá-lo é o que garante que não vazem ao remover.
+    const bNodeBefore = inputs()[1];
+    expect(bNodeBefore.value).toBe("b");
+
+    // Remove a opção de índice 0 ("a"). Cada linha tem um botão X; o primeiro
+    // botão com ícone é o X da primeira opção.
+    const removeButtons = screen
+      .getAllByRole("button")
+      .filter((b) => b.querySelector("svg"));
+    await user.click(removeButtons[0]);
+
+    await waitFor(() => {
+      expect(inputs().map((i) => i.value)).toEqual(["b", "c"]);
+    });
+
+    // Com key estável, o React MOVE o nó de "b" para a posição 0 (mesmo nó DOM).
+    // Com key={i}, reaproveitaria o nó da posição e trocaria o value → nó
+    // diferente, foco/cursor escorregando para a opção errada.
+    expect(inputs()[0]).toBe(bNodeBefore);
+  });
+
+  it("adicionar opção foca o novo input vazio no fim", async () => {
+    const user = userEvent.setup();
+    render(<ControlledEditor initial={["x"]} />);
+
+    await user.click(screen.getByRole("button", { name: /adicionar opção/i }));
+
+    await waitFor(() => expect(inputs()).toHaveLength(2));
+    const last = inputs()[1];
+    expect(last.value).toBe("");
+    expect(document.activeElement).toBe(last);
+  });
+});

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { AlertTriangle, Loader2, Trash2 } from "lucide-react";
 import { OptionsEditor } from "@/components/schema/OptionsEditor";
+import { useStableListIds } from "@/hooks/useStableListIds";
 import { ConditionEditor } from "@/components/schema/ConditionEditor";
 import { candidateTriggersFor } from "@/lib/conditional";
 import { RemoveOptionDialog } from "@/components/schema/RemoveOptionDialog";
@@ -103,6 +104,10 @@ export function EditFieldDialog({
     conflicts: ConditionConflict[];
     resolve: (confirmed: boolean) => void;
   } | null>(null);
+
+  // Keys estáveis para a lista editável de subcampos: o `key` do subfield é
+  // digitado pelo usuário (muda a cada tecla), logo não serve como React key.
+  const subfieldKeys = useStableListIds(subfields?.length ?? 0);
 
   const handleBeforeRemoveOption = async (opt: string): Promise<boolean> => {
     const conflicts = findConditionConflicts(allFields, fieldName, opt);
@@ -334,7 +339,7 @@ export function EditFieldDialog({
                     </div>
                   </div>
                   {subfields!.map((sf, si) => (
-                    <div key={si} className="flex items-center gap-1.5">
+                    <div key={subfieldKeys.ids[si]} className="flex items-center gap-1.5">
                       <Input
                         value={sf.key}
                         onChange={(e) => {
@@ -374,6 +379,7 @@ export function EditFieldDialog({
                         className="size-6 p-0"
                         onClick={() => {
                           const sfs = subfields!.filter((_, j) => j !== si);
+                          subfieldKeys.removeIdAt(si);
                           setSubfields(sfs.length > 0 ? sfs : undefined);
                           if (sfs.length === 0) setSubfieldRule("all");
                         }}
@@ -388,6 +394,7 @@ export function EditFieldDialog({
                     className="text-xs h-6"
                     onClick={() => {
                       const idx = subfields!.length + 1;
+                      subfieldKeys.appendId();
                       setSubfields([
                         ...subfields!,
                         { key: `campo_${idx}`, label: `Campo ${idx}`, required: true },

--- a/frontend/src/hooks/__tests__/useStableListIds.test.ts
+++ b/frontend/src/hooks/__tests__/useStableListIds.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+import { useStableListIds } from "../useStableListIds";
+
+afterEach(cleanup);
+
+describe("useStableListIds", () => {
+  it("gera um id estável por posição no primeiro render", () => {
+    const { result } = renderHook(({ n }) => useStableListIds(n), {
+      initialProps: { n: 3 },
+    });
+    expect(result.current.ids).toHaveLength(3);
+    // ids únicos
+    expect(new Set(result.current.ids).size).toBe(3);
+  });
+
+  it("preserva ids ao re-renderizar com o mesmo length", () => {
+    const { result, rerender } = renderHook(({ n }) => useStableListIds(n), {
+      initialProps: { n: 2 },
+    });
+    const before = [...result.current.ids];
+    rerender({ n: 2 });
+    expect(result.current.ids).toEqual(before);
+  });
+
+  it("appendId mais re-render com length+1 mantém o prefixo e cria id novo no fim", () => {
+    const { result, rerender } = renderHook(({ n }) => useStableListIds(n), {
+      initialProps: { n: 2 },
+    });
+    const before = [...result.current.ids];
+    // Simula o fluxo do caller: appendId() junto do onChange que aumenta o length.
+    act(() => result.current.appendId());
+    rerender({ n: 3 });
+    expect(result.current.ids).toHaveLength(3);
+    expect(result.current.ids.slice(0, 2)).toEqual(before);
+    expect(result.current.ids[2]).not.toBe(before[0]);
+    expect(result.current.ids[2]).not.toBe(before[1]);
+  });
+
+  it("removeIdAt no meio descarta o id certo (não o do fim)", () => {
+    const { result, rerender } = renderHook(({ n }) => useStableListIds(n), {
+      initialProps: { n: 3 },
+    });
+    const [id0, id1, id2] = result.current.ids;
+    // Remove a posição 0 (topo da lista).
+    act(() => result.current.removeIdAt(0));
+    rerender({ n: 2 });
+    // O id removido é o do índice 0; id1 e id2 sobrevivem e deslizam para 0/1.
+    expect(result.current.ids).toEqual([id1, id2]);
+    expect(result.current.ids).not.toContain(id0);
+  });
+
+  it("reconcilia mudança externa de length (sem handler) preservando o prefixo", () => {
+    const { result, rerender } = renderHook(({ n }) => useStableListIds(n), {
+      initialProps: { n: 1 },
+    });
+    const [id0] = result.current.ids;
+    // Mudança externa (ex.: troca de campo) aumenta o length sem appendId().
+    rerender({ n: 3 });
+    expect(result.current.ids).toHaveLength(3);
+    expect(result.current.ids[0]).toBe(id0);
+    expect(new Set(result.current.ids).size).toBe(3);
+  });
+
+  it("reconcilia encolhimento externo truncando do fim", () => {
+    const { result, rerender } = renderHook(({ n }) => useStableListIds(n), {
+      initialProps: { n: 3 },
+    });
+    const [id0, id1] = result.current.ids;
+    rerender({ n: 2 });
+    expect(result.current.ids).toEqual([id0, id1]);
+  });
+});

--- a/frontend/src/hooks/__tests__/useStableListIds.test.ts
+++ b/frontend/src/hooks/__tests__/useStableListIds.test.ts
@@ -43,12 +43,12 @@ describe("useStableListIds", () => {
       initialProps: { n: 3 },
     });
     const [id0, id1, id2] = result.current.ids;
-    // Remove a posição 0 (topo da lista).
-    act(() => result.current.removeIdAt(0));
+    // Remove a posição 1 (meio da lista) — o caso crítico do no-array-index-as-key.
+    act(() => result.current.removeIdAt(1));
     rerender({ n: 2 });
-    // O id removido é o do índice 0; id1 e id2 sobrevivem e deslizam para 0/1.
-    expect(result.current.ids).toEqual([id1, id2]);
-    expect(result.current.ids).not.toContain(id0);
+    // O id removido é o do meio; id0 e id2 sobrevivem e id2 desliza para 1.
+    expect(result.current.ids).toEqual([id0, id2]);
+    expect(result.current.ids).not.toContain(id1);
   });
 
   it("reconcilia mudança externa de length (sem handler) preservando o prefixo", () => {

--- a/frontend/src/hooks/useStableListIds.ts
+++ b/frontend/src/hooks/useStableListIds.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRef } from "react";
+
+// crypto.randomUUID is only exposed in secure contexts (HTTPS/localhost); fall
+// back so a dev server reached over a plain-http LAN IP doesn't crash editing.
+const makeId = () =>
+  crypto.randomUUID?.() ?? `lid-${Math.random().toString(36).slice(2)}`;
+
+export interface StableListIds {
+  /** One stable id per item, aligned by position to the controlled list. */
+  ids: string[];
+  /** Drop the id at `index`. Call alongside the caller's own array removal. */
+  removeIdAt: (index: number) => void;
+  /** Append a fresh id. Call alongside the caller's own array append. */
+  appendId: () => void;
+}
+
+/**
+ * Stable React keys for a *controlled* editable list whose external contract is
+ * a plain `T[]` (no ids of its own). The component owns the values; this hook
+ * owns a parallel array of ids aligned by position, so removing/reordering an
+ * item in the middle doesn't leak input state (focus/cursor) between rows via
+ * index keys (`no-array-index-as-key`).
+ *
+ * Mutations go through the caller's own handlers: call `removeIdAt`/`appendId`
+ * together with the value mutation + `onChange`, so ids and values stay aligned
+ * before the next render. The render-time reconcile below only kicks in for
+ * *external* length changes (field switch, toggling subfields, schema reset),
+ * preserving the ids of positions that remain.
+ */
+export function useStableListIds(length: number): StableListIds {
+  const idsRef = useRef<string[]>([]);
+
+  if (idsRef.current.length !== length) {
+    const cur = idsRef.current;
+    idsRef.current = Array.from({ length }, (_, i) => cur[i] ?? makeId());
+  }
+
+  const handlers = useRef<Pick<StableListIds, "removeIdAt" | "appendId">>({
+    removeIdAt: (index) => {
+      idsRef.current = idsRef.current.filter((_, i) => i !== index);
+    },
+    appendId: () => {
+      idsRef.current = [...idsRef.current, makeId()];
+    },
+  });
+
+  return {
+    ids: idsRef.current,
+    removeIdAt: handlers.current.removeIdAt,
+    appendId: handlers.current.appendId,
+  };
+}


### PR DESCRIPTION
## Contexto

`OptionsEditor.tsx:54` usava `key={i}` numa lista **editável** (append/remove) — o caso crítico do `no-array-index-as-key` (#316, sub-issue de #238, épico #239). Ao remover/reordenar um item do meio, o React reconcilia por posição e preserva o nó DOM do índice (foco, cursor, seleção do `<input>`), apenas trocando o `value` → o estado interno "escorrega" para o item vizinho.

A pedido, o PR também cobre o anti-padrão irmão `key={si}` nos **subcampos editáveis** de `FieldCard.tsx` e `EditFieldDialog.tsx`. Ali o `key` é digitado pelo usuário (muda a cada tecla), então `key={sf.key}` seria pior ainda — remontaria o input a cada caractere.

## Solução

Como há três call sites com a mesma necessidade e contrato externo sem IDs (`string[]` / `SubfieldDef[]`), extraí um hook compartilhado **`useStableListIds`** que mantém um array paralelo de IDs estáveis alinhado por posição, atualizado nos mesmos handlers de add/remove (e que reconcilia mudanças externas de tamanho — troca de campo, toggle de subcampos). O gerador de ID espelha o padrão já existente em `CsvPreviewTable.tsx` (`crypto.randomUUID` com fallback para contexto não-seguro).

- `hooks/useStableListIds.ts` (+ teste unitário, 6 casos)
- `OptionsEditor` → `key={ids[i]}`, wire de add/remove
- subcampos de `FieldCard` e `EditFieldDialog` idem
- teste de componente do `OptionsEditor` prova a preservação do nó DOM (regride com `key={i}`)

**Fora de escopo** (listas estáticas/não-editáveis, mantêm index key): `AssignmentTable.tsx:201`, `ValidationErrorPanel.tsx:76`, `ExportPanel.tsx:229`.

## Verificação

- `npm run react-doctor` → **zero** `no-array-index-as-key` em `OptionsEditor`/subcampos; restam só as 3 listas estáticas fora de escopo. Score 67/100 (sem regressão; hook não introduz diagnóstico novo).
- `npx vitest run` → **825/825** (8 novos). Regressão confirmada: o teste de componente falha com `key={i}` e passa com `key={ids[i]}`.
- `npm run typecheck` → limpo.
- Nota: o hook de pre-push `lint-types` foi pulado por causa do crash **pré-existente** do ESLint 10 × `eslint-plugin-react` (`react/display-name: getFilename is not a function`), alheio a este PR. Demais gates (tsc, fallow, semgrep) passaram.

Closes #316