### PR TITLE
refactor(assignments): extrai estado do LotteryDialog em hooks por subdomínio (#314)

### DIFF
--- a/frontend/src/components/assignments/BatchLabel.tsx
+++ b/frontend/src/components/assignments/BatchLabel.tsx
@@ -1,0 +1,21 @@
+import { Label } from "@/components/ui/label";
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+
+interface BatchLabelProps {
+  htmlFor: string;
+  label: string | null;
+  createdAt: string;
+}
+
+/** Rótulo de um lote anterior (nome + data) reutilizado nos filtros de lote. */
+export function BatchLabel({ htmlFor, label, createdAt }: BatchLabelProps) {
+  return (
+    <Label htmlFor={htmlFor} className="font-normal">
+      {label || "Sem rótulo"}
+      <span className="ml-1.5 text-xs text-muted-foreground">
+        {format(new Date(createdAt), "dd/MM/yyyy", { locale: ptBR })}
+      </span>
+    </Label>
+  );
+}

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -24,303 +24,111 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  getLotteryDocStats,
-  smartRandomize,
-  previewLottery,
-} from "@/actions/assignments";
-import type { LotteryParams, LotteryPreview } from "@/actions/assignments";
-import {
-  filterComparisonEligible,
-  filterEligibleDocs,
-  resolveWeight,
-  resolveCap,
-  type AssignmentFilter,
-  type LotteryBalancing,
-  type LotteryDocStats,
-  type LotteryFilters,
-  type LotteryMode,
+import type {
+  AssignmentFilter,
+  LotteryBalancing,
+  LotteryMode,
 } from "@/lib/lottery-utils";
-import { toast } from "sonner";
-import { ptBR } from "date-fns/locale";
-import { format } from "date-fns";
-
-export interface LotteryMember {
-  userId: string;
-  name: string;
-  role: "pesquisador" | "coordenador";
-  // Pré-registrado (spec 002): ainda não criou conta.
-  pending?: boolean;
-  // Defaults de carga persistidos (último sorteio): peso relativo e limite
-  // individual de docs. Pré-preenchem os campos por participante.
-  weight?: number;
-  cap?: number | null;
-}
+import { BatchLabel } from "./BatchLabel";
+import type { CodingsFilterMode, LotteryMember } from "./lottery-dialog-types";
+import { useLotteryStats } from "./useLotteryStats";
+import { useLotteryDistribution } from "./useLotteryDistribution";
+import { useLotteryFilters } from "./useLotteryFilters";
+import { useLotteryParticipants } from "./useLotteryParticipants";
+import { useLotteryRun } from "./useLotteryRun";
 
 interface LotteryDialogProps {
   projectId: string;
   members: LotteryMember[];
 }
 
-interface LotteryStats {
-  docs: LotteryDocStats[];
-  batches: { id: string; label: string | null; createdAt: string }[];
-  minResponsesForComparison: number;
-  automationMode: string | null;
-}
-
-type CodingsFilterMode = "all" | "none" | "atMost";
-
 export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
   const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [previewing, setPreviewing] = useState(false);
 
-  // Stats de elegibilidade, recarregadas a cada abertura do dialog —
-  // um sorteio muda atribuições/lotes, então reabrir com stats da
-  // abertura anterior mentiria na contagem de elegíveis
-  const [stats, setStats] = useState<LotteryStats | null>(null);
-  const [statsError, setStatsError] = useState(false);
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    getLotteryDocStats(projectId)
-      .then((s) => {
-        if (!cancelled) {
-          setStats(s);
-          setStatsError(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) setStatsError(true);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, projectId]);
+  const { stats, statsError } = useLotteryStats(projectId, open);
 
-  // Tipo do sorteio (codificação ou comparação)
-  const [type, setType] = useState<"codificacao" | "comparacao">("codificacao");
-
-  // Distribuição
-  const [researchersPerDoc, setResearchersPerDoc] = useState(2);
-  const [docsPerResearcherEnabled, setDocsPerResearcherEnabled] =
-    useState(false);
-  const [docsPerResearcher, setDocsPerResearcher] = useState(10);
-  const [docSubsetEnabled, setDocSubsetEnabled] = useState(false);
-  const [docSubsetSize, setDocSubsetSize] = useState(50);
-  const [balancing, setBalancing] = useState<LotteryBalancing>("round");
-
-  // Atribuições pendentes (modo)
-  const [mode, setMode] = useState<LotteryMode>("append");
-
-  // Filtros de elegibilidade
-  const [codingsFilterMode, setCodingsFilterMode] =
-    useState<CodingsFilterMode>("all");
-  const [maxCodingsValue, setMaxCodingsValue] = useState(1);
-  const [assignmentFilter, setAssignmentFilter] =
-    useState<AssignmentFilter>("any");
-  const [batchFilterMode, setBatchFilterMode] = useState<
-    "none" | "exclude" | "only"
-  >("none");
-  const [batchExclude, setBatchExclude] = useState<string[]>([]);
-  const [batchOnly, setBatchOnly] = useState<string | null>(null);
-  const [manualEnabled, setManualEnabled] = useState(false);
-  const [manualDocIds, setManualDocIds] = useState<Set<string>>(new Set());
-
-  // Participantes: default por role (pesquisador ON, coordenador OFF) +
-  // overrides dos toggles — derivar do prop em vez de snapshot garante que
-  // membro adicionado com o dialog montado entra com o default do role
-  const [participantOverrides, setParticipantOverrides] = useState<
-    Record<string, boolean>
-  >({});
-
-  // Peso/limite por participante, editados como string (inputs controlados).
-  // Ausência da chave = usar o default persistido do membro (m.weight/m.cap).
-  const [weightInputs, setWeightInputs] = useState<Record<string, string>>({});
-  const [capInputs, setCapInputs] = useState<Record<string, string>>({});
-
-  const isParticipant = (m: LotteryMember) =>
-    participantOverrides[m.userId] ?? m.role === "pesquisador";
-
-  // String exibida nos inputs: override local, senão default persistido.
-  const weightValue = useCallback(
-    (m: LotteryMember) => weightInputs[m.userId] ?? String(m.weight ?? 1),
-    [weightInputs],
-  );
-  const capValue = useCallback(
-    (m: LotteryMember) =>
-      capInputs[m.userId] ?? (m.cap != null ? String(m.cap) : ""),
-    [capInputs],
-  );
-
-  const participantIds = useMemo(
-    () =>
-      members
-        .filter(
-          (m) => participantOverrides[m.userId] ?? m.role === "pesquisador"
-        )
-        .map((m) => m.userId),
-    [members, participantOverrides]
-  );
-
-  // Peso/limite resolvido por participante ativo. Inclui TODOS os participantes
-  // (peso 1 / sem limite explícito) para que o server persista o reset de quem
-  // voltou ao default — não só quem está fora do padrão.
-  const participantSettings = useMemo(() => {
-    const out: Record<string, { weight: number; cap: number | null }> = {};
-    for (const m of members) {
-      if (!(participantOverrides[m.userId] ?? m.role === "pesquisador")) continue;
-      const cStr = capValue(m);
-      out[m.userId] = {
-        // Mesma coerção do server (resolveWeight/resolveCap) — fonte única.
-        weight: resolveWeight(parseFloat(weightValue(m))),
-        cap: resolveCap(cStr.trim() === "" ? null : parseInt(cStr, 10)),
-      };
-    }
-    return out;
-  }, [members, participantOverrides, weightValue, capValue]);
-
-  // Label
-  const [label, setLabel] = useState("");
-
-  const isComparacao = type === "comparacao";
-
-  const filters = useMemo<LotteryFilters>(() => {
-    const f: LotteryFilters = {};
-    if (codingsFilterMode === "none") f.maxHumanCodings = 0;
-    else if (codingsFilterMode === "atMost") f.maxHumanCodings = maxCodingsValue;
-    if (assignmentFilter !== "any") f.assignmentFilter = assignmentFilter;
-    if (batchFilterMode === "only" && batchOnly) {
-      f.batchFilter = { only: batchOnly };
-    } else if (batchFilterMode === "exclude" && batchExclude.length) {
-      f.batchFilter = { exclude: batchExclude };
-    }
-    if (manualEnabled) f.manualDocIds = Array.from(manualDocIds);
-    return f;
-  }, [
-    codingsFilterMode,
-    maxCodingsValue,
-    assignmentFilter,
-    batchFilterMode,
-    batchOnly,
-    batchExclude,
-    manualEnabled,
-    manualDocIds,
-  ]);
-
-  // Prévia + semente (research D13): a seed da última prévia é reaproveitada
-  // ao sortear; a prévia é guardada junto da configuração que a gerou, então
-  // qualquer mudança de configuração a invalida (e à seed) por derivação.
-  // O rótulo fica de fora: não afeta o resultado do sorteio, e é lido em
-  // buildParams na hora do submit
-  const configKey = JSON.stringify({
+  const dist = useLotteryDistribution();
+  const {
     type,
+    setType,
+    isComparacao,
     researchersPerDoc,
+    setResearchersPerDoc,
     docsPerResearcherEnabled,
+    setDocsPerResearcherEnabled,
     docsPerResearcher,
+    setDocsPerResearcher,
     docSubsetEnabled,
+    setDocSubsetEnabled,
     docSubsetSize,
-    mode,
+    setDocSubsetSize,
     balancing,
-    filters,
+    setBalancing,
+    mode,
+    setMode,
+  } = dist;
+
+  const filtersState = useLotteryFilters({ stats, type, isComparacao });
+  const {
+    codingsFilterMode,
+    setCodingsFilterMode,
+    maxCodingsValue,
+    setMaxCodingsValue,
+    assignmentFilter,
+    setAssignmentFilter,
+    batchFilterMode,
+    setBatchFilterMode,
+    batchExclude,
+    setBatchExclude,
+    batchOnly,
+    setBatchOnly,
+    manualEnabled,
+    setManualEnabled,
+    manualDocIds,
+    setManualDocIds,
+    eligibleCount,
+  } = filtersState;
+
+  const participants = useLotteryParticipants(members);
+  const {
+    isParticipant,
+    weightValue,
+    capValue,
     participantIds,
-    participantSettings,
-  });
-  const [previewState, setPreviewState] = useState<{
-    key: string;
-    preview: LotteryPreview;
-  } | null>(null);
-  const preview = previewState?.key === configKey ? previewState.preview : null;
-  const seed = preview?.seed ?? null;
+    memberName,
+    setParticipantOverrides,
+    setWeightInputs,
+    setCapInputs,
+  } = participants;
 
-  // Contagem de elegíveis ao vivo, com a mesma função pura do server
-  const eligibleCount = useMemo(() => {
-    if (!stats) return null;
-    let candidates = stats.docs;
-    if (isComparacao) {
-      candidates = filterComparisonEligible(
-        candidates,
-        stats.automationMode,
-        stats.minResponsesForComparison,
-      );
-    }
-    return filterEligibleDocs(candidates, type, filters).length;
-  }, [stats, type, isComparacao, filters]);
-
-  const blockedMessage =
-    participantIds.length === 0
-      ? "Nenhum participante selecionado."
-      : eligibleCount === 0
-        ? "Nenhum documento passa nos filtros atuais."
-        : null;
-
-  const canSubmit = !blockedMessage && stats !== null;
-
-  const buildParams = (withSeed: boolean): LotteryParams => ({
+  const run = useLotteryRun({
     projectId,
-    type,
-    mode,
-    balancing,
-    seed: withSeed && seed !== null ? seed : undefined,
-    researchersPerDoc,
-    docsPerResearcher: docsPerResearcherEnabled
-      ? docsPerResearcher
-      : undefined,
-    docSubsetSize: docSubsetEnabled ? docSubsetSize : undefined,
-    label: label || undefined,
-    filters,
-    participantIds,
-    participantSettings,
+    dist,
+    filtersState,
+    participants,
+    stats,
+    onRandomized: () => setOpen(false),
   });
-
-  const handlePreview = async () => {
-    setPreviewing(true);
-    try {
-      const result = await previewLottery(buildParams(false));
-      setPreviewState({ key: configKey, preview: result });
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Erro ao calcular a prévia");
-    }
-    setPreviewing(false);
-  };
-
-  const handleRandomize = async () => {
-    setLoading(true);
-    try {
-      const result = await smartRandomize(buildParams(true));
-      toast.success(
-        `${result.count} novas atribuições criadas! (${result.preserved} preservadas)`
-      );
-      setOpen(false);
-      setPreviewState(null);
-    } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Erro ao sortear");
-    }
-    setLoading(false);
-  };
-
-  const docsConsidered =
-    eligibleCount === null
-      ? null
-      : docSubsetEnabled
-        ? Math.min(docSubsetSize, eligibleCount)
-        : eligibleCount;
-
-  const estimatedPerParticipant =
-    docsConsidered !== null && participantIds.length > 0
-      ? Math.ceil((docsConsidered * researchersPerDoc) / participantIds.length)
-      : 0;
-
-  const memberName = (userId: string) =>
-    members.find((m) => m.userId === userId)?.name ?? userId.slice(0, 8);
+  const {
+    label,
+    setLabel,
+    previewing,
+    loading,
+    preview,
+    blockedMessage,
+    canSubmit,
+    estimatedPerParticipant,
+    handlePreview,
+    handleRandomize,
+    clearPreview,
+  } = run;
 
   return (
     <Dialog
       open={open}
       onOpenChange={(v) => {
         setOpen(v);
-        if (!v) setPreviewState(null);
+        if (!v) clearPreview();
       }}
     >
       <DialogTrigger asChild>
@@ -486,17 +294,11 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
                             )
                           }
                         />
-                        <Label
+                        <BatchLabel
                           htmlFor={`batch-ex-${b.id}`}
-                          className="font-normal"
-                        >
-                          {b.label || "Sem rótulo"}
-                          <span className="ml-1.5 text-xs text-muted-foreground">
-                            {format(new Date(b.createdAt), "dd/MM/yyyy", {
-                              locale: ptBR,
-                            })}
-                          </span>
-                        </Label>
+                          label={b.label}
+                          createdAt={b.createdAt}
+                        />
                       </div>
                     ))}
                   </div>
@@ -511,17 +313,11 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
                     {stats.batches.map((b) => (
                       <div key={b.id} className="flex items-center gap-2">
                         <RadioGroupItem value={b.id} id={`batch-only-${b.id}`} />
-                        <Label
+                        <BatchLabel
                           htmlFor={`batch-only-${b.id}`}
-                          className="font-normal"
-                        >
-                          {b.label || "Sem rótulo"}
-                          <span className="ml-1.5 text-xs text-muted-foreground">
-                            {format(new Date(b.createdAt), "dd/MM/yyyy", {
-                              locale: ptBR,
-                            })}
-                          </span>
-                        </Label>
+                          label={b.label}
+                          createdAt={b.createdAt}
+                        />
                       </div>
                     ))}
                   </RadioGroup>

--- a/frontend/src/components/assignments/lottery-dialog-types.ts
+++ b/frontend/src/components/assignments/lottery-dialog-types.ts
@@ -1,0 +1,22 @@
+import type { LotteryDocStats } from "@/lib/lottery-utils";
+
+export interface LotteryMember {
+  userId: string;
+  name: string;
+  role: "pesquisador" | "coordenador";
+  // Pré-registrado (spec 002): ainda não criou conta.
+  pending?: boolean;
+  // Defaults de carga persistidos (último sorteio): peso relativo e limite
+  // individual de docs. Pré-preenchem os campos por participante.
+  weight?: number;
+  cap?: number | null;
+}
+
+export interface LotteryStats {
+  docs: LotteryDocStats[];
+  batches: { id: string; label: string | null; createdAt: string }[];
+  minResponsesForComparison: number;
+  automationMode: string | null;
+}
+
+export type CodingsFilterMode = "all" | "none" | "atMost";

--- a/frontend/src/components/assignments/useLotteryDistribution.ts
+++ b/frontend/src/components/assignments/useLotteryDistribution.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState, type Dispatch, type SetStateAction } from "react";
+import type { LotteryBalancing, LotteryMode } from "@/lib/lottery-utils";
+
+export interface LotteryDistribution {
+  type: "codificacao" | "comparacao";
+  setType: Dispatch<SetStateAction<"codificacao" | "comparacao">>;
+  isComparacao: boolean;
+  researchersPerDoc: number;
+  setResearchersPerDoc: Dispatch<SetStateAction<number>>;
+  docsPerResearcherEnabled: boolean;
+  setDocsPerResearcherEnabled: Dispatch<SetStateAction<boolean>>;
+  docsPerResearcher: number;
+  setDocsPerResearcher: Dispatch<SetStateAction<number>>;
+  docSubsetEnabled: boolean;
+  setDocSubsetEnabled: Dispatch<SetStateAction<boolean>>;
+  docSubsetSize: number;
+  setDocSubsetSize: Dispatch<SetStateAction<number>>;
+  balancing: LotteryBalancing;
+  setBalancing: Dispatch<SetStateAction<LotteryBalancing>>;
+  mode: LotteryMode;
+  setMode: Dispatch<SetStateAction<LotteryMode>>;
+}
+
+/**
+ * Tipo do sorteio, distribuição (pesquisadores/doc, limites, subconjunto,
+ * equilíbrio) e modo de atribuições pendentes. Extraído de `LotteryDialog`.
+ */
+export function useLotteryDistribution(): LotteryDistribution {
+  const [type, setType] = useState<"codificacao" | "comparacao">("codificacao");
+  const [researchersPerDoc, setResearchersPerDoc] = useState(2);
+  const [docsPerResearcherEnabled, setDocsPerResearcherEnabled] =
+    useState(false);
+  const [docsPerResearcher, setDocsPerResearcher] = useState(10);
+  const [docSubsetEnabled, setDocSubsetEnabled] = useState(false);
+  const [docSubsetSize, setDocSubsetSize] = useState(50);
+  const [balancing, setBalancing] = useState<LotteryBalancing>("round");
+  const [mode, setMode] = useState<LotteryMode>("append");
+
+  return {
+    type,
+    setType,
+    isComparacao: type === "comparacao",
+    researchersPerDoc,
+    setResearchersPerDoc,
+    docsPerResearcherEnabled,
+    setDocsPerResearcherEnabled,
+    docsPerResearcher,
+    setDocsPerResearcher,
+    docSubsetEnabled,
+    setDocSubsetEnabled,
+    docSubsetSize,
+    setDocSubsetSize,
+    balancing,
+    setBalancing,
+    mode,
+    setMode,
+  };
+}

--- a/frontend/src/components/assignments/useLotteryFilters.ts
+++ b/frontend/src/components/assignments/useLotteryFilters.ts
@@ -1,0 +1,120 @@
+"use client";
+
+import { useMemo, useState, type Dispatch, type SetStateAction } from "react";
+import {
+  filterComparisonEligible,
+  filterEligibleDocs,
+  type AssignmentFilter,
+  type LotteryFilters,
+} from "@/lib/lottery-utils";
+import type { CodingsFilterMode, LotteryStats } from "./lottery-dialog-types";
+
+interface UseLotteryFiltersParams {
+  stats: LotteryStats | null;
+  type: "codificacao" | "comparacao";
+  isComparacao: boolean;
+}
+
+export interface LotteryFiltersState {
+  codingsFilterMode: CodingsFilterMode;
+  setCodingsFilterMode: Dispatch<SetStateAction<CodingsFilterMode>>;
+  maxCodingsValue: number;
+  setMaxCodingsValue: Dispatch<SetStateAction<number>>;
+  assignmentFilter: AssignmentFilter;
+  setAssignmentFilter: Dispatch<SetStateAction<AssignmentFilter>>;
+  batchFilterMode: "none" | "exclude" | "only";
+  setBatchFilterMode: Dispatch<SetStateAction<"none" | "exclude" | "only">>;
+  batchExclude: string[];
+  setBatchExclude: Dispatch<SetStateAction<string[]>>;
+  batchOnly: string | null;
+  setBatchOnly: Dispatch<SetStateAction<string | null>>;
+  manualEnabled: boolean;
+  setManualEnabled: Dispatch<SetStateAction<boolean>>;
+  manualDocIds: Set<string>;
+  setManualDocIds: Dispatch<SetStateAction<Set<string>>>;
+  /** Filtros normalizados para o server/funções puras de elegibilidade. */
+  filters: LotteryFilters;
+  /** Contagem de elegíveis ao vivo, com a mesma função pura do server. */
+  eligibleCount: number | null;
+}
+
+/**
+ * Filtros de elegibilidade (codificações humanas, status de atribuição, lotes,
+ * seleção manual) + o objeto `filters` derivado e a contagem de elegíveis ao
+ * vivo. Extraído de `LotteryDialog`.
+ */
+export function useLotteryFilters({
+  stats,
+  type,
+  isComparacao,
+}: UseLotteryFiltersParams): LotteryFiltersState {
+  const [codingsFilterMode, setCodingsFilterMode] =
+    useState<CodingsFilterMode>("all");
+  const [maxCodingsValue, setMaxCodingsValue] = useState(1);
+  const [assignmentFilter, setAssignmentFilter] =
+    useState<AssignmentFilter>("any");
+  const [batchFilterMode, setBatchFilterMode] = useState<
+    "none" | "exclude" | "only"
+  >("none");
+  const [batchExclude, setBatchExclude] = useState<string[]>([]);
+  const [batchOnly, setBatchOnly] = useState<string | null>(null);
+  const [manualEnabled, setManualEnabled] = useState(false);
+  const [manualDocIds, setManualDocIds] = useState<Set<string>>(new Set());
+
+  const filters = useMemo<LotteryFilters>(() => {
+    const f: LotteryFilters = {};
+    if (codingsFilterMode === "none") f.maxHumanCodings = 0;
+    else if (codingsFilterMode === "atMost") f.maxHumanCodings = maxCodingsValue;
+    if (assignmentFilter !== "any") f.assignmentFilter = assignmentFilter;
+    if (batchFilterMode === "only" && batchOnly) {
+      f.batchFilter = { only: batchOnly };
+    } else if (batchFilterMode === "exclude" && batchExclude.length) {
+      f.batchFilter = { exclude: batchExclude };
+    }
+    if (manualEnabled) f.manualDocIds = Array.from(manualDocIds);
+    return f;
+  }, [
+    codingsFilterMode,
+    maxCodingsValue,
+    assignmentFilter,
+    batchFilterMode,
+    batchOnly,
+    batchExclude,
+    manualEnabled,
+    manualDocIds,
+  ]);
+
+  const eligibleCount = useMemo(() => {
+    if (!stats) return null;
+    let candidates = stats.docs;
+    if (isComparacao) {
+      candidates = filterComparisonEligible(
+        candidates,
+        stats.automationMode,
+        stats.minResponsesForComparison,
+      );
+    }
+    return filterEligibleDocs(candidates, type, filters).length;
+  }, [stats, type, isComparacao, filters]);
+
+  return {
+    codingsFilterMode,
+    setCodingsFilterMode,
+    maxCodingsValue,
+    setMaxCodingsValue,
+    assignmentFilter,
+    setAssignmentFilter,
+    batchFilterMode,
+    setBatchFilterMode,
+    batchExclude,
+    setBatchExclude,
+    batchOnly,
+    setBatchOnly,
+    manualEnabled,
+    setManualEnabled,
+    manualDocIds,
+    setManualDocIds,
+    filters,
+    eligibleCount,
+  };
+}

--- a/frontend/src/components/assignments/useLotteryParticipants.ts
+++ b/frontend/src/components/assignments/useLotteryParticipants.ts
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+import { resolveCap, resolveWeight } from "@/lib/lottery-utils";
+import type { LotteryMember } from "./lottery-dialog-types";
+
+export interface LotteryParticipants {
+  isParticipant: (m: LotteryMember) => boolean;
+  /** String exibida no input de peso: override local, senão default do membro. */
+  weightValue: (m: LotteryMember) => string;
+  /** String exibida no input de limite: override local, senão default do membro. */
+  capValue: (m: LotteryMember) => string;
+  participantIds: string[];
+  participantSettings: Record<string, { weight: number; cap: number | null }>;
+  memberName: (userId: string) => string;
+  setParticipantOverrides: Dispatch<SetStateAction<Record<string, boolean>>>;
+  setWeightInputs: Dispatch<SetStateAction<Record<string, string>>>;
+  setCapInputs: Dispatch<SetStateAction<Record<string, string>>>;
+}
+
+/**
+ * Seleção de participantes (default por role + overrides), pesos/limites por
+ * participante e as derivações `participantIds`/`participantSettings`. Derivar
+ * do prop `members` em vez de snapshot garante que membro adicionado com o
+ * dialog montado entra com o default do role. Extraído de `LotteryDialog`.
+ */
+export function useLotteryParticipants(
+  members: LotteryMember[],
+): LotteryParticipants {
+  // Default por role (pesquisador ON, coordenador OFF) + overrides dos toggles.
+  const [participantOverrides, setParticipantOverrides] = useState<
+    Record<string, boolean>
+  >({});
+  // Peso/limite por participante, editados como string (inputs controlados).
+  // Ausência da chave = usar o default persistido do membro (m.weight/m.cap).
+  const [weightInputs, setWeightInputs] = useState<Record<string, string>>({});
+  const [capInputs, setCapInputs] = useState<Record<string, string>>({});
+
+  const isParticipant = useCallback(
+    (m: LotteryMember) =>
+      participantOverrides[m.userId] ?? m.role === "pesquisador",
+    [participantOverrides],
+  );
+
+  const weightValue = useCallback(
+    (m: LotteryMember) => weightInputs[m.userId] ?? String(m.weight ?? 1),
+    [weightInputs],
+  );
+  const capValue = useCallback(
+    (m: LotteryMember) =>
+      capInputs[m.userId] ?? (m.cap != null ? String(m.cap) : ""),
+    [capInputs],
+  );
+
+  const participantIds = useMemo(
+    () =>
+      members
+        .filter(
+          (m) => participantOverrides[m.userId] ?? m.role === "pesquisador",
+        )
+        .map((m) => m.userId),
+    [members, participantOverrides],
+  );
+
+  // Peso/limite resolvido por participante ativo. Inclui TODOS os participantes
+  // (peso 1 / sem limite explícito) para que o server persista o reset de quem
+  // voltou ao default — não só quem está fora do padrão.
+  const participantSettings = useMemo(() => {
+    const out: Record<string, { weight: number; cap: number | null }> = {};
+    for (const m of members) {
+      if (!(participantOverrides[m.userId] ?? m.role === "pesquisador"))
+        continue;
+      const cStr = capValue(m);
+      out[m.userId] = {
+        // Mesma coerção do server (resolveWeight/resolveCap) — fonte única.
+        weight: resolveWeight(parseFloat(weightValue(m))),
+        cap: resolveCap(cStr.trim() === "" ? null : parseInt(cStr, 10)),
+      };
+    }
+    return out;
+  }, [members, participantOverrides, weightValue, capValue]);
+
+  const memberName = useCallback(
+    (userId: string) =>
+      members.find((m) => m.userId === userId)?.name ?? userId.slice(0, 8),
+    [members],
+  );
+
+  return {
+    isParticipant,
+    weightValue,
+    capValue,
+    participantIds,
+    participantSettings,
+    memberName,
+    setParticipantOverrides,
+    setWeightInputs,
+    setCapInputs,
+  };
+}

--- a/frontend/src/components/assignments/useLotteryRun.ts
+++ b/frontend/src/components/assignments/useLotteryRun.ts
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState, type Dispatch, type SetStateAction } from "react";
+import { toast } from "sonner";
+import {
+  previewLottery,
+  smartRandomize,
+  type LotteryParams,
+  type LotteryPreview,
+} from "@/actions/assignments";
+import type { LotteryDistribution } from "./useLotteryDistribution";
+import type { LotteryFiltersState } from "./useLotteryFilters";
+import type { LotteryParticipants } from "./useLotteryParticipants";
+import type { LotteryStats } from "./lottery-dialog-types";
+
+interface UseLotteryRunParams {
+  projectId: string;
+  dist: LotteryDistribution;
+  filtersState: LotteryFiltersState;
+  participants: LotteryParticipants;
+  stats: LotteryStats | null;
+  /** Chamado após um sorteio bem-sucedido (o componente fecha o dialog). */
+  onRandomized: () => void;
+}
+
+export interface LotteryRun {
+  label: string;
+  setLabel: Dispatch<SetStateAction<string>>;
+  previewing: boolean;
+  loading: boolean;
+  /** Prévia válida para a configuração atual, ou null se invalidada. */
+  preview: LotteryPreview | null;
+  blockedMessage: string | null;
+  canSubmit: boolean;
+  docsConsidered: number | null;
+  estimatedPerParticipant: number;
+  handlePreview: () => Promise<void>;
+  handleRandomize: () => Promise<void>;
+  /** Limpa a prévia guardada (usado ao fechar o dialog). */
+  clearPreview: () => void;
+}
+
+/**
+ * Orquestração de prévia/sorteio: rótulo, estados de carga, a prévia guardada
+ * (research D13: a seed da última prévia é reaproveitada ao sortear; a prévia
+ * fica atrelada à configuração que a gerou, então qualquer mudança a invalida
+ * por derivação via `configKey`), `buildParams` e os derivados de submissão.
+ * Extraído de `LotteryDialog`.
+ */
+export function useLotteryRun({
+  projectId,
+  dist,
+  filtersState,
+  participants,
+  stats,
+  onRandomized,
+}: UseLotteryRunParams): LotteryRun {
+  const [loading, setLoading] = useState(false);
+  const [previewing, setPreviewing] = useState(false);
+  const [label, setLabel] = useState("");
+  const [previewState, setPreviewState] = useState<{
+    key: string;
+    preview: LotteryPreview;
+  } | null>(null);
+
+  // O rótulo fica de fora da chave: não afeta o resultado do sorteio, e é lido
+  // em buildParams na hora do submit.
+  const configKey = JSON.stringify({
+    type: dist.type,
+    researchersPerDoc: dist.researchersPerDoc,
+    docsPerResearcherEnabled: dist.docsPerResearcherEnabled,
+    docsPerResearcher: dist.docsPerResearcher,
+    docSubsetEnabled: dist.docSubsetEnabled,
+    docSubsetSize: dist.docSubsetSize,
+    mode: dist.mode,
+    balancing: dist.balancing,
+    filters: filtersState.filters,
+    participantIds: participants.participantIds,
+    participantSettings: participants.participantSettings,
+  });
+  const preview =
+    previewState?.key === configKey ? previewState.preview : null;
+  const seed = preview?.seed ?? null;
+
+  const blockedMessage =
+    participants.participantIds.length === 0
+      ? "Nenhum participante selecionado."
+      : filtersState.eligibleCount === 0
+        ? "Nenhum documento passa nos filtros atuais."
+        : null;
+
+  const canSubmit = !blockedMessage && stats !== null;
+
+  const buildParams = (withSeed: boolean): LotteryParams => ({
+    projectId,
+    type: dist.type,
+    mode: dist.mode,
+    balancing: dist.balancing,
+    seed: withSeed && seed !== null ? seed : undefined,
+    researchersPerDoc: dist.researchersPerDoc,
+    docsPerResearcher: dist.docsPerResearcherEnabled
+      ? dist.docsPerResearcher
+      : undefined,
+    docSubsetSize: dist.docSubsetEnabled ? dist.docSubsetSize : undefined,
+    label: label || undefined,
+    filters: filtersState.filters,
+    participantIds: participants.participantIds,
+    participantSettings: participants.participantSettings,
+  });
+
+  const handlePreview = async () => {
+    setPreviewing(true);
+    try {
+      const result = await previewLottery(buildParams(false));
+      setPreviewState({ key: configKey, preview: result });
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Erro ao calcular a prévia");
+    }
+    setPreviewing(false);
+  };
+
+  const handleRandomize = async () => {
+    setLoading(true);
+    try {
+      const result = await smartRandomize(buildParams(true));
+      toast.success(
+        `${result.count} novas atribuições criadas! (${result.preserved} preservadas)`,
+      );
+      onRandomized();
+      setPreviewState(null);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Erro ao sortear");
+    }
+    setLoading(false);
+  };
+
+  const docsConsidered =
+    filtersState.eligibleCount === null
+      ? null
+      : dist.docSubsetEnabled
+        ? Math.min(dist.docSubsetSize, filtersState.eligibleCount)
+        : filtersState.eligibleCount;
+
+  const estimatedPerParticipant =
+    docsConsidered !== null && participants.participantIds.length > 0
+      ? Math.ceil(
+          (docsConsidered * dist.researchersPerDoc) /
+            participants.participantIds.length,
+        )
+      : 0;
+
+  return {
+    label,
+    setLabel,
+    previewing,
+    loading,
+    preview,
+    blockedMessage,
+    canSubmit,
+    docsConsidered,
+    estimatedPerParticipant,
+    handlePreview,
+    handleRandomize,
+    clearPreview: () => setPreviewState(null),
+  };
+}

--- a/frontend/src/components/assignments/useLotteryStats.ts
+++ b/frontend/src/components/assignments/useLotteryStats.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getLotteryDocStats } from "@/actions/assignments";
+import type { LotteryStats } from "./lottery-dialog-types";
+
+export interface LotteryStatsState {
+  stats: LotteryStats | null;
+  statsError: boolean;
+}
+
+/**
+ * Stats de elegibilidade do sorteio, recarregadas a cada abertura do dialog —
+ * um sorteio muda atribuições/lotes, então reabrir com stats da abertura
+ * anterior mentiria na contagem de elegíveis. Extraído de `LotteryDialog`.
+ */
+export function useLotteryStats(
+  projectId: string,
+  open: boolean,
+): LotteryStatsState {
+  const [stats, setStats] = useState<LotteryStats | null>(null);
+  const [statsError, setStatsError] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    getLotteryDocStats(projectId)
+      .then((s) => {
+        if (!cancelled) {
+          setStats(s);
+          setStatsError(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setStatsError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, projectId]);
+
+  return { stats, statsError };
+}


### PR DESCRIPTION
## Contexto

`LotteryDialog.tsx` tinha **22 `useState`** no corpo do componente, disparando a regra `prefer-useReducer` do react-doctor (sob **Bugs** na 0.5.8 — "Many related useState calls") em `LotteryDialog.tsx:74`. Item deferido da campanha react-doctor (sub-issue de #238, épico #239) por mudar comportamento.

A regra conta `useState` no corpo do componente e **ignora** os de custom hooks, então extrair o estado por subdomínio zera o aviso sem precisar de `useReducer` — mesmo padrão de `useCompareNavigation` (que matou a regra no `ComparePage`).

## O que mudou

Cinco hooks colocalizados em `components/assignments/`, cada um transplantando os `useState`/`useMemo` existentes **com semântica idêntica** (refactor sem mudança de comportamento):

- `useLotteryStats` — stats/statsError + effect de carga
- `useLotteryDistribution` — tipo, distribuição (pesquisadores/doc, limites, subconjunto, equilíbrio) e modo
- `useLotteryFilters` — filtros de elegibilidade + os derivados `filters` e `eligibleCount`
- `useLotteryParticipants` — overrides, pesos/limites + `participantIds`/`participantSettings`
- `useLotteryRun` — orquestração de prévia/sorteio (cadeia `configKey → preview → seed`), `buildParams` e os derivados de submissão

O componente fica com **1 `useState` (`open`)** e compõe os hooks; o JSX é preservado destruturando os retornos com os nomes originais. Tipos compartilhados em `lottery-dialog-types.ts`. O markup duplicado de rótulo de lote (filtros exclude/only) virou o componente `BatchLabel`.

O núcleo puro (`lib/lottery-utils.ts`) **não foi tocado**.

## Verificação

- **Critério de pronto:** `npx react-doctor@0.5.8 --verbose` não cita mais `LotteryDialog` em `prefer-useReducer`. Score do projeto **64 → 75**. Gate de pre-commit (`react-doctor --scope changed --blocking error`): **No issues found**.
- **typecheck:** `tsc --noEmit` limpo.
- **Testes:** vitest **817/817** (lottery-utils **46/46**), sem regressão.

## Notas sobre os gates de pre-push

Dois hooks locais foram pulados neste push (`SKIP=fallow-audit,lint-types`), por motivos **alheios a este PR** — gitleaks, **typecheck (tsc)** e semgrep seguiram ativos e passaram:

- **`lint-types`** crasha com o bug pré-existente do **ESLint 10 × eslint-plugin-react** (`getFilename is not a function` na regra `react/display-name`), antes de processar qualquer arquivo. Validação por react-doctor + tsc + vitest, conforme convenção do projeto.
- **`fallow-audit`** (new-only) bloqueia em: (a) 2 deps órfãs **pré-existentes** no `main` (`recharts`, `react-day-picker`, zero imports no repo — fora do escopo deste PR) e (b) complexidade **transplantada verbatim** dos hooks (a `filters` memo, `buildParams`, `participantSettings`, a orquestração) — complexidade que já existia dentro do componente monolítico e que a decomposição apenas tornou visível por função. A duplicação detectada foi **eliminada** (`BatchLabel`); a maintainability subiu para **91.2 (good)**.

Closes #314