### PR TITLE
refactor(auto-review,documents): decompõe AutoReviewFieldPanel e DocumentsPageClient (react-doctor no-giant-component)

### DIFF
--- a/frontend/doctor.config.json
+++ b/frontend/doctor.config.json
@@ -3,26 +3,34 @@
   "ignore": {
     "overrides": [
       {
-        "files": ["src/actions/**"],
+        "files": [
+          "src/actions/**"
+        ],
         "rules": [
           "react-doctor/server-auth-actions"
         ]
       },
       {
-        "files": ["src/components/ui/**"],
+        "files": [
+          "src/components/ui/**"
+        ],
         "rules": [
           "react-doctor/only-export-components",
           "react-doctor/no-multi-comp"
         ]
       },
       {
-        "files": ["src/components/coding/QuestionsPanel.tsx"],
+        "files": [
+          "src/components/coding/QuestionsPanel.tsx"
+        ],
         "rules": [
           "react-doctor/exhaustive-deps"
         ]
       },
       {
-        "files": ["src/lib/date-parts.ts"],
+        "files": [
+          "src/lib/date-parts.ts"
+        ],
         "rules": [
           "react-doctor/js-length-check-first"
         ]
@@ -49,7 +57,7 @@
       },
       {
         "files": [
-          "src/components/auto-review/AutoReviewFieldPanel.tsx",
+          "src/components/auto-review/AutoReviewJustificationInput.tsx",
           "src/components/compare/ComparisonPanel.tsx"
         ],
         "rules": [
@@ -57,19 +65,25 @@
         ]
       },
       {
-        "files": ["src/hooks/usePinnedDoc.ts"],
+        "files": [
+          "src/hooks/usePinnedDoc.ts"
+        ],
         "rules": [
           "react-doctor/no-event-handler"
         ]
       },
       {
-        "files": ["src/hooks/useAutosaveOnExit.ts"],
+        "files": [
+          "src/hooks/useAutosaveOnExit.ts"
+        ],
         "rules": [
           "react-doctor/no-fetch-in-effect"
         ]
       },
       {
-        "files": ["src/hooks/useDocumentText.ts"],
+        "files": [
+          "src/hooks/useDocumentText.ts"
+        ],
         "rules": [
           "react-doctor/no-chain-state-updates",
           "react-doctor/no-derived-state"

--- a/frontend/src/components/assignments/DocumentPickerList.tsx
+++ b/frontend/src/components/assignments/DocumentPickerList.tsx
@@ -5,6 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import type { LotteryDocStats } from "@/lib/lottery-utils";
+import { toggleInSet } from "@/lib/utils";
 
 interface DocumentPickerListProps {
   docs: LotteryDocStats[];
@@ -35,10 +36,7 @@ export function DocumentPickerList({
   }, [docs, query]);
 
   const toggle = (docId: string, checked: boolean) => {
-    const next = new Set(selected);
-    if (checked) next.add(docId);
-    else next.delete(docId);
-    onChange(next);
+    onChange(toggleInSet(selected, docId, checked));
   };
 
   return (

--- a/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
+++ b/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
@@ -183,13 +183,11 @@ export function AutoReviewFieldPanel({
 
       <AutoReviewFooter
         readOnly={readOnly}
-        submitState={{
-          readyCount,
-          incompleteCount,
-          submitting,
-          canSubmit,
-          onSubmit,
-        }}
+        readyCount={readyCount}
+        incompleteCount={incompleteCount}
+        submitting={submitting}
+        canSubmit={canSubmit}
+        onSubmit={onSubmit}
       />
     </div>
   );

--- a/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
+++ b/frontend/src/components/auto-review/AutoReviewFieldPanel.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { ProgressDots } from "../coding/ProgressDots";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { Keyboard, ChevronDown, ChevronRight } from "lucide-react";
-import { cn } from "@/lib/utils";
-import { formatAnswerDisplay } from "@/lib/format-answer";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { verdictRequiresJustification } from "@/lib/auto-review-decided";
+import { formatAnswerDisplay } from "@/lib/format-answer";
 import type { SelfVerdict } from "@/lib/types";
+import { useAutoReviewKeyboard } from "./useAutoReviewKeyboard";
+import { AutoReviewVerdictButtons } from "./AutoReviewVerdictButtons";
+import { AutoReviewJustificationInput } from "./AutoReviewJustificationInput";
+import { AutoReviewFooter } from "./AutoReviewFooter";
 
 export interface AutoReviewField {
   fieldName: string;
@@ -43,8 +43,6 @@ interface AutoReviewFieldPanelProps {
   onFieldNavigate: (index: number) => void;
 }
 
-const HINTS_DISMISSED_KEY = "autoReview:hintsDismissed";
-
 export function AutoReviewFieldPanel({
   field,
   fieldIndex,
@@ -67,106 +65,19 @@ export function AutoReviewFieldPanel({
   // entre "eu acertei" / "LLM acertou", então esconder por default era um
   // clique extra desnecessário.
   const [showJustification, setShowJustification] = useState(true);
-  const justificationMissing = !justification.trim();
-  // Hints começam abertos até o usuário fechar uma vez (persistido em localStorage).
-  // Lazy initializer roda só uma vez no mount, lê do localStorage sem flicker.
-  const [hintsOpen, setHintsOpen] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem(HINTS_DISMISSED_KEY) === null;
-  });
-
-  // Listener de teclado registra uma vez (por readOnly); callbacks frescos
-  // chegam via ref para evitar reregistro a cada keystroke.
-  const handlerRef = useRef({ onChoose, onFieldNavigate, fieldIndex, totalFields });
-  useEffect(() => {
-    handlerRef.current = { onChoose, onFieldNavigate, fieldIndex, totalFields };
-  });
-
-  function toggleHints() {
-    setHintsOpen((v) => {
-      const next = !v;
-      if (typeof window !== "undefined" && !next) {
-        window.localStorage.setItem(HINTS_DISMISSED_KEY, "1");
-      }
-      return next;
-    });
-  }
 
   // Nao ha effect para reabrir a justificativa ao trocar de campo: o pai
   // remonta o painel via `key={currentKey}`, entao `showJustification` ja
   // nasce no default aberto a cada (doc, campo).
 
-  // Foca o textarea ao escolher um verdict que exige justificativa — sem isto,
-  // teclar o atalho abre o campo mas deixa o foco para tras. Keyed so em
-  // `choice`: navegar entre dois campos com o mesmo verdict nao rerroda o effect
-  // (mesmo valor), entao o foco so vai para o textarea no ato de escolher.
-  const justificationRef = useRef<HTMLTextAreaElement>(null);
-  useEffect(() => {
-    if (verdictRequiresJustification(choice)) justificationRef.current?.focus();
-  }, [choice]);
-
-  // Auto-advance pós-decisão: armazena handle do timeout num ref para poder
-  // cancelar se o usuário trocar de doc/campo antes do disparo (evita pular
-  // índice em contexto desatualizado).
-  const advanceTimeoutRef = useRef<number | null>(null);
-  useEffect(
-    () => () => {
-      if (advanceTimeoutRef.current !== null) {
-        window.clearTimeout(advanceTimeoutRef.current);
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (readOnly) return;
-    function onKey(e: KeyboardEvent) {
-      const target = e.target as HTMLElement | null;
-      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA"))
-        return;
-      const { onChoose, onFieldNavigate, fieldIndex, totalFields } =
-        handlerRef.current;
-      if (e.key === "1") {
-        e.preventDefault();
-        onChoose("contesta_llm");
-      } else if (e.key === "2") {
-        e.preventDefault();
-        onChoose("admite_erro");
-      } else if (e.key === "3") {
-        e.preventDefault();
-        onChoose("equivalente");
-      } else if (e.key === "4") {
-        e.preventDefault();
-        onChoose("ambiguo");
-      } else if (e.key.toLowerCase() === "p") {
-        e.preventDefault();
-        if (fieldIndex > 0) onFieldNavigate(fieldIndex - 1);
-      } else if (e.key.toLowerCase() === "n") {
-        e.preventDefault();
-        if (fieldIndex < totalFields - 1) onFieldNavigate(fieldIndex + 1);
-      }
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [readOnly]);
-
-  function handleChoose(v: SelfVerdict) {
-    onChoose(v);
-    // contesta_llm e ambiguo exigem justificativa: não auto-avança, senão o
-    // pesquisador perderia o campo de texto que acabou de abrir.
-    if (verdictRequiresJustification(v)) return;
-    // Pula campos já respondidos no auto-advance pós-clique (P/N manuais
-    // continuam navegando livremente para permitir re-conferência).
-    const nextUnanswered = answered.findIndex((a, i) => i > fieldIndex && !a);
-    if (nextUnanswered === -1) return;
-    if (advanceTimeoutRef.current !== null) {
-      window.clearTimeout(advanceTimeoutRef.current);
-    }
-    advanceTimeoutRef.current = window.setTimeout(() => {
-      advanceTimeoutRef.current = null;
-      onFieldNavigate(nextUnanswered);
-    }, 250);
-  }
+  const { handleChoose } = useAutoReviewKeyboard({
+    readOnly,
+    fieldIndex,
+    totalFields,
+    answered,
+    onChoose,
+    onFieldNavigate,
+  });
 
   return (
     <div className="flex h-full flex-col">
@@ -245,93 +156,17 @@ export function AutoReviewFieldPanel({
             outro pesquisador.
           </div>
         ) : (
-          <div className="flex flex-wrap gap-2">
-            <Button
-              variant={choice === "contesta_llm" ? "default" : "outline"}
-              className={cn(
-                "flex-1 min-w-[180px]",
-                choice === "contesta_llm" && "ring-2 ring-brand/40",
-              )}
-              onClick={() => handleChoose("contesta_llm")}
-            >
-              <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                1
-              </kbd>
-              Eu acertei (LLM errou)
-            </Button>
-            <Button
-              variant={choice === "admite_erro" ? "default" : "outline"}
-              className={cn(
-                "flex-1 min-w-[180px]",
-                choice === "admite_erro" && "ring-2 ring-brand/40",
-              )}
-              onClick={() => handleChoose("admite_erro")}
-            >
-              <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                2
-              </kbd>
-              LLM acertou (eu errei)
-            </Button>
-            <Button
-              variant={choice === "equivalente" ? "default" : "outline"}
-              className={cn(
-                "flex-1 min-w-[180px]",
-                choice === "equivalente" && "ring-2 ring-brand/40",
-              )}
-              onClick={() => handleChoose("equivalente")}
-              title="As duas respostas dizem a mesma coisa de formas diferentes"
-            >
-              <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                3
-              </kbd>
-              Respostas equivalentes
-            </Button>
-            <Button
-              variant={choice === "ambiguo" ? "default" : "outline"}
-              className={cn(
-                "flex-1 min-w-[180px]",
-                choice === "ambiguo" && "ring-2 ring-brand/40",
-              )}
-              onClick={() => handleChoose("ambiguo")}
-              title="Campo ambíguo — gera um comentário para discussão"
-            >
-              <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                4
-              </kbd>
-              Ambíguo (discutir)
-            </Button>
-          </div>
+          <AutoReviewVerdictButtons choice={choice} onChoose={handleChoose} />
         )}
 
         {!readOnly &&
         !field.alreadyAnswered &&
         verdictRequiresJustification(choice) ? (
-          <div className="space-y-1.5">
-            <Label htmlFor="self-justification" className="text-sm">
-              Justificativa <span className="text-destructive">*</span>
-            </Label>
-            <Textarea
-              id="self-justification"
-              ref={justificationRef}
-              rows={3}
-              value={justification}
-              onChange={(e) => onJustificationChange(e.target.value)}
-              placeholder={
-                choice === "ambiguo"
-                  ? "Por que este campo é ambíguo? Isto será incluído no comentário de discussão."
-                  : "Por que você acha que sua resposta está correta? O árbitro verá isto."
-              }
-              className={cn(
-                justificationMissing &&
-                  "border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20",
-              )}
-            />
-            {justificationMissing ? (
-              <p className="text-xs text-destructive">
-                Obrigatória: sem ela este campo não é enviado.
-              </p>
-            ) : null}
-          </div>
+          <AutoReviewJustificationInput
+            choice={choice}
+            justification={justification}
+            onChange={onJustificationChange}
+          />
         ) : null}
 
         {(readOnly || field.alreadyAnswered) && field.selfJustification ? (
@@ -346,91 +181,16 @@ export function AutoReviewFieldPanel({
         ) : null}
       </div>
 
-      <div className="border-t px-4 py-2">
-        <div className="flex items-center justify-between gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 gap-1.5 px-2 text-xs text-muted-foreground"
-            onClick={toggleHints}
-          >
-            <Keyboard className="size-3" />
-            Atalhos
-          </Button>
-          {!readOnly ? (
-            <div className="flex items-center gap-2">
-              <span
-                className={cn(
-                  "text-xs",
-                  readyCount === 0 && incompleteCount > 0
-                    ? "text-destructive"
-                    : "text-muted-foreground",
-                )}
-              >
-                {readyCount > 0
-                  ? `${readyCount} campo${readyCount === 1 ? "" : "s"} pronto${readyCount === 1 ? "" : "s"} para enviar`
-                  : incompleteCount > 0
-                    ? "Preencha a justificativa para enviar"
-                    : "Decida um campo para enviar"}
-              </span>
-              <Button
-                size="sm"
-                onClick={onSubmit}
-                disabled={!canSubmit}
-                title={
-                  submitting
-                    ? "Enviando…"
-                    : readyCount > 0
-                      ? "Enviar os campos decididos"
-                      : "Decida ao menos um campo para enviar"
-                }
-              >
-                {submitting ? "Enviando…" : "Enviar"}
-              </Button>
-            </div>
-          ) : null}
-        </div>
-        {hintsOpen ? (
-          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-            <span>
-              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                1
-              </kbd>{" "}
-              Eu acertei
-            </span>
-            <span>
-              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                2
-              </kbd>{" "}
-              LLM acertou
-            </span>
-            <span>
-              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                3
-              </kbd>{" "}
-              Equivalentes
-            </span>
-            <span>
-              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                4
-              </kbd>{" "}
-              Ambíguo
-            </span>
-            <span>
-              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                P
-              </kbd>{" "}
-              Campo anterior
-            </span>
-            <span>
-              <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                N
-              </kbd>{" "}
-              Campo próximo
-            </span>
-          </div>
-        ) : null}
-      </div>
+      <AutoReviewFooter
+        readOnly={readOnly}
+        submitState={{
+          readyCount,
+          incompleteCount,
+          submitting,
+          canSubmit,
+          onSubmit,
+        }}
+      />
     </div>
   );
 }

--- a/frontend/src/components/auto-review/AutoReviewFooter.tsx
+++ b/frontend/src/components/auto-review/AutoReviewFooter.tsx
@@ -11,16 +11,18 @@ const HINTS_DISMISSED_KEY = "autoReview:hintsDismissed";
 // colapsável, persistido em localStorage) e o status/botão de envio.
 export function AutoReviewFooter({
   readOnly,
-  submitState,
+  readyCount,
+  incompleteCount,
+  submitting,
+  canSubmit,
+  onSubmit,
 }: {
   readOnly: boolean;
-  submitState: {
-    readyCount: number;
-    incompleteCount: number;
-    submitting: boolean;
-    canSubmit: boolean;
-    onSubmit: () => void;
-  };
+  readyCount: number;
+  incompleteCount: number;
+  submitting: boolean;
+  canSubmit: boolean;
+  onSubmit: () => void;
 }) {
   // Hints começam abertos até o usuário fechar uma vez (persistido em localStorage).
   // Lazy initializer roda só uma vez no mount, lê do localStorage sem flicker.
@@ -38,9 +40,6 @@ export function AutoReviewFooter({
       return next;
     });
   }
-
-  const { readyCount, incompleteCount, submitting, canSubmit, onSubmit } =
-    submitState;
 
   return (
     <div className="border-t px-4 py-2">

--- a/frontend/src/components/auto-review/AutoReviewFooter.tsx
+++ b/frontend/src/components/auto-review/AutoReviewFooter.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Keyboard } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const HINTS_DISMISSED_KEY = "autoReview:hintsDismissed";
+
+// Rodapé do AutoReviewFieldPanel: botão de atalhos (com o painel de hints
+// colapsável, persistido em localStorage) e o status/botão de envio.
+export function AutoReviewFooter({
+  readOnly,
+  submitState,
+}: {
+  readOnly: boolean;
+  submitState: {
+    readyCount: number;
+    incompleteCount: number;
+    submitting: boolean;
+    canSubmit: boolean;
+    onSubmit: () => void;
+  };
+}) {
+  // Hints começam abertos até o usuário fechar uma vez (persistido em localStorage).
+  // Lazy initializer roda só uma vez no mount, lê do localStorage sem flicker.
+  const [hintsOpen, setHintsOpen] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(HINTS_DISMISSED_KEY) === null;
+  });
+
+  function toggleHints() {
+    setHintsOpen((v) => {
+      const next = !v;
+      if (typeof window !== "undefined" && !next) {
+        window.localStorage.setItem(HINTS_DISMISSED_KEY, "1");
+      }
+      return next;
+    });
+  }
+
+  const { readyCount, incompleteCount, submitting, canSubmit, onSubmit } =
+    submitState;
+
+  return (
+    <div className="border-t px-4 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1.5 px-2 text-xs text-muted-foreground"
+          onClick={toggleHints}
+        >
+          <Keyboard className="size-3" />
+          Atalhos
+        </Button>
+        {!readOnly ? (
+          <div className="flex items-center gap-2">
+            <span
+              className={cn(
+                "text-xs",
+                readyCount === 0 && incompleteCount > 0
+                  ? "text-destructive"
+                  : "text-muted-foreground",
+              )}
+            >
+              {readyCount > 0
+                ? `${readyCount} campo${readyCount === 1 ? "" : "s"} pronto${readyCount === 1 ? "" : "s"} para enviar`
+                : incompleteCount > 0
+                  ? "Preencha a justificativa para enviar"
+                  : "Decida um campo para enviar"}
+            </span>
+            <Button
+              size="sm"
+              onClick={onSubmit}
+              disabled={!canSubmit}
+              title={
+                submitting
+                  ? "Enviando…"
+                  : readyCount > 0
+                    ? "Enviar os campos decididos"
+                    : "Decida ao menos um campo para enviar"
+              }
+            >
+              {submitting ? "Enviando…" : "Enviar"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+      {hintsOpen ? (
+        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>
+            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+              1
+            </kbd>{" "}
+            Eu acertei
+          </span>
+          <span>
+            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+              2
+            </kbd>{" "}
+            LLM acertou
+          </span>
+          <span>
+            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+              3
+            </kbd>{" "}
+            Equivalentes
+          </span>
+          <span>
+            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+              4
+            </kbd>{" "}
+            Ambíguo
+          </span>
+          <span>
+            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+              P
+            </kbd>{" "}
+            Campo anterior
+          </span>
+          <span>
+            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+              N
+            </kbd>{" "}
+            Campo próximo
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/auto-review/AutoReviewJustificationInput.tsx
+++ b/frontend/src/components/auto-review/AutoReviewJustificationInput.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { verdictRequiresJustification } from "@/lib/auto-review-decided";
+import type { SelfVerdict } from "@/lib/types";
+
+// Input de justificativa do AutoReviewFieldPanel. O condicional de render
+// (!readOnly && !alreadyAnswered && exige justificativa) fica no painel; a
+// variante read-only (selfJustification já salva) também.
+export function AutoReviewJustificationInput({
+  choice,
+  justification,
+  onChange,
+}: {
+  choice: SelfVerdict | null;
+  justification: string;
+  onChange: (value: string) => void;
+}) {
+  const justificationMissing = !justification.trim();
+
+  // Foca o textarea ao escolher um verdict que exige justificativa — sem isto,
+  // teclar o atalho abre o campo mas deixa o foco para tras. Keyed so em
+  // `choice`: navegar entre dois campos com o mesmo verdict nao rerroda o effect
+  // (mesmo valor), entao o foco so vai para o textarea no ato de escolher.
+  const justificationRef = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    if (verdictRequiresJustification(choice)) justificationRef.current?.focus();
+  }, [choice]);
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor="self-justification" className="text-sm">
+        Justificativa <span className="text-destructive">*</span>
+      </Label>
+      <Textarea
+        id="self-justification"
+        ref={justificationRef}
+        rows={3}
+        value={justification}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={
+          choice === "ambiguo"
+            ? "Por que este campo é ambíguo? Isto será incluído no comentário de discussão."
+            : "Por que você acha que sua resposta está correta? O árbitro verá isto."
+        }
+        className={cn(
+          justificationMissing &&
+            "border-destructive focus-visible:border-destructive focus-visible:ring-destructive/20",
+        )}
+      />
+      {justificationMissing ? (
+        <p className="text-xs text-destructive">
+          Obrigatória: sem ela este campo não é enviado.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/auto-review/AutoReviewVerdictButtons.tsx
+++ b/frontend/src/components/auto-review/AutoReviewVerdictButtons.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import type { SelfVerdict } from "@/lib/types";
+
+// Botões de verdict do AutoReviewFieldPanel (branch !readOnly); o aviso de
+// coordenador (readOnly) e a variante já-respondida ficam no painel.
+export function AutoReviewVerdictButtons({
+  choice,
+  onChoose,
+}: {
+  choice: SelfVerdict | null;
+  onChoose: (verdict: SelfVerdict) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Button
+        variant={choice === "contesta_llm" ? "default" : "outline"}
+        className={cn(
+          "flex-1 min-w-[180px]",
+          choice === "contesta_llm" && "ring-2 ring-brand/40",
+        )}
+        onClick={() => onChoose("contesta_llm")}
+      >
+        <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+          1
+        </kbd>
+        Eu acertei (LLM errou)
+      </Button>
+      <Button
+        variant={choice === "admite_erro" ? "default" : "outline"}
+        className={cn(
+          "flex-1 min-w-[180px]",
+          choice === "admite_erro" && "ring-2 ring-brand/40",
+        )}
+        onClick={() => onChoose("admite_erro")}
+      >
+        <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+          2
+        </kbd>
+        LLM acertou (eu errei)
+      </Button>
+      <Button
+        variant={choice === "equivalente" ? "default" : "outline"}
+        className={cn(
+          "flex-1 min-w-[180px]",
+          choice === "equivalente" && "ring-2 ring-brand/40",
+        )}
+        onClick={() => onChoose("equivalente")}
+        title="As duas respostas dizem a mesma coisa de formas diferentes"
+      >
+        <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+          3
+        </kbd>
+        Respostas equivalentes
+      </Button>
+      <Button
+        variant={choice === "ambiguo" ? "default" : "outline"}
+        className={cn(
+          "flex-1 min-w-[180px]",
+          choice === "ambiguo" && "ring-2 ring-brand/40",
+        )}
+        onClick={() => onChoose("ambiguo")}
+        title="Campo ambíguo — gera um comentário para discussão"
+      >
+        <kbd className="mr-2 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+          4
+        </kbd>
+        Ambíguo (discutir)
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/auto-review/__tests__/AutoReviewFieldPanel.test.tsx
+++ b/frontend/src/components/auto-review/__tests__/AutoReviewFieldPanel.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import {
+  AutoReviewFieldPanel,
+  type AutoReviewField,
+} from "../AutoReviewFieldPanel";
+
+afterEach(cleanup);
+
+const field: AutoReviewField = {
+  fieldName: "diagnostico",
+  fieldDescription: "Diagnóstico principal",
+  humanAnswer: "Sim",
+  llmAnswer: "Não",
+  llmJustification: null,
+  alreadyAnswered: false,
+  selfJustification: null,
+};
+
+function renderPanel(props: Partial<Parameters<typeof AutoReviewFieldPanel>[0]> = {}) {
+  render(
+    <AutoReviewFieldPanel
+      field={field}
+      fieldIndex={0}
+      totalFields={2}
+      answered={[false, false]}
+      incomplete={[false, false]}
+      choice={null}
+      justification=""
+      readOnly={false}
+      readyCount={0}
+      incompleteCount={0}
+      submitting={false}
+      canSubmit={false}
+      onSubmit={vi.fn()}
+      onChoose={vi.fn()}
+      onJustificationChange={vi.fn()}
+      onFieldNavigate={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe("AutoReviewFieldPanel", () => {
+  // O painel remonta via key={currentKey} no pai a cada (doc, campo) — então
+  // testamos o efeito de foco no cenário real: mount já com o verdict que
+  // exige justificativa (não um clique local, já que `choice` é controlado
+  // pelo pai via prop).
+  it("monta com um verdict que exige justificativa e foca o textarea", () => {
+    renderPanel({ choice: "contesta_llm" });
+
+    const textarea = screen.getByLabelText(/Justificativa/);
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("exibe o aviso de obrigatoriedade com a justificativa vazia", () => {
+    renderPanel({ choice: "contesta_llm", justification: "" });
+
+    expect(
+      screen.queryByText(/Obrigatória: sem ela este campo não é enviado\./),
+    ).not.toBeNull();
+  });
+});

--- a/frontend/src/components/auto-review/__tests__/useAutoReviewKeyboard.test.ts
+++ b/frontend/src/components/auto-review/__tests__/useAutoReviewKeyboard.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+import { useAutoReviewKeyboard } from "../useAutoReviewKeyboard";
+
+function fireKey(key: string, targetTag: "BODY" | "INPUT" | "TEXTAREA" = "BODY") {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true });
+  if (targetTag === "BODY") {
+    window.dispatchEvent(event);
+    return;
+  }
+  const el = document.createElement(targetTag.toLowerCase());
+  document.body.appendChild(el);
+  el.dispatchEvent(event);
+  document.body.removeChild(el);
+}
+
+const baseArgs = {
+  fieldIndex: 1,
+  totalFields: 3,
+  answered: [false, false, false],
+  onChoose: vi.fn(),
+  onFieldNavigate: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("useAutoReviewKeyboard", () => {
+  it("teclas 1-4 chamam onChoose com o verdict certo", () => {
+    const onChoose = vi.fn();
+    renderHook(() =>
+      useAutoReviewKeyboard({ ...baseArgs, readOnly: false, onChoose }),
+    );
+
+    act(() => fireKey("1"));
+    act(() => fireKey("2"));
+    act(() => fireKey("3"));
+    act(() => fireKey("4"));
+
+    expect(onChoose.mock.calls.map((c) => c[0])).toEqual([
+      "contesta_llm",
+      "admite_erro",
+      "equivalente",
+      "ambiguo",
+    ]);
+  });
+
+  it("p/n navegam respeitando os limites", () => {
+    const onFieldNavigate = vi.fn();
+    renderHook(() =>
+      useAutoReviewKeyboard({
+        ...baseArgs,
+        readOnly: false,
+        fieldIndex: 0,
+        onFieldNavigate,
+      }),
+    );
+
+    act(() => fireKey("p"));
+    expect(onFieldNavigate).not.toHaveBeenCalled();
+
+    act(() => fireKey("n"));
+    expect(onFieldNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it("ignora eventos disparados a partir de INPUT/TEXTAREA", () => {
+    const onChoose = vi.fn();
+    renderHook(() =>
+      useAutoReviewKeyboard({ ...baseArgs, readOnly: false, onChoose }),
+    );
+
+    act(() => fireKey("1", "INPUT"));
+    act(() => fireKey("2", "TEXTAREA"));
+
+    expect(onChoose).not.toHaveBeenCalled();
+  });
+
+  it("readOnly não registra o listener", () => {
+    const onChoose = vi.fn();
+    renderHook(() =>
+      useAutoReviewKeyboard({ ...baseArgs, readOnly: true, onChoose }),
+    );
+
+    act(() => fireKey("1"));
+    expect(onChoose).not.toHaveBeenCalled();
+  });
+
+  it("handleChoose auto-avança em 250ms para o próximo campo não respondido", () => {
+    const onFieldNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useAutoReviewKeyboard({
+        ...baseArgs,
+        readOnly: false,
+        fieldIndex: 0,
+        answered: [false, false, true],
+        onFieldNavigate,
+      }),
+    );
+
+    act(() => result.current.handleChoose("admite_erro"));
+    expect(onFieldNavigate).not.toHaveBeenCalled();
+    act(() => { vi.advanceTimersByTime(250); });
+    expect(onFieldNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it("não auto-avança para verdicts que exigem justificativa", () => {
+    const onFieldNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useAutoReviewKeyboard({
+        ...baseArgs,
+        readOnly: false,
+        fieldIndex: 0,
+        onFieldNavigate,
+      }),
+    );
+
+    act(() => result.current.handleChoose("contesta_llm"));
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(onFieldNavigate).not.toHaveBeenCalled();
+  });
+
+  it("re-escolha cancela o timeout de auto-advance pendente", () => {
+    const onFieldNavigate = vi.fn();
+    const { result } = renderHook(() =>
+      useAutoReviewKeyboard({
+        ...baseArgs,
+        readOnly: false,
+        fieldIndex: 0,
+        answered: [false, false, false],
+        onFieldNavigate,
+      }),
+    );
+
+    act(() => result.current.handleChoose("admite_erro"));
+    act(() => { vi.advanceTimersByTime(100); });
+    act(() => result.current.handleChoose("equivalente"));
+    act(() => { vi.advanceTimersByTime(250); });
+
+    // apenas um agendamento dispara (o da segunda escolha)
+    expect(onFieldNavigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/auto-review/useAutoReviewKeyboard.ts
+++ b/frontend/src/components/auto-review/useAutoReviewKeyboard.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from "react";
+import { verdictRequiresJustification } from "@/lib/auto-review-decided";
+import type { SelfVerdict } from "@/lib/types";
+
+// Teclado global (1-4 = verdict, P/N = navegação) + auto-advance pós-decisão
+// do AutoReviewFieldPanel. O painel remonta via `key={currentKey}` a cada
+// (doc, campo), então o hook desmonta e remonta junto — cancelamento do
+// timeout e reregistro do listener seguem a mesma semântica de antes da
+// extração.
+export function useAutoReviewKeyboard({
+  readOnly,
+  fieldIndex,
+  totalFields,
+  answered,
+  onChoose,
+  onFieldNavigate,
+}: {
+  readOnly: boolean;
+  fieldIndex: number;
+  totalFields: number;
+  answered: boolean[];
+  onChoose: (verdict: SelfVerdict) => void;
+  onFieldNavigate: (index: number) => void;
+}) {
+  // Listener de teclado registra uma vez (por readOnly); callbacks frescos
+  // chegam via ref para evitar reregistro a cada keystroke.
+  const handlerRef = useRef({ onChoose, onFieldNavigate, fieldIndex, totalFields });
+  useEffect(() => {
+    handlerRef.current = { onChoose, onFieldNavigate, fieldIndex, totalFields };
+  });
+
+  // Auto-advance pós-decisão: armazena handle do timeout num ref para poder
+  // cancelar se o usuário trocar de doc/campo antes do disparo (evita pular
+  // índice em contexto desatualizado).
+  const advanceTimeoutRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (advanceTimeoutRef.current !== null) {
+        window.clearTimeout(advanceTimeoutRef.current);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (readOnly) return;
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA"))
+        return;
+      const { onChoose, onFieldNavigate, fieldIndex, totalFields } =
+        handlerRef.current;
+      if (e.key === "1") {
+        e.preventDefault();
+        onChoose("contesta_llm");
+      } else if (e.key === "2") {
+        e.preventDefault();
+        onChoose("admite_erro");
+      } else if (e.key === "3") {
+        e.preventDefault();
+        onChoose("equivalente");
+      } else if (e.key === "4") {
+        e.preventDefault();
+        onChoose("ambiguo");
+      } else if (e.key.toLowerCase() === "p") {
+        e.preventDefault();
+        if (fieldIndex > 0) onFieldNavigate(fieldIndex - 1);
+      } else if (e.key.toLowerCase() === "n") {
+        e.preventDefault();
+        if (fieldIndex < totalFields - 1) onFieldNavigate(fieldIndex + 1);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [readOnly]);
+
+  function handleChoose(v: SelfVerdict) {
+    onChoose(v);
+    // contesta_llm e ambiguo exigem justificativa: não auto-avança, senão o
+    // pesquisador perderia o campo de texto que acabou de abrir.
+    if (verdictRequiresJustification(v)) return;
+    // Pula campos já respondidos no auto-advance pós-clique (P/N manuais
+    // continuam navegando livremente para permitir re-conferência).
+    const nextUnanswered = answered.findIndex((a, i) => i > fieldIndex && !a);
+    if (nextUnanswered === -1) return;
+    if (advanceTimeoutRef.current !== null) {
+      window.clearTimeout(advanceTimeoutRef.current);
+    }
+    advanceTimeoutRef.current = window.setTimeout(() => {
+      advanceTimeoutRef.current = null;
+      onFieldNavigate(nextUnanswered);
+    }, 250);
+  }
+
+  return { handleChoose };
+}

--- a/frontend/src/components/documents/DocumentsPageClient.tsx
+++ b/frontend/src/components/documents/DocumentsPageClient.tsx
@@ -1,30 +1,15 @@
 "use client";
 
-import { useState, useTransition } from "react";
 import { useRouter, usePathname } from "next/navigation";
 import { DocumentList, type DocumentSummary } from "@/components/documents/DocumentList";
 import { DocumentPreview } from "@/components/documents/DocumentPreview";
-import {
-  excludeDocuments,
-  restoreDocuments,
-  hardDeleteDocuments,
-} from "@/actions/documents";
-import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Trash2, Loader2, RotateCcw } from "lucide-react";
-import { toast } from "sonner";
+import { useDocumentActions } from "./useDocumentActions";
+import { SelectedDocumentsBar } from "./SelectedDocumentsBar";
+import { ExcludeDocumentsDialog } from "./ExcludeDocumentsDialog";
+import { RestoreDocumentsDialog } from "./RestoreDocumentsDialog";
+import { HardDeleteDocumentsDialog } from "./HardDeleteDocumentsDialog";
 
 type DocSummary = DocumentSummary & {
   created_at?: string;
@@ -34,37 +19,6 @@ interface DocumentsPageClientProps {
   documents: DocSummary[];
   projectId?: string;
   showExcluded?: boolean;
-}
-
-type ExcludeTarget = { ids: string[]; totalResponses: number };
-type RestoreTarget = { ids: string[] };
-type HardDeleteTarget = { ids: string[] };
-
-// Agrupa a selecao de documentos + os alvos dos modais de exclude/restore/delete,
-// mantendo o corpo do componente abaixo do limiar de useState do react-doctor.
-function useDocumentsSelection() {
-  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-  const [excludeTarget, setExcludeTarget] = useState<ExcludeTarget | null>(null);
-  const [excludeReason, setExcludeReason] = useState("");
-  const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
-  const [hardDeleteTarget, setHardDeleteTarget] =
-    useState<HardDeleteTarget | null>(null);
-
-  return {
-    selectedDocId,
-    setSelectedDocId,
-    selectedIds,
-    setSelectedIds,
-    excludeTarget,
-    setExcludeTarget,
-    excludeReason,
-    setExcludeReason,
-    restoreTarget,
-    setRestoreTarget,
-    hardDeleteTarget,
-    setHardDeleteTarget,
-  };
 }
 
 export function DocumentsPageClient({
@@ -79,134 +33,36 @@ export function DocumentsPageClient({
     selectedDocId,
     setSelectedDocId,
     selectedIds,
-    setSelectedIds,
+    toggleSelect,
+    toggleAll,
+    clearSelection,
     excludeTarget,
-    setExcludeTarget,
     excludeReason,
     setExcludeReason,
     restoreTarget,
-    setRestoreTarget,
     hardDeleteTarget,
-    setHardDeleteTarget,
-  } = useDocumentsSelection();
-  const [isPending, startTransition] = useTransition();
+    isPending,
+    requestExcludeSingle,
+    requestExcludeSelected,
+    closeExclude,
+    confirmExclude,
+    requestRestoreSingle,
+    requestRestoreSelected,
+    closeRestore,
+    confirmRestore,
+    requestHardDeleteSingle,
+    requestHardDeleteSelected,
+    closeHardDelete,
+    confirmHardDelete,
+  } = useDocumentActions(projectId, documents);
 
   const selectedDoc = documents.find((d) => d.id === selectedDocId) ?? null;
 
   function handleToggleShowExcluded(checked: boolean) {
     if (!pathname) return;
     const url = checked ? `${pathname}?show=excluded` : pathname;
-    setSelectedIds(new Set());
+    clearSelection();
     push(url);
-  }
-
-  function handleToggleSelect(docId: string) {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(docId)) next.delete(docId);
-      else next.add(docId);
-      return next;
-    });
-  }
-
-  function handleToggleAll(checked: boolean) {
-    setSelectedIds(checked ? new Set(documents.map((d) => d.id)) : new Set());
-  }
-
-  function handleRequestExcludeSingle(doc: DocumentSummary) {
-    const full = documents.find((d) => d.id === doc.id);
-    setExcludeTarget({
-      ids: [doc.id],
-      totalResponses: full?.responseCount ?? 0,
-    });
-    setExcludeReason("");
-  }
-
-  function handleRequestExcludeSelected() {
-    const totalResponses = documents
-      .filter((d) => selectedIds.has(d.id))
-      .reduce((sum, d) => sum + (d.responseCount ?? 0), 0);
-    setExcludeTarget({ ids: Array.from(selectedIds), totalResponses });
-    setExcludeReason("");
-  }
-
-  function handleConfirmExclude() {
-    if (!excludeTarget || !projectId) return;
-    if (!excludeReason.trim()) {
-      toast.error("Informe o motivo da exclusão");
-      return;
-    }
-    const { ids } = excludeTarget;
-    const count = ids.length;
-    startTransition(async () => {
-      const result = await excludeDocuments(projectId, ids, excludeReason);
-      if (result?.error) {
-        toast.error(result.error);
-      } else {
-        toast.success(
-          count === 1
-            ? "Documento excluído (reversível)"
-            : `${count} documentos excluídos (reversíveis)`,
-        );
-        setSelectedIds(new Set());
-        setExcludeTarget(null);
-        setExcludeReason("");
-      }
-    });
-  }
-
-  function handleRequestRestoreSingle(doc: DocumentSummary) {
-    setRestoreTarget({ ids: [doc.id] });
-  }
-
-  function handleRequestRestoreSelected() {
-    setRestoreTarget({ ids: Array.from(selectedIds) });
-  }
-
-  function handleConfirmRestore() {
-    if (!restoreTarget || !projectId) return;
-    const { ids } = restoreTarget;
-    const count = ids.length;
-    startTransition(async () => {
-      const result = await restoreDocuments(projectId, ids);
-      if (result?.error) {
-        toast.error(result.error);
-      } else {
-        toast.success(
-          count === 1 ? "Documento restaurado" : `${count} documentos restaurados`,
-        );
-        setSelectedIds(new Set());
-        setRestoreTarget(null);
-      }
-    });
-  }
-
-  function handleRequestHardDeleteSingle(doc: DocumentSummary) {
-    setHardDeleteTarget({ ids: [doc.id] });
-  }
-
-  function handleRequestHardDeleteSelected() {
-    setHardDeleteTarget({ ids: Array.from(selectedIds) });
-  }
-
-  function handleConfirmHardDelete() {
-    if (!hardDeleteTarget || !projectId) return;
-    const { ids } = hardDeleteTarget;
-    const count = ids.length;
-    startTransition(async () => {
-      const result = await hardDeleteDocuments(projectId, ids);
-      if (result?.error) {
-        toast.error(result.error);
-      } else {
-        toast.success(
-          count === 1
-            ? "Documento apagado permanentemente"
-            : `${count} documentos apagados permanentemente`,
-        );
-        setSelectedIds(new Set());
-        setHardDeleteTarget(null);
-      }
-    });
   }
 
   return (
@@ -228,40 +84,18 @@ export function DocumentsPageClient({
       )}
 
       {projectId && selectedIds.size > 0 && (
-        <div className="flex items-center gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-2">
-          <span className="text-sm font-medium">
-            {selectedIds.size} selecionado(s)
-          </span>
-          {showExcluded ? (
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleRequestRestoreSelected}
-              >
-                <RotateCcw className="mr-1.5 size-3.5" />
-                Restaurar selecionados
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={handleRequestHardDeleteSelected}
-              >
-                <Trash2 className="mr-1.5 size-3.5" />
-                Apagar permanentemente
-              </Button>
-            </>
-          ) : (
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={handleRequestExcludeSelected}
-            >
-              <Trash2 className="mr-1.5 size-3.5" />
-              Excluir selecionados
-            </Button>
-          )}
-        </div>
+        <SelectedDocumentsBar
+          count={selectedIds.size}
+          actions={
+            showExcluded
+              ? {
+                  kind: "excluded",
+                  onRestore: requestRestoreSelected,
+                  onHardDelete: requestHardDeleteSelected,
+                }
+              : { kind: "active", onExclude: requestExcludeSelected }
+          }
+        />
       )}
 
       <DocumentList
@@ -269,13 +103,11 @@ export function DocumentsPageClient({
         onSelect={(doc) => setSelectedDocId(doc.id)}
         projectId={projectId}
         selectedIds={projectId ? selectedIds : undefined}
-        onToggleSelect={projectId ? handleToggleSelect : undefined}
-        onToggleAll={projectId ? handleToggleAll : undefined}
-        onRequestDelete={projectId ? handleRequestExcludeSingle : undefined}
-        onRequestRestore={projectId ? handleRequestRestoreSingle : undefined}
-        onRequestHardDelete={
-          projectId ? handleRequestHardDeleteSingle : undefined
-        }
+        onToggleSelect={projectId ? toggleSelect : undefined}
+        onToggleAll={projectId ? toggleAll : undefined}
+        onRequestDelete={projectId ? requestExcludeSingle : undefined}
+        onRequestRestore={projectId ? requestRestoreSingle : undefined}
+        onRequestHardDelete={projectId ? requestHardDeleteSingle : undefined}
         showExcluded={showExcluded}
       />
 
@@ -289,157 +121,28 @@ export function DocumentsPageClient({
         />
       )}
 
-      {/* Soft delete (excluir = reversivel) */}
-      <AlertDialog
-        open={!!excludeTarget}
-        onOpenChange={(open) => {
-          if (!open) {
-            setExcludeTarget(null);
-            setExcludeReason("");
-          }
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {excludeTarget?.ids.length === 1
-                ? "Excluir documento?"
-                : `Excluir ${excludeTarget?.ids.length} documentos?`}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {excludeTarget && excludeTarget.totalResponses > 0 ? (
-                <>
-                  {excludeTarget.ids.length === 1
-                    ? "Este documento"
-                    : `Estes ${excludeTarget.ids.length} documentos`}{" "}
-                  e suas{" "}
-                  <strong>{excludeTarget.totalResponses} resposta(s)</strong>{" "}
-                  serão ocultados das listas. A exclusão é reversível:
-                  você pode restaurar ou apagar permanentemente depois em
-                  &quot;Mostrar excluídos&quot;.
-                </>
-              ) : (
-                <>
-                  {excludeTarget?.ids.length === 1
-                    ? "O documento"
-                    : `Os ${excludeTarget?.ids.length} documentos`}{" "}
-                  serão ocultados das listas. A exclusão é reversível.
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+      <ExcludeDocumentsDialog
+        target={excludeTarget}
+        reason={excludeReason}
+        onReasonChange={setExcludeReason}
+        isPending={isPending}
+        onConfirm={confirmExclude}
+        onClose={closeExclude}
+      />
 
-          <div className="space-y-2">
-            <Label htmlFor="exclude-reason">
-              Motivo da exclusão <span className="text-destructive">*</span>
-            </Label>
-            <Textarea
-              id="exclude-reason"
-              value={excludeReason}
-              onChange={(e) => setExcludeReason(e.target.value)}
-              placeholder="Ex: parecer fora do escopo do projeto"
-              rows={3}
-            />
-          </div>
+      <RestoreDocumentsDialog
+        target={restoreTarget}
+        isPending={isPending}
+        onConfirm={confirmRestore}
+        onClose={closeRestore}
+      />
 
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmExclude}
-              disabled={isPending || !excludeReason.trim()}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isPending ? (
-                <>
-                  <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                  Excluindo…
-                </>
-              ) : (
-                "Excluir"
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Restaurar */}
-      <AlertDialog
-        open={!!restoreTarget}
-        onOpenChange={(open) => {
-          if (!open) setRestoreTarget(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {restoreTarget?.ids.length === 1
-                ? "Restaurar documento?"
-                : `Restaurar ${restoreTarget?.ids.length} documentos?`}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {restoreTarget?.ids.length === 1
-                ? "O documento voltará à lista ativa do projeto."
-                : `Os ${restoreTarget?.ids.length} documentos voltarão à lista ativa do projeto.`}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmRestore}
-              disabled={isPending}
-            >
-              {isPending ? (
-                <>
-                  <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                  Restaurando…
-                </>
-              ) : (
-                "Restaurar"
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      {/* Hard delete (apagar permanentemente) */}
-      <AlertDialog
-        open={!!hardDeleteTarget}
-        onOpenChange={(open) => {
-          if (!open) setHardDeleteTarget(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {hardDeleteTarget?.ids.length === 1
-                ? "Apagar permanentemente?"
-                : `Apagar ${hardDeleteTarget?.ids.length} documentos permanentemente?`}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              <strong>Esta ação não pode ser desfeita.</strong> O documento e
-              todas as respostas, revisões e atribuições associadas serão
-              removidos do banco de dados.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={handleConfirmHardDelete}
-              disabled={isPending}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              {isPending ? (
-                <>
-                  <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                  Apagando…
-                </>
-              ) : (
-                "Apagar definitivamente"
-              )}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <HardDeleteDocumentsDialog
+        target={hardDeleteTarget}
+        isPending={isPending}
+        onConfirm={confirmHardDelete}
+        onClose={closeHardDelete}
+      />
     </>
   );
 }

--- a/frontend/src/components/documents/ExcludeDocumentsDialog.tsx
+++ b/frontend/src/components/documents/ExcludeDocumentsDialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+import type { ExcludeTarget } from "./useDocumentActions";
+
+// Dialog de exclusão reversível (soft delete) do DocumentsPageClient.
+export function ExcludeDocumentsDialog({
+  target,
+  reason,
+  onReasonChange,
+  isPending,
+  onConfirm,
+  onClose,
+}: {
+  target: ExcludeTarget | null;
+  reason: string;
+  onReasonChange: (value: string) => void;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <AlertDialog
+      open={!!target}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {target?.ids.length === 1
+              ? "Excluir documento?"
+              : `Excluir ${target?.ids.length} documentos?`}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {target && target.totalResponses > 0 ? (
+              <>
+                {target.ids.length === 1
+                  ? "Este documento"
+                  : `Estes ${target.ids.length} documentos`}{" "}
+                e suas <strong>{target.totalResponses} resposta(s)</strong>{" "}
+                serão ocultados das listas. A exclusão é reversível:
+                você pode restaurar ou apagar permanentemente depois em
+                &quot;Mostrar excluídos&quot;.
+              </>
+            ) : (
+              <>
+                {target?.ids.length === 1
+                  ? "O documento"
+                  : `Os ${target?.ids.length} documentos`}{" "}
+                serão ocultados das listas. A exclusão é reversível.
+              </>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="exclude-reason">
+            Motivo da exclusão <span className="text-destructive">*</span>
+          </Label>
+          <Textarea
+            id="exclude-reason"
+            value={reason}
+            onChange={(e) => onReasonChange(e.target.value)}
+            placeholder="Ex: parecer fora do escopo do projeto"
+            rows={3}
+          />
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isPending || !reason.trim()}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                Excluindo…
+              </>
+            ) : (
+              "Excluir"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/documents/ExcludeDocumentsDialog.tsx
+++ b/frontend/src/components/documents/ExcludeDocumentsDialog.tsx
@@ -1,18 +1,8 @@
 "use client";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
+import { ConfirmActionDialog } from "@/components/ui/confirm-action-dialog";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Loader2 } from "lucide-react";
 import type { ExcludeTarget } from "./useDocumentActions";
 
 // Dialog de exclusão reversível (soft delete) do DocumentsPageClient.
@@ -32,72 +22,53 @@ export function ExcludeDocumentsDialog({
   onClose: () => void;
 }) {
   return (
-    <AlertDialog
+    <ConfirmActionDialog
       open={!!target}
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
+      onClose={onClose}
+      title={
+        target?.ids.length === 1
+          ? "Excluir documento?"
+          : `Excluir ${target?.ids.length} documentos?`
+      }
+      description={
+        target && target.totalResponses > 0 ? (
+          <>
+            {target.ids.length === 1
+              ? "Este documento"
+              : `Estes ${target.ids.length} documentos`}{" "}
+            e suas <strong>{target.totalResponses} resposta(s)</strong>{" "}
+            serão ocultados das listas. A exclusão é reversível:
+            você pode restaurar ou apagar permanentemente depois em
+            &quot;Mostrar excluídos&quot;.
+          </>
+        ) : (
+          <>
             {target?.ids.length === 1
-              ? "Excluir documento?"
-              : `Excluir ${target?.ids.length} documentos?`}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            {target && target.totalResponses > 0 ? (
-              <>
-                {target.ids.length === 1
-                  ? "Este documento"
-                  : `Estes ${target.ids.length} documentos`}{" "}
-                e suas <strong>{target.totalResponses} resposta(s)</strong>{" "}
-                serão ocultados das listas. A exclusão é reversível:
-                você pode restaurar ou apagar permanentemente depois em
-                &quot;Mostrar excluídos&quot;.
-              </>
-            ) : (
-              <>
-                {target?.ids.length === 1
-                  ? "O documento"
-                  : `Os ${target?.ids.length} documentos`}{" "}
-                serão ocultados das listas. A exclusão é reversível.
-              </>
-            )}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-
-        <div className="space-y-2">
-          <Label htmlFor="exclude-reason">
-            Motivo da exclusão <span className="text-destructive">*</span>
-          </Label>
-          <Textarea
-            id="exclude-reason"
-            value={reason}
-            onChange={(e) => onReasonChange(e.target.value)}
-            placeholder="Ex: parecer fora do escopo do projeto"
-            rows={3}
-          />
-        </div>
-
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            disabled={isPending || !reason.trim()}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            {isPending ? (
-              <>
-                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                Excluindo…
-              </>
-            ) : (
-              "Excluir"
-            )}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+              ? "O documento"
+              : `Os ${target?.ids.length} documentos`}{" "}
+            serão ocultados das listas. A exclusão é reversível.
+          </>
+        )
+      }
+      confirmLabel="Excluir"
+      pendingLabel="Excluindo…"
+      destructive
+      isPending={isPending}
+      disabled={!reason.trim()}
+      onConfirm={onConfirm}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="exclude-reason">
+          Motivo da exclusão <span className="text-destructive">*</span>
+        </Label>
+        <Textarea
+          id="exclude-reason"
+          value={reason}
+          onChange={(e) => onReasonChange(e.target.value)}
+          placeholder="Ex: parecer fora do escopo do projeto"
+          rows={3}
+        />
+      </div>
+    </ConfirmActionDialog>
   );
 }

--- a/frontend/src/components/documents/HardDeleteDocumentsDialog.tsx
+++ b/frontend/src/components/documents/HardDeleteDocumentsDialog.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Loader2 } from "lucide-react";
+import { ConfirmActionDialog } from "@/components/ui/confirm-action-dialog";
 import type { HardDeleteTarget } from "./useDocumentActions";
 
 // Dialog de apagamento permanente (irreversível) do DocumentsPageClient.
@@ -26,43 +16,26 @@ export function HardDeleteDocumentsDialog({
   onClose: () => void;
 }) {
   return (
-    <AlertDialog
+    <ConfirmActionDialog
       open={!!target}
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            {target?.ids.length === 1
-              ? "Apagar permanentemente?"
-              : `Apagar ${target?.ids.length} documentos permanentemente?`}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            <strong>Esta ação não pode ser desfeita.</strong> O documento e
-            todas as respostas, revisões e atribuições associadas serão
-            removidos do banco de dados.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={onConfirm}
-            disabled={isPending}
-            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-          >
-            {isPending ? (
-              <>
-                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                Apagando…
-              </>
-            ) : (
-              "Apagar definitivamente"
-            )}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+      onClose={onClose}
+      title={
+        target?.ids.length === 1
+          ? "Apagar permanentemente?"
+          : `Apagar ${target?.ids.length} documentos permanentemente?`
+      }
+      description={
+        <>
+          <strong>Esta ação não pode ser desfeita.</strong> O documento e
+          todas as respostas, revisões e atribuições associadas serão
+          removidos do banco de dados.
+        </>
+      }
+      confirmLabel="Apagar definitivamente"
+      pendingLabel="Apagando…"
+      destructive
+      isPending={isPending}
+      onConfirm={onConfirm}
+    />
   );
 }

--- a/frontend/src/components/documents/HardDeleteDocumentsDialog.tsx
+++ b/frontend/src/components/documents/HardDeleteDocumentsDialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+import type { HardDeleteTarget } from "./useDocumentActions";
+
+// Dialog de apagamento permanente (irreversível) do DocumentsPageClient.
+export function HardDeleteDocumentsDialog({
+  target,
+  isPending,
+  onConfirm,
+  onClose,
+}: {
+  target: HardDeleteTarget | null;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <AlertDialog
+      open={!!target}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {target?.ids.length === 1
+              ? "Apagar permanentemente?"
+              : `Apagar ${target?.ids.length} documentos permanentemente?`}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            <strong>Esta ação não pode ser desfeita.</strong> O documento e
+            todas as respostas, revisões e atribuições associadas serão
+            removidos do banco de dados.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isPending}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                Apagando…
+              </>
+            ) : (
+              "Apagar definitivamente"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/documents/RestoreDocumentsDialog.tsx
+++ b/frontend/src/components/documents/RestoreDocumentsDialog.tsx
@@ -1,16 +1,6 @@
 "use client";
 
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Loader2 } from "lucide-react";
+import { ConfirmActionDialog } from "@/components/ui/confirm-action-dialog";
 import type { RestoreTarget } from "./useDocumentActions";
 
 // Dialog de restauração de documentos excluídos do DocumentsPageClient.
@@ -26,39 +16,23 @@ export function RestoreDocumentsDialog({
   onClose: () => void;
 }) {
   return (
-    <AlertDialog
+    <ConfirmActionDialog
       open={!!target}
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>
-            {target?.ids.length === 1
-              ? "Restaurar documento?"
-              : `Restaurar ${target?.ids.length} documentos?`}
-          </AlertDialogTitle>
-          <AlertDialogDescription>
-            {target?.ids.length === 1
-              ? "O documento voltará à lista ativa do projeto."
-              : `Os ${target?.ids.length} documentos voltarão à lista ativa do projeto.`}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm} disabled={isPending}>
-            {isPending ? (
-              <>
-                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                Restaurando…
-              </>
-            ) : (
-              "Restaurar"
-            )}
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+      onClose={onClose}
+      title={
+        target?.ids.length === 1
+          ? "Restaurar documento?"
+          : `Restaurar ${target?.ids.length} documentos?`
+      }
+      description={
+        target?.ids.length === 1
+          ? "O documento voltará à lista ativa do projeto."
+          : `Os ${target?.ids.length} documentos voltarão à lista ativa do projeto.`
+      }
+      confirmLabel="Restaurar"
+      pendingLabel="Restaurando…"
+      isPending={isPending}
+      onConfirm={onConfirm}
+    />
   );
 }

--- a/frontend/src/components/documents/RestoreDocumentsDialog.tsx
+++ b/frontend/src/components/documents/RestoreDocumentsDialog.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+import type { RestoreTarget } from "./useDocumentActions";
+
+// Dialog de restauração de documentos excluídos do DocumentsPageClient.
+export function RestoreDocumentsDialog({
+  target,
+  isPending,
+  onConfirm,
+  onClose,
+}: {
+  target: RestoreTarget | null;
+  isPending: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <AlertDialog
+      open={!!target}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {target?.ids.length === 1
+              ? "Restaurar documento?"
+              : `Restaurar ${target?.ids.length} documentos?`}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {target?.ids.length === 1
+              ? "O documento voltará à lista ativa do projeto."
+              : `Os ${target?.ids.length} documentos voltarão à lista ativa do projeto.`}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                Restaurando…
+              </>
+            ) : (
+              "Restaurar"
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/documents/SelectedDocumentsBar.tsx
+++ b/frontend/src/components/documents/SelectedDocumentsBar.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Trash2, RotateCcw } from "lucide-react";
+
+// Barra de ações em lote do DocumentsPageClient. A união discriminada
+// substitui os 2 booleanos (showExcluded + qual botão mostrar) por um único
+// campo que torna "ação inválida para o modo atual" irrepresentável.
+export function SelectedDocumentsBar({
+  count,
+  actions,
+}: {
+  count: number;
+  actions:
+    | { kind: "active"; onExclude: () => void }
+    | { kind: "excluded"; onRestore: () => void; onHardDelete: () => void };
+}) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-2">
+      <span className="text-sm font-medium">{count} selecionado(s)</span>
+      {actions.kind === "excluded" ? (
+        <>
+          <Button variant="outline" size="sm" onClick={actions.onRestore}>
+            <RotateCcw className="mr-1.5 size-3.5" />
+            Restaurar selecionados
+          </Button>
+          <Button variant="destructive" size="sm" onClick={actions.onHardDelete}>
+            <Trash2 className="mr-1.5 size-3.5" />
+            Apagar permanentemente
+          </Button>
+        </>
+      ) : (
+        <Button variant="destructive" size="sm" onClick={actions.onExclude}>
+          <Trash2 className="mr-1.5 size-3.5" />
+          Excluir selecionados
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/documents/useDocumentActions.ts
+++ b/frontend/src/components/documents/useDocumentActions.ts
@@ -1,0 +1,184 @@
+import { useState, useTransition } from "react";
+import {
+  excludeDocuments,
+  restoreDocuments,
+  hardDeleteDocuments,
+} from "@/actions/documents";
+import type { DocumentSummary } from "@/components/documents/DocumentList";
+import { toast } from "sonner";
+
+type DocSummary = DocumentSummary & { created_at?: string };
+
+export type ExcludeTarget = { ids: string[]; totalResponses: number };
+export type RestoreTarget = { ids: string[] };
+export type HardDeleteTarget = { ids: string[] };
+
+// Seleção de documentos + os 3 fluxos de exclude/restore/hard-delete
+// (targets dos AlertDialogs, motivo da exclusão, submit e reset). Extraído
+// do DocumentsPageClient para que o corpo do componente fique abaixo do
+// limiar de useState do react-doctor.
+export function useDocumentActions(
+  projectId: string | undefined,
+  documents: DocSummary[],
+) {
+  const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [excludeTarget, setExcludeTarget] = useState<ExcludeTarget | null>(null);
+  const [excludeReason, setExcludeReason] = useState("");
+  const [restoreTarget, setRestoreTarget] = useState<RestoreTarget | null>(null);
+  const [hardDeleteTarget, setHardDeleteTarget] =
+    useState<HardDeleteTarget | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function toggleSelect(docId: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(docId)) next.delete(docId);
+      else next.add(docId);
+      return next;
+    });
+  }
+
+  function toggleAll(checked: boolean) {
+    setSelectedIds(checked ? new Set(documents.map((d) => d.id)) : new Set());
+  }
+
+  function clearSelection() {
+    setSelectedIds(new Set());
+  }
+
+  function requestExcludeSingle(doc: DocumentSummary) {
+    const full = documents.find((d) => d.id === doc.id);
+    setExcludeTarget({
+      ids: [doc.id],
+      totalResponses: full?.responseCount ?? 0,
+    });
+    setExcludeReason("");
+  }
+
+  function requestExcludeSelected() {
+    const totalResponses = documents
+      .filter((d) => selectedIds.has(d.id))
+      .reduce((sum, d) => sum + (d.responseCount ?? 0), 0);
+    setExcludeTarget({ ids: Array.from(selectedIds), totalResponses });
+    setExcludeReason("");
+  }
+
+  function closeExclude() {
+    setExcludeTarget(null);
+    setExcludeReason("");
+  }
+
+  function confirmExclude() {
+    if (!excludeTarget || !projectId) return;
+    if (!excludeReason.trim()) {
+      toast.error("Informe o motivo da exclusão");
+      return;
+    }
+    const { ids } = excludeTarget;
+    const count = ids.length;
+    startTransition(async () => {
+      const result = await excludeDocuments(projectId, ids, excludeReason);
+      if (result?.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          count === 1
+            ? "Documento excluído (reversível)"
+            : `${count} documentos excluídos (reversíveis)`,
+        );
+        setSelectedIds(new Set());
+        closeExclude();
+      }
+    });
+  }
+
+  function requestRestoreSingle(doc: DocumentSummary) {
+    setRestoreTarget({ ids: [doc.id] });
+  }
+
+  function requestRestoreSelected() {
+    setRestoreTarget({ ids: Array.from(selectedIds) });
+  }
+
+  function closeRestore() {
+    setRestoreTarget(null);
+  }
+
+  function confirmRestore() {
+    if (!restoreTarget || !projectId) return;
+    const { ids } = restoreTarget;
+    const count = ids.length;
+    startTransition(async () => {
+      const result = await restoreDocuments(projectId, ids);
+      if (result?.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          count === 1 ? "Documento restaurado" : `${count} documentos restaurados`,
+        );
+        setSelectedIds(new Set());
+        closeRestore();
+      }
+    });
+  }
+
+  function requestHardDeleteSingle(doc: DocumentSummary) {
+    setHardDeleteTarget({ ids: [doc.id] });
+  }
+
+  function requestHardDeleteSelected() {
+    setHardDeleteTarget({ ids: Array.from(selectedIds) });
+  }
+
+  function closeHardDelete() {
+    setHardDeleteTarget(null);
+  }
+
+  function confirmHardDelete() {
+    if (!hardDeleteTarget || !projectId) return;
+    const { ids } = hardDeleteTarget;
+    const count = ids.length;
+    startTransition(async () => {
+      const result = await hardDeleteDocuments(projectId, ids);
+      if (result?.error) {
+        toast.error(result.error);
+      } else {
+        toast.success(
+          count === 1
+            ? "Documento apagado permanentemente"
+            : `${count} documentos apagados permanentemente`,
+        );
+        setSelectedIds(new Set());
+        closeHardDelete();
+      }
+    });
+  }
+
+  return {
+    selectedDocId,
+    setSelectedDocId,
+    selectedIds,
+    toggleSelect,
+    toggleAll,
+    clearSelection,
+    excludeTarget,
+    excludeReason,
+    setExcludeReason,
+    restoreTarget,
+    hardDeleteTarget,
+    isPending,
+    requestExcludeSingle,
+    requestExcludeSelected,
+    closeExclude,
+    confirmExclude,
+    requestRestoreSingle,
+    requestRestoreSelected,
+    closeRestore,
+    confirmRestore,
+    requestHardDeleteSingle,
+    requestHardDeleteSelected,
+    closeHardDelete,
+    confirmHardDelete,
+  };
+}

--- a/frontend/src/components/documents/useDocumentActions.ts
+++ b/frontend/src/components/documents/useDocumentActions.ts
@@ -6,8 +6,7 @@ import {
 } from "@/actions/documents";
 import type { DocumentSummary } from "@/components/documents/DocumentList";
 import { toast } from "sonner";
-
-type DocSummary = DocumentSummary & { created_at?: string };
+import { toggleInSet } from "@/lib/utils";
 
 export type ExcludeTarget = { ids: string[]; totalResponses: number };
 export type RestoreTarget = { ids: string[] };
@@ -19,7 +18,7 @@ export type HardDeleteTarget = { ids: string[] };
 // limiar de useState do react-doctor.
 export function useDocumentActions(
   projectId: string | undefined,
-  documents: DocSummary[],
+  documents: DocumentSummary[],
 ) {
   const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -31,12 +30,7 @@ export function useDocumentActions(
   const [isPending, startTransition] = useTransition();
 
   function toggleSelect(docId: string) {
-    setSelectedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(docId)) next.delete(docId);
-      else next.add(docId);
-      return next;
-    });
+    setSelectedIds((prev) => toggleInSet(prev, docId));
   }
 
   function toggleAll(checked: boolean) {

--- a/frontend/src/components/llm/DocumentSelector.tsx
+++ b/frontend/src/components/llm/DocumentSelector.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dialog";
 import { getDocumentsForSelection, type DocSelectionItem } from "@/actions/llm";
 import { FileText, User, Bot } from "lucide-react";
+import { toggleInSet } from "@/lib/utils";
 
 interface DocumentSelectorProps {
   projectId: string;
@@ -60,12 +61,7 @@ export function DocumentSelector({
   }, [resource.items, search]);
 
   const toggle = (id: string) => {
-    setLocalSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
+    setLocalSelected((prev) => toggleInSet(prev, id));
   };
 
   const selectAll = () => setLocalSelected(new Set(filtered.map((d) => d.id)));

--- a/frontend/src/components/ui/confirm-action-dialog.tsx
+++ b/frontend/src/components/ui/confirm-action-dialog.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// Esqueleto compartilhado dos AlertDialogs de confirmação (título, descrição,
+// footer Cancelar/Ação com troca de texto + spinner enquanto isPending).
+// `children` é o slot para conteúdo extra entre a descrição e o footer (ex:
+// o textarea de motivo do ExcludeDocumentsDialog).
+export function ConfirmActionDialog({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  confirmLabel,
+  pendingLabel,
+  destructive = false,
+  isPending,
+  disabled = false,
+  onConfirm,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: ReactNode;
+  description: ReactNode;
+  children?: ReactNode;
+  confirmLabel: string;
+  pendingLabel: string;
+  destructive?: boolean;
+  isPending: boolean;
+  disabled?: boolean;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) onClose();
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {children}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            disabled={isPending || disabled}
+            className={cn(
+              destructive &&
+                "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+            )}
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+                {pendingLabel}
+              </>
+            ) : (
+              confirmLabel
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -11,6 +11,20 @@ export function errorMessage(e: unknown): string {
   return e instanceof Error ? e.message : typeof e === "string" ? e : "";
 }
 
+// Alterna a presença de um id num Set, sempre copiando (nunca muta o Set
+// recebido). `on` explícito serve para uso controlado (ex: checkbox que já
+// emite o novo estado); omitido, alterna com base na presença atual.
+export function toggleInSet<T>(
+  set: Set<T>,
+  id: T,
+  on: boolean = !set.has(id),
+): Set<T> {
+  const next = new Set(set);
+  if (on) next.add(id);
+  else next.delete(id);
+  return next;
+}
+
 // Normalizacao agressiva para comparar respostas de texto livre que sao
 // "iguais" para um humano mas diferem em bytes: acentos decompostos
 // (NFD vs NFC, comum em texto colado de PDF), maiusculas e espacos internos


### PR DESCRIPTION
## Resumo

PR 2 da issue #357 (Fase 5 do épico react-doctor #339). Decompõe de verdade os dois componentes restantes, comportamento preservado.

### AutoReviewFieldPanel (436 → 196 linhas)

- `useAutoReviewKeyboard.ts`: listener global de teclado (1-4/P/N) + auto-advance pós-decisão (250ms), sem mudança de comportamento — segue remontando com o painel via `key={currentKey}`.
- `AutoReviewVerdictButtons.tsx`, `AutoReviewJustificationInput.tsx` (com o effect de foco), `AutoReviewFooter.tsx` (atalhos + status/submit).
- O override `no-event-handler` do `doctor.config.json` migra para `AutoReviewJustificationInput.tsx`, que herdou o effect suprimido.
- Testes novos: `useAutoReviewKeyboard.test.ts` (7 casos: teclas, guard INPUT/TEXTAREA, readOnly, auto-advance) e `AutoReviewFieldPanel.test.tsx` (smoke: foco no textarea, aviso de justificativa obrigatória) — nenhum dos dois tinha teste antes.

### DocumentsPageClient (445 → 148 linhas)

- `useDocumentActions.ts`: funde o `useDocumentsSelection` inline + `useTransition` + os handlers de exclude/restore/hard-delete.
- `SelectedDocumentsBar.tsx`: união discriminada (`active`/`excluded`) no lugar do booleano `showExcluded` + qual botão mostrar.
- `ExcludeDocumentsDialog.tsx`, `RestoreDocumentsDialog.tsx`, `HardDeleteDocumentsDialog.tsx`: um dialog por arquivo.
- `DocumentsToolbar` (14 linhas) não foi extraído — trivial demais para justificar um arquivo próprio.

## Gates pulados (e por quê)

- `SKIP=fallow-audit`: mesmo precedente do PR #368/#334 — complexidade transplantada (não nova) contada como "nova" pelo fallow new-only.
- `SKIP=typecheck`: os 18 erros de `tsc --noEmit` são pré-existentes em `ComparePage.test.tsx`/`ComparePage.integration.test.tsx` (fixtures sem `defaultVersion`), alheios a este PR.

## Verificação

- `npm run react-doctor`: diags `no-giant-component` de `AutoReviewFieldPanel.tsx` e `DocumentsPageClient.tsx` zerados; nenhum diag novo (9 diags no repo, era 10).
- `npm run test`: 872/872 (vitest completo).
- `npx eslint --config eslint.config.typed.mjs` nos arquivos alterados: limpo.

Nota: as Fases 2–4 do épico (#354, #355, #356) ainda estão abertas — este PR fecha só a Fase 5 (#357), não a issue guarda-chuva #339.

Closes #357