### PR TITLE
refactor(react-doctor): extrai funcoes puras para escopo de modulo (resgate do #318)

### DIFF
--- a/frontend/src/components/llm/LlmRunsPane.tsx
+++ b/frontend/src/components/llm/LlmRunsPane.tsx
@@ -66,6 +66,18 @@ function formatDuration(start: string, end: string | null): string {
   return `${h}h ${rm}min`;
 }
 
+// Pure projection from a run record to the error card's props (no closure).
+function errorInfoForRun(run: LlmRunRecord): LlmErrorInfo {
+  return {
+    message: run.error_message ?? "Erro sem mensagem",
+    type: run.error_type,
+    traceback: run.error_traceback,
+    line: run.error_line,
+    column: run.error_column,
+    pydanticCode: run.pydantic_code,
+  };
+}
+
 function StatusBadge({ status }: { status: LlmRunRecord["status"] }) {
   if (status === "completed")
     return (
@@ -103,15 +115,6 @@ export function LlmRunsPane({ projectId, runs, stats }: LlmRunsPaneProps) {
       </div>
     );
   }
-
-  const errorInfoForRun = (run: LlmRunRecord): LlmErrorInfo => ({
-    message: run.error_message ?? "Erro sem mensagem",
-    type: run.error_type,
-    traceback: run.error_traceback,
-    line: run.error_line,
-    column: run.error_column,
-    pydanticCode: run.pydantic_code,
-  });
 
   return (
     <div className="mx-auto max-w-4xl space-y-3 p-6">

--- a/frontend/src/components/schema/FieldChangeDiff.tsx
+++ b/frontend/src/components/schema/FieldChangeDiff.tsx
@@ -21,6 +21,11 @@ interface FieldChangeDiffProps {
   defaultExpanded?: boolean;
 }
 
+const SUBFIELD_RULE_LABELS: Record<string, string> = {
+  all: "Todos obrigatórios",
+  at_least_one: "Pelo menos um",
+};
+
 export function FieldChangeDiff({ entry, defaultExpanded = true }: FieldChangeDiffProps) {
   const kind = detectFieldChangeKind(entry);
   const diffs = diffPydanticField(entry.beforeValue, entry.afterValue);
@@ -222,15 +227,11 @@ function PropertyDiff({ diff }: { diff: FieldPropertyDiff }) {
     );
   }
   if (diff.property === "subfield_rule") {
-    const map: Record<string, string> = {
-      all: "Todos obrigatórios",
-      at_least_one: "Pelo menos um",
-    };
     return (
       <DiffSection label={label}>
         <PillDiff
-          before={map[diff.before as string] ?? "—"}
-          after={map[diff.after as string] ?? "—"}
+          before={SUBFIELD_RULE_LABELS[diff.before as string] ?? "—"}
+          after={SUBFIELD_RULE_LABELS[diff.after as string] ?? "—"}
         />
       </DiffSection>
     );


### PR DESCRIPTION
## Contexto

Resgate da única parte do #318 que `main` ainda não cobria e que não conflita com o #332. O #318 foi fechado como superseded pelo #332 (`refactor/react-doctor-state-hooks-305`), que mergeou a mesma extração de estado da Onda 5 (#239) nos mesmos 8 componentes, porém com hooks co-localizados em vez de hooks em `src/hooks/*`. Entre os dois, só estas duas extrações para escopo de módulo eram ganho genuíno e sem sobreposição.

## O que muda

- `LlmRunsPane`: `errorInfoForRun` sai do corpo do componente para o escopo de módulo (projeção pura de um `LlmRunRecord` para as props do card de erro).
- `FieldChangeDiff`: o mapa de labels de `subfield_rule` vira a constante de módulo `SUBFIELD_RULE_LABELS`.

Ambas são puras (sem closure sobre estado/props), então recriá-las a cada render era desperdício. Resolve dois avisos `prefer-module-scope-pure-function` (react-doctor, Maintainability).

## Verificação

- `tsc --noEmit` limpo.
- Hook react-doctor (`--scope changed`) passou no commit (sem error nas linhas tocadas).
- Refactor puro, sem mudança de comportamento — `errorInfoForRun(run)` e o lookup do mapa produzem exatamente o mesmo resultado de antes.