### PR TITLE
feat(scripts): promove comentarios-relatorio ao repo com fixes da #349

### DIFF
--- a/frontend/scripts/comentarios-relatorio/apply-decisions.ts
+++ b/frontend/scripts/comentarios-relatorio/apply-decisions.ts
@@ -20,26 +20,22 @@
  *
  * Formato esperado do JSON: ver references/decisions-format.md (neste diretório).
  *
- * As primitivas de versionamento/auditoria (classifyChange, bumpVersion,
- * diffFields, computeFieldHash) e generatePydanticCode são importadas de
- * `src/lib/schema-utils` (puras, client-safe — extração da issue #63), as
- * mesmas usadas por saveSchemaFromGUI. Só a persistência (UPDATE/INSERT)
- * replica `src/actions/schema.ts`, porque server actions não são chamáveis
- * fora do Next runtime.
+ * O cálculo (classificação, versão, log de auditoria, código Pydantic e
+ * hash) usa `planSchemaPersistence` de `src/lib/schema-utils` (pura,
+ * client-safe — extração da issue #63/PR #352), a mesma função usada por
+ * saveSchemaFromGUI. A escrita em si usa `updateOrThrow` de
+ * `src/lib/supabase/rls-guard` (mesma guarda contra "histórico fantasma" —
+ * #178 — que saveSchema usa) porque é código puro sem `"use server"`, então
+ * é chamável fora do Next runtime; só a revalidação de cache
+ * (`revalidatePath`/`revalidateTag`) fica de fora, por depender do runtime.
  */
 
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
-import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import {
-  bumpVersion,
-  classifyChange,
-  computeFieldHash,
-  diffFields,
-  generatePydanticCode,
-} from "../../src/lib/schema-utils";
+import { planSchemaPersistence } from "../../src/lib/schema-utils";
+import { updateOrThrow } from "../../src/lib/supabase/rls-guard";
 import type { PydanticField } from "../../src/lib/types";
 import { loadEnv } from "./load-env";
 
@@ -141,16 +137,8 @@ async function applySchemaChanges(
     patch: project?.schema_version_patch ?? 0,
   };
 
-  const changeType = classifyChange(oldFields, newFields);
-  const bumped = changeType ? bumpVersion(current, changeType) : current;
-  const logEntries = diffFields(oldFields, newFields);
-
-  const code = generatePydanticCode(newFields);
-  const hash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
-  const fieldsWithHash = newFields.map((f) => ({
-    ...f,
-    hash: computeFieldHash(f.name, f.type, f.options, f.description),
-  }));
+  const { changeType, bumped, logEntries, code, hash, fieldsWithHash } =
+    planSchemaPersistence(oldFields, newFields, current);
 
   const summary = {
     changeType,
@@ -181,11 +169,15 @@ async function applySchemaChanges(
     updatePayload.schema_version_minor = bumped.minor;
     updatePayload.schema_version_patch = bumped.patch;
   }
-  const { error: updErr } = await supabase
-    .from("projects")
-    .update(updatePayload)
-    .eq("id", projectId);
-  if (updErr) throw new Error(`projects update: ${updErr.message}`);
+  // updateOrThrow (não .update().eq()) checa linhas afetadas: um projectId
+  // inexistente/desatualizado faria o UPDATE "suceder" com 0 linhas
+  // (comportamento normal do PostgREST) e o INSERT em schema_change_log
+  // abaixo gravaria histórico de uma mudança nunca persistida — o mesmo bug
+  // de "histórico fantasma" que updateOrThrow já existe para prevenir em
+  // saveSchema (issue #178).
+  await updateOrThrow(supabase, "projects", updatePayload, { id: projectId }, {
+    message: `Nenhuma linha atualizada em projects para id=${projectId} (registro inexistente): abortando antes de gravar schema_change_log.`,
+  });
 
   // Sem invalidação de responses na troca de schema: is_latest significa
   // "última resposta ativa por respondente", não "compatível com o schema
@@ -366,6 +358,43 @@ async function resolveComments(
     });
   }
 
+  // Checagem prévia de quais pares (project_id, response_id) já existem em
+  // note_resolutions/difficulty_resolutions: o upsert abaixo usa
+  // ignoreDuplicates (idempotente — pares já resolvidos ficam como estão,
+  // ver references/decisions-format.md), então sem esta checagem o relato
+  // final diria "success" mesmo quando uma nota nova em decisions.json foi
+  // silenciosamente descartada por já existir a linha.
+  const [existingNotaRes, existingDifRes] = await Promise.all([
+    notaRows.length > 0
+      ? supabase
+          .from("note_resolutions")
+          .select("response_id")
+          .eq("project_id", projectId)
+          .in("response_id", notaRows.map((r) => r.response_id as string))
+      : Promise.resolve({ data: [], error: null }),
+    difRows.length > 0
+      ? supabase
+          .from("difficulty_resolutions")
+          .select("response_id")
+          .eq("project_id", projectId)
+          .in("response_id", difRows.map((r) => r.response_id as string))
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  if (existingNotaRes.error) {
+    throw new Error(`note_resolutions select (guard): ${existingNotaRes.error.message}`);
+  }
+  if (existingDifRes.error) {
+    throw new Error(
+      `difficulty_resolutions select (guard): ${existingDifRes.error.message}`,
+    );
+  }
+  const existingNotaIds = new Set(
+    (existingNotaRes.data ?? []).map((d) => d.response_id as string),
+  );
+  const existingDifIds = new Set(
+    (existingDifRes.data ?? []).map((d) => d.response_id as string),
+  );
+
   // --- sugestao: approved em lote; rejected agrupado por motivo ---
   const sugestoes = resolutions.filter((r) => r.source === "sugestao") as Array<
     Extract<Resolution, { source: "sugestao" }>
@@ -434,44 +463,89 @@ async function resolveComments(
     for (const r of notas) {
       if (resultFor.get(r)?.success) resultFor.set(r, { success: false, error: msg });
     }
+  } else {
+    // upsert com ignoreDuplicates é idempotente: um par já resolvido não é
+    // sobrescrito. Sinalizar isso explicitamente em vez de "success" cego,
+    // para não sugerir que uma nota nova em decisions.json foi persistida.
+    for (const r of notas) {
+      if (resultFor.get(r)?.success && existingNotaIds.has(r.rawId)) {
+        resultFor.set(r, {
+          success: true,
+          detail:
+            "já resolvido anteriormente — nota não foi alterada (upsert idempotente ignora conflitos)",
+        });
+      }
+    }
   }
   if ((difInsert as { error: { message: string } | null }).error) {
     const msg = (difInsert as { error: { message: string } }).error.message;
     for (const r of dificuldades) {
       if (resultFor.get(r)?.success) resultFor.set(r, { success: false, error: msg });
     }
+  } else {
+    for (const r of dificuldades) {
+      if (resultFor.get(r)?.success && existingDifIds.has(r.rawId)) {
+        resultFor.set(r, {
+          success: true,
+          detail:
+            "já resolvido anteriormente — nota não foi alterada (upsert idempotente ignora conflitos)",
+        });
+      }
+    }
   }
 
-  // --- duvida: guard batched acima; UPDATE por par (review_id, respondent_id) ---
+  // --- duvida: guard batched acima; 1 único UPDATE em lote via .or(), não
+  // 1 UPDATE por par. verdict_acknowledgments tem chave composta
+  // (review_id, respondent_id) sem coluna `id` única, então batchResolveUpdate
+  // (.in("id", ids)) não se aplica direto — mas o filtro .or() do PostgREST
+  // combina os pares já validados pelo guard numa única query. review_id/
+  // respondent_id são UUIDs (sem vírgula/parênteses), então não precisam de
+  // escaping na string do filtro.
   const duvidas = resolutions.filter((r) => r.source === "duvida") as Array<
     Extract<Resolution, { source: "duvida" }>
   >;
-  await Promise.all(
-    duvidas.map(async (r) => {
-      const owner = reviewProject.get(r.reviewId);
-      if (!owner) {
-        resultFor.set(r, { success: false, error: "review não encontrado" });
-        return;
-      }
-      if (owner !== projectId) {
-        resultFor.set(r, { success: false, error: "review pertence a outro projeto" });
-        return;
-      }
-      const { data, error } = await supabase
-        .from("verdict_acknowledgments")
-        .update(resolvedPayload)
-        .eq("review_id", r.reviewId)
-        .eq("respondent_id", r.respondentId)
-        .select("review_id");
-      if (error) {
+  const eligibleDuvidas: Array<Extract<Resolution, { source: "duvida" }>> = [];
+  for (const r of duvidas) {
+    const owner = reviewProject.get(r.reviewId);
+    if (!owner) {
+      resultFor.set(r, { success: false, error: "review não encontrado" });
+      continue;
+    }
+    if (owner !== projectId) {
+      resultFor.set(r, { success: false, error: "review pertence a outro projeto" });
+      continue;
+    }
+    eligibleDuvidas.push(r);
+  }
+  if (eligibleDuvidas.length > 0) {
+    const orFilter = eligibleDuvidas
+      .map((r) => `and(review_id.eq.${r.reviewId},respondent_id.eq.${r.respondentId})`)
+      .join(",");
+    const { data, error } = await supabase
+      .from("verdict_acknowledgments")
+      .update(resolvedPayload)
+      .or(orFilter)
+      .select("review_id, respondent_id");
+    if (error) {
+      for (const r of eligibleDuvidas) {
         resultFor.set(r, { success: false, error: error.message });
-      } else if (!data || data.length === 0) {
-        resultFor.set(r, { success: false, error: "not found" });
-      } else {
-        resultFor.set(r, { success: true });
       }
-    }),
-  );
+    } else {
+      const matched = new Set(
+        (data ?? []).map(
+          (d) => `${d.review_id as string}|${d.respondent_id as string}`,
+        ),
+      );
+      for (const r of eligibleDuvidas) {
+        resultFor.set(
+          r,
+          matched.has(`${r.reviewId}|${r.respondentId}`)
+            ? { success: true }
+            : { success: false, error: "not found" },
+        );
+      }
+    }
+  }
 
   // --- montar resultados na ordem original ---
   return resolutions.map((r) => {
@@ -604,6 +678,18 @@ async function main() {
     } else {
       console.log("\n[info] summaryNote registrada em project_comments.");
     }
+  }
+
+  // Este script roda fora do runtime Next, então não pode chamar
+  // revalidatePath/revalidateTag como saveSchemaFromGUI faz — o cache da GUI
+  // (revalidateTag com expire:60) pode continuar servindo o schema/versão
+  // antigos por até ~60s após um --yes que aplicou mudança de schema.
+  if (write && (schemaResult as { applied?: boolean }).applied) {
+    console.log(
+      "\n[aviso] Schema atualizado no banco. A GUI pode levar até ~60s para " +
+        "refletir a mudança (cache do Next) — se precisar ver o resultado " +
+        "imediatamente, recarregue a página específica com Ctrl+Shift+R.",
+    );
   }
 }
 

--- a/frontend/scripts/comentarios-relatorio/apply-decisions.ts
+++ b/frontend/scripts/comentarios-relatorio/apply-decisions.ts
@@ -99,6 +99,18 @@ interface ResolutionResult {
   detail?: string;
 }
 
+// review_id/respondent_id de "duvida" entram num filtro .or() construído por
+// template string (verdict_acknowledgments tem chave composta, sem coluna
+// `id` única — batchResolveUpdate/.in() não se aplicam). .in() escapa valores
+// com vírgula/parênteses automaticamente; .or() com string crua não escapa
+// nada. reviewId chega implicitamente validado por já ter passado pelo guard
+// de posse (buildOwnershipMaps via .in(), só combina com uma review real),
+// mas respondentId nunca é comparado contra o banco — sem este check, um
+// respondentId malformado (decisions.json malformado ou mal extraído por LLM)
+// quebraria a sintaxe do filtro ou ampliaria o UPDATE para pares fora do
+// validado pelo guard.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // ----------------------- Schema apply -----------------------
 
 async function applySchemaChanges(
@@ -254,36 +266,49 @@ async function buildOwnershipMaps(supabase: SupabaseClient, resolutions: Resolut
 }
 
 // UPDATE em lote restrito ao projeto; devolve, por id pedido, sucesso ou
-// "not found" (id inexistente ou de outro projeto).
+// "not found" (id inexistente ou de outro projeto). Em preview (`write=false`),
+// faz o SELECT equivalente em vez do UPDATE — reporta o mesmo resultado
+// (existe e pertence ao projeto vs. não encontrado) sem gravar nada, para que
+// o preview não afirme sucesso para ids que na verdade falhariam em --yes.
 async function batchResolveUpdate(
   supabase: SupabaseClient,
   table: string,
   projectId: string,
   ids: string[],
   payload: Record<string, unknown>,
+  write: boolean,
 ): Promise<Map<string, ResolutionResult>> {
   const results = new Map<string, ResolutionResult>();
   if (ids.length === 0) return results;
-  const { data, error } = await supabase
-    .from(table)
-    .update(payload)
-    .in("id", ids)
-    .eq("project_id", projectId)
-    .select("id");
+  const { data, error } = write
+    ? await supabase.from(table).update(payload).in("id", ids).eq("project_id", projectId).select("id")
+    : await supabase.from(table).select("id").in("id", ids).eq("project_id", projectId);
   if (error) {
     for (const id of ids) results.set(id, { success: false, error: error.message });
     return results;
   }
-  const updated = new Set((data ?? []).map((d) => d.id as string));
+  const matched = new Set((data ?? []).map((d) => d.id as string));
   for (const id of ids) {
     results.set(
       id,
-      updated.has(id) ? { success: true } : { success: false, error: "not found" },
+      matched.has(id)
+        ? {
+            success: true,
+            ...(write ? {} : { detail: "PREVIEW: encontrado no projeto — seria resolvido" }),
+          }
+        : { success: false, error: "not found" },
     );
   }
   return results;
 }
 
+// Roda os mesmos guards de posse e checagens de existência em preview
+// (write=false) e em --yes: só as chamadas que gravam (UPDATE/INSERT/UPSERT)
+// são puladas em preview, substituídas por SELECTs equivalentes. Antes, o
+// preview retornava `success: true` cego para toda resolução — inclusive
+// `exclusao` (que SEMPRE falha em --yes, ver mapeamento final) e rawIds de
+// outro projeto (que o guard de posse sempre rejeitaria) — fazendo o preview
+// prometer sucesso que o `--yes` seguinte não entregava.
 async function resolveComments(
   supabase: SupabaseClient,
   projectId: string,
@@ -291,16 +316,6 @@ async function resolveComments(
   resolutions: Resolution[],
   write: boolean,
 ): Promise<Array<{ item: Resolution; result: ResolutionResult }>> {
-  if (!write) {
-    return resolutions.map((r) => ({
-      item: r,
-      result: {
-        success: true,
-        detail: `PREVIEW: would resolve ${r.source} ${JSON.stringify(r)}`,
-      },
-    }));
-  }
-
   const nowIso = new Date().toISOString();
   const { responseProject, reviewProject } = await buildOwnershipMaps(
     supabase,
@@ -423,13 +438,14 @@ async function resolveComments(
         projectId,
         anotacaoIds,
         resolvedPayload,
+        write,
       ),
-      batchResolveUpdate(supabase, "reviews", projectId, reviewIds, resolvedPayload),
+      batchResolveUpdate(supabase, "reviews", projectId, reviewIds, resolvedPayload, write),
       batchResolveUpdate(supabase, "schema_suggestions", projectId, approvedIds, {
         status: "approved",
         ...resolvedPayload,
-      }),
-      notaRows.length > 0
+      }, write),
+      notaRows.length > 0 && write
         ? supabase
             .from("note_resolutions")
             .upsert(notaRows, {
@@ -437,7 +453,7 @@ async function resolveComments(
               ignoreDuplicates: true,
             })
         : Promise.resolve({ error: null }),
-      difRows.length > 0
+      difRows.length > 0 && write
         ? supabase
             .from("difficulty_resolutions")
             .upsert(difRows, {
@@ -450,7 +466,7 @@ async function resolveComments(
           status: "rejected",
           ...resolvedPayload,
           ...(reason ? { rejection_reason: reason } : {}),
-        }),
+        }, write),
       ),
     ]);
 
@@ -494,13 +510,17 @@ async function resolveComments(
     }
   }
 
-  // --- duvida: guard batched acima; 1 único UPDATE em lote via .or(), não
-  // 1 UPDATE por par. verdict_acknowledgments tem chave composta
+  // --- duvida: guard batched acima; 1 único UPDATE (ou SELECT em preview) em
+  // lote via .or(), não 1 por par. verdict_acknowledgments tem chave composta
   // (review_id, respondent_id) sem coluna `id` única, então batchResolveUpdate
-  // (.in("id", ids)) não se aplica direto — mas o filtro .or() do PostgREST
-  // combina os pares já validados pelo guard numa única query. review_id/
-  // respondent_id são UUIDs (sem vírgula/parênteses), então não precisam de
-  // escaping na string do filtro.
+  // (.in("id", ids)) não se aplica direto — o filtro .or() combina os pares
+  // já validados numa única query. reviewId chega implicitamente validado por
+  // só passar no guard quando bate com uma review real (buildOwnershipMaps
+  // via .in(), que escapa vírgula/parênteses); respondentId nunca é
+  // comparado contra o banco, então precisa do check de formato explícito
+  // (UUID_RE) antes de entrar cru no filtro .or() — sem isso, um
+  // respondentId malformado quebraria a sintaxe do filtro ou ampliaria o
+  // UPDATE para pares fora do validado.
   const duvidas = resolutions.filter((r) => r.source === "duvida") as Array<
     Extract<Resolution, { source: "duvida" }>
   >;
@@ -515,17 +535,26 @@ async function resolveComments(
       resultFor.set(r, { success: false, error: "review pertence a outro projeto" });
       continue;
     }
+    if (!UUID_RE.test(r.respondentId)) {
+      resultFor.set(r, { success: false, error: "respondentId com formato inválido" });
+      continue;
+    }
     eligibleDuvidas.push(r);
   }
   if (eligibleDuvidas.length > 0) {
     const orFilter = eligibleDuvidas
       .map((r) => `and(review_id.eq.${r.reviewId},respondent_id.eq.${r.respondentId})`)
       .join(",");
-    const { data, error } = await supabase
-      .from("verdict_acknowledgments")
-      .update(resolvedPayload)
-      .or(orFilter)
-      .select("review_id, respondent_id");
+    const { data, error } = write
+      ? await supabase
+          .from("verdict_acknowledgments")
+          .update(resolvedPayload)
+          .or(orFilter)
+          .select("review_id, respondent_id")
+      : await supabase
+          .from("verdict_acknowledgments")
+          .select("review_id, respondent_id")
+          .or(orFilter);
     if (error) {
       for (const r of eligibleDuvidas) {
         resultFor.set(r, { success: false, error: error.message });
@@ -540,7 +569,10 @@ async function resolveComments(
         resultFor.set(
           r,
           matched.has(`${r.reviewId}|${r.respondentId}`)
-            ? { success: true }
+            ? {
+                success: true,
+                ...(write ? {} : { detail: "PREVIEW: encontrado — seria resolvido" }),
+              }
             : { success: false, error: "not found" },
         );
       }

--- a/frontend/scripts/comentarios-relatorio/apply-decisions.ts
+++ b/frontend/scripts/comentarios-relatorio/apply-decisions.ts
@@ -4,7 +4,7 @@
  *
  * Lê um arquivo JSON com a lista estruturada de decisões (produzido pelo Claude
  * a partir do .md anotado pelo usuário) e aplica:
- *   1. Mudanças no schema Pydantic (replicando primitivas de saveSchemaFromGUI):
+ *   1. Mudanças no schema Pydantic (mesmas primitivas de saveSchemaFromGUI):
  *      - update projects.{pydantic_code, pydantic_hash, pydantic_fields, schema_version_*}
  *      - insert schema_change_log entries
  *      (sem invalidar responses: is_latest não é flipado na troca de schema —
@@ -15,20 +15,17 @@
  *   cd frontend
  *   npx tsx scripts/comentarios-relatorio/apply-decisions.ts <decisions.json> [--dry-run] [--yes]
  *
- * Formato esperado do JSON: ver references/decisions-format.md
+ * Sem --yes, TUDO roda como preview (schema incluído) — nenhum write acontece.
+ * --dry-run é o alias explícito do mesmo comportamento.
  *
- * Observação: `generatePydanticCode` é importado diretamente de
- * `src/lib/schema-utils` (pure, client-safe) para manter paridade com a UI
- * e evitar drift. A lógica de classificação de versão e persistência duplica
- * `saveSchemaFromGUI` de `src/actions/schema.ts` porque server actions não
- * são chamáveis fora do Next runtime.
+ * Formato esperado do JSON: ver references/decisions-format.md (neste diretório).
  *
- * Fixes aplicados pós-commit 7247704 (PR #62 → revertido em #64):
- *   - classifyChange/snapshotOf/per-field diff agora consideram `condition`
- *     (introduzido em #58); sem isso, mudanças só em condição viravam no-op.
- *   - UPDATEs com service role key em reviews/schema_suggestions/verdict_acknowledgments
- *     agora restringem por project_id (defesa contra cross-project drift).
- *   A solução estrutural — extrair as primitivas para schema-utils.ts — é a issue #63.
+ * As primitivas de versionamento/auditoria (classifyChange, bumpVersion,
+ * diffFields, computeFieldHash) e generatePydanticCode são importadas de
+ * `src/lib/schema-utils` (puras, client-safe — extração da issue #63), as
+ * mesmas usadas por saveSchemaFromGUI. Só a persistência (UPDATE/INSERT)
+ * replica `src/actions/schema.ts`, porque server actions não são chamáveis
+ * fora do Next runtime.
  */
 
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
@@ -36,44 +33,15 @@ import crypto from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { generatePydanticCode } from "../../src/lib/schema-utils";
-import type { FieldCondition, PydanticField as LibPydanticField } from "../../src/lib/types";
-
-// ----------------------- Env loading -----------------------
-
-function loadEnv() {
-  const cwd = process.cwd();
-  // Honra SUPABASE_ENV_PATH explícito; caso contrário usa os caminhos
-  // canônicos relativos ao cwd (raiz do repo ou frontend/). Nunca subir a
-  // árvore de diretórios (../.env.local) — ver CLAUDE.md.
-  const candidates = [
-    process.env.SUPABASE_ENV_PATH,
-    resolve(cwd, ".env.local"),
-    resolve(cwd, "frontend/.env.local"),
-  ].filter((p): p is string => Boolean(p));
-  for (const path of candidates) {
-    try {
-      const content = readFileSync(path, "utf-8");
-      for (const line of content.split("\n")) {
-        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
-        if (!m) continue;
-        const key = m[1];
-        if (process.env[key]) continue;
-        let val = m[2].trim();
-        if (
-          (val.startsWith('"') && val.endsWith('"')) ||
-          (val.startsWith("'") && val.endsWith("'"))
-        ) {
-          val = val.slice(1, -1);
-        }
-        process.env[key] = val;
-      }
-      return;
-    } catch {
-      /* try next */
-    }
-  }
-}
+import {
+  bumpVersion,
+  classifyChange,
+  computeFieldHash,
+  diffFields,
+  generatePydanticCode,
+} from "../../src/lib/schema-utils";
+import type { PydanticField } from "../../src/lib/types";
+import { loadEnv } from "./load-env";
 
 loadEnv();
 
@@ -89,9 +57,33 @@ if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
 
 // ----------------------- Tipos -----------------------
 
-type PydanticField = LibPydanticField;
+// Formato do JSON de entrada. O Claude gera esse arquivo parseando o .md
+// anotado. Documentação completa: references/decisions-format.md
+type Resolution =
+  | { source: "anotacao"; rawId: string }
+  | { source: "review"; rawId: string }
+  | { source: "nota"; rawId: string; note?: string } // rawId = response_id
+  | {
+      source: "dificuldade";
+      rawId: string; // response_id
+      documentId: string;
+      note?: string;
+    }
+  | {
+      source: "duvida";
+      reviewId: string;
+      respondentId: string;
+    }
+  | {
+      source: "sugestao";
+      rawId: string; // suggestion_id
+      action: "approved" | "rejected";
+      rejectionReason?: string;
+    }
+  // Pedidos de exclusão de documento NÃO são resolvíveis por aqui: a aprovação
+  // exige excludeDocuments (soft delete + auditoria) — fluxo da plataforma.
+  | { source: "exclusao"; rawId: string };
 
-// Formato do JSON de entrada. O Claude gera esse arquivo parseando o .md anotado.
 interface DecisionsFile {
   projectId: string;
   // ID do usuário a registrar como changed_by / resolved_by.
@@ -100,165 +92,15 @@ interface DecisionsFile {
   // Nova lista completa de fields a persistir (já com add/remove/edit aplicados).
   newFields: PydanticField[];
   // Lista de comentários a resolver.
-  resolutions: Array<
-    | { source: "anotacao"; rawId: string }
-    | { source: "review"; rawId: string }
-    | { source: "nota"; rawId: string; note?: string } // rawId = response_id
-    | {
-        source: "dificuldade";
-        rawId: string; // response_id
-        documentId: string;
-        note?: string;
-      }
-    | {
-        source: "duvida";
-        reviewId: string;
-        respondentId: string;
-      }
-    | {
-        source: "sugestao";
-        rawId: string; // suggestion_id
-        action: "approved" | "rejected";
-        rejectionReason?: string;
-      }
-  >;
+  resolutions: Resolution[];
   // Opcional: nota resumo a registrar num project_comment "meta" após aplicação.
   summaryNote?: string;
 }
 
-// ----------------------- Funções puras -----------------------
-// `generatePydanticCode` vem de `src/lib/schema-utils` (mesma função usada pela UI).
-// Apenas utilitários específicos do script ficam aqui.
-
-function pythonListRepr(arr: string[]): string {
-  return "[" + arr.map((s) => `'${s}'`).join(", ") + "]";
-}
-
-// Stringify com chaves ordenadas: o jsonb do Postgres normaliza a ordem das
-// chaves (por tamanho, depois bytewise), então `condition`/`subfields` lidos
-// do banco nunca batem com o objeto autorado no JSON de decisões se a
-// comparação for JSON.stringify cru — todo run viraria um falso "minor"
-// com before == after no change log (visto na troca 1.1.0 do Judiciário).
-function stableStringify(value: unknown): string {
-  if (Array.isArray(value)) {
-    return "[" + value.map(stableStringify).join(",") + "]";
-  }
-  if (value !== null && typeof value === "object") {
-    const entries = Object.entries(value as Record<string, unknown>)
-      .filter(([, v]) => v !== undefined)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
-    return "{" + entries.map(([k, v]) => JSON.stringify(k) + ":" + stableStringify(v)).join(",") + "}";
-  }
-  return JSON.stringify(value);
-}
-
-function computeFieldHash(
-  name: string,
-  type: string,
-  options: string[] | null,
-  description: string,
-): string {
-  const optionsPart = options ? pythonListRepr([...options].sort()) : "";
-  const content = `${name}|${type}|${optionsPart}|${description}`;
-  return crypto.createHash("sha256").update(content).digest("hex").slice(0, 12);
-}
-
-type ChangeType = "major" | "minor" | "patch";
-
-function classifyChange(
-  oldFields: PydanticField[],
-  newFields: PydanticField[],
-): ChangeType | null {
-  const oldNames = new Set(oldFields.map((f) => f.name));
-  const newNames = new Set(newFields.map((f) => f.name));
-
-  const addedOrRemoved =
-    newFields.some((f) => !oldNames.has(f.name)) ||
-    oldFields.some((f) => !newNames.has(f.name));
-
-  if (addedOrRemoved) return "minor";
-
-  let hasStructural = false;
-  let hasTextual = false;
-  const oldMap = new Map(oldFields.map((f) => [f.name, f]));
-
-  for (const n of newFields) {
-    const o = oldMap.get(n.name);
-    if (!o) continue;
-
-    if (o.type !== n.type) hasStructural = true;
-    if ((o.target ?? "all") !== (n.target ?? "all")) hasStructural = true;
-    if ((o.required ?? true) !== (n.required ?? true)) hasStructural = true;
-    if ((o.subfield_rule ?? null) !== (n.subfield_rule ?? null)) hasStructural = true;
-    if ((o.allow_other ?? false) !== (n.allow_other ?? false)) hasStructural = true;
-    if (stableStringify(o.subfields ?? null) !== stableStringify(n.subfields ?? null)) {
-      hasStructural = true;
-    }
-    if (stableStringify(o.condition ?? null) !== stableStringify(n.condition ?? null)) {
-      hasStructural = true;
-    }
-
-    const optsOld = o.options ?? [];
-    const optsNew = n.options ?? [];
-    const setOld = new Set(optsOld);
-    const setNew = new Set(optsNew);
-    const sameSet =
-      setOld.size === setNew.size && [...setOld].every((x) => setNew.has(x));
-    if (!sameSet) {
-      hasStructural = true;
-    } else if (optsOld.length !== optsNew.length) {
-      hasStructural = true;
-    } else {
-      for (let i = 0; i < optsOld.length; i++) {
-        if (optsOld[i] !== optsNew[i]) {
-          hasTextual = true;
-          break;
-        }
-      }
-    }
-
-    if (o.description !== n.description) hasTextual = true;
-    if ((o.help_text || "") !== (n.help_text || "")) hasTextual = true;
-  }
-
-  if (!hasStructural && !hasTextual) {
-    for (let i = 0; i < newFields.length; i++) {
-      if (newFields[i].name !== oldFields[i]?.name) {
-        hasTextual = true;
-        break;
-      }
-    }
-  }
-
-  if (hasStructural) return "minor";
-  if (hasTextual) return "patch";
-  return null;
-}
-
-function bumpVersion(
-  current: { major: number; minor: number; patch: number },
-  type: ChangeType,
-): { major: number; minor: number; patch: number } {
-  if (type === "major") return { major: current.major + 1, minor: 0, patch: 0 };
-  if (type === "minor")
-    return { major: current.major, minor: current.minor + 1, patch: 0 };
-  return { major: current.major, minor: current.minor, patch: current.patch + 1 };
-}
-
-function snapshotOf(field: PydanticField): Record<string, unknown> {
-  return {
-    name: field.name,
-    type: field.type,
-    description: field.description,
-    help_text: field.help_text ?? null,
-    options: field.options ?? null,
-    target: field.target ?? null,
-    required: field.required ?? null,
-    subfields: field.subfields ?? null,
-    subfield_rule: field.subfield_rule ?? null,
-    allow_other: field.allow_other ?? null,
-    condition: field.condition ?? null,
-  };
+interface ResolutionResult {
+  success: boolean;
+  error?: string;
+  detail?: string;
 }
 
 // ----------------------- Schema apply -----------------------
@@ -268,20 +110,30 @@ async function applySchemaChanges(
   projectId: string,
   newFields: PydanticField[],
   changedBy: string,
-  dryRun: boolean,
+  write: boolean,
 ) {
   const { data: project, error: projErr } = await supabase
     .from("projects")
     .select(
-      "pydantic_fields, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch",
+      "pydantic_fields, pydantic_code, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch",
     )
     .eq("id", projectId)
     .single();
   if (projErr) throw new Error(`projects select: ${projErr.message}`);
 
   const oldFields = (project?.pydantic_fields as PydanticField[]) ?? [];
-  const oldMap = new Map(oldFields.map((f) => [f.name, f]));
-  const newMap = new Map(newFields.map((f) => [f.name, f]));
+
+  // Guarda anti-wipe — espelha saveSchemaFromGUI (src/actions/schema.ts):
+  // nunca gravar 0 campos por cima de um schema existente. Um decisions.json
+  // malformado (newFields vazio/parcial) apagaria o schema inteiro com a
+  // service role key.
+  const hasExistingSchema = oldFields.length > 0 || !!project?.pydantic_code;
+  if (newFields.length === 0 && hasExistingSchema) {
+    throw new Error(
+      "guarda anti-wipe: newFields está vazio mas o projeto já tem schema. " +
+        "Se a intenção é remover todos os campos, faça pela UI.",
+    );
+  }
 
   const current = {
     major: project?.schema_version_major ?? 0,
@@ -291,105 +143,7 @@ async function applySchemaChanges(
 
   const changeType = classifyChange(oldFields, newFields);
   const bumped = changeType ? bumpVersion(current, changeType) : current;
-
-  // Audit entries
-  const logEntries: Array<{
-    field_name: string;
-    change_summary: string;
-    before_value: Record<string, unknown>;
-    after_value: Record<string, unknown>;
-  }> = [];
-
-  for (const f of newFields) {
-    if (oldMap.has(f.name)) continue;
-    logEntries.push({
-      field_name: f.name,
-      change_summary: "campo adicionado",
-      before_value: {},
-      after_value: snapshotOf(f),
-    });
-  }
-  for (const o of oldFields) {
-    if (newMap.has(o.name)) continue;
-    logEntries.push({
-      field_name: o.name,
-      change_summary: "campo removido",
-      before_value: snapshotOf(o),
-      after_value: {},
-    });
-  }
-  for (const f of newFields) {
-    const old = oldMap.get(f.name);
-    if (!old) continue;
-    const diffs: string[] = [];
-    const before: Record<string, unknown> = {};
-    const after: Record<string, unknown> = {};
-
-    if (old.description !== f.description) {
-      diffs.push("descrição");
-      before.description = old.description;
-      after.description = f.description;
-    }
-    if ((old.help_text || "") !== (f.help_text || "")) {
-      diffs.push("instruções");
-      before.help_text = old.help_text || null;
-      after.help_text = f.help_text || null;
-    }
-    const oldOpts = JSON.stringify(old.options ?? null);
-    const newOpts = JSON.stringify(f.options ?? null);
-    if (oldOpts !== newOpts) {
-      diffs.push(f.type === "text" ? "respostas padronizadas" : "opções");
-      before.options = old.options;
-      after.options = f.options;
-    }
-    if (old.type !== f.type) {
-      diffs.push("tipo");
-      before.type = old.type;
-      after.type = f.type;
-    }
-    if ((old.target ?? "all") !== (f.target ?? "all")) {
-      diffs.push("alvo");
-      before.target = old.target ?? null;
-      after.target = f.target ?? null;
-    }
-    if ((old.required ?? true) !== (f.required ?? true)) {
-      diffs.push("obrigatório");
-      before.required = old.required ?? null;
-      after.required = f.required ?? null;
-    }
-    if ((old.subfield_rule ?? null) !== (f.subfield_rule ?? null)) {
-      diffs.push("regra de subcampos");
-      before.subfield_rule = old.subfield_rule ?? null;
-      after.subfield_rule = f.subfield_rule ?? null;
-    }
-    if ((old.allow_other ?? false) !== (f.allow_other ?? false)) {
-      diffs.push("permite outro");
-      before.allow_other = old.allow_other ?? false;
-      after.allow_other = f.allow_other ?? false;
-    }
-    const oldSubs = stableStringify(old.subfields ?? null);
-    const newSubs = stableStringify(f.subfields ?? null);
-    if (oldSubs !== newSubs) {
-      diffs.push("subcampos");
-      before.subfields = old.subfields ?? null;
-      after.subfields = f.subfields ?? null;
-    }
-    const oldCond = stableStringify(old.condition ?? null);
-    const newCond = stableStringify(f.condition ?? null);
-    if (oldCond !== newCond) {
-      diffs.push("condição");
-      before.condition = old.condition ?? null;
-      after.condition = f.condition ?? null;
-    }
-    if (diffs.length > 0) {
-      logEntries.push({
-        field_name: f.name,
-        change_summary: diffs.join(", "),
-        before_value: before,
-        after_value: after,
-      });
-    }
-  }
+  const logEntries = diffFields(oldFields, newFields);
 
   const code = generatePydanticCode(newFields);
   const hash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
@@ -408,12 +162,12 @@ async function applySchemaChanges(
     pydanticCodePreview: code.split("\n").slice(0, 10).join("\n") + "\n...",
   };
 
-  if (dryRun) {
-    return { dryRun: true, summary };
+  if (!write) {
+    return { preview: true, summary };
   }
 
   if (!changeType && logEntries.length === 0) {
-    return { dryRun: false, summary, applied: false, reason: "sem mudanças" };
+    return { preview: false, summary, applied: false, reason: "sem mudanças" };
   }
 
   // Update projects
@@ -456,111 +210,306 @@ async function applySchemaChanges(
     if (logErr) throw new Error(`schema_change_log insert: ${logErr.message}`);
   }
 
-  return { dryRun: false, summary, applied: true };
+  return { preview: false, summary, applied: true };
 }
 
 // ----------------------- Comment resolution -----------------------
 
-async function resolveComment(
+// Valida em lote a que projeto pertencem as responses (nota/dificuldade) e os
+// reviews (duvida) referenciados: note_resolutions/difficulty_resolutions não
+// têm constraint amarrando o project_id da linha ao da response, e
+// verdict_acknowledgments só tem review_id — sem o guard, um rawId de outro
+// projeto viraria linha órfã "resolvida" com sucesso aparente.
+async function buildOwnershipMaps(supabase: SupabaseClient, resolutions: Resolution[]) {
+  const responseIds = [
+    ...new Set(
+      resolutions
+        .filter((r) => r.source === "nota" || r.source === "dificuldade")
+        .map((r) => (r as { rawId: string }).rawId),
+    ),
+  ];
+  const reviewIds = [
+    ...new Set(
+      resolutions
+        .filter((r) => r.source === "duvida")
+        .map((r) => (r as { reviewId: string }).reviewId),
+    ),
+  ];
+
+  const [responsesRes, reviewsRes] = await Promise.all([
+    responseIds.length > 0
+      ? supabase.from("responses").select("id, project_id").in("id", responseIds)
+      : Promise.resolve({ data: [], error: null }),
+    reviewIds.length > 0
+      ? supabase.from("reviews").select("id, project_id").in("id", reviewIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+  if (responsesRes.error) {
+    throw new Error(`responses select (guard): ${responsesRes.error.message}`);
+  }
+  if (reviewsRes.error) {
+    throw new Error(`reviews select (guard): ${reviewsRes.error.message}`);
+  }
+
+  return {
+    responseProject: new Map(
+      (responsesRes.data ?? []).map((r) => [r.id as string, r.project_id as string]),
+    ),
+    reviewProject: new Map(
+      (reviewsRes.data ?? []).map((r) => [r.id as string, r.project_id as string]),
+    ),
+  };
+}
+
+// UPDATE em lote restrito ao projeto; devolve, por id pedido, sucesso ou
+// "not found" (id inexistente ou de outro projeto).
+async function batchResolveUpdate(
+  supabase: SupabaseClient,
+  table: string,
+  projectId: string,
+  ids: string[],
+  payload: Record<string, unknown>,
+): Promise<Map<string, ResolutionResult>> {
+  const results = new Map<string, ResolutionResult>();
+  if (ids.length === 0) return results;
+  const { data, error } = await supabase
+    .from(table)
+    .update(payload)
+    .in("id", ids)
+    .eq("project_id", projectId)
+    .select("id");
+  if (error) {
+    for (const id of ids) results.set(id, { success: false, error: error.message });
+    return results;
+  }
+  const updated = new Set((data ?? []).map((d) => d.id as string));
+  for (const id of ids) {
+    results.set(
+      id,
+      updated.has(id) ? { success: true } : { success: false, error: "not found" },
+    );
+  }
+  return results;
+}
+
+async function resolveComments(
   supabase: SupabaseClient,
   projectId: string,
   changedBy: string,
-  r: DecisionsFile["resolutions"][number],
-  dryRun: boolean,
-): Promise<{ success: boolean; error?: string; detail?: string }> {
-  if (dryRun) {
-    return { success: true, detail: `DRY RUN: would resolve ${r.source} ${JSON.stringify(r)}` };
+  resolutions: Resolution[],
+  write: boolean,
+): Promise<Array<{ item: Resolution; result: ResolutionResult }>> {
+  if (!write) {
+    return resolutions.map((r) => ({
+      item: r,
+      result: {
+        success: true,
+        detail: `PREVIEW: would resolve ${r.source} ${JSON.stringify(r)}`,
+      },
+    }));
   }
+
   const nowIso = new Date().toISOString();
-  try {
-    if (r.source === "anotacao") {
-      const { data, error } = await supabase
-        .from("project_comments")
-        .update({ resolved_at: nowIso, resolved_by: changedBy })
-        .eq("id", r.rawId)
-        .eq("project_id", projectId)
-        .select("id");
-      if (error) return { success: false, error: error.message };
-      if (!data || data.length === 0) return { success: false, error: "not found" };
-      return { success: true };
+  const { responseProject, reviewProject } = await buildOwnershipMaps(
+    supabase,
+    resolutions,
+  );
+  const resolvedPayload = { resolved_at: nowIso, resolved_by: changedBy };
+  const resultFor = new Map<Resolution, ResolutionResult>();
+
+  const guardResponse = (rawId: string): ResolutionResult | null => {
+    const owner = responseProject.get(rawId);
+    if (!owner) return { success: false, error: "response não encontrada" };
+    if (owner !== projectId) {
+      return { success: false, error: "response pertence a outro projeto" };
     }
-    if (r.source === "review") {
-      const { data, error } = await supabase
-        .from("reviews")
-        .update({ resolved_at: nowIso, resolved_by: changedBy })
-        .eq("id", r.rawId)
-        .eq("project_id", projectId)
-        .select("id");
-      if (error) return { success: false, error: error.message };
-      if (!data || data.length === 0) return { success: false, error: "not found" };
-      return { success: true };
+    return null;
+  };
+
+  // --- nota / dificuldade: guard + INSERT em lote (upsert ignora par já resolvido) ---
+  const notas = resolutions.filter((r) => r.source === "nota") as Array<
+    Extract<Resolution, { source: "nota" }>
+  >;
+  const dificuldades = resolutions.filter((r) => r.source === "dificuldade") as Array<
+    Extract<Resolution, { source: "dificuldade" }>
+  >;
+
+  const notaRows: Record<string, unknown>[] = [];
+  for (const r of notas) {
+    const guardErr = guardResponse(r.rawId);
+    if (guardErr) {
+      resultFor.set(r, guardErr);
+      continue;
     }
-    if (r.source === "nota") {
-      const { error } = await supabase.from("note_resolutions").insert({
-        project_id: projectId,
-        response_id: r.rawId,
-        resolved_by: changedBy,
-        note: r.note || null,
-      });
-      if (error) return { success: false, error: error.message };
-      return { success: true };
+    resultFor.set(r, { success: true });
+    notaRows.push({
+      project_id: projectId,
+      response_id: r.rawId,
+      resolved_by: changedBy,
+      note: r.note || null,
+    });
+  }
+  const difRows: Record<string, unknown>[] = [];
+  for (const r of dificuldades) {
+    const guardErr = guardResponse(r.rawId);
+    if (guardErr) {
+      resultFor.set(r, guardErr);
+      continue;
     }
-    if (r.source === "dificuldade") {
-      const { error } = await supabase.from("difficulty_resolutions").insert({
-        project_id: projectId,
-        response_id: r.rawId,
-        document_id: r.documentId,
-        resolved_by: changedBy,
-        note: r.note || null,
-      });
-      if (error) return { success: false, error: error.message };
-      return { success: true };
+    resultFor.set(r, { success: true });
+    difRows.push({
+      project_id: projectId,
+      response_id: r.rawId,
+      document_id: r.documentId,
+      resolved_by: changedBy,
+      note: r.note || null,
+    });
+  }
+
+  // --- sugestao: approved em lote; rejected agrupado por motivo ---
+  const sugestoes = resolutions.filter((r) => r.source === "sugestao") as Array<
+    Extract<Resolution, { source: "sugestao" }>
+  >;
+  const approvedIds = sugestoes
+    .filter((s) => s.action === "approved")
+    .map((s) => s.rawId);
+  const rejectedByReason = new Map<string | null, string[]>();
+  for (const s of sugestoes.filter((s) => s.action === "rejected")) {
+    const key = s.rejectionReason ?? null;
+    rejectedByReason.set(key, [...(rejectedByReason.get(key) ?? []), s.rawId]);
+  }
+
+  const anotacaoIds = resolutions
+    .filter((r) => r.source === "anotacao")
+    .map((r) => (r as { rawId: string }).rawId);
+  const reviewIds = resolutions
+    .filter((r) => r.source === "review")
+    .map((r) => (r as { rawId: string }).rawId);
+
+  const [anotacaoResults, reviewResults, approvedResults, notaInsert, difInsert, ...rejectedMaps] =
+    await Promise.all([
+      batchResolveUpdate(
+        supabase,
+        "project_comments",
+        projectId,
+        anotacaoIds,
+        resolvedPayload,
+      ),
+      batchResolveUpdate(supabase, "reviews", projectId, reviewIds, resolvedPayload),
+      batchResolveUpdate(supabase, "schema_suggestions", projectId, approvedIds, {
+        status: "approved",
+        ...resolvedPayload,
+      }),
+      notaRows.length > 0
+        ? supabase
+            .from("note_resolutions")
+            .upsert(notaRows, {
+              onConflict: "project_id,response_id",
+              ignoreDuplicates: true,
+            })
+        : Promise.resolve({ error: null }),
+      difRows.length > 0
+        ? supabase
+            .from("difficulty_resolutions")
+            .upsert(difRows, {
+              onConflict: "project_id,response_id",
+              ignoreDuplicates: true,
+            })
+        : Promise.resolve({ error: null }),
+      ...[...rejectedByReason.entries()].map(([reason, ids]) =>
+        batchResolveUpdate(supabase, "schema_suggestions", projectId, ids, {
+          status: "rejected",
+          ...resolvedPayload,
+          ...(reason ? { rejection_reason: reason } : {}),
+        }),
+      ),
+    ]);
+
+  const rejectedResults = new Map<string, ResolutionResult>();
+  for (const m of rejectedMaps as Map<string, ResolutionResult>[]) {
+    for (const [k, v] of m) rejectedResults.set(k, v);
+  }
+  if ((notaInsert as { error: { message: string } | null }).error) {
+    const msg = (notaInsert as { error: { message: string } }).error.message;
+    for (const r of notas) {
+      if (resultFor.get(r)?.success) resultFor.set(r, { success: false, error: msg });
     }
-    if (r.source === "duvida") {
-      // Cross-project guard: confirma que o review pertence a este projeto
-      // antes de tocar a verdict_acknowledgments (tabela só tem review_id, não project_id).
-      const { data: rev, error: revErr } = await supabase
-        .from("reviews")
-        .select("project_id")
-        .eq("id", r.reviewId)
-        .single();
-      if (revErr) return { success: false, error: revErr.message };
-      if (rev?.project_id !== projectId) {
-        return { success: false, error: "review pertence a outro projeto" };
+  }
+  if ((difInsert as { error: { message: string } | null }).error) {
+    const msg = (difInsert as { error: { message: string } }).error.message;
+    for (const r of dificuldades) {
+      if (resultFor.get(r)?.success) resultFor.set(r, { success: false, error: msg });
+    }
+  }
+
+  // --- duvida: guard batched acima; UPDATE por par (review_id, respondent_id) ---
+  const duvidas = resolutions.filter((r) => r.source === "duvida") as Array<
+    Extract<Resolution, { source: "duvida" }>
+  >;
+  await Promise.all(
+    duvidas.map(async (r) => {
+      const owner = reviewProject.get(r.reviewId);
+      if (!owner) {
+        resultFor.set(r, { success: false, error: "review não encontrado" });
+        return;
+      }
+      if (owner !== projectId) {
+        resultFor.set(r, { success: false, error: "review pertence a outro projeto" });
+        return;
       }
       const { data, error } = await supabase
         .from("verdict_acknowledgments")
-        .update({ resolved_at: nowIso, resolved_by: changedBy })
+        .update(resolvedPayload)
         .eq("review_id", r.reviewId)
         .eq("respondent_id", r.respondentId)
         .select("review_id");
-      if (error) return { success: false, error: error.message };
-      if (!data || data.length === 0) return { success: false, error: "not found" };
-      return { success: true };
+      if (error) {
+        resultFor.set(r, { success: false, error: error.message });
+      } else if (!data || data.length === 0) {
+        resultFor.set(r, { success: false, error: "not found" });
+      } else {
+        resultFor.set(r, { success: true });
+      }
+    }),
+  );
+
+  // --- montar resultados na ordem original ---
+  return resolutions.map((r) => {
+    if (r.source === "anotacao") {
+      return {
+        item: r,
+        result: anotacaoResults.get(r.rawId) ?? { success: false, error: "not found" },
+      };
+    }
+    if (r.source === "review") {
+      return {
+        item: r,
+        result: reviewResults.get(r.rawId) ?? { success: false, error: "not found" },
+      };
     }
     if (r.source === "sugestao") {
-      const payload: Record<string, unknown> = {
-        status: r.action,
-        resolved_by: changedBy,
-        resolved_at: nowIso,
+      const m = r.action === "approved" ? approvedResults : rejectedResults;
+      return {
+        item: r,
+        result: m.get(r.rawId) ?? { success: false, error: "not found" },
       };
-      if (r.action === "rejected" && r.rejectionReason) {
-        payload.rejection_reason = r.rejectionReason;
-      }
-      const { data, error } = await supabase
-        .from("schema_suggestions")
-        .update(payload)
-        .eq("id", r.rawId)
-        .eq("project_id", projectId)
-        .select("id");
-      if (error) return { success: false, error: error.message };
-      if (!data || data.length === 0) return { success: false, error: "not found" };
-      return { success: true };
     }
-  } catch (e) {
-    return { success: false, error: e instanceof Error ? e.message : String(e) };
-  }
-  return { success: false, error: "unknown source" };
+    if (r.source === "exclusao") {
+      return {
+        item: r,
+        result: {
+          success: false,
+          error:
+            "pedido de exclusão de documento: resolver pela plataforma " +
+            "(aprovação exige excludeDocuments — soft delete + auditoria)",
+        },
+      };
+    }
+    return {
+      item: r,
+      result: resultFor.get(r) ?? { success: false, error: "unknown source" },
+    };
+  });
 }
 
 // ----------------------- Main -----------------------
@@ -606,12 +555,17 @@ async function main() {
     changedBy = proj?.created_by as string;
   }
   if (!changedBy) {
-    console.error("Não foi possível resolver changedBy. Forneça decisions.changedBy.");
+    console.error(
+      "Não foi possível resolver changedBy. Forneça decisions.changedBy.",
+    );
     process.exit(1);
   }
 
+  // Sem --yes, nada é gravado: schema E resoluções rodam como preview.
+  const write = args.yes && !args.dryRun;
+
   console.log(
-    `Projeto: ${decisions.projectId}\nchangedBy: ${changedBy}\nNovos fields: ${decisions.newFields.length}\nResoluções: ${decisions.resolutions.length}\ndry-run: ${args.dryRun}\n`,
+    `Projeto: ${decisions.projectId}\nchangedBy: ${changedBy}\nNovos fields: ${decisions.newFields.length}\nResoluções: ${decisions.resolutions.length}\nmodo: ${write ? "APLICAR" : "preview (use --yes para gravar)"}\n`,
   );
 
   // Step 1: schema
@@ -620,36 +574,24 @@ async function main() {
     decisions.projectId,
     decisions.newFields,
     changedBy,
-    args.dryRun,
+    write,
   );
   console.log("---- SCHEMA ----");
   console.log(JSON.stringify(schemaResult, null, 2));
 
-  // Step 2: confirmação antes de resolver comentários (se não dry-run e não --yes)
-  if (!args.dryRun && !args.yes) {
-    console.log(
-      "\n[info] Para prosseguir com a resolução dos comentários, rode novamente com --yes.",
-    );
-    return;
-  }
-
-  // Step 3: resolutions
+  // Step 2: resolutions
   console.log("\n---- RESOLUÇÕES ----");
-  const results: Array<{ item: unknown; result: unknown }> = [];
-  for (const r of decisions.resolutions) {
-    const res = await resolveComment(
-      supabase,
-      decisions.projectId,
-      changedBy,
-      r,
-      args.dryRun,
-    );
-    results.push({ item: r, result: res });
-  }
+  const results = await resolveComments(
+    supabase,
+    decisions.projectId,
+    changedBy,
+    decisions.resolutions,
+    write,
+  );
   console.log(JSON.stringify(results, null, 2));
 
-  // Step 4: summaryNote (opcional)
-  if (decisions.summaryNote && !args.dryRun) {
+  // Step 3: summaryNote (opcional)
+  if (decisions.summaryNote && write) {
     const { error } = await supabase.from("project_comments").insert({
       project_id: decisions.projectId,
       author_id: changedBy,

--- a/frontend/scripts/comentarios-relatorio/apply-decisions.ts
+++ b/frontend/scripts/comentarios-relatorio/apply-decisions.ts
@@ -1,0 +1,671 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * apply-decisions.ts
+ *
+ * Lê um arquivo JSON com a lista estruturada de decisões (produzido pelo Claude
+ * a partir do .md anotado pelo usuário) e aplica:
+ *   1. Mudanças no schema Pydantic (replicando primitivas de saveSchemaFromGUI):
+ *      - update projects.{pydantic_code, pydantic_hash, pydantic_fields, schema_version_*}
+ *      - insert schema_change_log entries
+ *      (sem invalidar responses: is_latest não é flipado na troca de schema —
+ *       staleness é por pydantic_hash/answer_field_hashes; ver issue #349)
+ *   2. Resolução dos comentários via INSERT/UPDATE nas tabelas corretas.
+ *
+ * Uso:
+ *   cd frontend
+ *   npx tsx scripts/comentarios-relatorio/apply-decisions.ts <decisions.json> [--dry-run] [--yes]
+ *
+ * Formato esperado do JSON: ver references/decisions-format.md
+ *
+ * Observação: `generatePydanticCode` é importado diretamente de
+ * `src/lib/schema-utils` (pure, client-safe) para manter paridade com a UI
+ * e evitar drift. A lógica de classificação de versão e persistência duplica
+ * `saveSchemaFromGUI` de `src/actions/schema.ts` porque server actions não
+ * são chamáveis fora do Next runtime.
+ *
+ * Fixes aplicados pós-commit 7247704 (PR #62 → revertido em #64):
+ *   - classifyChange/snapshotOf/per-field diff agora consideram `condition`
+ *     (introduzido em #58); sem isso, mudanças só em condição viravam no-op.
+ *   - UPDATEs com service role key em reviews/schema_suggestions/verdict_acknowledgments
+ *     agora restringem por project_id (defesa contra cross-project drift).
+ *   A solução estrutural — extrair as primitivas para schema-utils.ts — é a issue #63.
+ */
+
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import crypto from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { generatePydanticCode } from "../../src/lib/schema-utils";
+import type { FieldCondition, PydanticField as LibPydanticField } from "../../src/lib/types";
+
+// ----------------------- Env loading -----------------------
+
+function loadEnv() {
+  const cwd = process.cwd();
+  // Honra SUPABASE_ENV_PATH explícito; caso contrário usa os caminhos
+  // canônicos relativos ao cwd (raiz do repo ou frontend/). Nunca subir a
+  // árvore de diretórios (../.env.local) — ver CLAUDE.md.
+  const candidates = [
+    process.env.SUPABASE_ENV_PATH,
+    resolve(cwd, ".env.local"),
+    resolve(cwd, "frontend/.env.local"),
+  ].filter((p): p is string => Boolean(p));
+  for (const path of candidates) {
+    try {
+      const content = readFileSync(path, "utf-8");
+      for (const line of content.split("\n")) {
+        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+        if (!m) continue;
+        const key = m[1];
+        if (process.env[key]) continue;
+        let val = m[2].trim();
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1);
+        }
+        process.env[key] = val;
+      }
+      return;
+    } catch {
+      /* try next */
+    }
+  }
+}
+
+loadEnv();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error(
+    "Faltam NEXT_PUBLIC_SUPABASE_URL e/ou SUPABASE_SERVICE_ROLE_KEY no .env.local",
+  );
+  process.exit(1);
+}
+
+// ----------------------- Tipos -----------------------
+
+type PydanticField = LibPydanticField;
+
+// Formato do JSON de entrada. O Claude gera esse arquivo parseando o .md anotado.
+interface DecisionsFile {
+  projectId: string;
+  // ID do usuário a registrar como changed_by / resolved_by.
+  // Se omitido, tenta pegar o created_by do projeto.
+  changedBy?: string;
+  // Nova lista completa de fields a persistir (já com add/remove/edit aplicados).
+  newFields: PydanticField[];
+  // Lista de comentários a resolver.
+  resolutions: Array<
+    | { source: "anotacao"; rawId: string }
+    | { source: "review"; rawId: string }
+    | { source: "nota"; rawId: string; note?: string } // rawId = response_id
+    | {
+        source: "dificuldade";
+        rawId: string; // response_id
+        documentId: string;
+        note?: string;
+      }
+    | {
+        source: "duvida";
+        reviewId: string;
+        respondentId: string;
+      }
+    | {
+        source: "sugestao";
+        rawId: string; // suggestion_id
+        action: "approved" | "rejected";
+        rejectionReason?: string;
+      }
+  >;
+  // Opcional: nota resumo a registrar num project_comment "meta" após aplicação.
+  summaryNote?: string;
+}
+
+// ----------------------- Funções puras -----------------------
+// `generatePydanticCode` vem de `src/lib/schema-utils` (mesma função usada pela UI).
+// Apenas utilitários específicos do script ficam aqui.
+
+function pythonListRepr(arr: string[]): string {
+  return "[" + arr.map((s) => `'${s}'`).join(", ") + "]";
+}
+
+// Stringify com chaves ordenadas: o jsonb do Postgres normaliza a ordem das
+// chaves (por tamanho, depois bytewise), então `condition`/`subfields` lidos
+// do banco nunca batem com o objeto autorado no JSON de decisões se a
+// comparação for JSON.stringify cru — todo run viraria um falso "minor"
+// com before == after no change log (visto na troca 1.1.0 do Judiciário).
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return "{" + entries.map(([k, v]) => JSON.stringify(k) + ":" + stableStringify(v)).join(",") + "}";
+  }
+  return JSON.stringify(value);
+}
+
+function computeFieldHash(
+  name: string,
+  type: string,
+  options: string[] | null,
+  description: string,
+): string {
+  const optionsPart = options ? pythonListRepr([...options].sort()) : "";
+  const content = `${name}|${type}|${optionsPart}|${description}`;
+  return crypto.createHash("sha256").update(content).digest("hex").slice(0, 12);
+}
+
+type ChangeType = "major" | "minor" | "patch";
+
+function classifyChange(
+  oldFields: PydanticField[],
+  newFields: PydanticField[],
+): ChangeType | null {
+  const oldNames = new Set(oldFields.map((f) => f.name));
+  const newNames = new Set(newFields.map((f) => f.name));
+
+  const addedOrRemoved =
+    newFields.some((f) => !oldNames.has(f.name)) ||
+    oldFields.some((f) => !newNames.has(f.name));
+
+  if (addedOrRemoved) return "minor";
+
+  let hasStructural = false;
+  let hasTextual = false;
+  const oldMap = new Map(oldFields.map((f) => [f.name, f]));
+
+  for (const n of newFields) {
+    const o = oldMap.get(n.name);
+    if (!o) continue;
+
+    if (o.type !== n.type) hasStructural = true;
+    if ((o.target ?? "all") !== (n.target ?? "all")) hasStructural = true;
+    if ((o.required ?? true) !== (n.required ?? true)) hasStructural = true;
+    if ((o.subfield_rule ?? null) !== (n.subfield_rule ?? null)) hasStructural = true;
+    if ((o.allow_other ?? false) !== (n.allow_other ?? false)) hasStructural = true;
+    if (stableStringify(o.subfields ?? null) !== stableStringify(n.subfields ?? null)) {
+      hasStructural = true;
+    }
+    if (stableStringify(o.condition ?? null) !== stableStringify(n.condition ?? null)) {
+      hasStructural = true;
+    }
+
+    const optsOld = o.options ?? [];
+    const optsNew = n.options ?? [];
+    const setOld = new Set(optsOld);
+    const setNew = new Set(optsNew);
+    const sameSet =
+      setOld.size === setNew.size && [...setOld].every((x) => setNew.has(x));
+    if (!sameSet) {
+      hasStructural = true;
+    } else if (optsOld.length !== optsNew.length) {
+      hasStructural = true;
+    } else {
+      for (let i = 0; i < optsOld.length; i++) {
+        if (optsOld[i] !== optsNew[i]) {
+          hasTextual = true;
+          break;
+        }
+      }
+    }
+
+    if (o.description !== n.description) hasTextual = true;
+    if ((o.help_text || "") !== (n.help_text || "")) hasTextual = true;
+  }
+
+  if (!hasStructural && !hasTextual) {
+    for (let i = 0; i < newFields.length; i++) {
+      if (newFields[i].name !== oldFields[i]?.name) {
+        hasTextual = true;
+        break;
+      }
+    }
+  }
+
+  if (hasStructural) return "minor";
+  if (hasTextual) return "patch";
+  return null;
+}
+
+function bumpVersion(
+  current: { major: number; minor: number; patch: number },
+  type: ChangeType,
+): { major: number; minor: number; patch: number } {
+  if (type === "major") return { major: current.major + 1, minor: 0, patch: 0 };
+  if (type === "minor")
+    return { major: current.major, minor: current.minor + 1, patch: 0 };
+  return { major: current.major, minor: current.minor, patch: current.patch + 1 };
+}
+
+function snapshotOf(field: PydanticField): Record<string, unknown> {
+  return {
+    name: field.name,
+    type: field.type,
+    description: field.description,
+    help_text: field.help_text ?? null,
+    options: field.options ?? null,
+    target: field.target ?? null,
+    required: field.required ?? null,
+    subfields: field.subfields ?? null,
+    subfield_rule: field.subfield_rule ?? null,
+    allow_other: field.allow_other ?? null,
+    condition: field.condition ?? null,
+  };
+}
+
+// ----------------------- Schema apply -----------------------
+
+async function applySchemaChanges(
+  supabase: SupabaseClient,
+  projectId: string,
+  newFields: PydanticField[],
+  changedBy: string,
+  dryRun: boolean,
+) {
+  const { data: project, error: projErr } = await supabase
+    .from("projects")
+    .select(
+      "pydantic_fields, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch",
+    )
+    .eq("id", projectId)
+    .single();
+  if (projErr) throw new Error(`projects select: ${projErr.message}`);
+
+  const oldFields = (project?.pydantic_fields as PydanticField[]) ?? [];
+  const oldMap = new Map(oldFields.map((f) => [f.name, f]));
+  const newMap = new Map(newFields.map((f) => [f.name, f]));
+
+  const current = {
+    major: project?.schema_version_major ?? 0,
+    minor: project?.schema_version_minor ?? 1,
+    patch: project?.schema_version_patch ?? 0,
+  };
+
+  const changeType = classifyChange(oldFields, newFields);
+  const bumped = changeType ? bumpVersion(current, changeType) : current;
+
+  // Audit entries
+  const logEntries: Array<{
+    field_name: string;
+    change_summary: string;
+    before_value: Record<string, unknown>;
+    after_value: Record<string, unknown>;
+  }> = [];
+
+  for (const f of newFields) {
+    if (oldMap.has(f.name)) continue;
+    logEntries.push({
+      field_name: f.name,
+      change_summary: "campo adicionado",
+      before_value: {},
+      after_value: snapshotOf(f),
+    });
+  }
+  for (const o of oldFields) {
+    if (newMap.has(o.name)) continue;
+    logEntries.push({
+      field_name: o.name,
+      change_summary: "campo removido",
+      before_value: snapshotOf(o),
+      after_value: {},
+    });
+  }
+  for (const f of newFields) {
+    const old = oldMap.get(f.name);
+    if (!old) continue;
+    const diffs: string[] = [];
+    const before: Record<string, unknown> = {};
+    const after: Record<string, unknown> = {};
+
+    if (old.description !== f.description) {
+      diffs.push("descrição");
+      before.description = old.description;
+      after.description = f.description;
+    }
+    if ((old.help_text || "") !== (f.help_text || "")) {
+      diffs.push("instruções");
+      before.help_text = old.help_text || null;
+      after.help_text = f.help_text || null;
+    }
+    const oldOpts = JSON.stringify(old.options ?? null);
+    const newOpts = JSON.stringify(f.options ?? null);
+    if (oldOpts !== newOpts) {
+      diffs.push(f.type === "text" ? "respostas padronizadas" : "opções");
+      before.options = old.options;
+      after.options = f.options;
+    }
+    if (old.type !== f.type) {
+      diffs.push("tipo");
+      before.type = old.type;
+      after.type = f.type;
+    }
+    if ((old.target ?? "all") !== (f.target ?? "all")) {
+      diffs.push("alvo");
+      before.target = old.target ?? null;
+      after.target = f.target ?? null;
+    }
+    if ((old.required ?? true) !== (f.required ?? true)) {
+      diffs.push("obrigatório");
+      before.required = old.required ?? null;
+      after.required = f.required ?? null;
+    }
+    if ((old.subfield_rule ?? null) !== (f.subfield_rule ?? null)) {
+      diffs.push("regra de subcampos");
+      before.subfield_rule = old.subfield_rule ?? null;
+      after.subfield_rule = f.subfield_rule ?? null;
+    }
+    if ((old.allow_other ?? false) !== (f.allow_other ?? false)) {
+      diffs.push("permite outro");
+      before.allow_other = old.allow_other ?? false;
+      after.allow_other = f.allow_other ?? false;
+    }
+    const oldSubs = stableStringify(old.subfields ?? null);
+    const newSubs = stableStringify(f.subfields ?? null);
+    if (oldSubs !== newSubs) {
+      diffs.push("subcampos");
+      before.subfields = old.subfields ?? null;
+      after.subfields = f.subfields ?? null;
+    }
+    const oldCond = stableStringify(old.condition ?? null);
+    const newCond = stableStringify(f.condition ?? null);
+    if (oldCond !== newCond) {
+      diffs.push("condição");
+      before.condition = old.condition ?? null;
+      after.condition = f.condition ?? null;
+    }
+    if (diffs.length > 0) {
+      logEntries.push({
+        field_name: f.name,
+        change_summary: diffs.join(", "),
+        before_value: before,
+        after_value: after,
+      });
+    }
+  }
+
+  const code = generatePydanticCode(newFields);
+  const hash = crypto.createHash("sha256").update(code).digest("hex").slice(0, 16);
+  const fieldsWithHash = newFields.map((f) => ({
+    ...f,
+    hash: computeFieldHash(f.name, f.type, f.options, f.description),
+  }));
+
+  const summary = {
+    changeType,
+    currentVersion: `${current.major}.${current.minor}.${current.patch}`,
+    newVersion: `${bumped.major}.${bumped.minor}.${bumped.patch}`,
+    hashChanged: project?.pydantic_hash !== hash,
+    logEntryCount: logEntries.length,
+    logEntries,
+    pydanticCodePreview: code.split("\n").slice(0, 10).join("\n") + "\n...",
+  };
+
+  if (dryRun) {
+    return { dryRun: true, summary };
+  }
+
+  if (!changeType && logEntries.length === 0) {
+    return { dryRun: false, summary, applied: false, reason: "sem mudanças" };
+  }
+
+  // Update projects
+  const updatePayload: Record<string, unknown> = {
+    pydantic_code: code,
+    pydantic_hash: hash,
+    pydantic_fields: fieldsWithHash,
+  };
+  if (changeType) {
+    updatePayload.schema_version_major = bumped.major;
+    updatePayload.schema_version_minor = bumped.minor;
+    updatePayload.schema_version_patch = bumped.patch;
+  }
+  const { error: updErr } = await supabase
+    .from("projects")
+    .update(updatePayload)
+    .eq("id", projectId);
+  if (updErr) throw new Error(`projects update: ${updErr.message}`);
+
+  // Sem invalidação de responses na troca de schema: is_latest significa
+  // "última resposta ativa por respondente", não "compatível com o schema
+  // vigente" (rename + semântica em 20260514190000; saveSchema também não
+  // flipa — src/actions/schema.ts). Staleness é detectada por
+  // pydantic_hash/answer_field_hashes. Flipar aqui reintroduziria o bug de
+  // respostas LLM órfãs revivido pela migration 20260505000001 (issue #349).
+
+  // Audit log
+  if (logEntries.length > 0) {
+    const { error: logErr } = await supabase.from("schema_change_log").insert(
+      logEntries.map((e) => ({
+        project_id: projectId,
+        changed_by: changedBy,
+        change_type: changeType ?? "patch",
+        version_major: bumped.major,
+        version_minor: bumped.minor,
+        version_patch: bumped.patch,
+        ...e,
+      })),
+    );
+    if (logErr) throw new Error(`schema_change_log insert: ${logErr.message}`);
+  }
+
+  return { dryRun: false, summary, applied: true };
+}
+
+// ----------------------- Comment resolution -----------------------
+
+async function resolveComment(
+  supabase: SupabaseClient,
+  projectId: string,
+  changedBy: string,
+  r: DecisionsFile["resolutions"][number],
+  dryRun: boolean,
+): Promise<{ success: boolean; error?: string; detail?: string }> {
+  if (dryRun) {
+    return { success: true, detail: `DRY RUN: would resolve ${r.source} ${JSON.stringify(r)}` };
+  }
+  const nowIso = new Date().toISOString();
+  try {
+    if (r.source === "anotacao") {
+      const { data, error } = await supabase
+        .from("project_comments")
+        .update({ resolved_at: nowIso, resolved_by: changedBy })
+        .eq("id", r.rawId)
+        .eq("project_id", projectId)
+        .select("id");
+      if (error) return { success: false, error: error.message };
+      if (!data || data.length === 0) return { success: false, error: "not found" };
+      return { success: true };
+    }
+    if (r.source === "review") {
+      const { data, error } = await supabase
+        .from("reviews")
+        .update({ resolved_at: nowIso, resolved_by: changedBy })
+        .eq("id", r.rawId)
+        .eq("project_id", projectId)
+        .select("id");
+      if (error) return { success: false, error: error.message };
+      if (!data || data.length === 0) return { success: false, error: "not found" };
+      return { success: true };
+    }
+    if (r.source === "nota") {
+      const { error } = await supabase.from("note_resolutions").insert({
+        project_id: projectId,
+        response_id: r.rawId,
+        resolved_by: changedBy,
+        note: r.note || null,
+      });
+      if (error) return { success: false, error: error.message };
+      return { success: true };
+    }
+    if (r.source === "dificuldade") {
+      const { error } = await supabase.from("difficulty_resolutions").insert({
+        project_id: projectId,
+        response_id: r.rawId,
+        document_id: r.documentId,
+        resolved_by: changedBy,
+        note: r.note || null,
+      });
+      if (error) return { success: false, error: error.message };
+      return { success: true };
+    }
+    if (r.source === "duvida") {
+      // Cross-project guard: confirma que o review pertence a este projeto
+      // antes de tocar a verdict_acknowledgments (tabela só tem review_id, não project_id).
+      const { data: rev, error: revErr } = await supabase
+        .from("reviews")
+        .select("project_id")
+        .eq("id", r.reviewId)
+        .single();
+      if (revErr) return { success: false, error: revErr.message };
+      if (rev?.project_id !== projectId) {
+        return { success: false, error: "review pertence a outro projeto" };
+      }
+      const { data, error } = await supabase
+        .from("verdict_acknowledgments")
+        .update({ resolved_at: nowIso, resolved_by: changedBy })
+        .eq("review_id", r.reviewId)
+        .eq("respondent_id", r.respondentId)
+        .select("review_id");
+      if (error) return { success: false, error: error.message };
+      if (!data || data.length === 0) return { success: false, error: "not found" };
+      return { success: true };
+    }
+    if (r.source === "sugestao") {
+      const payload: Record<string, unknown> = {
+        status: r.action,
+        resolved_by: changedBy,
+        resolved_at: nowIso,
+      };
+      if (r.action === "rejected" && r.rejectionReason) {
+        payload.rejection_reason = r.rejectionReason;
+      }
+      const { data, error } = await supabase
+        .from("schema_suggestions")
+        .update(payload)
+        .eq("id", r.rawId)
+        .eq("project_id", projectId)
+        .select("id");
+      if (error) return { success: false, error: error.message };
+      if (!data || data.length === 0) return { success: false, error: "not found" };
+      return { success: true };
+    }
+  } catch (e) {
+    return { success: false, error: e instanceof Error ? e.message : String(e) };
+  }
+  return { success: false, error: "unknown source" };
+}
+
+// ----------------------- Main -----------------------
+
+function parseArgs(argv: string[]) {
+  const out: { file?: string; dryRun: boolean; yes: boolean } = {
+    dryRun: false,
+    yes: false,
+  };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dry-run") out.dryRun = true;
+    else if (a === "--yes" || a === "-y") out.yes = true;
+    else if (!a.startsWith("-")) out.file = a;
+  }
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (!args.file) {
+    console.error(
+      "Uso: npx tsx apply-decisions.ts <decisions.json> [--dry-run] [--yes]",
+    );
+    process.exit(1);
+  }
+  const decisionsPath = resolve(process.cwd(), args.file);
+  const raw = readFileSync(decisionsPath, "utf-8");
+  const decisions = JSON.parse(raw) as DecisionsFile;
+
+  const supabase = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Resolve changedBy
+  let changedBy = decisions.changedBy;
+  if (!changedBy) {
+    const { data: proj } = await supabase
+      .from("projects")
+      .select("created_by")
+      .eq("id", decisions.projectId)
+      .single();
+    changedBy = proj?.created_by as string;
+  }
+  if (!changedBy) {
+    console.error("Não foi possível resolver changedBy. Forneça decisions.changedBy.");
+    process.exit(1);
+  }
+
+  console.log(
+    `Projeto: ${decisions.projectId}\nchangedBy: ${changedBy}\nNovos fields: ${decisions.newFields.length}\nResoluções: ${decisions.resolutions.length}\ndry-run: ${args.dryRun}\n`,
+  );
+
+  // Step 1: schema
+  const schemaResult = await applySchemaChanges(
+    supabase,
+    decisions.projectId,
+    decisions.newFields,
+    changedBy,
+    args.dryRun,
+  );
+  console.log("---- SCHEMA ----");
+  console.log(JSON.stringify(schemaResult, null, 2));
+
+  // Step 2: confirmação antes de resolver comentários (se não dry-run e não --yes)
+  if (!args.dryRun && !args.yes) {
+    console.log(
+      "\n[info] Para prosseguir com a resolução dos comentários, rode novamente com --yes.",
+    );
+    return;
+  }
+
+  // Step 3: resolutions
+  console.log("\n---- RESOLUÇÕES ----");
+  const results: Array<{ item: unknown; result: unknown }> = [];
+  for (const r of decisions.resolutions) {
+    const res = await resolveComment(
+      supabase,
+      decisions.projectId,
+      changedBy,
+      r,
+      args.dryRun,
+    );
+    results.push({ item: r, result: res });
+  }
+  console.log(JSON.stringify(results, null, 2));
+
+  // Step 4: summaryNote (opcional)
+  if (decisions.summaryNote && !args.dryRun) {
+    const { error } = await supabase.from("project_comments").insert({
+      project_id: decisions.projectId,
+      author_id: changedBy,
+      body: decisions.summaryNote,
+      resolved_at: new Date().toISOString(),
+      resolved_by: changedBy,
+    });
+    if (error) {
+      console.error(`summary note insert: ${error.message}`);
+    } else {
+      console.log("\n[info] summaryNote registrada em project_comments.");
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(`ERRO: ${err?.message ?? err}`);
+  process.exit(1);
+});

--- a/frontend/scripts/comentarios-relatorio/fetch-open-comments.ts
+++ b/frontend/scripts/comentarios-relatorio/fetch-open-comments.ts
@@ -7,7 +7,7 @@
  *
  * Uso:
  *   cd frontend
- *   npx tsx ../.claude/skills/comentarios-relatorio/scripts/fetch-open-comments.ts \
+ *   npx tsx scripts/comentarios-relatorio/fetch-open-comments.ts \
  *     [--project-id <uuid>] [--project-name <fragmento>] [--list]
  *
  * Sem argumentos: imprime lista de projetos disponíveis (JSON).
@@ -15,46 +15,15 @@
  *
  * Espelha a lógica de frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
  * mas filtrando apenas abertos. Requer SUPABASE_SERVICE_ROLE_KEY no .env.local.
+ *
+ * Qualquer query que falhe aborta com exit 1 — um relatório parcial silencioso
+ * faria itens já resolvidos reaparecerem como abertos (Sets de resolução vazios).
  */
 
 import { createClient } from "@supabase/supabase-js";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 
-function loadEnv() {
-  // Carrega frontend/.env.local se variáveis não vierem do ambiente.
-  // Honra SUPABASE_ENV_PATH explícito; caso contrário usa os caminhos
-  // canônicos relativos ao cwd (raiz do repo ou frontend/). Nunca subir a
-  // árvore de diretórios (../.env.local) — ver CLAUDE.md.
-  const cwd = process.cwd();
-  const candidates = [
-    process.env.SUPABASE_ENV_PATH,
-    resolve(cwd, ".env.local"),
-    resolve(cwd, "frontend/.env.local"),
-  ].filter((p): p is string => Boolean(p));
-  for (const path of candidates) {
-    try {
-      const content = readFileSync(path, "utf-8");
-      for (const line of content.split("\n")) {
-        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
-        if (!m) continue;
-        const key = m[1];
-        if (process.env[key]) continue;
-        let val = m[2].trim();
-        if (
-          (val.startsWith('"') && val.endsWith('"')) ||
-          (val.startsWith("'") && val.endsWith("'"))
-        ) {
-          val = val.slice(1, -1);
-        }
-        process.env[key] = val;
-      }
-      return;
-    } catch {
-      /* try next */
-    }
-  }
-}
+import type { PydanticField } from "../../src/lib/types";
+import { loadEnv } from "./load-env";
 
 loadEnv();
 
@@ -75,25 +44,28 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
   auth: { autoRefreshToken: false, persistSession: false },
 });
 
-// ----------------------- Tipos -----------------------
-
-interface PydanticField {
-  name: string;
-  type: "single" | "multi" | "text" | "date";
-  options: string[] | null;
-  description: string;
-  help_text?: string;
-  target?: "all" | "llm_only" | "human_only";
-  required?: boolean;
-  hash?: string;
-  subfields?: Array<{ key: string; label: string; required?: boolean }>;
-  subfield_rule?: "all" | "at_least_one";
-  allow_other?: boolean;
+// Lança em vez de deixar `data=null` virar `[]` silencioso — supabase-js não
+// rejeita a promise em erro de query.
+function must<T>(
+  label: string,
+  res: { data: T | null; error: { message: string } | null },
+): T {
+  if (res.error) throw new Error(`query ${label}: ${res.error.message}`);
+  return (res.data ?? []) as T;
 }
+
+// ----------------------- Tipos -----------------------
 
 interface OpenComment {
   id: string;
-  source: "review" | "nota" | "sugestao" | "dificuldade" | "duvida" | "anotacao";
+  source:
+    | "review"
+    | "nota"
+    | "sugestao"
+    | "dificuldade"
+    | "duvida"
+    | "anotacao"
+    | "exclusao";
   rawId: string;
   fieldName: string;
   documentId: string | null;
@@ -172,15 +144,15 @@ async function resolveProject(args: Record<string, string | boolean>) {
 
 async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
   const [
-    { data: reviews },
-    { data: documents },
-    { data: responsesWithNotes },
-    { data: suggestions },
-    { data: llmResponses },
-    { data: difficultyResolutions },
-    { data: projectComments },
-    { data: verdictQuestions },
-    { data: noteResolutions },
+    reviews,
+    documents,
+    responsesWithNotes,
+    suggestions,
+    llmResponses,
+    difficultyResolutions,
+    projectComments,
+    verdictQuestions,
+    noteResolutions,
   ] = await Promise.all([
     // Reviews abertos (com comentário e não resolvidos)
     supabase
@@ -191,18 +163,24 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
       .eq("project_id", projectId)
       .not("comment", "is", null)
       .is("resolved_at", null)
-      .order("created_at", { ascending: false }),
+      .order("created_at", { ascending: false })
+      .then((r) => must<Record<string, unknown>[]>("reviews", r)),
     supabase
       .from("documents")
       .select("id, title, external_id")
-      .eq("project_id", projectId),
-    // Notas de pesquisador (humano)
+      .eq("project_id", projectId)
+      .then((r) => must<Record<string, unknown>[]>("documents", r)),
+    // Notas de pesquisador (humano) — só a chave _notes do jsonb, não o
+    // objeto de justificativas inteiro
     supabase
       .from("responses")
-      .select("id, document_id, respondent_id, respondent_name, justifications, created_at")
+      .select(
+        "id, document_id, respondent_id, respondent_name, created_at, notes:justifications->>_notes",
+      )
       .eq("project_id", projectId)
       .eq("respondent_type", "humano")
-      .not("justifications", "is", null),
+      .not("justifications->>_notes", "is", null)
+      .then((r) => must<Record<string, unknown>[]>("responses (notas)", r)),
     // Sugestões pendentes
     supabase
       .from("schema_suggestions")
@@ -211,29 +189,36 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
       )
       .eq("project_id", projectId)
       .eq("status", "pending")
-      .order("created_at", { ascending: false }),
-    // Respostas LLM ativas (para extrair llm_ambiguidades)
+      .order("created_at", { ascending: false })
+      .then((r) => must<Record<string, unknown>[]>("schema_suggestions", r)),
+    // Respostas LLM ativas — só a chave llm_ambiguidades do answers
     supabase
       .from("responses")
-      .select("id, document_id, answers, respondent_name, created_at")
+      .select(
+        "id, document_id, respondent_name, created_at, llm_ambiguidades:answers->>llm_ambiguidades",
+      )
       .eq("project_id", projectId)
       .eq("respondent_type", "llm")
-      .eq("is_latest", true),
+      .eq("is_latest", true)
+      .then((r) => must<Record<string, unknown>[]>("responses (llm)", r)),
     // Dificuldades já resolvidas → filtrar fora
     supabase
       .from("difficulty_resolutions")
       .select("response_id")
-      .eq("project_id", projectId),
-    // project_comments abertos (root, não resolvidos)
+      .eq("project_id", projectId)
+      .then((r) => must<Record<string, unknown>[]>("difficulty_resolutions", r)),
+    // project_comments abertos (root, não resolvidos) — `kind` separa anotação
+    // comum de pedido de exclusão de documento
     supabase
       .from("project_comments")
       .select(
-        "id, document_id, field_name, author_id, body, parent_id, resolved_at, created_at, profiles!author_id(email)",
+        "id, document_id, field_name, author_id, body, parent_id, kind, resolved_at, created_at, profiles!author_id(email)",
       )
       .eq("project_id", projectId)
       .is("parent_id", null)
       .is("resolved_at", null)
-      .order("created_at", { ascending: false }),
+      .order("created_at", { ascending: false })
+      .then((r) => must<Record<string, unknown>[]>("project_comments", r)),
     // Dúvidas abertas
     supabase
       .from("verdict_acknowledgments")
@@ -244,12 +229,14 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
       .is("resolved_at", null)
       .not("comment", "is", null)
       .eq("reviews.project_id", projectId)
-      .order("created_at", { ascending: false }),
+      .order("created_at", { ascending: false })
+      .then((r) => must<Record<string, unknown>[]>("verdict_acknowledgments", r)),
     // Notas já resolvidas → filtrar fora
     supabase
       .from("note_resolutions")
       .select("response_id")
-      .eq("project_id", projectId),
+      .eq("project_id", projectId)
+      .then((r) => must<Record<string, unknown>[]>("note_resolutions", r)),
   ]);
 
   const fieldMap = new Map(fields.map((f) => [f.name, f]));
@@ -265,24 +252,27 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
 
   // Coletar ids de profiles para resolver nomes
   const profileIds = new Set<string>();
-  (reviews ?? []).forEach((r) => r.reviewer_id && profileIds.add(r.reviewer_id));
+  (reviews ?? []).forEach((r) => r.reviewer_id && profileIds.add(r.reviewer_id as string));
   (responsesWithNotes ?? []).forEach(
-    (r) => r.respondent_id && profileIds.add(r.respondent_id),
+    (r) => r.respondent_id && profileIds.add(r.respondent_id as string),
   );
   (verdictQuestions ?? []).forEach(
-    (q) => q.respondent_id && profileIds.add(q.respondent_id),
+    (q) => q.respondent_id && profileIds.add(q.respondent_id as string),
   );
 
   const profileMap = new Map<string, string>();
   if (profileIds.size > 0) {
-    const { data: profiles } = await supabase
-      .from("profiles")
-      .select("id, email, first_name, last_name")
-      .in("id", Array.from(profileIds));
+    const profiles = must<Record<string, unknown>[]>(
+      "profiles",
+      await supabase
+        .from("profiles")
+        .select("id, email, first_name, last_name")
+        .in("id", Array.from(profileIds)),
+    );
     (profiles ?? []).forEach((p) => {
       const name =
         [p.first_name, p.last_name].filter(Boolean).join(" ") ||
-        p.email?.split("@")[0] ||
+        (p.email as string | null)?.split("@")[0] ||
         "Anônimo";
       profileMap.set(p.id as string, name);
     });
@@ -299,7 +289,7 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
       rawId: r.id as string,
       fieldName: r.field_name as string,
       documentId: r.document_id as string,
-      documentTitle: docMap.get(r.document_id as string) ?? null,
+      documentTitle: (docMap.get(r.document_id as string) as string) ?? null,
       text: (r.comment as string) ?? "",
       author: r.reviewer_id
         ? profileMap.get(r.reviewer_id as string) ?? "Anônimo"
@@ -318,8 +308,7 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
   // nota (humano, não resolvida)
   for (const r of responsesWithNotes ?? []) {
     if (resolvedNoteIds.has(r.id as string)) continue;
-    const j = r.justifications as Record<string, string> | null;
-    const note = j && typeof j._notes === "string" ? j._notes.trim() : "";
+    const note = typeof r.notes === "string" ? r.notes.trim() : "";
     if (!note) continue;
     comments.push({
       id: `nota-${r.id}`,
@@ -327,13 +316,14 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
       rawId: r.id as string,
       fieldName: "(geral)",
       documentId: r.document_id as string,
-      documentTitle: docMap.get(r.document_id as string) ?? null,
+      documentTitle: (docMap.get(r.document_id as string) as string) ?? null,
       text: note,
       author:
-        (r.respondent_id &&
-          (profileMap.get(r.respondent_id as string) ||
-            (r.respondent_name as string))) ||
-        (r.respondent_name as string) ||
+        (r.respondent_id
+          ? profileMap.get(r.respondent_id as string) ||
+            (r.respondent_name as string | null)
+          : null) ||
+        (r.respondent_name as string | null) ||
         "Anônimo",
       createdAt: r.created_at as string,
       extra: {
@@ -378,10 +368,8 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
   // dificuldade (LLM, não resolvida)
   for (const r of llmResponses ?? []) {
     if (resolvedDiffIds.has(r.id as string)) continue;
-    const ambiguidades = (r.answers as Record<string, unknown>)
-      ?.llm_ambiguidades;
     const txt =
-      typeof ambiguidades === "string" ? ambiguidades.trim() : "";
+      typeof r.llm_ambiguidades === "string" ? r.llm_ambiguidades.trim() : "";
     if (!txt) continue;
     comments.push({
       id: `dificuldade-${r.id}`,
@@ -389,7 +377,7 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
       rawId: r.id as string,
       fieldName: "(geral)",
       documentId: r.document_id as string,
-      documentTitle: docMap.get(r.document_id as string) ?? null,
+      documentTitle: (docMap.get(r.document_id as string) as string) ?? null,
       text: txt,
       author: (r.respondent_name as string) || "LLM",
       createdAt: r.created_at as string,
@@ -425,7 +413,7 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
       rawId: `${q.review_id}|${q.respondent_id}`,
       fieldName: r.field_name,
       documentId: r.document_id,
-      documentTitle: docMap.get(r.document_id) ?? null,
+      documentTitle: (docMap.get(r.document_id) as string) ?? null,
       text: q.comment,
       author: profileMap.get(q.respondent_id) ?? "Anônimo",
       createdAt: q.created_at,
@@ -439,25 +427,30 @@ async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
     });
   }
 
-  // anotacao (project_comments root, não resolvidos)
+  // anotacao (project_comments root, não resolvidos) + exclusao
+  // (kind='exclusion_request' — pedido de exclusão de documento, que NÃO é
+  // resolvível pelo apply-decisions: aprovação exige excludeDocuments, fluxo
+  // da plataforma; entra no relatório como item informativo)
   for (const c of projectComments ?? []) {
     const p = c.profiles as unknown as { email: string | null } | null;
     const field = c.field_name
       ? fieldMap.get(c.field_name as string)
       : undefined;
+    const isExclusion = c.kind === "exclusion_request";
     comments.push({
-      id: `anotacao-${c.id}`,
-      source: "anotacao",
+      id: `${isExclusion ? "exclusao" : "anotacao"}-${c.id}`,
+      source: isExclusion ? "exclusao" : "anotacao",
       rawId: c.id as string,
       fieldName: (c.field_name as string | null) ?? "(geral)",
       documentId: (c.document_id as string | null) ?? null,
       documentTitle: c.document_id
-        ? docMap.get(c.document_id as string) ?? null
+        ? (docMap.get(c.document_id as string) as string) ?? null
         : null,
       text: c.body as string,
       author: p?.email?.split("@")[0] ?? "Anônimo",
       createdAt: c.created_at as string,
       extra: {
+        kind: c.kind,
         fieldType: field?.type,
         fieldOptions: field?.options,
       },

--- a/frontend/scripts/comentarios-relatorio/fetch-open-comments.ts
+++ b/frontend/scripts/comentarios-relatorio/fetch-open-comments.ts
@@ -1,0 +1,546 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * fetch-open-comments.ts
+ *
+ * Lê comentários ABERTOS de um projeto dataframeitGUI e imprime JSON estruturado
+ * no stdout para ser consumido pela skill comentarios-relatorio.
+ *
+ * Uso:
+ *   cd frontend
+ *   npx tsx ../.claude/skills/comentarios-relatorio/scripts/fetch-open-comments.ts \
+ *     [--project-id <uuid>] [--project-name <fragmento>] [--list]
+ *
+ * Sem argumentos: imprime lista de projetos disponíveis (JSON).
+ * Com --project-id ou --project-name (match case-insensitive contém): busca os comentários.
+ *
+ * Espelha a lógica de frontend/src/app/(app)/projects/[id]/reviews/comments/page.tsx
+ * mas filtrando apenas abertos. Requer SUPABASE_SERVICE_ROLE_KEY no .env.local.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function loadEnv() {
+  // Carrega frontend/.env.local se variáveis não vierem do ambiente.
+  // Honra SUPABASE_ENV_PATH explícito; caso contrário usa os caminhos
+  // canônicos relativos ao cwd (raiz do repo ou frontend/). Nunca subir a
+  // árvore de diretórios (../.env.local) — ver CLAUDE.md.
+  const cwd = process.cwd();
+  const candidates = [
+    process.env.SUPABASE_ENV_PATH,
+    resolve(cwd, ".env.local"),
+    resolve(cwd, "frontend/.env.local"),
+  ].filter((p): p is string => Boolean(p));
+  for (const path of candidates) {
+    try {
+      const content = readFileSync(path, "utf-8");
+      for (const line of content.split("\n")) {
+        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+        if (!m) continue;
+        const key = m[1];
+        if (process.env[key]) continue;
+        let val = m[2].trim();
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1);
+        }
+        process.env[key] = val;
+      }
+      return;
+    } catch {
+      /* try next */
+    }
+  }
+}
+
+loadEnv();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+  console.error(
+    JSON.stringify({
+      error:
+        "Faltam NEXT_PUBLIC_SUPABASE_URL e/ou SUPABASE_SERVICE_ROLE_KEY. Rode de dentro de frontend/ ou defina as vars manualmente.",
+    }),
+  );
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// ----------------------- Tipos -----------------------
+
+interface PydanticField {
+  name: string;
+  type: "single" | "multi" | "text" | "date";
+  options: string[] | null;
+  description: string;
+  help_text?: string;
+  target?: "all" | "llm_only" | "human_only";
+  required?: boolean;
+  hash?: string;
+  subfields?: Array<{ key: string; label: string; required?: boolean }>;
+  subfield_rule?: "all" | "at_least_one";
+  allow_other?: boolean;
+}
+
+interface OpenComment {
+  id: string;
+  source: "review" | "nota" | "sugestao" | "dificuldade" | "duvida" | "anotacao";
+  rawId: string;
+  fieldName: string;
+  documentId: string | null;
+  documentTitle: string | null;
+  text: string;
+  author: string;
+  createdAt: string;
+  extra: Record<string, unknown>;
+}
+
+// ----------------------- CLI parsing -----------------------
+
+function parseArgs(argv: string[]) {
+  const out: Record<string, string | boolean> = {};
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--list") {
+      out.list = true;
+    } else if (a === "--project-id" || a === "--id") {
+      out.projectId = argv[++i];
+    } else if (a === "--project-name" || a === "--name") {
+      out.projectName = argv[++i];
+    } else if (a === "--help" || a === "-h") {
+      out.help = true;
+    }
+  }
+  return out;
+}
+
+async function listProjects() {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, name, created_at, schema_version_major, schema_version_minor, schema_version_patch")
+    .order("created_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return data ?? [];
+}
+
+async function resolveProject(args: Record<string, string | boolean>) {
+  if (typeof args.projectId === "string") {
+    const { data, error } = await supabase
+      .from("projects")
+      .select(
+        "id, name, created_by, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch",
+      )
+      .eq("id", args.projectId)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    if (!data) throw new Error(`Projeto ${args.projectId} não encontrado`);
+    return data;
+  }
+  if (typeof args.projectName === "string") {
+    const { data, error } = await supabase
+      .from("projects")
+      .select(
+        "id, name, created_by, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch",
+      )
+      .ilike("name", `%${args.projectName}%`)
+      .order("created_at", { ascending: false });
+    if (error) throw new Error(error.message);
+    if (!data || data.length === 0)
+      throw new Error(`Nenhum projeto corresponde a "${args.projectName}"`);
+    if (data.length > 1) {
+      throw new Error(
+        `Múltiplos projetos correspondem a "${args.projectName}": ${data
+          .map((p) => `${p.name} (${p.id})`)
+          .join(", ")}. Use --project-id.`,
+      );
+    }
+    return data[0];
+  }
+  return null;
+}
+
+// ----------------------- Fetching -----------------------
+
+async function fetchOpenComments(projectId: string, fields: PydanticField[]) {
+  const [
+    { data: reviews },
+    { data: documents },
+    { data: responsesWithNotes },
+    { data: suggestions },
+    { data: llmResponses },
+    { data: difficultyResolutions },
+    { data: projectComments },
+    { data: verdictQuestions },
+    { data: noteResolutions },
+  ] = await Promise.all([
+    // Reviews abertos (com comentário e não resolvidos)
+    supabase
+      .from("reviews")
+      .select(
+        "id, document_id, field_name, verdict, comment, chosen_response_id, resolved_at, reviewer_id, created_at, response_snapshot",
+      )
+      .eq("project_id", projectId)
+      .not("comment", "is", null)
+      .is("resolved_at", null)
+      .order("created_at", { ascending: false }),
+    supabase
+      .from("documents")
+      .select("id, title, external_id")
+      .eq("project_id", projectId),
+    // Notas de pesquisador (humano)
+    supabase
+      .from("responses")
+      .select("id, document_id, respondent_id, respondent_name, justifications, created_at")
+      .eq("project_id", projectId)
+      .eq("respondent_type", "humano")
+      .not("justifications", "is", null),
+    // Sugestões pendentes
+    supabase
+      .from("schema_suggestions")
+      .select(
+        "id, field_name, suggested_changes, reason, status, resolved_at, created_at, suggested_by, profiles!suggested_by(email)",
+      )
+      .eq("project_id", projectId)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false }),
+    // Respostas LLM ativas (para extrair llm_ambiguidades)
+    supabase
+      .from("responses")
+      .select("id, document_id, answers, respondent_name, created_at")
+      .eq("project_id", projectId)
+      .eq("respondent_type", "llm")
+      .eq("is_latest", true),
+    // Dificuldades já resolvidas → filtrar fora
+    supabase
+      .from("difficulty_resolutions")
+      .select("response_id")
+      .eq("project_id", projectId),
+    // project_comments abertos (root, não resolvidos)
+    supabase
+      .from("project_comments")
+      .select(
+        "id, document_id, field_name, author_id, body, parent_id, resolved_at, created_at, profiles!author_id(email)",
+      )
+      .eq("project_id", projectId)
+      .is("parent_id", null)
+      .is("resolved_at", null)
+      .order("created_at", { ascending: false }),
+    // Dúvidas abertas
+    supabase
+      .from("verdict_acknowledgments")
+      .select(
+        "review_id, respondent_id, comment, resolved_at, created_at, reviews!inner(id, project_id, document_id, field_name, verdict)",
+      )
+      .eq("status", "questioned")
+      .is("resolved_at", null)
+      .not("comment", "is", null)
+      .eq("reviews.project_id", projectId)
+      .order("created_at", { ascending: false }),
+    // Notas já resolvidas → filtrar fora
+    supabase
+      .from("note_resolutions")
+      .select("response_id")
+      .eq("project_id", projectId),
+  ]);
+
+  const fieldMap = new Map(fields.map((f) => [f.name, f]));
+  const docMap = new Map(
+    (documents ?? []).map((d) => [d.id, d.title || d.external_id || d.id]),
+  );
+  const resolvedNoteIds = new Set(
+    (noteResolutions ?? []).map((n) => n.response_id),
+  );
+  const resolvedDiffIds = new Set(
+    (difficultyResolutions ?? []).map((d) => d.response_id),
+  );
+
+  // Coletar ids de profiles para resolver nomes
+  const profileIds = new Set<string>();
+  (reviews ?? []).forEach((r) => r.reviewer_id && profileIds.add(r.reviewer_id));
+  (responsesWithNotes ?? []).forEach(
+    (r) => r.respondent_id && profileIds.add(r.respondent_id),
+  );
+  (verdictQuestions ?? []).forEach(
+    (q) => q.respondent_id && profileIds.add(q.respondent_id),
+  );
+
+  const profileMap = new Map<string, string>();
+  if (profileIds.size > 0) {
+    const { data: profiles } = await supabase
+      .from("profiles")
+      .select("id, email, first_name, last_name")
+      .in("id", Array.from(profileIds));
+    (profiles ?? []).forEach((p) => {
+      const name =
+        [p.first_name, p.last_name].filter(Boolean).join(" ") ||
+        p.email?.split("@")[0] ||
+        "Anônimo";
+      profileMap.set(p.id as string, name);
+    });
+  }
+
+  const comments: OpenComment[] = [];
+
+  // review
+  for (const r of reviews ?? []) {
+    const field = fieldMap.get(r.field_name as string);
+    comments.push({
+      id: `review-${r.id}`,
+      source: "review",
+      rawId: r.id as string,
+      fieldName: r.field_name as string,
+      documentId: r.document_id as string,
+      documentTitle: docMap.get(r.document_id as string) ?? null,
+      text: (r.comment as string) ?? "",
+      author: r.reviewer_id
+        ? profileMap.get(r.reviewer_id as string) ?? "Anônimo"
+        : "Anônimo",
+      createdAt: r.created_at as string,
+      extra: {
+        verdict: r.verdict,
+        chosenResponseId: r.chosen_response_id,
+        responseSnapshot: r.response_snapshot,
+        fieldType: field?.type,
+        fieldOptions: field?.options,
+      },
+    });
+  }
+
+  // nota (humano, não resolvida)
+  for (const r of responsesWithNotes ?? []) {
+    if (resolvedNoteIds.has(r.id as string)) continue;
+    const j = r.justifications as Record<string, string> | null;
+    const note = j && typeof j._notes === "string" ? j._notes.trim() : "";
+    if (!note) continue;
+    comments.push({
+      id: `nota-${r.id}`,
+      source: "nota",
+      rawId: r.id as string,
+      fieldName: "(geral)",
+      documentId: r.document_id as string,
+      documentTitle: docMap.get(r.document_id as string) ?? null,
+      text: note,
+      author:
+        (r.respondent_id &&
+          (profileMap.get(r.respondent_id as string) ||
+            (r.respondent_name as string))) ||
+        (r.respondent_name as string) ||
+        "Anônimo",
+      createdAt: r.created_at as string,
+      extra: {
+        responseId: r.id,
+        respondentId: r.respondent_id,
+      },
+    });
+  }
+
+  // sugestao (pending)
+  for (const s of suggestions ?? []) {
+    const changes = s.suggested_changes as Record<string, unknown>;
+    const changedKeys = Object.keys(changes);
+    const p = s.profiles as unknown as { email: string | null } | null;
+    const field = fieldMap.get(s.field_name as string);
+    comments.push({
+      id: `sugestao-${s.id}`,
+      source: "sugestao",
+      rawId: s.id as string,
+      fieldName: s.field_name as string,
+      documentId: null,
+      documentTitle: null,
+      text: (s.reason as string) || "Sem motivo",
+      author: p?.email?.split("@")[0] ?? "Anônimo",
+      createdAt: s.created_at as string,
+      extra: {
+        suggestedChanges: changes,
+        changedKeys,
+        status: s.status,
+        currentField: field
+          ? {
+              description: field.description,
+              help_text: field.help_text,
+              options: field.options,
+              type: field.type,
+            }
+          : null,
+      },
+    });
+  }
+
+  // dificuldade (LLM, não resolvida)
+  for (const r of llmResponses ?? []) {
+    if (resolvedDiffIds.has(r.id as string)) continue;
+    const ambiguidades = (r.answers as Record<string, unknown>)
+      ?.llm_ambiguidades;
+    const txt =
+      typeof ambiguidades === "string" ? ambiguidades.trim() : "";
+    if (!txt) continue;
+    comments.push({
+      id: `dificuldade-${r.id}`,
+      source: "dificuldade",
+      rawId: r.id as string,
+      fieldName: "(geral)",
+      documentId: r.document_id as string,
+      documentTitle: docMap.get(r.document_id as string) ?? null,
+      text: txt,
+      author: (r.respondent_name as string) || "LLM",
+      createdAt: r.created_at as string,
+      extra: {
+        responseId: r.id,
+        documentId: r.document_id,
+      },
+    });
+  }
+
+  // duvida (verdict_acknowledgments abertas).
+  // O join !inner em many-to-one retorna um único objeto em runtime, mas os
+  // tipos gerados pelo Supabase o inferem como array. Usar `as unknown as`
+  // pelo mesmo motivo que o cast de `c.profiles` abaixo.
+  for (const q of (verdictQuestions ?? []) as unknown as Array<{
+    review_id: string;
+    respondent_id: string;
+    comment: string;
+    resolved_at: string | null;
+    created_at: string;
+    reviews: {
+      id: string;
+      document_id: string;
+      field_name: string;
+      verdict: string;
+    };
+  }>) {
+    const r = q.reviews;
+    const field = fieldMap.get(r.field_name);
+    comments.push({
+      id: `duvida-${q.review_id}-${q.respondent_id}`,
+      source: "duvida",
+      rawId: `${q.review_id}|${q.respondent_id}`,
+      fieldName: r.field_name,
+      documentId: r.document_id,
+      documentTitle: docMap.get(r.document_id) ?? null,
+      text: q.comment,
+      author: profileMap.get(q.respondent_id) ?? "Anônimo",
+      createdAt: q.created_at,
+      extra: {
+        reviewId: q.review_id,
+        respondentId: q.respondent_id,
+        verdict: r.verdict,
+        fieldType: field?.type,
+        fieldOptions: field?.options,
+      },
+    });
+  }
+
+  // anotacao (project_comments root, não resolvidos)
+  for (const c of projectComments ?? []) {
+    const p = c.profiles as unknown as { email: string | null } | null;
+    const field = c.field_name
+      ? fieldMap.get(c.field_name as string)
+      : undefined;
+    comments.push({
+      id: `anotacao-${c.id}`,
+      source: "anotacao",
+      rawId: c.id as string,
+      fieldName: (c.field_name as string | null) ?? "(geral)",
+      documentId: (c.document_id as string | null) ?? null,
+      documentTitle: c.document_id
+        ? docMap.get(c.document_id as string) ?? null
+        : null,
+      text: c.body as string,
+      author: p?.email?.split("@")[0] ?? "Anônimo",
+      createdAt: c.created_at as string,
+      extra: {
+        fieldType: field?.type,
+        fieldOptions: field?.options,
+      },
+    });
+  }
+
+  comments.sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return comments;
+}
+
+// ----------------------- Main -----------------------
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    console.log(
+      `fetch-open-comments.ts\n\nUso:\n  npx tsx fetch-open-comments.ts [--project-id <uuid>] [--project-name <fragmento>] [--list]\n\nImprime JSON estruturado com os comentários abertos do projeto.\n`,
+    );
+    return;
+  }
+
+  if (args.list) {
+    const projects = await listProjects();
+    console.log(JSON.stringify({ projects }, null, 2));
+    return;
+  }
+
+  const project = await resolveProject(args);
+  if (!project) {
+    // Sem id nem name → lista projetos para escolher
+    const projects = await listProjects();
+    console.log(
+      JSON.stringify(
+        {
+          message:
+            "Nenhum projeto identificado. Use --project-id ou --project-name.",
+          projects,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const fields = (project.pydantic_fields as PydanticField[]) ?? [];
+  const comments = await fetchOpenComments(project.id as string, fields);
+
+  const version = {
+    major: project.schema_version_major ?? 0,
+    minor: project.schema_version_minor ?? 1,
+    patch: project.schema_version_patch ?? 0,
+  };
+
+  console.log(
+    JSON.stringify(
+      {
+        project: {
+          id: project.id,
+          name: project.name,
+          version: `${version.major}.${version.minor}.${version.patch}`,
+        },
+        fields,
+        stats: {
+          totalOpen: comments.length,
+          bySource: comments.reduce<Record<string, number>>((acc, c) => {
+            acc[c.source] = (acc[c.source] ?? 0) + 1;
+            return acc;
+          }, {}),
+        },
+        comments,
+        generatedAt: new Date().toISOString(),
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((err) => {
+  console.error(JSON.stringify({ error: err?.message ?? String(err) }));
+  process.exit(1);
+});

--- a/frontend/scripts/comentarios-relatorio/generate-report.py
+++ b/frontend/scripts/comentarios-relatorio/generate-report.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""
+generate-report.py
+
+Transforma o JSON produzido por fetch-open-comments.ts em um relatório .md
+em formato conversacional, destacando a redação exata de cada pergunta e
+agrupando discussões relacionadas (ex: múltiplos pesquisadores contestando
+o mesmo veredito).
+
+Uso:
+    python3 generate-report.py <comments.json> <output.md>
+
+O .md gerado tem blocos com diretivas em HTML comments; o apply-decisions.ts
+consome esse mesmo formato (via JSON intermediário produzido pelo Claude).
+
+Agrupamento (clusters por campo):
+1. Cada `review` vira um cluster — arrasta junto todas as `duvida` com
+   `extra.reviewId` igual ao `rawId` do review + `anotacao` do mesmo documento.
+2. `duvida` órfãs (sem review correspondente no aberto) → cluster por reviewId.
+3. `anotacao` restantes → cluster por documentId dentro do campo.
+4. `sugestao` → um cluster por sugestão.
+
+Para `(geral)` (notas e dificuldades): cada item um bloco; nota humana vira
+"Nota de pesquisador", dificuldade LLM vira "Ambiguidade reportada pelo LLM".
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def norm(s: str) -> str:
+    return re.sub(r"\s+", " ", s.strip().lower())
+
+
+def pretty_author(email_local: str) -> str:
+    """Tenta extrair um primeiro nome do email local part. Heurística."""
+    if not email_local or email_local == "Anônimo":
+        return email_local or "Anônimo"
+    if "." in email_local:
+        parts = [p for p in email_local.split(".") if p]
+        alpha = [p for p in parts if p.isalpha()]
+        if alpha:
+            return max(alpha, key=len).capitalize()
+    return email_local.capitalize()
+
+
+NUMERO_EXTENSO_MASC = {
+    1: "Um", 2: "Dois", 3: "Três", 4: "Quatro", 5: "Cinco",
+    6: "Seis", 7: "Sete", 8: "Oito", 9: "Nove", 10: "Dez",
+}
+NUMERO_EXTENSO_FEM = {
+    1: "Uma", 2: "Duas", 3: "Três", 4: "Quatro", 5: "Cinco",
+    6: "Seis", 7: "Sete", 8: "Oito", 9: "Nove", 10: "Dez",
+}
+
+
+def n_palavras(n: int, singular: str, plural: str, fem: bool = False) -> str:
+    tbl = NUMERO_EXTENSO_FEM if fem else NUMERO_EXTENSO_MASC
+    extenso = tbl.get(n, str(n))
+    return f"{extenso} {singular if n == 1 else plural}"
+
+
+def format_verdict(v) -> str:
+    """Vereditos de multi-select vêm como JSON dict. Resume em lista legível."""
+    if v is None:
+        return "—"
+    if isinstance(v, str):
+        s = v.strip()
+        # Se for JSON serializado, tenta parsear
+        if s.startswith("{") and s.endswith("}"):
+            try:
+                parsed = json.loads(s)
+                return format_verdict(parsed)
+            except Exception:
+                pass
+        return s or "—"
+    if isinstance(v, dict):
+        marcados = [k for k, val in v.items() if val is True]
+        if not marcados:
+            return "(nenhuma opção marcada)"
+        if len(marcados) <= 3:
+            return ", ".join(marcados)
+        return f"{', '.join(marcados[:3])} e mais {len(marcados) - 3}"
+    if isinstance(v, list):
+        return ", ".join(str(x) for x in v) or "—"
+    return str(v)
+
+
+def render_field_header(f: dict) -> list[str]:
+    lines: list[str] = []
+    lines.append(f"## `{f['name']}`")
+    lines.append("")
+    lines.append(f"**Pergunta:** {f['description']}")
+    if f.get("help_text"):
+        help_clean = f["help_text"].strip()
+        lines.append(f"**Orientação aos pesquisadores:** {help_clean}")
+    if f.get("options"):
+        opts = " · ".join(f["options"])
+        lines.append(f"**Opções:** {opts}")
+    if f.get("subfields"):
+        sub_lines = [f"{s['key']} ({s['label']})" for s in f["subfields"]]
+        rule = f.get("subfield_rule") or "all"
+        regra_txt = "todos obrigatórios" if rule == "all" else "pelo menos um"
+        lines.append(f"**Subcampos:** {', '.join(sub_lines)} ({regra_txt})")
+    lines.append("")
+    return lines
+
+
+def render_decision_block(heading: str, body_lines: list[str], ids: list[str]) -> list[str]:
+    out: list[str] = []
+    out.append(f"### {heading}")
+    out.append("")
+    out.extend(body_lines)
+    out.append("")
+    out.append("**Decisão:** <!-- aprovar | rejeitar | reformular | ignorar -->")
+    out.append("**Mudança no schema:** <!-- descreva em português o que mudar, ou deixe vazio -->")
+    out.append("**Nota ao resolver:** <!-- opcional: texto a registrar junto da resolução -->")
+    out.append("")
+    out.append(f"<!-- ids: {'; '.join(ids)} -->")
+    out.append("")
+    return out
+
+
+def build_clusters(field_comments: list[dict]) -> list[dict]:
+    clusters: list[dict] = []
+    consumed: set[str] = set()
+
+    reviews = [c for c in field_comments if c["source"] == "review"]
+    duvidas = [c for c in field_comments if c["source"] == "duvida"]
+    anotacoes = [c for c in field_comments if c["source"] == "anotacao"]
+    sugestoes = [c for c in field_comments if c["source"] == "sugestao"]
+
+    # 1. Cluster por review
+    for r in reviews:
+        if r["id"] in consumed:
+            continue
+        duvs = [
+            d for d in duvidas
+            if d["id"] not in consumed
+            and d.get("extra", {}).get("reviewId") == r["rawId"]
+        ]
+        anots = [
+            a for a in anotacoes
+            if a["id"] not in consumed and a.get("documentId") == r.get("documentId")
+        ]
+        clusters.append({
+            "type": "review",
+            "anchor": r,
+            "duvidas": duvs,
+            "anotacoes": anots,
+        })
+        consumed.update([r["id"], *(d["id"] for d in duvs), *(a["id"] for a in anots)])
+
+    # 2. Dúvidas órfãs — por reviewId
+    by_review: dict[str, list[dict]] = {}
+    for d in duvidas:
+        if d["id"] in consumed:
+            continue
+        rid = d.get("extra", {}).get("reviewId") or d["rawId"]
+        by_review.setdefault(rid, []).append(d)
+    for rid, group in by_review.items():
+        anots = [
+            a for a in anotacoes
+            if a["id"] not in consumed and a.get("documentId") == group[0].get("documentId")
+        ]
+        clusters.append({
+            "type": "duvidas-orphans",
+            "duvidas": group,
+            "anotacoes": anots,
+            "reviewId": rid,
+        })
+        consumed.update([*(d["id"] for d in group), *(a["id"] for a in anots)])
+
+    # 3. Anotações avulsas — por documentId
+    anot_by_doc: dict[str, list[dict]] = {}
+    for a in anotacoes:
+        if a["id"] in consumed:
+            continue
+        key = a.get("documentId") or f"solo-{a['id']}"
+        anot_by_doc.setdefault(key, []).append(a)
+    for group in anot_by_doc.values():
+        clusters.append({"type": "anotacoes", "anotacoes": group})
+        consumed.update(a["id"] for a in group)
+
+    # 4. Sugestões
+    for s in sugestoes:
+        clusters.append({"type": "sugestao", "sugestao": s})
+
+    return clusters
+
+
+def render_review_cluster(cl: dict) -> list[str]:
+    r = cl["anchor"]
+    duvs = cl["duvidas"]
+    anots = cl["anotacoes"]
+    doc = r.get("documentTitle") or "(documento)"
+    date = r["createdAt"][:10]
+    verdict = format_verdict((r.get("extra") or {}).get("verdict"))
+    reviewer = pretty_author(r.get("author"))
+
+    n_q = len(duvs)
+    n_a = len(anots)
+    if n_q > 0:
+        heading = (
+            f"Review de **{reviewer}** em *{doc}* — contestado por "
+            f"{n_palavras(n_q, 'pesquisador', 'pesquisadores')}"
+        )
+    else:
+        heading = f"Review de **{reviewer}** em *{doc}*"
+
+    body: list[str] = []
+    body.append(
+        f"Em {date}, **{reviewer}** revisou este documento e escolheu o veredito "
+        f"**\"{verdict}\"**, deixando a seguinte observação:"
+    )
+    body.append("")
+    for ln in r["text"].splitlines():
+        body.append(f"> {ln}" if ln.strip() else ">")
+    body.append("")
+
+    if duvs:
+        body.append(
+            f"{n_palavras(n_q, 'pesquisador manifestou dúvida', 'pesquisadores manifestaram dúvida')} "
+            f"sobre esse veredito:"
+        )
+        body.append("")
+        for d in duvs:
+            nm = pretty_author(d.get("author"))
+            txt = d["text"].strip().replace("\n", " ")
+            body.append(f"- **{nm}** — {txt}")
+        body.append("")
+
+    if anots:
+        body.append(
+            f"Além disso, {n_palavras(n_a, 'anotação', 'anotações', fem=True)} "
+            f"no mesmo documento:"
+        )
+        body.append("")
+        for a in anots:
+            nm = pretty_author(a.get("author"))
+            txt = a["text"].strip().replace("\n", " ")
+            body.append(f"- **{nm}** — {txt}")
+        body.append("")
+
+    ids = [r["id"], *(d["id"] for d in duvs), *(a["id"] for a in anots)]
+    return render_decision_block(heading, body, ids)
+
+
+def render_duvidas_orphan_cluster(cl: dict) -> list[str]:
+    duvs = cl["duvidas"]
+    anots = cl.get("anotacoes", [])
+    doc = duvs[0].get("documentTitle") or "(documento)"
+    verdict = format_verdict((duvs[0].get("extra") or {}).get("verdict"))
+
+    n_q = len(duvs)
+    heading = (
+        f"Dúvidas em *{doc}* sobre o veredito \"{verdict}\" "
+        f"({n_palavras(n_q, 'pesquisador', 'pesquisadores')})"
+    )
+
+    body: list[str] = []
+    for d in duvs:
+        nm = pretty_author(d.get("author"))
+        date = d["createdAt"][:10]
+        txt = d["text"].strip().replace("\n", " ")
+        body.append(f"- **{nm}** ({date}) — {txt}")
+    body.append("")
+
+    if anots:
+        body.append(
+            f"No mesmo documento há {n_palavras(len(anots), 'anotação', 'anotações', fem=True)}:"
+        )
+        body.append("")
+        for a in anots:
+            nm = pretty_author(a.get("author"))
+            txt = a["text"].strip().replace("\n", " ")
+            body.append(f"- **{nm}** — {txt}")
+        body.append("")
+
+    ids = [*(d["id"] for d in duvs), *(a["id"] for a in anots)]
+    return render_decision_block(heading, body, ids)
+
+
+def render_anotacoes_cluster(cl: dict) -> list[str]:
+    anots = cl["anotacoes"]
+    doc = anots[0].get("documentTitle") or "—"
+    n = len(anots)
+
+    if n == 1:
+        a = anots[0]
+        nm = pretty_author(a.get("author"))
+        date = a["createdAt"][:10]
+        heading = f"Anotação de **{nm}** em *{doc}* ({date})"
+        body = [f"> {ln}" if ln.strip() else ">" for ln in a["text"].splitlines()]
+        return render_decision_block(heading, body, [a["id"]])
+
+    heading = f"{n_palavras(n, 'anotação', 'anotações', fem=True)} em *{doc}*"
+    body: list[str] = []
+    for a in anots:
+        nm = pretty_author(a.get("author"))
+        date = a["createdAt"][:10]
+        txt = a["text"].strip().replace("\n", " ")
+        body.append(f"- **{nm}** ({date}) — {txt}")
+    body.append("")
+    ids = [a["id"] for a in anots]
+    return render_decision_block(heading, body, ids)
+
+
+def render_sugestao_cluster(cl: dict) -> list[str]:
+    s = cl["sugestao"]
+    nm = pretty_author(s.get("author"))
+    date = s["createdAt"][:10]
+    changes = (s.get("extra") or {}).get("suggestedChanges") or {}
+    changed_keys = (s.get("extra") or {}).get("changedKeys") or []
+    current = (s.get("extra") or {}).get("currentField") or {}
+
+    heading = f"Sugestão de schema por **{nm}** ({date})"
+    body: list[str] = []
+    body.append(f"Motivo: {s['text'].strip() or '(sem motivo)'}")
+    body.append("")
+    body.append(f"Alterações propostas em: {', '.join(changed_keys) or '(nenhuma)'}")
+    body.append("")
+    if changes:
+        body.append("```json")
+        body.append(json.dumps(changes, ensure_ascii=False, indent=2))
+        body.append("```")
+        body.append("")
+    if current:
+        body.append(
+            f"Estado atual: description=\"{current.get('description','')}\"; "
+            f"help_text=\"{current.get('help_text') or ''}\"; options={current.get('options')}"
+        )
+        body.append("")
+    return render_decision_block(heading, body, [s["id"]])
+
+
+def render_field_section(f: dict, field_comments: list[dict]) -> list[str]:
+    lines = render_field_header(f)
+    clusters = build_clusters(field_comments)
+    for cl in clusters:
+        if cl["type"] == "review":
+            lines.extend(render_review_cluster(cl))
+        elif cl["type"] == "duvidas-orphans":
+            lines.extend(render_duvidas_orphan_cluster(cl))
+        elif cl["type"] == "anotacoes":
+            lines.extend(render_anotacoes_cluster(cl))
+        elif cl["type"] == "sugestao":
+            lines.extend(render_sugestao_cluster(cl))
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def render_geral(comments: list[dict]) -> list[str]:
+    lines: list[str] = []
+    lines.append("## Notas gerais")
+    lines.append("")
+    lines.append(
+        "Comentários não atrelados a uma pergunta específica. O pesquisador "
+        "pode ter mencionado mais de uma pergunta — ao anotar, liste em "
+        "`Campos mencionados:` quais perguntas a nota afeta."
+    )
+    lines.append("")
+
+    for c in comments:
+        nm = pretty_author(c.get("author"))
+        date = c["createdAt"][:10]
+        doc = c.get("documentTitle") or "—"
+        if c["source"] == "nota":
+            heading = f"Nota de pesquisador de **{nm}** ao codificar *{doc}* ({date})"
+        elif c["source"] == "dificuldade":
+            heading = f"Ambiguidade reportada pelo LLM em *{doc}* ({date})"
+        else:
+            heading = f"[{c['source']}] **{nm}** em *{doc}* ({date})"
+        body = [f"> {ln}" if ln.strip() else ">" for ln in c["text"].splitlines()]
+        body.append("")
+        body.append("**Campos mencionados:** <!-- ex: q2, q14 -->")
+        lines.extend(render_decision_block(heading, body, [c["id"]]))
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def render(data: dict) -> str:
+    project = data["project"]
+    fields = data["fields"]
+    comments = data["comments"]
+    stats = data["stats"]
+
+    by_field: dict[str, list[dict]] = {}
+    for c in comments:
+        by_field.setdefault(c["fieldName"], []).append(c)
+
+    lines: list[str] = []
+    lines.append(f"# Comentários em aberto — {project['name']}")
+    lines.append("")
+    n_fields = len([f for f in by_field if f != "(geral)"])
+    n_geral = len(by_field.get("(geral)", []))
+    src_summary = ", ".join(f"{v} {k}" for k, v in sorted(stats["bySource"].items()))
+    lines.append(
+        f"Projeto `{project['id']}` na versão do schema `{project['version']}`. "
+        f"Gerado em {data['generatedAt'][:10]}."
+    )
+    lines.append("")
+    lines.append(
+        f"Há **{stats['totalOpen']} comentários em aberto** — "
+        f"{n_fields} perguntas com comentários específicos e {n_geral} "
+        f"nota(s) geral(is). Por fonte: {src_summary}."
+    )
+    lines.append("")
+    lines.append(
+        "Para cada bloco, preencha `Decisão:` dentro do comentário HTML "
+        "(`<!-- ... -->`). Valores: **aprovar** (aplica a mudança e fecha), "
+        "**rejeitar** (fecha sem mudar), **reformular** (fecha registrando uma "
+        "nota com orientação), **ignorar** (pula — não fecha nada)."
+    )
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+
+    for f in fields:
+        if f["name"] not in by_field:
+            continue
+        lines.extend(render_field_section(f, by_field[f["name"]]))
+
+    if "(geral)" in by_field:
+        lines.extend(render_geral(by_field["(geral)"]))
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print(
+            "Uso: python3 generate-report.py <comments.json> <output.md>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    data = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+    md = render(data)
+    Path(sys.argv[2]).write_text(md, encoding="utf-8")
+    print(f"Relatório gerado: {sys.argv[2]} ({len(md)} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/scripts/comentarios-relatorio/generate-report.py
+++ b/frontend/scripts/comentarios-relatorio/generate-report.py
@@ -8,7 +8,8 @@ agrupando discussões relacionadas (ex: múltiplos pesquisadores contestando
 o mesmo veredito).
 
 Uso:
-    python3 generate-report.py <comments.json> <output.md>
+    uv run generate-report.py <comments.json> <output.md>
+    (stdlib puro — `python3 generate-report.py ...` também funciona)
 
 O .md gerado tem blocos com diretivas em HTML comments; o apply-decisions.ts
 consome esse mesmo formato (via JSON intermediário produzido pelo Claude).
@@ -22,6 +23,11 @@ Agrupamento (clusters por campo):
 
 Para `(geral)` (notas e dificuldades): cada item um bloco; nota humana vira
 "Nota de pesquisador", dificuldade LLM vira "Ambiguidade reportada pelo LLM".
+
+Comentários de campos que saíram do schema atual NÃO são descartados: entram
+na seção "Campos fora do schema atual". Pedidos de exclusão de documento
+(source `exclusao`) entram numa seção informativa, sem bloco de decisão — a
+aprovação exige excludeDocuments e é feita pela plataforma.
 """
 
 from __future__ import annotations
@@ -48,20 +54,20 @@ def pretty_author(email_local: str) -> str:
     return email_local.capitalize()
 
 
-NUMERO_EXTENSO_MASC = {
+NUMBER_WORDS_MASC = {
     1: "Um", 2: "Dois", 3: "Três", 4: "Quatro", 5: "Cinco",
     6: "Seis", 7: "Sete", 8: "Oito", 9: "Nove", 10: "Dez",
 }
-NUMERO_EXTENSO_FEM = {
+NUMBER_WORDS_FEM = {
     1: "Uma", 2: "Duas", 3: "Três", 4: "Quatro", 5: "Cinco",
     6: "Seis", 7: "Sete", 8: "Oito", 9: "Nove", 10: "Dez",
 }
 
 
-def n_palavras(n: int, singular: str, plural: str, fem: bool = False) -> str:
-    tbl = NUMERO_EXTENSO_FEM if fem else NUMERO_EXTENSO_MASC
-    extenso = tbl.get(n, str(n))
-    return f"{extenso} {singular if n == 1 else plural}"
+def count_in_words(n: int, singular: str, plural: str, fem: bool = False) -> str:
+    table = NUMBER_WORDS_FEM if fem else NUMBER_WORDS_MASC
+    spelled = table.get(n, str(n))
+    return f"{spelled} {singular if n == 1 else plural}"
 
 
 def format_verdict(v) -> str:
@@ -79,12 +85,12 @@ def format_verdict(v) -> str:
                 pass
         return s or "—"
     if isinstance(v, dict):
-        marcados = [k for k, val in v.items() if val is True]
-        if not marcados:
+        checked = [k for k, val in v.items() if val is True]
+        if not checked:
             return "(nenhuma opção marcada)"
-        if len(marcados) <= 3:
-            return ", ".join(marcados)
-        return f"{', '.join(marcados[:3])} e mais {len(marcados) - 3}"
+        if len(checked) <= 3:
+            return ", ".join(checked)
+        return f"{', '.join(checked[:3])} e mais {len(checked) - 3}"
     if isinstance(v, list):
         return ", ".join(str(x) for x in v) or "—"
     return str(v)
@@ -104,8 +110,8 @@ def render_field_header(f: dict) -> list[str]:
     if f.get("subfields"):
         sub_lines = [f"{s['key']} ({s['label']})" for s in f["subfields"]]
         rule = f.get("subfield_rule") or "all"
-        regra_txt = "todos obrigatórios" if rule == "all" else "pelo menos um"
-        lines.append(f"**Subcampos:** {', '.join(sub_lines)} ({regra_txt})")
+        rule_txt = "todos obrigatórios" if rule == "all" else "pelo menos um"
+        lines.append(f"**Subcampos:** {', '.join(sub_lines)} ({rule_txt})")
     lines.append("")
     return lines
 
@@ -130,84 +136,91 @@ def build_clusters(field_comments: list[dict]) -> list[dict]:
     consumed: set[str] = set()
 
     reviews = [c for c in field_comments if c["source"] == "review"]
-    duvidas = [c for c in field_comments if c["source"] == "duvida"]
-    anotacoes = [c for c in field_comments if c["source"] == "anotacao"]
-    sugestoes = [c for c in field_comments if c["source"] == "sugestao"]
+    doubts = [c for c in field_comments if c["source"] == "duvida"]
+    annotations = [c for c in field_comments if c["source"] == "anotacao"]
+    suggestions = [c for c in field_comments if c["source"] == "sugestao"]
 
     # 1. Cluster por review
     for r in reviews:
         if r["id"] in consumed:
             continue
-        duvs = [
-            d for d in duvidas
+        cluster_doubts = [
+            d for d in doubts
             if d["id"] not in consumed
             and d.get("extra", {}).get("reviewId") == r["rawId"]
         ]
-        anots = [
-            a for a in anotacoes
+        cluster_annots = [
+            a for a in annotations
             if a["id"] not in consumed and a.get("documentId") == r.get("documentId")
         ]
         clusters.append({
             "type": "review",
             "anchor": r,
-            "duvidas": duvs,
-            "anotacoes": anots,
+            "doubts": cluster_doubts,
+            "annotations": cluster_annots,
         })
-        consumed.update([r["id"], *(d["id"] for d in duvs), *(a["id"] for a in anots)])
+        consumed.update([
+            r["id"],
+            *(d["id"] for d in cluster_doubts),
+            *(a["id"] for a in cluster_annots),
+        ])
 
     # 2. Dúvidas órfãs — por reviewId
     by_review: dict[str, list[dict]] = {}
-    for d in duvidas:
+    for d in doubts:
         if d["id"] in consumed:
             continue
         rid = d.get("extra", {}).get("reviewId") or d["rawId"]
         by_review.setdefault(rid, []).append(d)
     for rid, group in by_review.items():
-        anots = [
-            a for a in anotacoes
+        cluster_annots = [
+            a for a in annotations
             if a["id"] not in consumed and a.get("documentId") == group[0].get("documentId")
         ]
         clusters.append({
             "type": "duvidas-orphans",
-            "duvidas": group,
-            "anotacoes": anots,
+            "doubts": group,
+            "annotations": cluster_annots,
             "reviewId": rid,
         })
-        consumed.update([*(d["id"] for d in group), *(a["id"] for a in anots)])
+        consumed.update([
+            *(d["id"] for d in group),
+            *(a["id"] for a in cluster_annots),
+        ])
 
     # 3. Anotações avulsas — por documentId
-    anot_by_doc: dict[str, list[dict]] = {}
-    for a in anotacoes:
+    annots_by_doc: dict[str, list[dict]] = {}
+    for a in annotations:
         if a["id"] in consumed:
             continue
         key = a.get("documentId") or f"solo-{a['id']}"
-        anot_by_doc.setdefault(key, []).append(a)
-    for group in anot_by_doc.values():
-        clusters.append({"type": "anotacoes", "anotacoes": group})
+        annots_by_doc.setdefault(key, []).append(a)
+    for group in annots_by_doc.values():
+        clusters.append({"type": "anotacoes", "annotations": group})
         consumed.update(a["id"] for a in group)
 
     # 4. Sugestões
-    for s in sugestoes:
-        clusters.append({"type": "sugestao", "sugestao": s})
+    for s in suggestions:
+        clusters.append({"type": "sugestao", "suggestion": s})
 
     return clusters
 
 
 def render_review_cluster(cl: dict) -> list[str]:
     r = cl["anchor"]
-    duvs = cl["duvidas"]
-    anots = cl["anotacoes"]
+    doubts = cl["doubts"]
+    annots = cl["annotations"]
     doc = r.get("documentTitle") or "(documento)"
     date = r["createdAt"][:10]
     verdict = format_verdict((r.get("extra") or {}).get("verdict"))
     reviewer = pretty_author(r.get("author"))
 
-    n_q = len(duvs)
-    n_a = len(anots)
+    n_q = len(doubts)
+    n_a = len(annots)
     if n_q > 0:
         heading = (
             f"Review de **{reviewer}** em *{doc}* — contestado por "
-            f"{n_palavras(n_q, 'pesquisador', 'pesquisadores')}"
+            f"{count_in_words(n_q, 'pesquisador', 'pesquisadores')}"
         )
     else:
         heading = f"Review de **{reviewer}** em *{doc}*"
@@ -222,96 +235,96 @@ def render_review_cluster(cl: dict) -> list[str]:
         body.append(f"> {ln}" if ln.strip() else ">")
     body.append("")
 
-    if duvs:
+    if doubts:
         body.append(
-            f"{n_palavras(n_q, 'pesquisador manifestou dúvida', 'pesquisadores manifestaram dúvida')} "
+            f"{count_in_words(n_q, 'pesquisador manifestou dúvida', 'pesquisadores manifestaram dúvida')} "
             f"sobre esse veredito:"
         )
         body.append("")
-        for d in duvs:
+        for d in doubts:
             nm = pretty_author(d.get("author"))
             txt = d["text"].strip().replace("\n", " ")
             body.append(f"- **{nm}** — {txt}")
         body.append("")
 
-    if anots:
+    if annots:
         body.append(
-            f"Além disso, {n_palavras(n_a, 'anotação', 'anotações', fem=True)} "
+            f"Além disso, {count_in_words(n_a, 'anotação', 'anotações', fem=True)} "
             f"no mesmo documento:"
         )
         body.append("")
-        for a in anots:
+        for a in annots:
             nm = pretty_author(a.get("author"))
             txt = a["text"].strip().replace("\n", " ")
             body.append(f"- **{nm}** — {txt}")
         body.append("")
 
-    ids = [r["id"], *(d["id"] for d in duvs), *(a["id"] for a in anots)]
+    ids = [r["id"], *(d["id"] for d in doubts), *(a["id"] for a in annots)]
     return render_decision_block(heading, body, ids)
 
 
-def render_duvidas_orphan_cluster(cl: dict) -> list[str]:
-    duvs = cl["duvidas"]
-    anots = cl.get("anotacoes", [])
-    doc = duvs[0].get("documentTitle") or "(documento)"
-    verdict = format_verdict((duvs[0].get("extra") or {}).get("verdict"))
+def render_doubts_orphan_cluster(cl: dict) -> list[str]:
+    doubts = cl["doubts"]
+    annots = cl.get("annotations", [])
+    doc = doubts[0].get("documentTitle") or "(documento)"
+    verdict = format_verdict((doubts[0].get("extra") or {}).get("verdict"))
 
-    n_q = len(duvs)
+    n_q = len(doubts)
     heading = (
         f"Dúvidas em *{doc}* sobre o veredito \"{verdict}\" "
-        f"({n_palavras(n_q, 'pesquisador', 'pesquisadores')})"
+        f"({count_in_words(n_q, 'pesquisador', 'pesquisadores')})"
     )
 
     body: list[str] = []
-    for d in duvs:
+    for d in doubts:
         nm = pretty_author(d.get("author"))
         date = d["createdAt"][:10]
         txt = d["text"].strip().replace("\n", " ")
         body.append(f"- **{nm}** ({date}) — {txt}")
     body.append("")
 
-    if anots:
+    if annots:
         body.append(
-            f"No mesmo documento há {n_palavras(len(anots), 'anotação', 'anotações', fem=True)}:"
+            f"No mesmo documento há {count_in_words(len(annots), 'anotação', 'anotações', fem=True)}:"
         )
         body.append("")
-        for a in anots:
+        for a in annots:
             nm = pretty_author(a.get("author"))
             txt = a["text"].strip().replace("\n", " ")
             body.append(f"- **{nm}** — {txt}")
         body.append("")
 
-    ids = [*(d["id"] for d in duvs), *(a["id"] for a in anots)]
+    ids = [*(d["id"] for d in doubts), *(a["id"] for a in annots)]
     return render_decision_block(heading, body, ids)
 
 
-def render_anotacoes_cluster(cl: dict) -> list[str]:
-    anots = cl["anotacoes"]
-    doc = anots[0].get("documentTitle") or "—"
-    n = len(anots)
+def render_annotations_cluster(cl: dict) -> list[str]:
+    annots = cl["annotations"]
+    doc = annots[0].get("documentTitle") or "—"
+    n = len(annots)
 
     if n == 1:
-        a = anots[0]
+        a = annots[0]
         nm = pretty_author(a.get("author"))
         date = a["createdAt"][:10]
         heading = f"Anotação de **{nm}** em *{doc}* ({date})"
         body = [f"> {ln}" if ln.strip() else ">" for ln in a["text"].splitlines()]
         return render_decision_block(heading, body, [a["id"]])
 
-    heading = f"{n_palavras(n, 'anotação', 'anotações', fem=True)} em *{doc}*"
+    heading = f"{count_in_words(n, 'anotação', 'anotações', fem=True)} em *{doc}*"
     body: list[str] = []
-    for a in anots:
+    for a in annots:
         nm = pretty_author(a.get("author"))
         date = a["createdAt"][:10]
         txt = a["text"].strip().replace("\n", " ")
         body.append(f"- **{nm}** ({date}) — {txt}")
     body.append("")
-    ids = [a["id"] for a in anots]
+    ids = [a["id"] for a in annots]
     return render_decision_block(heading, body, ids)
 
 
-def render_sugestao_cluster(cl: dict) -> list[str]:
-    s = cl["sugestao"]
+def render_suggestion_cluster(cl: dict) -> list[str]:
+    s = cl["suggestion"]
     nm = pretty_author(s.get("author"))
     date = s["createdAt"][:10]
     changes = (s.get("extra") or {}).get("suggestedChanges") or {}
@@ -338,24 +351,49 @@ def render_sugestao_cluster(cl: dict) -> list[str]:
     return render_decision_block(heading, body, [s["id"]])
 
 
-def render_field_section(f: dict, field_comments: list[dict]) -> list[str]:
-    lines = render_field_header(f)
+def render_clusters(field_comments: list[dict]) -> list[str]:
+    lines: list[str] = []
     clusters = build_clusters(field_comments)
     for cl in clusters:
         if cl["type"] == "review":
             lines.extend(render_review_cluster(cl))
         elif cl["type"] == "duvidas-orphans":
-            lines.extend(render_duvidas_orphan_cluster(cl))
+            lines.extend(render_doubts_orphan_cluster(cl))
         elif cl["type"] == "anotacoes":
-            lines.extend(render_anotacoes_cluster(cl))
+            lines.extend(render_annotations_cluster(cl))
         elif cl["type"] == "sugestao":
-            lines.extend(render_sugestao_cluster(cl))
+            lines.extend(render_suggestion_cluster(cl))
+    return lines
+
+
+def render_field_section(f: dict, field_comments: list[dict]) -> list[str]:
+    lines = render_field_header(f)
+    lines.extend(render_clusters(field_comments))
     lines.append("---")
     lines.append("")
     return lines
 
 
-def render_geral(comments: list[dict]) -> list[str]:
+def render_orphan_field_section(field_name: str, field_comments: list[dict]) -> list[str]:
+    """Comentários cujo fieldName não existe mais no schema atual (campo
+    removido ou renomeado). Sem isso, seriam silenciosamente omitidos do
+    relatório apesar de contados no total do cabeçalho."""
+    lines: list[str] = []
+    lines.append(f"## `{field_name}` (fora do schema atual)")
+    lines.append("")
+    lines.append(
+        "Este campo não existe mais no schema atual (removido ou renomeado), "
+        "mas ainda tem comentários abertos. Resolva-os normalmente ou indique "
+        "em `Mudança no schema:` a qual campo atual a discussão se refere."
+    )
+    lines.append("")
+    lines.extend(render_clusters(field_comments))
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
+def render_general(comments: list[dict]) -> list[str]:
     lines: list[str] = []
     lines.append("## Notas gerais")
     lines.append("")
@@ -385,21 +423,51 @@ def render_geral(comments: list[dict]) -> list[str]:
     return lines
 
 
+def render_exclusions(comments: list[dict]) -> list[str]:
+    """Pedidos de exclusão de documento — informativos, sem bloco de decisão.
+    A aprovação exige excludeDocuments (soft delete + auditoria) e é feita
+    pela plataforma, não pelo apply-decisions."""
+    lines: list[str] = []
+    lines.append("## Pedidos de exclusão de documento (resolver pela plataforma)")
+    lines.append("")
+    lines.append(
+        "Os pedidos abaixo NÃO são resolvidos por este fluxo: aprovar exige "
+        "excluir o documento (soft delete + auditoria), o que só a plataforma "
+        "faz. Trate-os na página de comentários do projeto."
+    )
+    lines.append("")
+    for c in comments:
+        nm = pretty_author(c.get("author"))
+        date = c["createdAt"][:10]
+        doc = c.get("documentTitle") or "—"
+        lines.append(f"### Exclusão solicitada por **{nm}** — *{doc}* ({date})")
+        lines.append("")
+        for ln in c["text"].splitlines():
+            lines.append(f"> {ln}" if ln.strip() else ">")
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+    return lines
+
+
 def render(data: dict) -> str:
     project = data["project"]
     fields = data["fields"]
     comments = data["comments"]
     stats = data["stats"]
 
+    exclusions = [c for c in comments if c["source"] == "exclusao"]
+    decidable = [c for c in comments if c["source"] != "exclusao"]
+
     by_field: dict[str, list[dict]] = {}
-    for c in comments:
+    for c in decidable:
         by_field.setdefault(c["fieldName"], []).append(c)
 
     lines: list[str] = []
     lines.append(f"# Comentários em aberto — {project['name']}")
     lines.append("")
     n_fields = len([f for f in by_field if f != "(geral)"])
-    n_geral = len(by_field.get("(geral)", []))
+    n_general = len(by_field.get("(geral)", []))
     src_summary = ", ".join(f"{v} {k}" for k, v in sorted(stats["bySource"].items()))
     lines.append(
         f"Projeto `{project['id']}` na versão do schema `{project['version']}`. "
@@ -408,7 +476,7 @@ def render(data: dict) -> str:
     lines.append("")
     lines.append(
         f"Há **{stats['totalOpen']} comentários em aberto** — "
-        f"{n_fields} perguntas com comentários específicos e {n_geral} "
+        f"{n_fields} perguntas com comentários específicos e {n_general} "
         f"nota(s) geral(is). Por fonte: {src_summary}."
     )
     lines.append("")
@@ -422,13 +490,23 @@ def render(data: dict) -> str:
     lines.append("---")
     lines.append("")
 
+    schema_field_names = {f["name"] for f in fields}
     for f in fields:
         if f["name"] not in by_field:
             continue
         lines.extend(render_field_section(f, by_field[f["name"]]))
 
+    # Campos com comentários mas fora do schema atual (removidos/renomeados)
+    for field_name, field_comments in by_field.items():
+        if field_name == "(geral)" or field_name in schema_field_names:
+            continue
+        lines.extend(render_orphan_field_section(field_name, field_comments))
+
     if "(geral)" in by_field:
-        lines.extend(render_geral(by_field["(geral)"]))
+        lines.extend(render_general(by_field["(geral)"]))
+
+    if exclusions:
+        lines.extend(render_exclusions(exclusions))
 
     return "\n".join(lines) + "\n"
 
@@ -436,7 +514,7 @@ def render(data: dict) -> str:
 def main() -> None:
     if len(sys.argv) != 3:
         print(
-            "Uso: python3 generate-report.py <comments.json> <output.md>",
+            "Uso: uv run generate-report.py <comments.json> <output.md>",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/frontend/scripts/comentarios-relatorio/generate-report.py
+++ b/frontend/scripts/comentarios-relatorio/generate-report.py
@@ -17,6 +17,11 @@ consome esse mesmo formato (via JSON intermediário produzido pelo Claude).
 Agrupamento (clusters por campo):
 1. Cada `review` vira um cluster — arrasta junto todas as `duvida` com
    `extra.reviewId` igual ao `rawId` do review + `anotacao` do mesmo documento.
+   Quando há mais de um review em aberto no mesmo documento+campo (dois
+   revisores), uma anotação do documento é "possuída" (resolvida) só pelo
+   primeiro cluster, mas ainda aparece como contexto (sem bloco de decisão
+   próprio) nos demais clusters do mesmo documento — ver
+   `render_annotation_context_bullets`.
 2. `duvida` órfãs (sem review correspondente no aberto) → cluster por reviewId.
 3. `anotacao` restantes → cluster por documentId dentro do campo.
 4. `sugestao` → um cluster por sugestão.
@@ -141,6 +146,15 @@ def build_clusters(field_comments: list[dict]) -> list[dict]:
     suggestions = [c for c in field_comments if c["source"] == "sugestao"]
 
     # 1. Cluster por review
+    #
+    # Uma anotação no mesmo documento pode ser contexto relevante para MAIS de
+    # um review em aberto (dois revisores no mesmo documento+campo). Ela só é
+    # "possuída" (resolvida) por um único bloco — o primeiro review processado
+    # — mas os demais reviews do mesmo documento ainda precisam VER o
+    # conteúdo, senão o segundo revisor perde contexto ao decidir. Por isso
+    # `annotations` (possuídas, entram no `<!-- ids: ... -->` do bloco) fica
+    # separado de `context_annotations` (só exibidas, já resolvidas em outro
+    # bloco).
     for r in reviews:
         if r["id"] in consumed:
             continue
@@ -149,15 +163,17 @@ def build_clusters(field_comments: list[dict]) -> list[dict]:
             if d["id"] not in consumed
             and d.get("extra", {}).get("reviewId") == r["rawId"]
         ]
-        cluster_annots = [
-            a for a in annotations
-            if a["id"] not in consumed and a.get("documentId") == r.get("documentId")
+        doc_annots = [
+            a for a in annotations if a.get("documentId") == r.get("documentId")
         ]
+        cluster_annots = [a for a in doc_annots if a["id"] not in consumed]
+        context_annots = [a for a in doc_annots if a["id"] in consumed]
         clusters.append({
             "type": "review",
             "anchor": r,
             "doubts": cluster_doubts,
             "annotations": cluster_annots,
+            "context_annotations": context_annots,
         })
         consumed.update([
             r["id"],
@@ -173,14 +189,17 @@ def build_clusters(field_comments: list[dict]) -> list[dict]:
         rid = d.get("extra", {}).get("reviewId") or d["rawId"]
         by_review.setdefault(rid, []).append(d)
     for rid, group in by_review.items():
-        cluster_annots = [
+        doc_annots = [
             a for a in annotations
-            if a["id"] not in consumed and a.get("documentId") == group[0].get("documentId")
+            if a.get("documentId") == group[0].get("documentId")
         ]
+        cluster_annots = [a for a in doc_annots if a["id"] not in consumed]
+        context_annots = [a for a in doc_annots if a["id"] in consumed]
         clusters.append({
             "type": "duvidas-orphans",
             "doubts": group,
             "annotations": cluster_annots,
+            "context_annotations": context_annots,
             "reviewId": rid,
         })
         consumed.update([
@@ -206,10 +225,33 @@ def build_clusters(field_comments: list[dict]) -> list[dict]:
     return clusters
 
 
+def render_annotation_context_bullets(context_annots: list[dict]) -> list[str]:
+    """Anotações do mesmo documento já vinculadas (resolvidas) a outro bloco —
+    mostradas aqui só como contexto, sem entrar no `ids` deste bloco."""
+    if not context_annots:
+        return []
+    plural = len(context_annots) > 1
+    vinculada = "vinculadas" if plural else "vinculada"
+    mostrada = "mostradas" if plural else "mostrada"
+    lines: list[str] = []
+    lines.append(
+        f"{count_in_words(len(context_annots), 'anotação', 'anotações', fem=True)} "
+        f"no mesmo documento já {vinculada} a outro bloco ({mostrada} aqui como contexto):"
+    )
+    lines.append("")
+    for a in context_annots:
+        nm = pretty_author(a.get("author"))
+        txt = a["text"].strip().replace("\n", " ")
+        lines.append(f"- **{nm}** — {txt}")
+    lines.append("")
+    return lines
+
+
 def render_review_cluster(cl: dict) -> list[str]:
     r = cl["anchor"]
     doubts = cl["doubts"]
     annots = cl["annotations"]
+    context_annots = cl.get("context_annotations", [])
     doc = r.get("documentTitle") or "(documento)"
     date = r["createdAt"][:10]
     verdict = format_verdict((r.get("extra") or {}).get("verdict"))
@@ -259,6 +301,8 @@ def render_review_cluster(cl: dict) -> list[str]:
             body.append(f"- **{nm}** — {txt}")
         body.append("")
 
+    body.extend(render_annotation_context_bullets(context_annots))
+
     ids = [r["id"], *(d["id"] for d in doubts), *(a["id"] for a in annots)]
     return render_decision_block(heading, body, ids)
 
@@ -266,6 +310,7 @@ def render_review_cluster(cl: dict) -> list[str]:
 def render_doubts_orphan_cluster(cl: dict) -> list[str]:
     doubts = cl["doubts"]
     annots = cl.get("annotations", [])
+    context_annots = cl.get("context_annotations", [])
     doc = doubts[0].get("documentTitle") or "(documento)"
     verdict = format_verdict((doubts[0].get("extra") or {}).get("verdict"))
 
@@ -293,6 +338,8 @@ def render_doubts_orphan_cluster(cl: dict) -> list[str]:
             txt = a["text"].strip().replace("\n", " ")
             body.append(f"- **{nm}** — {txt}")
         body.append("")
+
+    body.extend(render_annotation_context_bullets(context_annots))
 
     ids = [*(d["id"] for d in doubts), *(a["id"] for a in annots)]
     return render_decision_block(heading, body, ids)

--- a/frontend/scripts/comentarios-relatorio/load-env.ts
+++ b/frontend/scripts/comentarios-relatorio/load-env.ts
@@ -1,0 +1,41 @@
+/**
+ * load-env.ts — carga de .env.local compartilhada pelos scripts deste diretório.
+ *
+ * Honra SUPABASE_ENV_PATH explícito; caso contrário usa os caminhos canônicos
+ * relativos ao cwd (raiz do repo ou frontend/). Nunca sobe a árvore de
+ * diretórios (../.env.local) — ver CLAUDE.md.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+export function loadEnv(): void {
+  const cwd = process.cwd();
+  const candidates = [
+    process.env.SUPABASE_ENV_PATH,
+    resolve(cwd, ".env.local"),
+    resolve(cwd, "frontend/.env.local"),
+  ].filter((p): p is string => Boolean(p));
+  for (const path of candidates) {
+    try {
+      const content = readFileSync(path, "utf-8");
+      for (const line of content.split("\n")) {
+        const m = line.match(/^([A-Z_][A-Z0-9_]*)=(.*)$/);
+        if (!m) continue;
+        const key = m[1];
+        if (process.env[key]) continue;
+        let val = m[2].trim();
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1);
+        }
+        process.env[key] = val;
+      }
+      return;
+    } catch {
+      /* try next */
+    }
+  }
+}

--- a/frontend/scripts/comentarios-relatorio/references/decisions-format.md
+++ b/frontend/scripts/comentarios-relatorio/references/decisions-format.md
@@ -45,6 +45,8 @@ Todas as resoluções são validadas contra o `projectId` (ids de outro projeto 
 
 Sem `--yes`, **nada é gravado**: schema e resoluções rodam como preview (o output mostra o que seria feito). `--dry-run` é o alias explícito do mesmo comportamento. Só `--yes` (sem `--dry-run`) executa os writes — schema, resoluções e `summaryNote`.
 
+O preview roda os mesmos guards de posse (`projectId`) e checagens de existência que o `--yes` — só a escrita em si (UPDATE/INSERT/UPSERT) é trocada por um SELECT equivalente. Isso significa que `exclusao` já aparece como erro no preview (idêntico ao que `--yes` faria), e um `rawId`/`reviewId`/`respondentId` de outro projeto ou malformado também falha no preview, em vez de aparecer como "sucesso" e só falhar quando rodado com `--yes`.
+
 ## Cache da GUI após uma mudança de schema
 
 Este script roda fora do runtime Next (processo `tsx` standalone) e por isso não pode chamar `revalidatePath`/`revalidateTag` como `saveSchemaFromGUI` faz. Depois de um `--yes` que aplica mudança de schema, a GUI pode continuar mostrando o schema/versão anteriores por até ~60s (TTL do cache de `project-{id}-progress`) até o cache expirar naturalmente ou outra mutação pela própria GUI revalidar as mesmas rotas/tag. Se precisar ver o resultado imediatamente numa página específica, recarregue com Ctrl+Shift+R.

--- a/frontend/scripts/comentarios-relatorio/references/decisions-format.md
+++ b/frontend/scripts/comentarios-relatorio/references/decisions-format.md
@@ -1,0 +1,46 @@
+# Formato do decisions.json (apply-decisions.ts)
+
+Contrato do arquivo consumido por `apply-decisions.ts`. O JSON normalmente é gerado pelo Claude a partir do `.md` anotado pelo usuário (fluxo da skill comentarios-relatorio), mas nada impede autoria manual — desde que respeite este shape.
+
+## Estrutura
+
+```jsonc
+{
+  "projectId": "<uuid do projeto>",
+  "changedBy": "<uuid do usuário>",      // opcional; default: created_by do projeto
+  "newFields": [ /* PydanticField[] */ ], // lista COMPLETA pós-edições (não é um delta)
+  "resolutions": [ /* ver variantes abaixo */ ],
+  "summaryNote": "texto opcional"         // vira project_comment já resolvido
+}
+```
+
+## `newFields` — lista completa, nunca delta
+
+`newFields` substitui `projects.pydantic_fields` por inteiro: campos ausentes são tratados como **removidos** (entry "campo removido" no `schema_change_log`). Portanto, parta sempre do `fields` retornado por `fetch-open-comments.ts` e aplique as edições sobre ele.
+
+O shape de cada campo é o `PydanticField` de `frontend/src/lib/types.ts` (name, type, options, description, help_text, target, required, subfields, subfield_rule, allow_other, condition, justification_prompt). Não inclua `hash` — o script recalcula.
+
+**Guarda anti-wipe**: `newFields: []` sobre projeto que já tem schema é rejeitado com erro (espelha `saveSchemaFromGUI`). Remoção total de campos, se um dia for legítima, é feita pela UI.
+
+## `resolutions` — variantes por source
+
+Os `rawId`/ids vêm do JSON do `fetch-open-comments.ts` (campo `rawId` de cada comentário, salvo indicação em contrário).
+
+| source | shape | efeito |
+|--------|-------|--------|
+| `anotacao` | `{ "source": "anotacao", "rawId": "<project_comment id>" }` | UPDATE `project_comments` (resolved_at/by) |
+| `review` | `{ "source": "review", "rawId": "<review id>" }` | UPDATE `reviews` (resolved_at/by) |
+| `nota` | `{ "source": "nota", "rawId": "<response id>", "note": "opcional" }` | INSERT `note_resolutions` |
+| `dificuldade` | `{ "source": "dificuldade", "rawId": "<response id>", "documentId": "<doc id>", "note": "opcional" }` | INSERT `difficulty_resolutions` |
+| `duvida` | `{ "source": "duvida", "reviewId": "<review id>", "respondentId": "<user id>" }` | UPDATE `verdict_acknowledgments` |
+| `sugestao` | `{ "source": "sugestao", "rawId": "<suggestion id>", "action": "approved" \| "rejected", "rejectionReason": "opcional" }` | UPDATE `schema_suggestions` |
+
+Atenção ao caso `duvida`: o `rawId` do fetch é composto (`"reviewId|respondentId"`) — **não o parseie**; use `extra.reviewId` e `extra.respondentId` do próprio comentário, que já vêm separados.
+
+Pedidos de exclusão de documento (source `exclusao` no fetch) **não são resolvíveis por aqui**: a aprovação exige `excludeDocuments` (soft delete + auditoria), fluxo da plataforma. Se aparecerem em `resolutions`, o script devolve erro por item sem tocar o banco.
+
+Todas as resoluções são validadas contra o `projectId` (ids de outro projeto retornam erro por item), e `nota`/`dificuldade` são idempotentes — pares já resolvidos são ignorados via `UNIQUE(project_id, response_id)`.
+
+## Semântica de `--dry-run` / `--yes`
+
+Sem `--yes`, **nada é gravado**: schema e resoluções rodam como preview (o output mostra o que seria feito). `--dry-run` é o alias explícito do mesmo comportamento. Só `--yes` (sem `--dry-run`) executa os writes — schema, resoluções e `summaryNote`.

--- a/frontend/scripts/comentarios-relatorio/references/decisions-format.md
+++ b/frontend/scripts/comentarios-relatorio/references/decisions-format.md
@@ -39,8 +39,12 @@ Atenção ao caso `duvida`: o `rawId` do fetch é composto (`"reviewId|responden
 
 Pedidos de exclusão de documento (source `exclusao` no fetch) **não são resolvíveis por aqui**: a aprovação exige `excludeDocuments` (soft delete + auditoria), fluxo da plataforma. Se aparecerem em `resolutions`, o script devolve erro por item sem tocar o banco.
 
-Todas as resoluções são validadas contra o `projectId` (ids de outro projeto retornam erro por item), e `nota`/`dificuldade` são idempotentes — pares já resolvidos são ignorados via `UNIQUE(project_id, response_id)`.
+Todas as resoluções são validadas contra o `projectId` (ids de outro projeto retornam erro por item), e `nota`/`dificuldade` são idempotentes — pares já resolvidos são ignorados via `UNIQUE(project_id, response_id)`. **Importante**: idempotente aqui significa que o par existente **não é alterado** — se um `nota`/`dificuldade` já resolvido reaparecer em `decisions.json` com um `note` diferente do que já está gravado, essa nota nova é descartada silenciosamente (o upsert ignora o conflito) e o item volta com `result.detail` indicando "já resolvido anteriormente — nota não foi alterada" em vez de sugerir que a nota nova foi persistida.
 
 ## Semântica de `--dry-run` / `--yes`
 
 Sem `--yes`, **nada é gravado**: schema e resoluções rodam como preview (o output mostra o que seria feito). `--dry-run` é o alias explícito do mesmo comportamento. Só `--yes` (sem `--dry-run`) executa os writes — schema, resoluções e `summaryNote`.
+
+## Cache da GUI após uma mudança de schema
+
+Este script roda fora do runtime Next (processo `tsx` standalone) e por isso não pode chamar `revalidatePath`/`revalidateTag` como `saveSchemaFromGUI` faz. Depois de um `--yes` que aplica mudança de schema, a GUI pode continuar mostrando o schema/versão anteriores por até ~60s (TTL do cache de `project-{id}-progress`) até o cache expirar naturalmente ou outra mutação pela própria GUI revalidar as mesmas rotas/tag. Se precisar ver o resultado imediatamente numa página específica, recarregue com Ctrl+Shift+R.

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -6,12 +6,10 @@ import { revalidatePath, revalidateTag } from "next/cache";
 import { fetchFastAPIServer } from "@/lib/api-server";
 import type { PydanticField } from "@/lib/types";
 import {
-  generatePydanticCode,
   computeFieldHash,
-  classifyChange,
   bumpVersion,
-  diffFields,
   fieldDiffIsStructural,
+  planSchemaPersistence,
   type ChangeType,
 } from "@/lib/schema-utils";
 import { updateOrThrow } from "@/lib/supabase/rls-guard";
@@ -127,10 +125,10 @@ export async function savePrompt(
 
 // ---------- Save from GUI ----------
 //
-// Orquestrador fino: lê o estado antigo, delega a classificação/diff às
-// primitivas puras de lib/schema-utils.ts e faz os writes. As primitivas
-// (classifyChange, bumpVersion, diffFields, computeFieldHash) são compartilhadas
-// com scripts fora do Next runtime para eliminar drift — ver #63.
+// Orquestrador fino: lê o estado antigo, delega o cálculo a
+// planSchemaPersistence (lib/schema-utils.ts, pura) e faz os writes. A mesma
+// função é usada por apply-decisions.ts (fora do Next runtime) para eliminar
+// drift — ver #63/PR #352.
 
 export async function saveSchemaFromGUI(
   projectId: string,
@@ -179,18 +177,15 @@ export async function saveSchemaFromGUI(
     patch: project?.schema_version_patch ?? 0,
   };
 
-  const changeType = classifyChange(oldFields, fields);
-  const bumped = changeType ? bumpVersion(current, changeType) : current;
+  // Classificação, versão, log de auditoria, código Pydantic e hash: cálculo
+  // puro compartilhado com apply-decisions.ts via planSchemaPersistence
+  // (schema-utils.ts) — ver #63/PR #352 (evita drift entre os dois callers).
+  const { changeType, bumped, logEntries, code, fieldsWithHash } = planSchemaPersistence(
+    oldFields,
+    fields,
+    current,
+  );
 
-  // Detect per-field changes and build log entries
-  const logEntries = diffFields(oldFields, fields);
-
-  // Save schema com versão bumpada (ou mantida se não houve mudança)
-  const code = generatePydanticCode(fields);
-  const fieldsWithHash = fields.map((f) => ({
-    ...f,
-    hash: computeFieldHash(f.name, f.type, f.options, f.description),
-  }));
   const saved = await saveSchema(projectId, code, fieldsWithHash, changeType ? bumped : undefined);
   if (saved.error) return saved;
 

--- a/frontend/src/lib/__tests__/schema-change-utils.test.ts
+++ b/frontend/src/lib/__tests__/schema-change-utils.test.ts
@@ -107,13 +107,34 @@ describe("diffPydanticField", () => {
     expect(diffs).toEqual([]);
   });
 
-  it("captura mudança de subfields via JSON.stringify", () => {
+  it("captura mudança de subfields", () => {
     const diffs = diffPydanticField(
       { subfields: [{ key: "a", label: "A", required: true }] },
       { subfields: [{ key: "a", label: "A", required: false }] },
     );
     expect(diffs).toHaveLength(1);
     expect(diffs[0].property).toBe("subfields");
+  });
+
+  // O jsonb do Postgres normaliza a ordem das chaves; before/after lidos do
+  // banco podem vir com subfields/condition reordenados em relação ao que
+  // foi autorado no cliente. subfieldsEqual/conditionEqual usam
+  // stableStringify (não JSON.stringify) por isso — mesma correção de
+  // schema-utils.ts (classifyChange/diffFields), ver PR #352.
+  it("não reporta mudança de subfields quando só a ordem das chaves difere (round-trip jsonb)", () => {
+    const diffs = diffPydanticField(
+      { subfields: [JSON.parse('{"required":true,"key":"a","label":"A"}')] },
+      { subfields: [{ key: "a", label: "A", required: true }] },
+    );
+    expect(diffs).toHaveLength(0);
+  });
+
+  it("não reporta mudança de condition quando só a ordem das chaves difere (round-trip jsonb)", () => {
+    const diffs = diffPydanticField(
+      { condition: JSON.parse('{"equals":"a","field":"x"}') },
+      { condition: { field: "x", equals: "a" } },
+    );
+    expect(diffs).toHaveLength(0);
   });
 
   it("captura propriedades novas no SubfieldDef futuro (futureproof)", () => {

--- a/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
+++ b/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
@@ -8,8 +8,9 @@ import {
   diffFields,
   fieldDiffIsStructural,
   generatePydanticCode,
+  stableStringify,
 } from "@/lib/schema-utils";
-import type { PydanticField } from "@/lib/types";
+import type { FieldCondition, PydanticField } from "@/lib/types";
 
 const baseField = (over: Partial<PydanticField>): PydanticField => ({
   name: "x",
@@ -103,6 +104,57 @@ describe("classifyChange", () => {
       baseField({ name: "q1", options: ["A"], justification_prompt: "cite o trecho" }),
     ];
     expect(classifyChange(oldF, newF)).toBe("patch");
+  });
+});
+
+// O jsonb do Postgres normaliza a ordem das chaves; condition/subfields lidos
+// do banco voltam com chaves reordenadas em relação ao objeto autorado no
+// cliente. As comparações precisam ser insensíveis a isso.
+describe("stableStringify (round-trip jsonb)", () => {
+  // Mesma condição com as chaves em ordens opostas, como o jsonb devolveria.
+  const condA = { field: "q0", equals: "Sim" } as FieldCondition;
+  const condB = JSON.parse('{"equals":"Sim","field":"q0"}') as FieldCondition;
+
+  it("é insensível à ordem das chaves, inclusive aninhadas", () => {
+    expect(stableStringify(condA)).toBe(stableStringify(condB));
+    expect(
+      stableStringify([{ key: "a", label: "A" }, { label: "B", key: "b" }]),
+    ).toBe(stableStringify([{ label: "A", key: "a" }, { key: "b", label: "B" }]));
+  });
+
+  it("distingue valores realmente diferentes e omite undefined", () => {
+    expect(stableStringify({ field: "q0", equals: "Sim" })).not.toBe(
+      stableStringify({ field: "q0", equals: "Não" }),
+    );
+    expect(stableStringify({ a: 1, b: undefined })).toBe(stableStringify({ a: 1 }));
+  });
+
+  it("classifyChange retorna null para condition idêntica com chaves reordenadas", () => {
+    const oldF = [baseField({ name: "q1", options: ["A"], condition: condB })];
+    const newF = [baseField({ name: "q1", options: ["A"], condition: condA })];
+    expect(classifyChange(oldF, newF)).toBeNull();
+    expect(diffFields(oldF, newF)).toHaveLength(0);
+  });
+
+  it("classifyChange segue minor para mudança real de condition", () => {
+    const oldF = [baseField({ name: "q1", options: ["A"], condition: condA })];
+    const newF = [
+      baseField({
+        name: "q1",
+        options: ["A"],
+        condition: { field: "q0", equals: "Não" },
+      }),
+    ];
+    expect(classifyChange(oldF, newF)).toBe("minor");
+    const entries = diffFields(oldF, newF);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].change_summary).toContain("condição");
+  });
+
+  it("fieldDiffIsStructural ignora reordenação de chaves em condition", () => {
+    expect(fieldDiffIsStructural({ condition: condA }, { condition: condB })).toBe(
+      false,
+    );
   });
 });
 

--- a/frontend/src/lib/schema-change-utils.ts
+++ b/frontend/src/lib/schema-change-utils.ts
@@ -1,3 +1,4 @@
+import { stableStringify } from "./schema-utils";
 import type {
   FieldCondition,
   SchemaChangeEntry,
@@ -64,13 +65,19 @@ function arraysEqual<T>(a: T[] | null | undefined, b: T[] | null | undefined): b
   return true;
 }
 
+// stableStringify (não JSON.stringify) — o jsonb do Postgres normaliza a
+// ordem das chaves, então before/after vindos do banco podem ter subfields/
+// condition com chaves reordenadas em relação ao que foi autorado no
+// cliente. Mesma correção de schema-utils.ts (classifyChange/diffFields),
+// aplicada aqui para o diff de histórico ficar em sincronia — ver CLAUDE.md
+// regra (d) e PR #352.
 function subfieldsEqual(
   a: SubfieldDef[] | null | undefined,
   b: SubfieldDef[] | null | undefined,
 ): boolean {
   if (!a && !b) return true;
   if (!a || !b) return false;
-  return JSON.stringify(a) === JSON.stringify(b);
+  return stableStringify(a) === stableStringify(b);
 }
 
 function conditionEqual(
@@ -79,7 +86,7 @@ function conditionEqual(
 ): boolean {
   if (!a && !b) return true;
   if (!a || !b) return false;
-  return JSON.stringify(a) === JSON.stringify(b);
+  return stableStringify(a) === stableStringify(b);
 }
 
 export function diffPydanticField(

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -845,3 +845,37 @@ export function diffFields(
 
   return logEntries;
 }
+
+export interface SchemaPersistencePlan {
+  changeType: ChangeType | null;
+  bumped: { major: number; minor: number; patch: number };
+  logEntries: SchemaLogEntry[];
+  code: string;
+  hash: string;
+  fieldsWithHash: PydanticField[];
+}
+
+// Calcula tudo que uma troca de schema precisa persistir — classificação,
+// versão, log de auditoria, código Pydantic e hash — sem escrever nada.
+// Extraído para eliminar a duplicação entre `saveSchemaFromGUI`
+// (src/actions/schema.ts, autenticado via Clerk/RLS) e o script
+// `apply-decisions.ts` (fora do runtime Next, service-role key): os dois
+// clientes Supabase e as regras de revalidação de cache continuam
+// específicos de cada chamador, mas o que calcular é a mesma coisa e não
+// deve ser reimplementado em paralelo (risco de drift — ver #63/PR #352).
+export function planSchemaPersistence(
+  oldFields: PydanticField[],
+  newFields: PydanticField[],
+  current: { major: number; minor: number; patch: number },
+): SchemaPersistencePlan {
+  const changeType = classifyChange(oldFields, newFields);
+  const bumped = changeType ? bumpVersion(current, changeType) : current;
+  const logEntries = diffFields(oldFields, newFields);
+  const code = generatePydanticCode(newFields);
+  const hash = sha256Hex(code).slice(0, 16);
+  const fieldsWithHash = newFields.map((f) => ({
+    ...f,
+    hash: computeFieldHash(f.name, f.type, f.options, f.description),
+  }));
+  return { changeType, bumped, logEntries, code, hash, fieldsWithHash };
+}

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -536,6 +536,28 @@ function pythonListRepr(arr: string[]): string {
   return "[" + arr.map((s) => `'${s}'`).join(", ") + "]";
 }
 
+// Stringify canônico (chaves ordenadas, `undefined` omitido) para comparar
+// valores que fazem round-trip pelo jsonb do Postgres, que normaliza a ordem
+// das chaves — `JSON.stringify` cru sobre `condition`/`subfields` lidos do
+// banco vs. autorados no cliente gera falso diff (bump minor com
+// before == after no schema_change_log).
+export function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return "[" + value.map(stableStringify).join(",") + "]";
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return (
+      "{" +
+      entries.map(([k, v]) => JSON.stringify(k) + ":" + stableStringify(v)).join(",") +
+      "}"
+    );
+  }
+  return JSON.stringify(value);
+}
+
 // Hash estável por campo — espelha _field_hash do backend. Exclui `target`,
 // `condition`, `help_text` (carregados estruturalmente) de propósito: mudá-los
 // não invalida respostas já coletadas.
@@ -584,10 +606,10 @@ export function classifyChange(
     if ((o.required ?? true) !== (n.required ?? true)) hasStructural = true;
     if ((o.subfield_rule ?? null) !== (n.subfield_rule ?? null)) hasStructural = true;
     if ((o.allow_other ?? false) !== (n.allow_other ?? false)) hasStructural = true;
-    if (JSON.stringify(o.subfields ?? null) !== JSON.stringify(n.subfields ?? null)) {
+    if (stableStringify(o.subfields ?? null) !== stableStringify(n.subfields ?? null)) {
       hasStructural = true;
     }
-    if (JSON.stringify(o.condition ?? null) !== JSON.stringify(n.condition ?? null)) {
+    if (stableStringify(o.condition ?? null) !== stableStringify(n.condition ?? null)) {
       hasStructural = true;
     }
 
@@ -678,13 +700,13 @@ export function fieldDiffIsStructural(
   }
 
   if (before.subfields !== undefined || after.subfields !== undefined) {
-    if (JSON.stringify(before.subfields ?? null) !== JSON.stringify(after.subfields ?? null)) {
+    if (stableStringify(before.subfields ?? null) !== stableStringify(after.subfields ?? null)) {
       return true;
     }
   }
 
   if (before.condition !== undefined || after.condition !== undefined) {
-    if (JSON.stringify(before.condition ?? null) !== JSON.stringify(after.condition ?? null)) {
+    if (stableStringify(before.condition ?? null) !== stableStringify(after.condition ?? null)) {
       return true;
     }
   }
@@ -791,15 +813,15 @@ export function diffFields(
       before.allow_other = old.allow_other ?? false;
       after.allow_other = f.allow_other ?? false;
     }
-    const oldSubs = JSON.stringify(old.subfields ?? null);
-    const newSubs = JSON.stringify(f.subfields ?? null);
+    const oldSubs = stableStringify(old.subfields ?? null);
+    const newSubs = stableStringify(f.subfields ?? null);
     if (oldSubs !== newSubs) {
       diffs.push("subcampos");
       before.subfields = old.subfields ?? null;
       after.subfields = f.subfields ?? null;
     }
-    const oldCond = JSON.stringify(old.condition ?? null);
-    const newCond = JSON.stringify(f.condition ?? null);
+    const oldCond = stableStringify(old.condition ?? null);
+    const newCond = stableStringify(f.condition ?? null);
     if (oldCond !== newCond) {
       diffs.push("condição");
       before.condition = old.condition ?? null;


### PR DESCRIPTION
## Contexto

Os scripts de `frontend/scripts/comentarios-relatorio/` viviam **fora do repo** (`.git/info/exclude`) e referenciavam a coluna morta `responses.is_current`, renomeada para `is_latest` pela migration `20260514190000_rename_is_current_to_is_latest.sql`. A #349 documenta o problema e a decisão de promovê-los ao repo (são genéricos — recebem `projectId` por parâmetro, sem UUIDs hardcoded, sem segredos embutidos).

Este PR traz os 3 scripts com os fixes já aplicados localmente em 2026-07-02.

## Fixes embutidos

- **`apply-decisions.ts`**: bloco de invalidação de responses **removido** (não renomeado). `is_latest` não é flipado na troca de schema (`src/actions/schema.ts:94`); staleness é detectada por `pydantic_hash`/`answer_field_hashes`. Renomear a coluna reintroduziria o bug de respostas LLM órfãs que a migration `20260505000001` reviveu. De quebra, o insert em `schema_change_log` deixa de ter um passo falível na frente (antes, o UPDATE com `is_current` abortava **depois** do update em `projects` e **antes** da auditoria — schema aplicado, histórico perdido).
- **`fetch-open-comments.ts:218`**: filtro de leitura agora `.eq("is_latest", true)`.
- **Falso-diff jsonb** (`condition`/`subfields`): resolvido com `stableStringify` (chaves ordenadas). O jsonb do Postgres normaliza a ordem das chaves, então `JSON.stringify` cru fazia todo re-run virar falso bump minor com entries `before == after`.

## Extra (alinhamento ao CLAUDE.md)

`loadEnv()` nos dois `.ts` deixa de subir a árvore de diretórios (`../.env.local`, proibido): honra `SUPABASE_ENV_PATH` explícito e cai nos caminhos canônicos relativos ao cwd.

## Escopo

Só os 3 arquivos de `comentarios-relatorio/`. A skill (`.claude/skills/comentarios-relatorio/`) e `docs/comentarios/` seguem **local-only** (linha correspondente mantida no `.git/info/exclude`).

## Verificação

- `tsc --noEmit -p tsconfig.json`: **zero erros** nos scripts promovidos (os 18 erros restantes são pré-existentes nos fixtures de `ComparePage.test.tsx` — `defaultVersion`, alheios ao PR).
- `grep is_current` → vazio; `grep ../.env.local` (código) → vazio.
- Hooks de pre-push pulados: `typecheck` (red pré-existente do ComparePage), `lint-types` (crash do ESLint 10 × plugin-react, pré-existente), `fallow-audit` ("unused files" — natureza de script CLI standalone, não importado). gitleaks + semgrep + react-doctor passaram.

Closes #349