### PR TITLE
fix(schema): corrige build do deploy — subfieldKeys fora de escopo em EditFieldDialog

### DIFF
--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -156,6 +156,7 @@ function useEditFieldForm(
     pendingRemoval,
     setPendingRemoval,
     handleBeforeRemoveOption,
+    subfieldKeys,
   };
 }
 
@@ -191,6 +192,7 @@ export function EditFieldDialog({
     pendingRemoval,
     setPendingRemoval,
     handleBeforeRemoveOption,
+    subfieldKeys,
   } = useEditFieldForm(field, fieldName, allFields, pendingSuggestion);
 
   if (!field) return null;


### PR DESCRIPTION
## Problema

O deploy do frontend (Fly.io) estava falhando em `npm run build` com saída truncada (`<Input value={sf.key} ...>` ~linha 398, sem o texto do erro).

Reproduzindo o build sobre `origin/main` — não o `main` local, que estava 10 commits atrás —, o erro real é de **TypeScript**:

```
./src/components/stats/EditFieldDialog.tsx:397:31
Type error: Cannot find name 'subfieldKeys'. Did you mean 'subfields'?
> 397 |  <div key={subfieldKeys.ids[si]} className="flex items-center gap-1.5">
  398 |    <Input
  399 |      value={sf.key}
```

`next build` (Next 16) compila com Turbopack ("Compiled successfully") e só **depois** roda o type-check; por isso a mensagem genérica "Next.js build worker exited with code: 1".

## Causa-raiz

O #316 (`fix(schema): IDs estáveis em listas editáveis`) introduziu `key={subfieldKeys.ids[si]}` (e `removeIdAt`/`appendId`) no JSX de `EditFieldDialog`. Mas neste arquivo o estado do formulário foi extraído para o hook `useEditFieldForm`: `subfieldKeys` era declarado e usado **só dentro do hook**, sem entrar no objeto de retorno nem ser desestruturado pelo componente. `FieldCard.tsx` (fix gêmeo do #316) não quebra porque lá o estado vive direto no componente.

## Mudança

Expõe `subfieldKeys` pela fronteira do hook: adiciona ao `return` de `useEditFieldForm` e à desestruturação em `EditFieldDialog`. Sem mudança de comportamento — apenas expõe o objeto de `useStableListIds` que já existia.

## Verificação

- `cd frontend && npx next build` → type-check completo passa (era onde o deploy quebrava).
- `npx vitest run src/hooks/__tests__/useStableListIds.test.ts` → 6/6 passam.

> Nota: o hook de pre-push `typecheck` (tsc global) está vermelho na `main` por débito pré-existente em `ComparePage.test.tsx` (prop `defaultVersion` ausente nos mocks de teste), alheio a este PR — o `next build`, que é o gate real do deploy, passa.

