### PR TITLE
fix(cutover): remove redirect que derrubou o acesso ao domínio de produção

### DIFF
--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,12 +1,4 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
-import { NextResponse } from "next/server";
-
-// Cutover de dominio (#194): o dominio antigo na Vercel passa a apontar para o
-// frontend no Fly; aqui redirecionamos 308 (preserva metodo + corpo) para o
-// dominio canonico, preservando path + query. Inerte ate o DNS de LEGACY_HOST
-// apontar para o Fly, entao e seguro deployar cedo.
-const LEGACY_HOST = "ac.brunodcdo.com.br";
-const CANONICAL_HOST = "dataframeit.com.br";
 
 const isPublicRoute = createRouteMatcher([
   "/auth/(.*)",
@@ -15,12 +7,6 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export default clerkMiddleware(async (auth, request) => {
-  if (request.headers.get("host") === LEGACY_HOST) {
-    return NextResponse.redirect(
-      `https://${CANONICAL_HOST}${request.nextUrl.pathname}${request.nextUrl.search}`,
-      308,
-    );
-  }
   if (!isPublicRoute(request)) {
     await auth.protect();
   }


### PR DESCRIPTION
## Problema

O redirect 308 de `ac.brunodcdo.com.br` → `dataframeit.com.br` introduzido no #304 (Parte A do cutover) **derrubou o acesso de todos os usuários**. A premissa de que ele ficaria "inerte até o DNS apontar para o Fly" estava errada: o middleware Next dispara pelo header `Host` da requisição, não por onde o app roda. Como `ac.brunodcdo.com.br` segue apontando para a Vercel, a Vercel redeployou o middleware no merge e passou a responder 308 para `dataframeit.com.br` — domínio cujo DNS ainda não existe.

Estado ao vivo verificado (2026-06-30):
- `ac.brunodcdo.com.br` → **308 → https://dataframeit.com.br/** (`server: Vercel`)
- `dataframeit.com.br` → **não resolve** (DNS ainda não criado)

## Correção

Remove o bloco de redirect (e o import `NextResponse` que só ele usava), revertendo `proxy.ts` ao estado pré-#304. Restaura o acesso **sem** desfazer o resto do cutover, que segue inerte para a produção servida pela Vercel.

Ao retomar a transição, o redirect deve ser re-adicionado como **último** passo, apenas depois que `dataframeit.com.br` tiver DNS e o Fly servindo o domínio.

## Verificação
- `proxy.ts` sem erros de tipo (os erros de `tsc` no repo são pré-existentes em `ComparePage.test.tsx`, alheios a este diff — gate real é o `next build` da Vercel).
- Pós-merge: `curl -I https://ac.brunodcdo.com.br/` deve retornar 307 → `/auth/login`, não 308.

Refs #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)