### PR TITLE
fix(ci): adiciona retry ao deploy do frontend no Fly.io

### DIFF
--- a/.github/workflows/frontend-fly-deploy.yml
+++ b/.github/workflows/frontend-fly-deploy.yml
@@ -21,10 +21,27 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Pin a SHA (tag 1.6) por supply-chain safety — @master é floating ref.
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
-      - run: flyctl deploy --remote-only -a gui-analise-sistematica-frontend
+      - name: flyctl deploy
         working-directory: frontend
         env:
           # Token app-scoped DESTE app (gui-analise-sistematica-frontend). O
           # FLY_API_TOKEN compartilhado com o backend tem escopo do app da API
           # e dava `unauthorized` aqui — tokens de deploy do Fly sao por app.
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_FRONTEND }}
+        run: |
+          # Retry: o builder remoto (Depot, via --remote-only) as vezes encerra
+          # a conexao no meio do build (rpc "goaway"/"graceful_stop") por causa
+          # transitoria do lado do provedor, sem relacao com o codigo do app.
+          for attempt in 1 2 3; do
+            if flyctl deploy --remote-only -a gui-analise-sistematica-frontend; then
+              exit 0
+            fi
+            echo "flyctl deploy falhou (tentativa $attempt/3)"
+            if [ "$attempt" -lt 3 ]; then
+              sleep_time=$((attempt * 30))
+              echo "Tentando novamente em ${sleep_time}s..."
+              sleep "$sleep_time"
+            fi
+          done
+          echo "flyctl deploy falhou apos 3 tentativas"
+          exit 1


### PR DESCRIPTION
## Contexto

Um deploy do frontend via GitHub Actions falhou com:

```
Error: failed to fetch an image or build from source: error building: failed to receive status: rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data: "graceful_stop"
```

Investigação descartou causa no repositório: o build progride normalmente até `npm ci` terminar e falha depois, num erro de transporte gRPC (`goaway`/`graceful_stop`) — assinatura de o builder remoto (Depot, usado internamente pelo `flyctl deploy --remote-only`) encerrar a conexão no meio do processo, sem relação com o código do app. `Dockerfile`, `fly.toml` e `.dockerignore` não têm nada anômalo.

A lacuna real: o workflow não tinha nenhum retry — qualquer glitch transitório do builder derrubava o deploy inteiro e exigia re-run manual.

## Mudança

Adiciona retry (3 tentativas, backoff linear 30s/60s) em torno do `flyctl deploy` no step de deploy do frontend. Optei por um loop de shell inline em vez de uma Action de terceiros (ex.: `nick-fields/retry`) para não introduzir mais uma dependência de supply-chain pinada por SHA — o workflow já segue essa convenção nos outros steps — quando um loop simples resolve.

Escopo intencionalmente limitado ao `frontend-fly-deploy.yml`; o workflow irmão do backend (`fly-deploy.yml`) tem a mesma lacuna, mas fica fora deste PR por decisão explícita (mudança separada, se desejada).

## Test plan

- [x] YAML validado (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Hooks de pre-commit/pre-push passaram (gitleaks, semgrep)
- [ ] Observacional pós-merge: próximo deploy do frontend deve seguir funcionando no caminho feliz (1ª tentativa); uma falha transitória futura do builder deve se autorrecuperar sem exigir re-run manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)