### PR TITLE
feat(cutover): reintroduz redirect 308 do domínio legado → dataframeit.com.br

### DIFF
--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,4 +1,13 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+// Cutover de dominio (#194): redirect 308 (preserva metodo + corpo) do dominio
+// legado para o canonico, preservando path + query. O middleware dispara pelo
+// header Host da requisicao, independente de onde o app roda (licao do #341) —
+// so pode estar em producao com o DNS de CANONICAL_HOST no ar e LEGACY_HOST ja
+// servido por este app.
+const LEGACY_HOST = "ac.brunodcdo.com.br";
+const CANONICAL_HOST = "dataframeit.com.br";
 
 const isPublicRoute = createRouteMatcher([
   "/auth/(.*)",
@@ -7,6 +16,12 @@ const isPublicRoute = createRouteMatcher([
 ]);
 
 export default clerkMiddleware(async (auth, request) => {
+  if (request.headers.get("host") === LEGACY_HOST) {
+    return NextResponse.redirect(
+      `https://${CANONICAL_HOST}${request.nextUrl.pathname}${request.nextUrl.search}`,
+      308,
+    );
+  }
   if (!isPublicRoute(request)) {
     await auth.protect();
   }


### PR DESCRIPTION
## Contexto

Reverte o revert do #341, agora na ordem segura do cutover (#194/#309). O #341 removeu o redirect porque ele foi deployado com o DNS de `dataframeit.com.br` ainda inexistente — o middleware dispara pelo header `Host`, não por onde o app roda, e a Vercel (produção à época) passou a responder 308 para um domínio morto.

Agora as premissas valem:

- `dataframeit.com.br` está no ar servido pelo Fly (cert emitido, `/api/health` 200, CORS ok);
- `ac.brunodcdo.com.br` teve o DNS flipado para o Fly (cert pré-emitido via `_acme-challenge`).

## O que muda

- `frontend/src/proxy.ts`: redirect 308 (preserva método + corpo) de `ac.brunodcdo.com.br` → `https://dataframeit.com.br`, preservando path + query — mesmo código do #304, com o comentário corrigido registrando a lição do #341.

## ⚠️ Não mergear até

- [ ] Registro `ac` publicado no autoritativo do Registro.br e servido pelo Fly (`curl https://ac.brunodcdo.com.br/api/health` → 200 via Fly)
- [ ] Janela de TTL (3600s) do registro antigo esgotada — quem ainda cai na Vercel também recebe este middleware pelo auto-deploy da main, então o 308 precisa apontar para um destino já validado (ok) e o ideal é mergear com o `ac` já estável

Validação pós-merge: `curl -I https://ac.brunodcdo.com.br/dashboard` → 308 com `location: https://dataframeit.com.br/dashboard`.

Refs #194, #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)