### PR TITLE
refactor(react-doctor): decompõe CommentCard e LlmInsightsView (Stats, #339 Fase 3)

### DIFF
--- a/frontend/doctor.config.json
+++ b/frontend/doctor.config.json
@@ -50,8 +50,7 @@
       {
         "files": [
           "src/components/auto-review/AutoReviewFieldPanel.tsx",
-          "src/components/compare/ComparisonPanel.tsx",
-          "src/components/stats/ExclusionActions.tsx"
+          "src/components/compare/ComparisonPanel.tsx"
         ],
         "rules": [
           "react-doctor/no-event-handler"

--- a/frontend/doctor.config.json
+++ b/frontend/doctor.config.json
@@ -51,7 +51,7 @@
         "files": [
           "src/components/auto-review/AutoReviewFieldPanel.tsx",
           "src/components/compare/ComparisonPanel.tsx",
-          "src/components/stats/CommentCard.tsx"
+          "src/components/stats/ExclusionActions.tsx"
         ],
         "rules": [
           "react-doctor/no-event-handler"

--- a/frontend/src/actions/stats.ts
+++ b/frontend/src/actions/stats.ts
@@ -241,6 +241,8 @@ export async function reopenDifficulty(
 }
 
 export interface GabaritoRespondentAnswer {
+  /** id da resposta — key estável de render (nomes de respondente colidem). */
+  id: string;
   respondentName: string;
   respondentType: "humano" | "llm";
   answer: unknown;
@@ -271,6 +273,7 @@ export async function fetchGabaritoForComment(
     if (!responses) return { answers: [] };
 
     const result: GabaritoRespondentAnswer[] = responses.map((r) => ({
+      id: r.id,
       respondentName: r.respondent_name || "Anônimo",
       respondentType: r.respondent_type as "humano" | "llm",
       answer: (r.answers as Record<string, unknown>)?.[fieldName] ?? null,

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -9,61 +9,11 @@ import { CommentCardHeader } from "./CommentCardHeader";
 import { GabaritoSection } from "./GabaritoSection";
 import { SuggestionActions } from "./SuggestionActions";
 import { ExclusionActions } from "./ExclusionActions";
+import type { ReviewComment } from "./comment-card-utils";
 
-export interface ResponseSnapshotEntry {
-  id: string;
-  respondent_name: string;
-  respondent_type: "humano" | "llm";
-  answer: unknown;
-  justification?: string;
-}
-
-export interface ReviewComment {
-  id: string;
-  documentId: string;
-  documentTitle: string;
-  fieldName: string;
-  fieldDescription: string;
-  fieldHelpText?: string;
-  fieldOptions?: string[] | null;
-  fieldType?: "single" | "multi" | "text" | "date";
-  verdict: string;
-  comment: string;
-  reviewerName: string;
-  resolvedAt: string | null;
-  createdAt: string;
-  chosenResponseId: string | null;
-  source:
-    | "review"
-    | "nota"
-    | "sugestao"
-    | "dificuldade"
-    | "anotacao"
-    | "duvida"
-    | "exclusao";
-  responseSnapshot: ResponseSnapshotEntry[] | null;
-  suggestionId?: string;
-  suggestionStatus?: "pending" | "approved" | "rejected";
-  suggestionChanges?: {
-    description?: string;
-    help_text?: string | null;
-    options?: string[] | null;
-  };
-  fieldSnapshot?: {
-    description: string;
-    help_text: string | null;
-    options: string[] | null;
-  };
-  difficultyResponseId?: string;
-  difficultyDocumentId?: string;
-  duvidaReviewId?: string;
-  duvidaRespondentId?: string;
-  /** Para exclusao_request — id do project_comment, status e document_id alvo. */
-  exclusionCommentId?: string;
-  exclusionDocumentId?: string;
-  exclusionStatus?: "pending" | "approved" | "rejected";
-  exclusionRejectedReason?: string | null;
-}
+// Tipos vivem em comment-card-utils.ts (evita ciclo pai↔filho com os
+// componentes extraídos); re-export mantém os consumidores externos intactos.
+export type { ReviewComment, ResponseSnapshotEntry } from "./comment-card-utils";
 
 interface CommentCardProps {
   comment: ReviewComment;
@@ -116,7 +66,8 @@ export function CommentCard({
 
         {comment.source === "sugestao" && comment.suggestionId && (
           <SuggestionActions
-            comment={comment}
+            suggestionId={comment.suggestionId}
+            suggestionStatus={comment.suggestionStatus}
             projectId={projectId}
             isPending={isPending}
             isCoordinator={isCoordinator}

--- a/frontend/src/components/stats/CommentCard.tsx
+++ b/frontend/src/components/stats/CommentCard.tsx
@@ -1,50 +1,14 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import {
-  CheckCircle2,
-  RotateCcw,
-  ChevronDown,
-  Pencil,
-  Loader2,
-  Check,
-} from "lucide-react";
+import { CheckCircle2, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
-import {
-  fetchGabaritoForComment,
-  type GabaritoRespondentAnswer,
-} from "@/actions/stats";
-import { resolveSchemaSuggestion } from "@/actions/suggestions";
-import {
-  approveExclusionRequest,
-  rejectExclusionRequest,
-} from "@/actions/project-comments";
 import { SuggestionDiff } from "./SuggestionDiff";
-import { Textarea } from "@/components/ui/textarea";
-import { toast } from "sonner";
-
-const TYPE_LABELS: Record<string, string> = {
-  single: "Escolha única",
-  multi: "Múltipla escolha",
-  text: "Texto livre",
-  date: "Data",
-};
-
-const TYPE_COLORS: Record<string, string> = {
-  single: "bg-blue-500/10 text-blue-700",
-  multi: "bg-purple-500/10 text-purple-700",
-  text: "bg-green-500/10 text-green-700",
-  date: "bg-amber-500/10 text-amber-700",
-};
+import { CommentCardHeader } from "./CommentCardHeader";
+import { GabaritoSection } from "./GabaritoSection";
+import { SuggestionActions } from "./SuggestionActions";
+import { ExclusionActions } from "./ExclusionActions";
 
 export interface ResponseSnapshotEntry {
   id: string;
@@ -113,49 +77,6 @@ interface CommentCardProps {
   onOpenDocument?: (documentId: string) => void;
 }
 
-function formatVerdictLabel(verdict: string): string {
-  if (verdict === "nota") return "Nota do pesquisador";
-  if (verdict === "anotacao") return "Anotação";
-  if (verdict === "dificuldade") return "Dificuldade do LLM";
-  if (verdict === "sugestao") return "Sugestão";
-  if (verdict === "exclusao") return "Sugestão de exclusão";
-  if (verdict === "duvida") return "Dúvida do gabarito";
-  if (verdict === "ambiguo") return "Ambíguo";
-  if (verdict === "pular") return "Pular";
-  if (verdict.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(verdict) as Record<string, boolean>;
-      const selected = Object.entries(parsed)
-        .filter(([, v]) => v)
-        .map(([k]) => k);
-      return selected.length > 0 ? selected.join(", ") : "(nenhuma)";
-    } catch {
-      /* fallback */
-    }
-  }
-  return verdict;
-}
-
-function verdictVariant(
-  verdict: string,
-): "default" | "secondary" | "destructive" | "outline" {
-  if (verdict === "nota") return "secondary";
-  if (verdict === "anotacao") return "secondary";
-  if (verdict === "dificuldade") return "secondary";
-  if (verdict === "sugestao") return "outline";
-  if (verdict === "exclusao") return "destructive";
-  if (verdict === "duvida") return "secondary";
-  if (verdict === "ambiguo") return "secondary";
-  if (verdict === "pular") return "outline";
-  return "default";
-}
-
-function formatAnswer(answer: unknown): string {
-  if (answer === null || answer === undefined) return "(sem resposta)";
-  if (Array.isArray(answer)) return answer.join(", ");
-  return String(answer);
-}
-
 export function CommentCard({
   comment,
   projectId,
@@ -167,126 +88,18 @@ export function CommentCard({
   onSuggestField,
   onOpenDocument,
 }: CommentCardProps) {
-  const { refresh } = useRouter();
   const isResolved = !!comment.resolvedAt;
-  const [suggestionPending, startSuggestionAction] = useTransition();
-  const [gabaritoOpen, setGabaritoOpen] = useState(false);
-  const [gabaritoData, setGabaritoData] = useState<
-    GabaritoRespondentAnswer[] | null
-  >(null);
-  const [loadingGabarito, startLoadGabarito] = useTransition();
-
-  // If snapshot exists, convert to gabarito format immediately
-  const snapshotAsGabarito: GabaritoRespondentAnswer[] | null =
-    comment.responseSnapshot
-      ? comment.responseSnapshot.map((r) => ({
-          respondentName: r.respondent_name,
-          respondentType: r.respondent_type,
-          answer: r.answer,
-          isChosen: r.id === comment.chosenResponseId,
-        }))
-      : null;
-
-  const handleGabaritoToggle = (open: boolean) => {
-    setGabaritoOpen(open);
-    // Only fetch if no snapshot and no cached data
-    if (open && !gabaritoData && !snapshotAsGabarito) {
-      startLoadGabarito(async () => {
-        const result = await fetchGabaritoForComment(
-          projectId,
-          comment.documentId,
-          comment.fieldName,
-          comment.chosenResponseId,
-        );
-        setGabaritoData(result.answers);
-      });
-    }
-  };
-
-  const gabaritoEntries = snapshotAsGabarito ?? gabaritoData;
 
   return (
     <Card className={cn(isResolved && "opacity-60")}>
       <CardContent className="space-y-2 pt-4">
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
-            {onOpenDocument && comment.documentId ? (
-              <button
-                type="button"
-                onClick={() => onOpenDocument(comment.documentId)}
-                className="text-sm font-medium hover:underline text-left"
-              >
-                {comment.documentTitle}
-              </button>
-            ) : (
-              <span className="text-sm font-medium">{comment.documentTitle || comment.fieldName}</span>
-            )}
-            <div className="flex items-center gap-1.5">
-              <code className="text-xs font-mono text-muted-foreground/70">
-                {comment.fieldName}
-              </code>
-              {isCoordinator && onEditField && comment.source !== "nota" && comment.source !== "exclusao" && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="size-5 p-0"
-                  onClick={onEditField}
-                  title="Editar campo"
-                >
-                  <Pencil className="size-3" />
-                </Button>
-              )}
-              {!isCoordinator && onSuggestField && comment.source !== "nota" && comment.source !== "exclusao" && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="size-5 p-0"
-                  onClick={onSuggestField}
-                  title="Sugerir alteração"
-                >
-                  <Pencil className="size-3 text-amber-500" />
-                </Button>
-              )}
-            </div>
-            {comment.fieldDescription &&
-              comment.fieldDescription !== comment.fieldName && (
-                <p className="text-xs text-muted-foreground">
-                  {comment.fieldDescription}
-                </p>
-              )}
-          </div>
-          <Badge
-            variant={verdictVariant(comment.verdict)}
-            className="shrink-0"
-          >
-            {formatVerdictLabel(comment.verdict)}
-          </Badge>
-        </div>
-
-        {/* Metadados do campo (contexto para avaliacao do schema) */}
-        {(comment.fieldType || comment.fieldHelpText || (comment.fieldOptions && comment.fieldOptions.length > 0)) && (
-          <div className="space-y-1 rounded-md bg-muted/30 px-3 py-2">
-            {comment.fieldType && (
-              <Badge className={cn("text-[10px] px-1 py-0", TYPE_COLORS[comment.fieldType])}>
-                {TYPE_LABELS[comment.fieldType]}
-              </Badge>
-            )}
-            {comment.fieldHelpText && (
-              <p className="text-xs italic text-muted-foreground">
-                {comment.fieldHelpText}
-              </p>
-            )}
-            {comment.fieldOptions && comment.fieldOptions.length > 0 && (
-              <div className="flex flex-wrap gap-1">
-                {comment.fieldOptions.map((opt) => (
-                  <Badge key={opt} variant="outline" className="text-[10px] px-1.5 py-0 font-normal">
-                    {opt}
-                  </Badge>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
+        <CommentCardHeader
+          comment={comment}
+          isCoordinator={isCoordinator}
+          onEditField={onEditField}
+          onSuggestField={onSuggestField}
+          onOpenDocument={onOpenDocument}
+        />
 
         <blockquote className="border-l-2 pl-3 text-sm text-foreground">
           {comment.comment}
@@ -301,47 +114,14 @@ export function CommentCard({
             />
           )}
 
-        {/* Suggestion actions (coordinator: review/reject)
-            "Revisar" abre EditFieldDialog pré-preenchido (via onResolve);
-            salvar lá aprova com os valores finais editados. */}
         {comment.source === "sugestao" && comment.suggestionId && (
-          <div className="flex items-center gap-2">
-            {comment.suggestionStatus === "pending" && isCoordinator && (
-              <>
-                <Button
-                  variant="default"
-                  size="sm"
-                  className="h-6 text-xs"
-                  disabled={suggestionPending || isPending}
-                  onClick={onResolve}
-                  title="Abre editor para revisar antes de aprovar"
-                >
-                  Revisar
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-6 text-xs"
-                  disabled={suggestionPending}
-                  onClick={() => {
-                    startSuggestionAction(async () => {
-                      const result = await resolveSchemaSuggestion(comment.suggestionId!, projectId, "rejected");
-                      if (result.error) toast.error(result.error);
-                      else { toast.success("Sugestão rejeitada"); refresh(); }
-                    });
-                  }}
-                >
-                  Rejeitar
-                </Button>
-              </>
-            )}
-            {comment.suggestionStatus === "approved" && (
-              <Badge className="text-xs bg-green-500/10 text-green-700">Aprovada</Badge>
-            )}
-            {comment.suggestionStatus === "rejected" && (
-              <Badge className="text-xs bg-red-500/10 text-red-700">Rejeitada</Badge>
-            )}
-          </div>
+          <SuggestionActions
+            comment={comment}
+            projectId={projectId}
+            isPending={isPending}
+            isCoordinator={isCoordinator}
+            onResolve={onResolve}
+          />
         )}
 
         {/* Acoes de sugestao de exclusao */}
@@ -356,78 +136,12 @@ export function CommentCard({
         )}
 
         {/* Gabarito expansível (só para reviews, não para notas) */}
-        {comment.source !== "nota" && comment.source !== "dificuldade" && comment.source !== "anotacao" && comment.source !== "exclusao" && <Collapsible open={gabaritoOpen} onOpenChange={handleGabaritoToggle}>
-          <CollapsibleTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-7 gap-1 px-2 text-xs text-muted-foreground"
-            >
-              Ver gabarito
-              {loadingGabarito ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <ChevronDown
-                  className={cn(
-                    "size-3 transition-transform",
-                    gabaritoOpen && "rotate-180",
-                  )}
-                />
-              )}
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent>
-            <div className="mt-1 space-y-1.5 rounded-md bg-muted/50 p-3">
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-medium">Gabarito:</span>
-                <Badge
-                  variant={verdictVariant(comment.verdict)}
-                  className="text-xs"
-                >
-                  {formatVerdictLabel(comment.verdict)}
-                </Badge>
-              </div>
-              {gabaritoEntries && gabaritoEntries.length > 0 ? (
-                <div className="space-y-1">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Respostas dos respondentes:
-                  </span>
-                  {gabaritoEntries.map((a) => (
-                    <div
-                      key={a.respondentName}
-                      className={cn(
-                        "flex items-start gap-2 rounded px-2 py-1 text-xs",
-                        a.isChosen && "bg-brand/5",
-                      )}
-                    >
-                      {a.isChosen && (
-                        <Check className="mt-0.5 size-3 shrink-0 text-brand" />
-                      )}
-                      <div className="min-w-0">
-                        <span className="font-medium">
-                          {a.respondentName}
-                        </span>
-                        <Badge
-                          variant="outline"
-                          className="ml-1.5 text-[10px] px-1 py-0"
-                        >
-                          {a.respondentType === "humano" ? "Humano" : "LLM"}
-                        </Badge>
-                        <span className="ml-2 text-muted-foreground">
-                          {formatAnswer(a.answer)}
-                        </span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              ) : gabaritoEntries && gabaritoEntries.length === 0 ? (
-                <p className="text-xs text-muted-foreground">
-                  Nenhuma resposta encontrada.
-                </p>
-              ) : null}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>}
+        {comment.source !== "nota" &&
+          comment.source !== "dificuldade" &&
+          comment.source !== "anotacao" &&
+          comment.source !== "exclusao" && (
+            <GabaritoSection comment={comment} projectId={projectId} />
+          )}
 
         <div className="flex items-center justify-between">
           <p className="text-xs text-muted-foreground" suppressHydrationWarning>
@@ -468,144 +182,5 @@ export function CommentCard({
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-function ExclusionActions({
-  commentId,
-  projectId,
-  status,
-  rejectedReason,
-  isCoordinator,
-}: {
-  commentId: string;
-  projectId: string;
-  status: "pending" | "approved" | "rejected";
-  rejectedReason?: string | null;
-  isCoordinator: boolean;
-}) {
-  const { refresh } = useRouter();
-  const [isPending, startAction] = useTransition();
-  const [showRejectInput, setShowRejectInput] = useState(false);
-  const [rejectReason, setRejectReason] = useState("");
-  const rejectTextareaRef = useRef<HTMLTextAreaElement | null>(null);
-
-  useEffect(() => {
-    if (showRejectInput) {
-      rejectTextareaRef.current?.focus();
-    }
-  }, [showRejectInput]);
-
-  if (status === "approved") {
-    return (
-      <Badge className="text-xs bg-red-500/10 text-red-700 w-fit">
-        Documento excluído
-      </Badge>
-    );
-  }
-  if (status === "rejected") {
-    return (
-      <div className="flex flex-col gap-1">
-        <Badge className="text-xs bg-muted text-muted-foreground w-fit">
-          Sugestão rejeitada
-        </Badge>
-        {rejectedReason && (
-          <p className="text-xs text-muted-foreground italic">
-            Motivo: {rejectedReason}
-          </p>
-        )}
-      </div>
-    );
-  }
-
-  if (!isCoordinator) {
-    return (
-      <Badge className="text-xs bg-amber-500/10 text-amber-700 w-fit">
-        Aguardando coordenador
-      </Badge>
-    );
-  }
-
-  if (showRejectInput) {
-    return (
-      <div className="flex flex-col gap-2">
-        <Textarea
-          ref={rejectTextareaRef}
-          className="text-xs"
-          placeholder="Motivo da rejeição"
-          value={rejectReason}
-          onChange={(e) => setRejectReason(e.target.value)}
-          rows={2}
-        />
-        <div className="flex gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-6 text-xs"
-            disabled={isPending}
-            onClick={() => {
-              setShowRejectInput(false);
-              setRejectReason("");
-            }}
-          >
-            Cancelar
-          </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            className="h-6 text-xs"
-            disabled={isPending || !rejectReason.trim()}
-            onClick={() => {
-              startAction(async () => {
-                const result = await rejectExclusionRequest(
-                  commentId,
-                  projectId,
-                  rejectReason,
-                );
-                if (result.error) toast.error(result.error);
-                else {
-                  toast.success("Sugestão rejeitada");
-                  refresh();
-                }
-              });
-            }}
-          >
-            Confirmar rejeição
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex items-center gap-2">
-      <Button
-        variant="destructive"
-        size="sm"
-        className="h-6 text-xs"
-        disabled={isPending}
-        onClick={() => {
-          startAction(async () => {
-            const result = await approveExclusionRequest(commentId, projectId);
-            if (result.error) toast.error(result.error);
-            else {
-              toast.success("Documento excluído");
-              refresh();
-            }
-          });
-        }}
-      >
-        Aprovar e excluir
-      </Button>
-      <Button
-        variant="outline"
-        size="sm"
-        className="h-6 text-xs"
-        disabled={isPending}
-        onClick={() => setShowRejectInput(true)}
-      >
-        Rejeitar
-      </Button>
-    </div>
   );
 }

--- a/frontend/src/components/stats/CommentCardHeader.tsx
+++ b/frontend/src/components/stats/CommentCardHeader.tsx
@@ -4,8 +4,8 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Pencil } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { ReviewComment } from "./CommentCard";
 import {
+  type ReviewComment,
   TYPE_LABELS,
   TYPE_COLORS,
   formatVerdictLabel,

--- a/frontend/src/components/stats/CommentCardHeader.tsx
+++ b/frontend/src/components/stats/CommentCardHeader.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Pencil } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ReviewComment } from "./CommentCard";
+import {
+  TYPE_LABELS,
+  TYPE_COLORS,
+  formatVerdictLabel,
+  verdictVariant,
+} from "./comment-card-utils";
+
+interface CommentCardHeaderProps {
+  comment: ReviewComment;
+  isCoordinator?: boolean;
+  onEditField?: () => void;
+  onSuggestField?: () => void;
+  onOpenDocument?: (documentId: string) => void;
+}
+
+export function CommentCardHeader({
+  comment,
+  isCoordinator,
+  onEditField,
+  onSuggestField,
+  onOpenDocument,
+}: CommentCardHeaderProps) {
+  return (
+    <>
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          {onOpenDocument && comment.documentId ? (
+            <button
+              type="button"
+              onClick={() => onOpenDocument(comment.documentId)}
+              className="text-sm font-medium hover:underline text-left"
+            >
+              {comment.documentTitle}
+            </button>
+          ) : (
+            <span className="text-sm font-medium">{comment.documentTitle || comment.fieldName}</span>
+          )}
+          <div className="flex items-center gap-1.5">
+            <code className="text-xs font-mono text-muted-foreground/70">
+              {comment.fieldName}
+            </code>
+            {isCoordinator && onEditField && comment.source !== "nota" && comment.source !== "exclusao" && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="size-5 p-0"
+                onClick={onEditField}
+                title="Editar campo"
+              >
+                <Pencil className="size-3" />
+              </Button>
+            )}
+            {!isCoordinator && onSuggestField && comment.source !== "nota" && comment.source !== "exclusao" && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="size-5 p-0"
+                onClick={onSuggestField}
+                title="Sugerir alteração"
+              >
+                <Pencil className="size-3 text-amber-500" />
+              </Button>
+            )}
+          </div>
+          {comment.fieldDescription &&
+            comment.fieldDescription !== comment.fieldName && (
+              <p className="text-xs text-muted-foreground">
+                {comment.fieldDescription}
+              </p>
+            )}
+        </div>
+        <Badge
+          variant={verdictVariant(comment.verdict)}
+          className="shrink-0"
+        >
+          {formatVerdictLabel(comment.verdict)}
+        </Badge>
+      </div>
+
+      {/* Metadados do campo (contexto para avaliacao do schema) */}
+      {(comment.fieldType || comment.fieldHelpText || (comment.fieldOptions && comment.fieldOptions.length > 0)) && (
+        <div className="space-y-1 rounded-md bg-muted/30 px-3 py-2">
+          {comment.fieldType && (
+            <Badge className={cn("text-[10px] px-1 py-0", TYPE_COLORS[comment.fieldType])}>
+              {TYPE_LABELS[comment.fieldType]}
+            </Badge>
+          )}
+          {comment.fieldHelpText && (
+            <p className="text-xs italic text-muted-foreground">
+              {comment.fieldHelpText}
+            </p>
+          )}
+          {comment.fieldOptions && comment.fieldOptions.length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {comment.fieldOptions.map((opt) => (
+                <Badge key={opt} variant="outline" className="text-[10px] px-1.5 py-0 font-normal">
+                  {opt}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/stats/CommentsSplitView.tsx
+++ b/frontend/src/components/stats/CommentsSplitView.tsx
@@ -29,50 +29,15 @@ import {
 } from "@/actions/stats";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
-import type { ReviewComment, ResponseSnapshotEntry } from "./CommentCard";
-
-const TYPE_LABELS: Record<string, string> = {
-  single: "Escolha única",
-  multi: "Múltipla escolha",
-  text: "Texto livre",
-  date: "Data",
-};
-
-const TYPE_COLORS: Record<string, string> = {
-  single: "bg-blue-500/10 text-blue-700",
-  multi: "bg-purple-500/10 text-purple-700",
-  text: "bg-green-500/10 text-green-700",
-  date: "bg-amber-500/10 text-amber-700",
-};
-
-function formatAnswer(answer: unknown): string {
-  if (answer === null || answer === undefined) return "(sem resposta)";
-  if (Array.isArray(answer)) return answer.join(", ");
-  return String(answer);
-}
-
-function verdictVariant(verdict: string): "default" | "secondary" | "outline" {
-  if (verdict === "ambiguo") return "secondary";
-  if (verdict === "pular") return "outline";
-  return "default";
-}
-
-function formatVerdictLabel(verdict: string): string {
-  if (verdict === "ambiguo") return "Ambíguo";
-  if (verdict === "pular") return "Pular";
-  if (verdict.startsWith("{")) {
-    try {
-      const parsed = JSON.parse(verdict) as Record<string, boolean>;
-      const selected = Object.entries(parsed)
-        .filter(([, v]) => v)
-        .map(([k]) => k);
-      return selected.length > 0 ? selected.join(", ") : "(nenhuma)";
-    } catch {
-      // fallback
-    }
-  }
-  return verdict;
-}
+import { formatAnswer } from "@/lib/reviews/verdict-format";
+import {
+  type ReviewComment,
+  type ResponseSnapshotEntry,
+  TYPE_LABELS,
+  TYPE_COLORS,
+  formatVerdictLabel,
+  verdictVariant,
+} from "./comment-card-utils";
 
 interface CommentsSplitViewProps {
   projectId: string;

--- a/frontend/src/components/stats/ErrorFiltersToolbar.tsx
+++ b/frontend/src/components/stats/ErrorFiltersToolbar.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import type { DatePreset, SortBy } from "@/hooks/useLlmErrorFiltering";
+
+interface ErrorFiltersToolbarProps {
+  fields: { name: string; description: string }[];
+  errorSearchQuery: string;
+  setErrorSearchQuery: (v: string) => void;
+  errorFieldFilter: string;
+  setErrorFieldFilter: (v: string) => void;
+  errorStatusFilter: string;
+  setErrorStatusFilter: (v: string) => void;
+  errorDateFilter: DatePreset;
+  setErrorDateFilter: (v: DatePreset) => void;
+  errorSinceDate: string;
+  setErrorSinceDate: (v: string) => void;
+  availableVersions: string[];
+  effectiveVersionFilter: string;
+  setErrorVersionFilter: (v: string) => void;
+  sortBy: SortBy;
+  setSortBy: (v: SortBy) => void;
+  sortedCount: number;
+  openErrorCount: number;
+}
+
+export function ErrorFiltersToolbar({
+  fields,
+  errorSearchQuery,
+  setErrorSearchQuery,
+  errorFieldFilter,
+  setErrorFieldFilter,
+  errorStatusFilter,
+  setErrorStatusFilter,
+  errorDateFilter,
+  setErrorDateFilter,
+  errorSinceDate,
+  setErrorSinceDate,
+  availableVersions,
+  effectiveVersionFilter,
+  setErrorVersionFilter,
+  sortBy,
+  setSortBy,
+  sortedCount,
+  openErrorCount,
+}: ErrorFiltersToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Input
+        placeholder="Buscar documento..."
+        value={errorSearchQuery}
+        onChange={(e) => setErrorSearchQuery(e.target.value)}
+        className="w-56"
+      />
+      <Select value={errorFieldFilter} onValueChange={setErrorFieldFilter}>
+        <SelectTrigger className="w-44">
+          <SelectValue placeholder="Campo" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Todos os campos</SelectItem>
+          {fields.map((f) => (
+            <SelectItem key={f.name} value={f.name}>
+              {f.description || f.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select value={errorStatusFilter} onValueChange={setErrorStatusFilter}>
+        <SelectTrigger className="w-32">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="open">Abertos</SelectItem>
+          <SelectItem value="resolved">Resolvidos</SelectItem>
+          <SelectItem value="all">Todos</SelectItem>
+        </SelectContent>
+      </Select>
+      <Select
+        value={errorDateFilter}
+        onValueChange={(v) => {
+          setErrorDateFilter(v as DatePreset);
+          setErrorSinceDate("");
+        }}
+      >
+        <SelectTrigger className="w-36" title="Data de criação da revisão">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Qualquer data</SelectItem>
+          <SelectItem value="24h">Últimas 24h</SelectItem>
+          <SelectItem value="7d">Últimos 7 dias</SelectItem>
+          <SelectItem value="30d">Últimos 30 dias</SelectItem>
+        </SelectContent>
+      </Select>
+      <Input
+        type="date"
+        value={errorSinceDate}
+        onChange={(e) => {
+          setErrorSinceDate(e.target.value);
+          if (e.target.value) setErrorDateFilter("all");
+        }}
+        className="w-40"
+        title="Apenas revisões criadas a partir desta data"
+      />
+      {availableVersions.length > 0 && (
+        <Select
+          value={effectiveVersionFilter}
+          onValueChange={setErrorVersionFilter}
+        >
+          <SelectTrigger className="w-36" title="Versão do schema">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">Todas as versões</SelectItem>
+            {availableVersions.map((v) => (
+              <SelectItem key={v} value={v}>
+                v{v}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+      <Select value={sortBy} onValueChange={(v) => setSortBy(v as SortBy)}>
+        <SelectTrigger className="w-44" title="Ordenar por">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="default">Ordem padrão</SelectItem>
+          <SelectItem value="field">Por pergunta (A→Z)</SelectItem>
+          <SelectItem value="document">Por documento (A→Z)</SelectItem>
+          <SelectItem value="recent">Mais recentes primeiro</SelectItem>
+        </SelectContent>
+      </Select>
+      <span className="ml-auto text-sm text-muted-foreground">
+        {sortedCount} erro{sortedCount !== 1 ? "s" : ""}
+        {openErrorCount > 0 && (
+          <Badge variant="destructive" className="ml-1.5">
+            {openErrorCount} aberto{openErrorCount !== 1 ? "s" : ""}
+          </Badge>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/stats/ErrorFiltersToolbar.tsx
+++ b/frontend/src/components/stats/ErrorFiltersToolbar.tsx
@@ -9,49 +9,41 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import type { DatePreset, SortBy } from "@/hooks/useLlmErrorFiltering";
+import type {
+  DatePreset,
+  LlmErrorFilteringControls,
+  SortBy,
+} from "@/hooks/useLlmErrorFiltering";
 
 interface ErrorFiltersToolbarProps {
   fields: { name: string; description: string }[];
-  errorSearchQuery: string;
-  setErrorSearchQuery: (v: string) => void;
-  errorFieldFilter: string;
-  setErrorFieldFilter: (v: string) => void;
-  errorStatusFilter: string;
-  setErrorStatusFilter: (v: string) => void;
-  errorDateFilter: DatePreset;
-  setErrorDateFilter: (v: DatePreset) => void;
-  errorSinceDate: string;
-  setErrorSinceDate: (v: string) => void;
-  availableVersions: string[];
-  effectiveVersionFilter: string;
-  setErrorVersionFilter: (v: string) => void;
-  sortBy: SortBy;
-  setSortBy: (v: SortBy) => void;
-  sortedCount: number;
-  openErrorCount: number;
+  /** Retorno de useLlmErrorFiltering — controles + contagens, numa prop só. */
+  filtering: LlmErrorFilteringControls;
 }
 
 export function ErrorFiltersToolbar({
   fields,
-  errorSearchQuery,
-  setErrorSearchQuery,
-  errorFieldFilter,
-  setErrorFieldFilter,
-  errorStatusFilter,
-  setErrorStatusFilter,
-  errorDateFilter,
-  setErrorDateFilter,
-  errorSinceDate,
-  setErrorSinceDate,
-  availableVersions,
-  effectiveVersionFilter,
-  setErrorVersionFilter,
-  sortBy,
-  setSortBy,
-  sortedCount,
-  openErrorCount,
+  filtering,
 }: ErrorFiltersToolbarProps) {
+  const {
+    errorSearchQuery,
+    setErrorSearchQuery,
+    errorFieldFilter,
+    setErrorFieldFilter,
+    errorStatusFilter,
+    setErrorStatusFilter,
+    errorDateFilter,
+    setErrorDateFilter,
+    errorSinceDate,
+    setErrorSinceDate,
+    availableVersions,
+    effectiveVersionFilter,
+    setErrorVersionFilter,
+    sortBy,
+    setSortBy,
+    sortedCount,
+    openErrorCount,
+  } = filtering;
   return (
     <div className="flex flex-wrap items-center gap-2">
       <Input

--- a/frontend/src/components/stats/ErrorStatsCards.tsx
+++ b/frontend/src/components/stats/ErrorStatsCards.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { Bot, AlertTriangle } from "lucide-react";
+
+interface ErrorStatsCardsProps {
+  totalLlmDocs: number;
+  errorCount: number;
+  errorRatePct: number;
+  unreviewedLlmDocs?: number;
+}
+
+export function ErrorStatsCards({
+  totalLlmDocs,
+  errorCount,
+  errorRatePct,
+  unreviewedLlmDocs,
+}: ErrorStatsCardsProps) {
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Card>
+          <CardContent className="flex items-center gap-3 pt-6">
+            <Bot className="size-5 text-brand" />
+            <div>
+              <p className="text-2xl font-bold tabular-nums">
+                {totalLlmDocs}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Docs com LLM
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-3 pt-6">
+            <AlertTriangle className="size-5 text-red-500" />
+            <div>
+              <p className="text-2xl font-bold tabular-nums">
+                {errorCount}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                Campos incorretos
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-6 text-center">
+            <p className="text-2xl font-bold tabular-nums">
+              {errorRatePct}%
+            </p>
+            <p className="text-xs text-muted-foreground">Taxa de erro</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {!!unreviewedLlmDocs && unreviewedLlmDocs > 0 && (
+        <p className="text-xs text-muted-foreground text-center">
+          {unreviewedLlmDocs} documento{unreviewedLlmDocs !== 1 ? "s" : ""} com respostas do LLM ainda não {unreviewedLlmDocs !== 1 ? "foram revisados" : "foi revisado"}.
+          Erros só aparecem após a revisão humana.
+        </p>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/stats/ExclusionActions.tsx
+++ b/frontend/src/components/stats/ExclusionActions.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  approveExclusionRequest,
+  rejectExclusionRequest,
+} from "@/actions/project-comments";
+import { Textarea } from "@/components/ui/textarea";
+import { toast } from "sonner";
+
+export function ExclusionActions({
+  commentId,
+  projectId,
+  status,
+  rejectedReason,
+  isCoordinator,
+}: {
+  commentId: string;
+  projectId: string;
+  status: "pending" | "approved" | "rejected";
+  rejectedReason?: string | null;
+  isCoordinator: boolean;
+}) {
+  const { refresh } = useRouter();
+  const [isPending, startAction] = useTransition();
+  const [showRejectInput, setShowRejectInput] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+  const rejectTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (showRejectInput) {
+      rejectTextareaRef.current?.focus();
+    }
+  }, [showRejectInput]);
+
+  if (status === "approved") {
+    return (
+      <Badge className="text-xs bg-red-500/10 text-red-700 w-fit">
+        Documento excluído
+      </Badge>
+    );
+  }
+  if (status === "rejected") {
+    return (
+      <div className="flex flex-col gap-1">
+        <Badge className="text-xs bg-muted text-muted-foreground w-fit">
+          Sugestão rejeitada
+        </Badge>
+        {rejectedReason && (
+          <p className="text-xs text-muted-foreground italic">
+            Motivo: {rejectedReason}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (!isCoordinator) {
+    return (
+      <Badge className="text-xs bg-amber-500/10 text-amber-700 w-fit">
+        Aguardando coordenador
+      </Badge>
+    );
+  }
+
+  if (showRejectInput) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Textarea
+          ref={rejectTextareaRef}
+          className="text-xs"
+          placeholder="Motivo da rejeição"
+          value={rejectReason}
+          onChange={(e) => setRejectReason(e.target.value)}
+          rows={2}
+        />
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 text-xs"
+            disabled={isPending}
+            onClick={() => {
+              setShowRejectInput(false);
+              setRejectReason("");
+            }}
+          >
+            Cancelar
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            className="h-6 text-xs"
+            disabled={isPending || !rejectReason.trim()}
+            onClick={() => {
+              startAction(async () => {
+                const result = await rejectExclusionRequest(
+                  commentId,
+                  projectId,
+                  rejectReason,
+                );
+                if (result.error) toast.error(result.error);
+                else {
+                  toast.success("Sugestão rejeitada");
+                  refresh();
+                }
+              });
+            }}
+          >
+            Confirmar rejeição
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        variant="destructive"
+        size="sm"
+        className="h-6 text-xs"
+        disabled={isPending}
+        onClick={() => {
+          startAction(async () => {
+            const result = await approveExclusionRequest(commentId, projectId);
+            if (result.error) toast.error(result.error);
+            else {
+              toast.success("Documento excluído");
+              refresh();
+            }
+          });
+        }}
+      >
+        Aprovar e excluir
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className="h-6 text-xs"
+        disabled={isPending}
+        onClick={() => setShowRejectInput(true)}
+      >
+        Rejeitar
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/stats/ExclusionActions.tsx
+++ b/frontend/src/components/stats/ExclusionActions.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -28,13 +28,6 @@ export function ExclusionActions({
   const [isPending, startAction] = useTransition();
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
-  const rejectTextareaRef = useRef<HTMLTextAreaElement | null>(null);
-
-  useEffect(() => {
-    if (showRejectInput) {
-      rejectTextareaRef.current?.focus();
-    }
-  }, [showRejectInput]);
 
   if (status === "approved") {
     return (
@@ -69,8 +62,10 @@ export function ExclusionActions({
   if (showRejectInput) {
     return (
       <div className="flex flex-col gap-2">
+        {/* autoFocus vale aqui: a Textarea só monta quando showRejectInput
+            vira true, então o foco dispara exatamente no clique em Rejeitar. */}
         <Textarea
-          ref={rejectTextareaRef}
+          autoFocus
           className="text-xs"
           placeholder="Motivo da rejeição"
           value={rejectReason}

--- a/frontend/src/components/stats/GabaritoSection.tsx
+++ b/frontend/src/components/stats/GabaritoSection.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ChevronDown, Loader2, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  fetchGabaritoForComment,
+  type GabaritoRespondentAnswer,
+} from "@/actions/stats";
+import type { ReviewComment } from "./CommentCard";
+import {
+  formatVerdictLabel,
+  verdictVariant,
+  formatAnswer,
+} from "./comment-card-utils";
+
+interface GabaritoSectionProps {
+  comment: ReviewComment;
+  projectId: string;
+}
+
+export function GabaritoSection({ comment, projectId }: GabaritoSectionProps) {
+  const [gabaritoOpen, setGabaritoOpen] = useState(false);
+  const [gabaritoData, setGabaritoData] = useState<
+    GabaritoRespondentAnswer[] | null
+  >(null);
+  const [loadingGabarito, startLoadGabarito] = useTransition();
+
+  // If snapshot exists, convert to gabarito format immediately
+  const snapshotAsGabarito: GabaritoRespondentAnswer[] | null =
+    comment.responseSnapshot
+      ? comment.responseSnapshot.map((r) => ({
+          respondentName: r.respondent_name,
+          respondentType: r.respondent_type,
+          answer: r.answer,
+          isChosen: r.id === comment.chosenResponseId,
+        }))
+      : null;
+
+  const handleGabaritoToggle = (open: boolean) => {
+    setGabaritoOpen(open);
+    // Only fetch if no snapshot and no cached data
+    if (open && !gabaritoData && !snapshotAsGabarito) {
+      startLoadGabarito(async () => {
+        const result = await fetchGabaritoForComment(
+          projectId,
+          comment.documentId,
+          comment.fieldName,
+          comment.chosenResponseId,
+        );
+        setGabaritoData(result.answers);
+      });
+    }
+  };
+
+  const gabaritoEntries = snapshotAsGabarito ?? gabaritoData;
+
+  return (
+    <Collapsible open={gabaritoOpen} onOpenChange={handleGabaritoToggle}>
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs text-muted-foreground"
+        >
+          Ver gabarito
+          {loadingGabarito ? (
+            <Loader2 className="size-3 animate-spin" />
+          ) : (
+            <ChevronDown
+              className={cn(
+                "size-3 transition-transform",
+                gabaritoOpen && "rotate-180",
+              )}
+            />
+          )}
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-1 space-y-1.5 rounded-md bg-muted/50 p-3">
+          <div className="flex items-center gap-2">
+            <span className="text-xs font-medium">Gabarito:</span>
+            <Badge
+              variant={verdictVariant(comment.verdict)}
+              className="text-xs"
+            >
+              {formatVerdictLabel(comment.verdict)}
+            </Badge>
+          </div>
+          {gabaritoEntries && gabaritoEntries.length > 0 ? (
+            <div className="space-y-1">
+              <span className="text-xs font-medium text-muted-foreground">
+                Respostas dos respondentes:
+              </span>
+              {gabaritoEntries.map((a) => (
+                <div
+                  key={a.respondentName}
+                  className={cn(
+                    "flex items-start gap-2 rounded px-2 py-1 text-xs",
+                    a.isChosen && "bg-brand/5",
+                  )}
+                >
+                  {a.isChosen && (
+                    <Check className="mt-0.5 size-3 shrink-0 text-brand" />
+                  )}
+                  <div className="min-w-0">
+                    <span className="font-medium">
+                      {a.respondentName}
+                    </span>
+                    <Badge
+                      variant="outline"
+                      className="ml-1.5 text-[10px] px-1 py-0"
+                    >
+                      {a.respondentType === "humano" ? "Humano" : "LLM"}
+                    </Badge>
+                    <span className="ml-2 text-muted-foreground">
+                      {formatAnswer(a.answer)}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : gabaritoEntries && gabaritoEntries.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              Nenhuma resposta encontrada.
+            </p>
+          ) : null}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/frontend/src/components/stats/GabaritoSection.tsx
+++ b/frontend/src/components/stats/GabaritoSection.tsx
@@ -14,11 +14,11 @@ import {
   fetchGabaritoForComment,
   type GabaritoRespondentAnswer,
 } from "@/actions/stats";
-import type { ReviewComment } from "./CommentCard";
+import { formatAnswer } from "@/lib/reviews/verdict-format";
 import {
+  type ReviewComment,
   formatVerdictLabel,
   verdictVariant,
-  formatAnswer,
 } from "./comment-card-utils";
 
 interface GabaritoSectionProps {
@@ -37,6 +37,7 @@ export function GabaritoSection({ comment, projectId }: GabaritoSectionProps) {
   const snapshotAsGabarito: GabaritoRespondentAnswer[] | null =
     comment.responseSnapshot
       ? comment.responseSnapshot.map((r) => ({
+          id: r.id,
           respondentName: r.respondent_name,
           respondentType: r.respondent_type,
           answer: r.answer,
@@ -101,7 +102,7 @@ export function GabaritoSection({ comment, projectId }: GabaritoSectionProps) {
               </span>
               {gabaritoEntries.map((a) => (
                 <div
-                  key={a.respondentName}
+                  key={a.id}
                   className={cn(
                     "flex items-start gap-2 rounded px-2 py-1 text-xs",
                     a.isChosen && "bg-brand/5",

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -134,7 +134,7 @@ export function LlmInsightsView({
           <Button
             variant="outline"
             size="sm"
-            onClick={handleRegenerateBacklog}
+            onClick={() => void handleRegenerateBacklog()}
             disabled={regenerating}
           >
             {regenerating ? "Regenerando…" : "Regenerar backlog"}

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -1,23 +1,12 @@
 "use client";
 
-import { useState, useMemo, useTransition, useEffect } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
-import { Card, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Badge } from "@/components/ui/badge";
-import {
-  Bot,
-  AlertTriangle,
-} from "lucide-react";
 import { LlmErrorCard } from "./LlmErrorCard";
 import { EditFieldDialog } from "./EditFieldDialog";
+import { ErrorStatsCards } from "./ErrorStatsCards";
+import { ErrorFiltersToolbar } from "./ErrorFiltersToolbar";
+import { useLlmErrorFiltering } from "@/hooks/useLlmErrorFiltering";
 import {
   resolveError,
   reopenError,
@@ -42,57 +31,6 @@ interface LlmInsightsViewProps {
   summary: {
     totalLlmDocs: number;
     unreviewedLlmDocs?: number;
-  };
-}
-
-type DatePreset = "all" | "24h" | "7d" | "30d";
-type SortBy = "default" | "field" | "document" | "recent";
-
-function presetCutoffMs(preset: DatePreset, now: number): number | null {
-  if (preset === "24h") return now - 24 * 3600_000;
-  if (preset === "7d") return now - 7 * 24 * 3600_000;
-  if (preset === "30d") return now - 30 * 24 * 3600_000;
-  return null;
-}
-
-function compareSemverDesc(a: string, b: string): number {
-  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
-  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
-  for (let i = 0; i < 3; i++) {
-    const da = pa[i] ?? 0;
-    const db = pb[i] ?? 0;
-    if (da !== db) return db - da;
-  }
-  return 0;
-}
-
-// Agrupa o estado dos filtros da lista de erros (6 filtros + ordenação)
-// num hook co-localizado para manter o componente abaixo do limite de
-// useState. Pura relocação de estado: nenhuma lógica muda.
-function useLlmErrorFilters() {
-  const [errorFieldFilter, setErrorFieldFilter] = useState("all");
-  const [errorSearchQuery, setErrorSearchQuery] = useState("");
-  const [errorStatusFilter, setErrorStatusFilter] = useState("open");
-  const [errorDateFilter, setErrorDateFilter] = useState<DatePreset>("all");
-  const [errorSinceDate, setErrorSinceDate] = useState("");
-  const [errorVersionFilter, setErrorVersionFilter] = useState("all");
-  const [sortBy, setSortBy] = useState<SortBy>("default");
-
-  return {
-    errorFieldFilter,
-    setErrorFieldFilter,
-    errorSearchQuery,
-    setErrorSearchQuery,
-    errorStatusFilter,
-    setErrorStatusFilter,
-    errorDateFilter,
-    setErrorDateFilter,
-    errorSinceDate,
-    setErrorSinceDate,
-    errorVersionFilter,
-    setErrorVersionFilter,
-    sortBy,
-    setSortBy,
   };
 }
 
@@ -132,119 +70,10 @@ export function LlmInsightsView({
     refresh();
   }
 
-  // Error filters
-  const {
-    errorFieldFilter,
-    setErrorFieldFilter,
-    errorSearchQuery,
-    setErrorSearchQuery,
-    errorStatusFilter,
-    setErrorStatusFilter,
-    errorDateFilter,
-    setErrorDateFilter,
-    errorSinceDate,
-    setErrorSinceDate,
-    errorVersionFilter,
-    setErrorVersionFilter,
-    sortBy,
-    setSortBy,
-  } = useLlmErrorFilters();
-
-  // Tick the "now" reference once a minute so the "Últimas 24h/7d/30d"
-  // cutoff doesn't freeze on long-open pages. State (rather than a raw
-  // Date.now() in render) keeps the component pure per React rules.
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    const id = setInterval(() => setNow(Date.now()), 60_000);
-    return () => clearInterval(id);
-  }, []);
-
-  // Derived from the full reviewed population so a version with 0 errors is
-  // still selectable — useful for "0% rate" sanity checks.
-  const availableVersions = useMemo(() => {
-    const set = new Set<string>();
-    for (const r of reviewedEntries) if (r.schemaVersion) set.add(r.schemaVersion);
-    return Array.from(set).toSorted(compareSemverDesc);
-  }, [reviewedEntries]);
-
-  // Derive the effective version filter: if the selected version is no
-  // longer present (status filter toggled, all errors of that version
-  // resolved, etc.) treat it as "all" instead of letting the stale value
-  // zero out the list with no UI to fix it. Derivation in render avoids
-  // a setState-in-effect cascade.
-  const effectiveVersionFilter = availableVersions.includes(errorVersionFilter)
-    ? errorVersionFilter
-    : "all";
-
-  const sinceMs = errorSinceDate
-    ? new Date(errorSinceDate + "T00:00:00").getTime()
-    : presetCutoffMs(errorDateFilter, now);
-
-  // Scope filters affect both numerator and denominator (so the rate matches
-  // the population the user is looking at). Status only affects which errors
-  // the user wants to see in the list and in the card.
-  const matchesScopeFilters = (e: {
-    fieldName: string;
-    documentTitle: string;
-    reviewedAt: string;
-    schemaVersion: string | null;
-  }): boolean => {
-    if (errorFieldFilter !== "all" && e.fieldName !== errorFieldFilter)
-      return false;
-    if (
-      errorSearchQuery &&
-      !e.documentTitle
-        .toLowerCase()
-        .includes(errorSearchQuery.toLowerCase())
-    )
-      return false;
-    if (sinceMs && new Date(e.reviewedAt).getTime() < sinceMs) return false;
-    if (
-      effectiveVersionFilter !== "all" &&
-      e.schemaVersion !== effectiveVersionFilter
-    )
-      return false;
-    return true;
-  };
-
-  const filteredReviewed = reviewedEntries.filter(matchesScopeFilters);
-
-  const filteredErrors = errors.filter((e) => {
-    if (errorStatusFilter === "open" && e.resolvedAt) return false;
-    if (errorStatusFilter === "resolved" && !e.resolvedAt) return false;
-    return matchesScopeFilters(e);
-  });
-
-  // Rate uses the same numerator shown in the card (so the two are always
-  // consistent) over the scope-filtered reviewed population.
-  const filteredErrorRate =
-    filteredReviewed.length > 0
-      ? Math.round((filteredErrors.length / filteredReviewed.length) * 100)
-      : 0;
-
-  const sortedErrors = (() => {
-    if (sortBy === "default") return filteredErrors;
-    const arr = [...filteredErrors];
-    if (sortBy === "field") {
-      arr.sort((a, b) => {
-        const fa = a.fieldDescription.localeCompare(b.fieldDescription, "pt-BR");
-        if (fa !== 0) return fa;
-        return a.documentTitle.localeCompare(b.documentTitle, "pt-BR");
-      });
-    } else if (sortBy === "document") {
-      arr.sort((a, b) =>
-        a.documentTitle.localeCompare(b.documentTitle, "pt-BR"),
-      );
-    } else if (sortBy === "recent") {
-      arr.sort((a, b) => b.reviewedAt.localeCompare(a.reviewedAt));
-    }
-    return arr;
-  })();
-
-  // Counted within the current scope so the badge matches the cards.
-  const openErrorCount = errors.filter(
-    (e) => !e.resolvedAt && matchesScopeFilters(e),
-  ).length;
+  // Error filters + derivation (filtered population, rate, sorting, counts)
+  const filtering = useLlmErrorFiltering(errors, reviewedEntries);
+  const { filteredErrors, filteredErrorRate, sortedErrors, openErrorCount } =
+    filtering;
 
   // Error handlers
   const handleResolveError = (documentId: string, fieldName: string) => {
@@ -313,145 +142,33 @@ export function LlmInsightsView({
         </div>
       ) : null}
 
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-        <Card>
-          <CardContent className="flex items-center gap-3 pt-6">
-            <Bot className="size-5 text-brand" />
-            <div>
-              <p className="text-2xl font-bold tabular-nums">
-                {summary.totalLlmDocs}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                Docs com LLM
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="flex items-center gap-3 pt-6">
-            <AlertTriangle className="size-5 text-red-500" />
-            <div>
-              <p className="text-2xl font-bold tabular-nums">
-                {filteredErrors.length}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                Campos incorretos
-              </p>
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="pt-6 text-center">
-            <p className="text-2xl font-bold tabular-nums">
-              {filteredErrorRate}%
-            </p>
-            <p className="text-xs text-muted-foreground">Taxa de erro</p>
-          </CardContent>
-        </Card>
-      </div>
+      <ErrorStatsCards
+        totalLlmDocs={summary.totalLlmDocs}
+        errorCount={filteredErrors.length}
+        errorRatePct={filteredErrorRate}
+        unreviewedLlmDocs={summary.unreviewedLlmDocs}
+      />
 
-      {!!summary.unreviewedLlmDocs && summary.unreviewedLlmDocs > 0 && (
-        <p className="text-xs text-muted-foreground text-center">
-          {summary.unreviewedLlmDocs} documento{summary.unreviewedLlmDocs !== 1 ? "s" : ""} com respostas do LLM ainda não {summary.unreviewedLlmDocs !== 1 ? "foram revisados" : "foi revisado"}.
-          Erros só aparecem após a revisão humana.
-        </p>
-      )}
-
-      <div className="flex flex-wrap items-center gap-2">
-        <Input
-          placeholder="Buscar documento..."
-          value={errorSearchQuery}
-          onChange={(e) => setErrorSearchQuery(e.target.value)}
-          className="w-56"
-        />
-        <Select value={errorFieldFilter} onValueChange={setErrorFieldFilter}>
-          <SelectTrigger className="w-44">
-            <SelectValue placeholder="Campo" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Todos os campos</SelectItem>
-            {fields.map((f) => (
-              <SelectItem key={f.name} value={f.name}>
-                {f.description || f.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Select value={errorStatusFilter} onValueChange={setErrorStatusFilter}>
-          <SelectTrigger className="w-32">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="open">Abertos</SelectItem>
-            <SelectItem value="resolved">Resolvidos</SelectItem>
-            <SelectItem value="all">Todos</SelectItem>
-          </SelectContent>
-        </Select>
-        <Select
-          value={errorDateFilter}
-          onValueChange={(v) => {
-            setErrorDateFilter(v as DatePreset);
-            setErrorSinceDate("");
-          }}
-        >
-          <SelectTrigger className="w-36" title="Data de criação da revisão">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">Qualquer data</SelectItem>
-            <SelectItem value="24h">Últimas 24h</SelectItem>
-            <SelectItem value="7d">Últimos 7 dias</SelectItem>
-            <SelectItem value="30d">Últimos 30 dias</SelectItem>
-          </SelectContent>
-        </Select>
-        <Input
-          type="date"
-          value={errorSinceDate}
-          onChange={(e) => {
-            setErrorSinceDate(e.target.value);
-            if (e.target.value) setErrorDateFilter("all");
-          }}
-          className="w-40"
-          title="Apenas revisões criadas a partir desta data"
-        />
-        {availableVersions.length > 0 && (
-          <Select
-            value={effectiveVersionFilter}
-            onValueChange={setErrorVersionFilter}
-          >
-            <SelectTrigger className="w-36" title="Versão do schema">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Todas as versões</SelectItem>
-              {availableVersions.map((v) => (
-                <SelectItem key={v} value={v}>
-                  v{v}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-        <Select value={sortBy} onValueChange={(v) => setSortBy(v as SortBy)}>
-          <SelectTrigger className="w-44" title="Ordenar por">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="default">Ordem padrão</SelectItem>
-            <SelectItem value="field">Por pergunta (A→Z)</SelectItem>
-            <SelectItem value="document">Por documento (A→Z)</SelectItem>
-            <SelectItem value="recent">Mais recentes primeiro</SelectItem>
-          </SelectContent>
-        </Select>
-        <span className="ml-auto text-sm text-muted-foreground">
-          {sortedErrors.length} erro{sortedErrors.length !== 1 ? "s" : ""}
-          {openErrorCount > 0 && (
-            <Badge variant="destructive" className="ml-1.5">
-              {openErrorCount} aberto{openErrorCount !== 1 ? "s" : ""}
-            </Badge>
-          )}
-        </span>
-      </div>
+      <ErrorFiltersToolbar
+        fields={fields}
+        errorSearchQuery={filtering.errorSearchQuery}
+        setErrorSearchQuery={filtering.setErrorSearchQuery}
+        errorFieldFilter={filtering.errorFieldFilter}
+        setErrorFieldFilter={filtering.setErrorFieldFilter}
+        errorStatusFilter={filtering.errorStatusFilter}
+        setErrorStatusFilter={filtering.setErrorStatusFilter}
+        errorDateFilter={filtering.errorDateFilter}
+        setErrorDateFilter={filtering.setErrorDateFilter}
+        errorSinceDate={filtering.errorSinceDate}
+        setErrorSinceDate={filtering.setErrorSinceDate}
+        availableVersions={filtering.availableVersions}
+        effectiveVersionFilter={filtering.effectiveVersionFilter}
+        setErrorVersionFilter={filtering.setErrorVersionFilter}
+        sortBy={filtering.sortBy}
+        setSortBy={filtering.setSortBy}
+        sortedCount={sortedErrors.length}
+        openErrorCount={openErrorCount}
+      />
 
       {sortedErrors.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -50,30 +50,38 @@ export function LlmInsightsView({
 
   async function handleRegenerateBacklog() {
     setRegenerating(true);
-    const result = await regenerateAutoReviewBacklog(projectId);
-    setRegenerating(false);
-    if (!result.success) {
-      toast.error(result.error ?? "Falha ao regenerar backlog");
-      return;
+    // try/finally: uma rejeição da action (queda de rede, erro não capturado
+    // no servidor) não pode deixar o botão preso em "Regenerando…".
+    try {
+      const result = await regenerateAutoReviewBacklog(projectId);
+      if (!result.success) {
+        toast.error(result.error ?? "Falha ao regenerar backlog");
+        return;
+      }
+      const parts = [
+        `${result.scanned ?? 0} resposta(s) escaneada(s)`,
+        `${result.regenerated ?? 0} doc(s) com divergência`,
+      ];
+      if (result.removed) {
+        parts.push(`${result.removed} revisão(ões) obsoleta(s) removida(s)`);
+      }
+      if (result.keptResolved) {
+        parts.push(`${result.keptResolved} já resolvida(s) mantida(s)`);
+      }
+      toast.success(`Backlog regenerado. ${parts.join(", ")}.`);
+      refresh();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Falha ao regenerar backlog",
+      );
+    } finally {
+      setRegenerating(false);
     }
-    const parts = [
-      `${result.scanned ?? 0} resposta(s) escaneada(s)`,
-      `${result.regenerated ?? 0} doc(s) com divergência`,
-    ];
-    if (result.removed) {
-      parts.push(`${result.removed} revisão(ões) obsoleta(s) removida(s)`);
-    }
-    if (result.keptResolved) {
-      parts.push(`${result.keptResolved} já resolvida(s) mantida(s)`);
-    }
-    toast.success(`Backlog regenerado. ${parts.join(", ")}.`);
-    refresh();
   }
 
   // Error filters + derivation (filtered population, rate, sorting, counts)
   const filtering = useLlmErrorFiltering(errors, reviewedEntries);
-  const { filteredErrors, filteredErrorRate, sortedErrors, openErrorCount } =
-    filtering;
+  const { filteredErrors, filteredErrorRate, sortedErrors } = filtering;
 
   // Error handlers
   const handleResolveError = (documentId: string, fieldName: string) => {
@@ -149,26 +157,7 @@ export function LlmInsightsView({
         unreviewedLlmDocs={summary.unreviewedLlmDocs}
       />
 
-      <ErrorFiltersToolbar
-        fields={fields}
-        errorSearchQuery={filtering.errorSearchQuery}
-        setErrorSearchQuery={filtering.setErrorSearchQuery}
-        errorFieldFilter={filtering.errorFieldFilter}
-        setErrorFieldFilter={filtering.setErrorFieldFilter}
-        errorStatusFilter={filtering.errorStatusFilter}
-        setErrorStatusFilter={filtering.setErrorStatusFilter}
-        errorDateFilter={filtering.errorDateFilter}
-        setErrorDateFilter={filtering.setErrorDateFilter}
-        errorSinceDate={filtering.errorSinceDate}
-        setErrorSinceDate={filtering.setErrorSinceDate}
-        availableVersions={filtering.availableVersions}
-        effectiveVersionFilter={filtering.effectiveVersionFilter}
-        setErrorVersionFilter={filtering.setErrorVersionFilter}
-        sortBy={filtering.sortBy}
-        setSortBy={filtering.setSortBy}
-        sortedCount={sortedErrors.length}
-        openErrorCount={openErrorCount}
-      />
+      <ErrorFiltersToolbar fields={fields} filtering={filtering} />
 
       {sortedErrors.length === 0 ? (
         <p className="py-12 text-center text-sm text-muted-foreground">

--- a/frontend/src/components/stats/SuggestionActions.tsx
+++ b/frontend/src/components/stats/SuggestionActions.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { resolveSchemaSuggestion } from "@/actions/suggestions";
+import { toast } from "sonner";
+import type { ReviewComment } from "./CommentCard";
+
+interface SuggestionActionsProps {
+  comment: ReviewComment;
+  projectId: string;
+  isPending: boolean;
+  isCoordinator?: boolean;
+  onResolve: () => void;
+}
+
+/* Suggestion actions (coordinator: review/reject)
+   "Revisar" abre EditFieldDialog pré-preenchido (via onResolve);
+   salvar lá aprova com os valores finais editados. */
+export function SuggestionActions({
+  comment,
+  projectId,
+  isPending,
+  isCoordinator,
+  onResolve,
+}: SuggestionActionsProps) {
+  const { refresh } = useRouter();
+  const [suggestionPending, startSuggestionAction] = useTransition();
+
+  return (
+    <div className="flex items-center gap-2">
+      {comment.suggestionStatus === "pending" && isCoordinator && (
+        <>
+          <Button
+            variant="default"
+            size="sm"
+            className="h-6 text-xs"
+            disabled={suggestionPending || isPending}
+            onClick={onResolve}
+            title="Abre editor para revisar antes de aprovar"
+          >
+            Revisar
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-6 text-xs"
+            disabled={suggestionPending}
+            onClick={() => {
+              startSuggestionAction(async () => {
+                const result = await resolveSchemaSuggestion(comment.suggestionId!, projectId, "rejected");
+                if (result.error) toast.error(result.error);
+                else { toast.success("Sugestão rejeitada"); refresh(); }
+              });
+            }}
+          >
+            Rejeitar
+          </Button>
+        </>
+      )}
+      {comment.suggestionStatus === "approved" && (
+        <Badge className="text-xs bg-green-500/10 text-green-700">Aprovada</Badge>
+      )}
+      {comment.suggestionStatus === "rejected" && (
+        <Badge className="text-xs bg-red-500/10 text-red-700">Rejeitada</Badge>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/stats/SuggestionActions.tsx
+++ b/frontend/src/components/stats/SuggestionActions.tsx
@@ -6,10 +6,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { resolveSchemaSuggestion } from "@/actions/suggestions";
 import { toast } from "sonner";
-import type { ReviewComment } from "./CommentCard";
 
 interface SuggestionActionsProps {
-  comment: ReviewComment;
+  suggestionId: string;
+  suggestionStatus?: "pending" | "approved" | "rejected";
   projectId: string;
   isPending: boolean;
   isCoordinator?: boolean;
@@ -20,7 +20,8 @@ interface SuggestionActionsProps {
    "Revisar" abre EditFieldDialog pré-preenchido (via onResolve);
    salvar lá aprova com os valores finais editados. */
 export function SuggestionActions({
-  comment,
+  suggestionId,
+  suggestionStatus,
   projectId,
   isPending,
   isCoordinator,
@@ -31,7 +32,7 @@ export function SuggestionActions({
 
   return (
     <div className="flex items-center gap-2">
-      {comment.suggestionStatus === "pending" && isCoordinator && (
+      {suggestionStatus === "pending" && isCoordinator && (
         <>
           <Button
             variant="default"
@@ -50,7 +51,7 @@ export function SuggestionActions({
             disabled={suggestionPending}
             onClick={() => {
               startSuggestionAction(async () => {
-                const result = await resolveSchemaSuggestion(comment.suggestionId!, projectId, "rejected");
+                const result = await resolveSchemaSuggestion(suggestionId, projectId, "rejected");
                 if (result.error) toast.error(result.error);
                 else { toast.success("Sugestão rejeitada"); refresh(); }
               });
@@ -60,10 +61,10 @@ export function SuggestionActions({
           </Button>
         </>
       )}
-      {comment.suggestionStatus === "approved" && (
+      {suggestionStatus === "approved" && (
         <Badge className="text-xs bg-green-500/10 text-green-700">Aprovada</Badge>
       )}
-      {comment.suggestionStatus === "rejected" && (
+      {suggestionStatus === "rejected" && (
         <Badge className="text-xs bg-red-500/10 text-red-700">Rejeitada</Badge>
       )}
     </div>

--- a/frontend/src/components/stats/comment-card-utils.ts
+++ b/frontend/src/components/stats/comment-card-utils.ts
@@ -1,0 +1,56 @@
+export const TYPE_LABELS: Record<string, string> = {
+  single: "Escolha única",
+  multi: "Múltipla escolha",
+  text: "Texto livre",
+  date: "Data",
+};
+
+export const TYPE_COLORS: Record<string, string> = {
+  single: "bg-blue-500/10 text-blue-700",
+  multi: "bg-purple-500/10 text-purple-700",
+  text: "bg-green-500/10 text-green-700",
+  date: "bg-amber-500/10 text-amber-700",
+};
+
+export function formatVerdictLabel(verdict: string): string {
+  if (verdict === "nota") return "Nota do pesquisador";
+  if (verdict === "anotacao") return "Anotação";
+  if (verdict === "dificuldade") return "Dificuldade do LLM";
+  if (verdict === "sugestao") return "Sugestão";
+  if (verdict === "exclusao") return "Sugestão de exclusão";
+  if (verdict === "duvida") return "Dúvida do gabarito";
+  if (verdict === "ambiguo") return "Ambíguo";
+  if (verdict === "pular") return "Pular";
+  if (verdict.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(verdict) as Record<string, boolean>;
+      const selected = Object.entries(parsed)
+        .filter(([, v]) => v)
+        .map(([k]) => k);
+      return selected.length > 0 ? selected.join(", ") : "(nenhuma)";
+    } catch {
+      /* fallback */
+    }
+  }
+  return verdict;
+}
+
+export function verdictVariant(
+  verdict: string,
+): "default" | "secondary" | "destructive" | "outline" {
+  if (verdict === "nota") return "secondary";
+  if (verdict === "anotacao") return "secondary";
+  if (verdict === "dificuldade") return "secondary";
+  if (verdict === "sugestao") return "outline";
+  if (verdict === "exclusao") return "destructive";
+  if (verdict === "duvida") return "secondary";
+  if (verdict === "ambiguo") return "secondary";
+  if (verdict === "pular") return "outline";
+  return "default";
+}
+
+export function formatAnswer(answer: unknown): string {
+  if (answer === null || answer === undefined) return "(sem resposta)";
+  if (Array.isArray(answer)) return answer.join(", ");
+  return String(answer);
+}

--- a/frontend/src/components/stats/comment-card-utils.ts
+++ b/frontend/src/components/stats/comment-card-utils.ts
@@ -1,3 +1,58 @@
+export interface ResponseSnapshotEntry {
+  id: string;
+  respondent_name: string;
+  respondent_type: "humano" | "llm";
+  answer: unknown;
+  justification?: string;
+}
+
+export interface ReviewComment {
+  id: string;
+  documentId: string;
+  documentTitle: string;
+  fieldName: string;
+  fieldDescription: string;
+  fieldHelpText?: string;
+  fieldOptions?: string[] | null;
+  fieldType?: "single" | "multi" | "text" | "date";
+  verdict: string;
+  comment: string;
+  reviewerName: string;
+  resolvedAt: string | null;
+  createdAt: string;
+  chosenResponseId: string | null;
+  source:
+    | "review"
+    | "nota"
+    | "sugestao"
+    | "dificuldade"
+    | "anotacao"
+    | "duvida"
+    | "exclusao";
+  responseSnapshot: ResponseSnapshotEntry[] | null;
+  suggestionId?: string;
+  suggestionStatus?: "pending" | "approved" | "rejected";
+  suggestionChanges?: {
+    description?: string;
+    help_text?: string | null;
+    options?: string[] | null;
+  };
+  fieldSnapshot?: {
+    description: string;
+    help_text: string | null;
+    options: string[] | null;
+  };
+  difficultyResponseId?: string;
+  difficultyDocumentId?: string;
+  duvidaReviewId?: string;
+  duvidaRespondentId?: string;
+  /** Para exclusao_request — id do project_comment, status e document_id alvo. */
+  exclusionCommentId?: string;
+  exclusionDocumentId?: string;
+  exclusionStatus?: "pending" | "approved" | "rejected";
+  exclusionRejectedReason?: string | null;
+}
+
 export const TYPE_LABELS: Record<string, string> = {
   single: "Escolha única",
   multi: "Múltipla escolha",
@@ -47,10 +102,4 @@ export function verdictVariant(
   if (verdict === "ambiguo") return "secondary";
   if (verdict === "pular") return "outline";
   return "default";
-}
-
-export function formatAnswer(answer: unknown): string {
-  if (answer === null || answer === undefined) return "(sem resposta)";
-  if (Array.isArray(answer)) return answer.join(", ");
-  return String(answer);
 }

--- a/frontend/src/hooks/useLlmErrorFiltering.ts
+++ b/frontend/src/hooks/useLlmErrorFiltering.ts
@@ -164,5 +164,3 @@ export function useLlmErrorFiltering<
     openErrorCount,
   };
 }
-
-export type LlmErrorFiltering = ReturnType<typeof useLlmErrorFiltering>;

--- a/frontend/src/hooks/useLlmErrorFiltering.ts
+++ b/frontend/src/hooks/useLlmErrorFiltering.ts
@@ -1,0 +1,168 @@
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+
+export type DatePreset = "all" | "24h" | "7d" | "30d";
+export type SortBy = "default" | "field" | "document" | "recent";
+
+// Campos mínimos que os filtros de escopo consultam (numerador e denominador).
+interface ScopeFilterable {
+  fieldName: string;
+  documentTitle: string;
+  reviewedAt: string;
+  schemaVersion: string | null;
+}
+
+interface FilterableError extends ScopeFilterable {
+  fieldDescription: string;
+  resolvedAt: string | null;
+}
+
+function presetCutoffMs(preset: DatePreset, now: number): number | null {
+  if (preset === "24h") return now - 24 * 3600_000;
+  if (preset === "7d") return now - 7 * 24 * 3600_000;
+  if (preset === "30d") return now - 30 * 24 * 3600_000;
+  return null;
+}
+
+function compareSemverDesc(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    const da = pa[i] ?? 0;
+    const db = pb[i] ?? 0;
+    if (da !== db) return db - da;
+  }
+  return 0;
+}
+
+// Estado dos 6 filtros + ordenação da lista de erros do LLM, junto com toda a
+// derivação (população filtrada, taxa de erro, ordenação, contagem de abertos).
+// Extraído de LlmInsightsView (#355): pura relocação de estado e derivação.
+export function useLlmErrorFiltering<
+  E extends FilterableError,
+  R extends ScopeFilterable,
+>(errors: E[], reviewedEntries: R[]) {
+  const [errorFieldFilter, setErrorFieldFilter] = useState("all");
+  const [errorSearchQuery, setErrorSearchQuery] = useState("");
+  const [errorStatusFilter, setErrorStatusFilter] = useState("open");
+  const [errorDateFilter, setErrorDateFilter] = useState<DatePreset>("all");
+  const [errorSinceDate, setErrorSinceDate] = useState("");
+  const [errorVersionFilter, setErrorVersionFilter] = useState("all");
+  const [sortBy, setSortBy] = useState<SortBy>("default");
+
+  // Tick the "now" reference once a minute so the "Últimas 24h/7d/30d"
+  // cutoff doesn't freeze on long-open pages. State (rather than a raw
+  // Date.now() in render) keeps the component pure per React rules.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Derived from the full reviewed population so a version with 0 errors is
+  // still selectable — useful for "0% rate" sanity checks.
+  const availableVersions = useMemo(() => {
+    const set = new Set<string>();
+    for (const r of reviewedEntries) if (r.schemaVersion) set.add(r.schemaVersion);
+    return Array.from(set).toSorted(compareSemverDesc);
+  }, [reviewedEntries]);
+
+  // Derive the effective version filter: if the selected version is no
+  // longer present (status filter toggled, all errors of that version
+  // resolved, etc.) treat it as "all" instead of letting the stale value
+  // zero out the list with no UI to fix it. Derivation in render avoids
+  // a setState-in-effect cascade.
+  const effectiveVersionFilter = availableVersions.includes(errorVersionFilter)
+    ? errorVersionFilter
+    : "all";
+
+  const sinceMs = errorSinceDate
+    ? new Date(errorSinceDate + "T00:00:00").getTime()
+    : presetCutoffMs(errorDateFilter, now);
+
+  // Scope filters affect both numerator and denominator (so the rate matches
+  // the population the user is looking at). Status only affects which errors
+  // the user wants to see in the list and in the card.
+  const matchesScopeFilters = (e: ScopeFilterable): boolean => {
+    if (errorFieldFilter !== "all" && e.fieldName !== errorFieldFilter)
+      return false;
+    if (
+      errorSearchQuery &&
+      !e.documentTitle
+        .toLowerCase()
+        .includes(errorSearchQuery.toLowerCase())
+    )
+      return false;
+    if (sinceMs && new Date(e.reviewedAt).getTime() < sinceMs) return false;
+    if (
+      effectiveVersionFilter !== "all" &&
+      e.schemaVersion !== effectiveVersionFilter
+    )
+      return false;
+    return true;
+  };
+
+  const filteredReviewed = reviewedEntries.filter(matchesScopeFilters);
+
+  const filteredErrors = errors.filter((e) => {
+    if (errorStatusFilter === "open" && e.resolvedAt) return false;
+    if (errorStatusFilter === "resolved" && !e.resolvedAt) return false;
+    return matchesScopeFilters(e);
+  });
+
+  // Rate uses the same numerator shown in the card (so the two are always
+  // consistent) over the scope-filtered reviewed population.
+  const filteredErrorRate =
+    filteredReviewed.length > 0
+      ? Math.round((filteredErrors.length / filteredReviewed.length) * 100)
+      : 0;
+
+  const sortedErrors = (() => {
+    if (sortBy === "default") return filteredErrors;
+    const arr = [...filteredErrors];
+    if (sortBy === "field") {
+      arr.sort((a, b) => {
+        const fa = a.fieldDescription.localeCompare(b.fieldDescription, "pt-BR");
+        if (fa !== 0) return fa;
+        return a.documentTitle.localeCompare(b.documentTitle, "pt-BR");
+      });
+    } else if (sortBy === "document") {
+      arr.sort((a, b) =>
+        a.documentTitle.localeCompare(b.documentTitle, "pt-BR"),
+      );
+    } else if (sortBy === "recent") {
+      arr.sort((a, b) => b.reviewedAt.localeCompare(a.reviewedAt));
+    }
+    return arr;
+  })();
+
+  // Counted within the current scope so the badge matches the cards.
+  const openErrorCount = errors.filter(
+    (e) => !e.resolvedAt && matchesScopeFilters(e),
+  ).length;
+
+  return {
+    errorFieldFilter,
+    setErrorFieldFilter,
+    errorSearchQuery,
+    setErrorSearchQuery,
+    errorStatusFilter,
+    setErrorStatusFilter,
+    errorDateFilter,
+    setErrorDateFilter,
+    errorSinceDate,
+    setErrorSinceDate,
+    setErrorVersionFilter,
+    sortBy,
+    setSortBy,
+    availableVersions,
+    effectiveVersionFilter,
+    filteredErrors,
+    filteredErrorRate,
+    sortedErrors,
+    openErrorCount,
+  };
+}
+
+export type LlmErrorFiltering = ReturnType<typeof useLlmErrorFiltering>;

--- a/frontend/src/hooks/useLlmErrorFiltering.ts
+++ b/frontend/src/hooks/useLlmErrorFiltering.ts
@@ -1,9 +1,34 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
+import { compareVersions } from "@/lib/compare-version";
 
 export type DatePreset = "all" | "24h" | "7d" | "30d";
 export type SortBy = "default" | "field" | "document" | "recent";
+
+// Subconjunto não-genérico do retorno do hook consumido pela toolbar de
+// filtros (ErrorFiltersToolbar): controles + contagens. Uma prop única
+// `filtering` no lugar de re-plumbar cada membro evita edições em três
+// lugares (retorno do hook, props, wiring) a cada filtro novo.
+export interface LlmErrorFilteringControls {
+  errorSearchQuery: string;
+  setErrorSearchQuery: (v: string) => void;
+  errorFieldFilter: string;
+  setErrorFieldFilter: (v: string) => void;
+  errorStatusFilter: string;
+  setErrorStatusFilter: (v: string) => void;
+  errorDateFilter: DatePreset;
+  setErrorDateFilter: (v: DatePreset) => void;
+  errorSinceDate: string;
+  setErrorSinceDate: (v: string) => void;
+  availableVersions: string[];
+  effectiveVersionFilter: string;
+  setErrorVersionFilter: (v: string) => void;
+  sortBy: SortBy;
+  setSortBy: (v: SortBy) => void;
+  sortedCount: number;
+  openErrorCount: number;
+}
 
 // Campos mínimos que os filtros de escopo consultam (numerador e denominador).
 interface ScopeFilterable {
@@ -23,17 +48,6 @@ function presetCutoffMs(preset: DatePreset, now: number): number | null {
   if (preset === "7d") return now - 7 * 24 * 3600_000;
   if (preset === "30d") return now - 30 * 24 * 3600_000;
   return null;
-}
-
-function compareSemverDesc(a: string, b: string): number {
-  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
-  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
-  for (let i = 0; i < 3; i++) {
-    const da = pa[i] ?? 0;
-    const db = pb[i] ?? 0;
-    if (da !== db) return db - da;
-  }
-  return 0;
 }
 
 // Estado dos 6 filtros + ordenação da lista de erros do LLM, junto com toda a
@@ -65,7 +79,7 @@ export function useLlmErrorFiltering<
   const availableVersions = useMemo(() => {
     const set = new Set<string>();
     for (const r of reviewedEntries) if (r.schemaVersion) set.add(r.schemaVersion);
-    return Array.from(set).toSorted(compareSemverDesc);
+    return Array.from(set).toSorted((a, b) => compareVersions(b, a));
   }, [reviewedEntries]);
 
   // Derive the effective version filter: if the selected version is no
@@ -161,6 +175,7 @@ export function useLlmErrorFiltering<
     filteredErrors,
     filteredErrorRate,
     sortedErrors,
+    sortedCount: sortedErrors.length,
     openErrorCount,
   };
 }

--- a/frontend/src/lib/__tests__/compare-version.test.ts
+++ b/frontend/src/lib/__tests__/compare-version.test.ts
@@ -3,6 +3,7 @@ import {
   versionGte,
   parseVersionStr,
   formatVersion,
+  compareVersions,
   latestMajorAnchor,
   resolveMinVersion,
   responseQualifiesForVersion,
@@ -62,6 +63,28 @@ describe("versionGte", () => {
     expect(versionGte(v(0, 20, 0), v(0, 20, 0))).toBe(true);
     expect(versionGte(v(0, 19, 9), v(0, 20, 0))).toBe(false);
     expect(versionGte(v(1, 0, 0), v(0, 99, 99))).toBe(true);
+  });
+});
+
+describe("compareVersions", () => {
+  it("ordena strings X.Y.Z em major > minor > patch", () => {
+    expect(compareVersions("0.20.3", "0.20.0")).toBeGreaterThan(0);
+    expect(compareVersions("0.19.9", "0.20.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0", "0.99.99")).toBeGreaterThan(0);
+    expect(compareVersions("0.20.0", "0.20.0")).toBe(0);
+  });
+  it("ordena descendente via sort((a, b) => compareVersions(b, a))", () => {
+    const versions = ["0.2.0", "1.0.0", "0.10.0", "0.2.1"];
+    expect(versions.toSorted((a, b) => compareVersions(b, a))).toEqual([
+      "1.0.0",
+      "0.10.0",
+      "0.2.1",
+      "0.2.0",
+    ]);
+  });
+  it("malformadas ordenam como {0,0,0}, antes de versões válidas", () => {
+    expect(compareVersions("lixo", "0.0.1")).toBeLessThan(0);
+    expect(compareVersions("lixo", "0.0.0")).toBe(0);
   });
 });
 

--- a/frontend/src/lib/compare-version.ts
+++ b/frontend/src/lib/compare-version.ts
@@ -74,6 +74,17 @@ export function formatVersion(v: SchemaVersion): string {
   return `${v.major}.${v.minor}.${v.patch}`;
 }
 
+// Comparador 3-way ascendente para strings "X.Y.Z" (ordem major > minor >
+// patch). Strings malformadas (parseVersionStr → null) ordenam como {0,0,0},
+// isto é, antes de qualquer versão válida — determinístico, sem lançar.
+export function compareVersions(a: string, b: string): number {
+  const va = parseVersionStr(a) ?? { major: 0, minor: 0, patch: 0 };
+  const vb = parseVersionStr(b) ?? { major: 0, minor: 0, patch: 0 };
+  if (va.major !== vb.major) return va.major - vb.major;
+  if (va.minor !== vb.minor) return va.minor - vb.minor;
+  return va.patch - vb.patch;
+}
+
 // Piso de versão para o filtro "última grande versão".
 //
 // Em projetos major ≥ 1 a fronteira de rodada é o MAJOR corrente


### PR DESCRIPTION
## Resumo

Fase 3 da campanha react-doctor Onda 5 (épico #239, rastreada por #339): decomposição real dos dois componentes giant da área Stats, preservando comportamento, até saírem do threshold de `no-giant-component` (~300 linhas da função do componente).

Closes #355

## O que mudou

**CommentCard.tsx (314 → ~105 linhas de função)** — extração pura para arquivos novos em `src/components/stats/`:
- `CommentCardHeader.tsx` — título/documento, código do campo, botões Editar/Sugerir, badge de verdict e metadados do campo;
- `GabaritoSection.tsx` — o Collapsible do gabarito com seu estado e fetch (`fetchGabaritoForComment`), autocontido;
- `SuggestionActions.tsx` — ações de sugestão (Revisar/Rejeitar) com o `useTransition` próprio;
- `ExclusionActions.tsx` — componente já existente, movido para arquivo próprio sem mudança;
- `comment-card-utils.ts` — `TYPE_LABELS`/`TYPE_COLORS`/`formatVerdictLabel`/`verdictVariant`/`formatAnswer`.

`ReviewComment` e `ResponseSnapshotEntry` continuam exportados de `CommentCard.tsx` — nenhum dos 4 consumidores foi tocado.

**LlmInsightsView.tsx (396 → ~120 linhas de função)**:
- `src/hooks/useLlmErrorFiltering.ts` — funde o hook co-localizado `useLlmErrorFilters` (estado dos 7 filtros, do #332) com toda a derivação (tick do `now`, versões disponíveis, filtro efetivo de versão, população filtrada, taxa de erro, ordenação, contagem de abertos). Tipado estruturalmente (genérico) para não depender dos types da rota;
- `ErrorStatsCards.tsx` — os 3 cards de resumo + aviso de docs não revisados;
- `ErrorFiltersToolbar.tsx` — a toolbar completa de filtros e o contador com badge.

**doctor.config.json** — o override de `no-event-handler` acompanha o código movido (`CommentCard.tsx` → `ExclusionActions.tsx`): relocação de débito já suprimido, não supressão nova.

**Fix colateral exigido pelo gate** — `onClick={() => void handleRegenerateBacklog()}` (`no-misused-promises`, débito que já existia no arquivo e ficou exposto pelo gate file-scoped ao tocá-lo).

## Validação

- **react-doctor**: 16 → 14 diagnósticos no run completo; os dois `no-giant-component` de stats sumiram e nenhum diagnóstico novo apareceu nos arquivos criados (resta em stats só o de `EditFieldDialog`, pré-existente e fora do escopo desta fase).
- **vitest**: 863/863 verdes.
- **typecheck**: nenhum erro novo — os 18 erros existentes estão nos fixtures de `ComparePage` (débito pré-existente da main, alheio a este PR).
- **Pre-push**: `SKIP=typecheck,fallow-audit` — typecheck red pelos fixtures acima; fallow-audit acusa como "nova" a complexidade transplantada pela decomposição (precedente do PR #334). O único achado genuíno do fallow (type export `LlmErrorFiltering` sem consumidor) foi corrigido no segundo commit. `lint:types` e `semgrep` passaram.

A extração é relocação pura de JSX/estado: nenhuma mudança de lógica, strings de UI, classes ou comportamento observável.

🤖 Generated with [Claude Code](https://claude.com/claude-code)