### PR TITLE
fix(fly): 512 MB + swap no frontend — next-server era OOM-killed em 256 MB

### DIFF
--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -7,6 +7,10 @@
 app = "gui-analise-sistematica-frontend"
 primary_region = "gru"
 
+# Swap como amortecedor de picos de memoria: o next-server chegava a ~152 MB
+# de RSS sob trafego real e era OOM-killed nas VMs de 256 MB (2026-07-02).
+swap_size_mb = 512
+
 [build]
   dockerfile = "Dockerfile"
 
@@ -39,3 +43,11 @@ primary_region = "gru"
     method = "GET"
     timeout = "5s"
     path = "/api/health"
+
+[[vm]]
+  # 512 MB persiste o `fly scale memory 512` de 2026-07-02: sem esta secao,
+  # um `fly deploy` futuro recriaria as maquinas com o default de 256 MB e
+  # o OOM-kill do next-server voltaria.
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1


### PR DESCRIPTION
## Problema

O Fly Doctor acusou dois sintomas no `gui-analise-sistematica-frontend` (produção, dataframeit.com.br): proxy sem candidato em `0.0.0.0:3000` e restarts frequentes na machine `48e74def46d458`. A causa raiz é uma só: **OOM-kill**. As VMs tinham 256 MB de RAM e o `next-server` chegava a ~152 MB de RSS sob tráfego real — os logs mostram `exit_code=137, oom_killed=true` repetido nas duas máquinas em 2026-07-02. Os erros de load balancing são consequência: durante o reboot não há instância saudável para rotear.

## Mudança

- `[[vm]]` com `memory = "512mb"` — persiste o `fly scale memory 512` já aplicado em produção (2026-07-02, as duas máquinas healthy); sem isso, um deploy futuro recriaria as máquinas com 256 MB.
- `swap_size_mb = 512` — amortecedor de picos (entra em vigor no primeiro deploy após o merge).

Decisões do Bruno: 512 MB + swap (não 1 GB) e manter as 2 máquinas always-on. Custo ≈ US$ 3,19/mês por máquina.

## Verificação

- `fly scale memory 512` aplicado: as 2 máquinas atualizaram e voltaram healthy (1/1 passing).
- Após o merge, o workflow `frontend-fly-deploy.yml` consolida `[[vm]]` + swap; conferir `fly status` e ausência de novos `oom_killed=true` nos logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)