### PR TITLE
chore(hooks): adiciona vitest run como gate de pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 #
 # Divisao de estagios (ver docs/CODE_QUALITY_TOOLING.md):
 #   pre-commit (todo commit, leve / file-scoped): gitleaks, ruff, react-doctor
-#   pre-push   (todo push,  pesado / grafo):       typecheck, lint:types, fallow, semgrep
+#   pre-push   (todo push,  pesado / grafo):       typecheck, vitest, lint:types, fallow, semgrep
 #
 # O CI roda o mesmo gitleaks em todo PR e push para `main` via
 # .github/workflows/secret-scan.yml — este hook e a primeira barreira local.
@@ -65,6 +65,21 @@ repos:
       - id: typecheck
         name: typecheck (tsc --noEmit, pre-push)
         entry: bash -c 'cd frontend && test -x ./node_modules/.bin/tsc && exec ./node_modules/.bin/tsc --noEmit || { echo "tsc ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }'
+        language: system
+        files: ^frontend/.*\.(ts|tsx)$
+        pass_filenames: false
+        require_serial: true
+        stages: [pre-push]
+
+      # vitest run: suite unitaria/integracao completa. Hoje passa limpo, entao
+      # roda full sem grandfathering — qualquer teste que quebre barra o push.
+      # E o gate de regressao de teste que nem o build da Vercel nem o `next
+      # build` do deploy Fly pegavam. Falha fechado se o binario estiver ausente.
+      # Escopo por .ts/.tsx alterado (nao por arquivo de teste): mudar codigo de
+      # producao roda a suite inteira, que e o comportamento desejado.
+      - id: vitest
+        name: vitest run (full suite, pre-push)
+        entry: bash -c 'cd frontend && test -x ./node_modules/.bin/vitest && exec ./node_modules/.bin/vitest run || { echo "vitest ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }'
         language: system
         files: ^frontend/.*\.(ts|tsx)$
         pass_filenames: false


### PR DESCRIPTION
## Contexto

Com a Vercel sendo aposentada (produção migrou para o Fly), os hooks de **pre-push** passam a ser o único gate pré-merge do frontend. Até aqui eles cobriam `typecheck` + `lint:types` + `fallow` + `semgrep`, mas **não rodavam a suíte de testes** — regressão de teste passava sem barreira (nem o build da Vercel nem o `next build` do deploy Fly a pegavam; e o Fly só roda pós-merge, em `push: [main]`).

## Mudança

Adiciona `vitest run` como hook de pre-push em `.pre-commit-config.yaml`, espelhando o padrão do hook `typecheck`:

- suíte **completa, sem grandfathering** — qualquer teste que quebre barra o push;
- binário pinado em `frontend/node_modules/.bin/vitest` (não `npx`), falha fechado se ausente pedindo `npm install`;
- escopo por `.ts/.tsx` alterado — mudar código de produção dispara a suíte inteira.

## Verificação

- `vitest run` na worktree com `npm ci` limpo: **849 testes / 85 arquivos, todos passando** (~8,6s).
- YAML validado; hook `vitest` presente na ordem `typecheck → vitest → lint-types → fallow → semgrep`.

## Ressalva registrada (não resolvida aqui)

Hooks locais **não cobrem PRs do Dependabot**, que empurra o branch server-side sem passar por hook. Bumps de dependência seguem exigindo validação manual na revisão. Trade-off consciente ao optar por gate pré-PR em vez de GitHub Actions.