### PR TITLE
test(compare): cobre o caminho de erro do fluxo de equivalência

### DIFF
--- a/frontend/src/actions/__tests__/equivalences.test.ts
+++ b/frontend/src/actions/__tests__/equivalences.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Cobertura de regressão para o bug relatado na issue #366 ("não tá indo a
+// resposta da equivalencia"): antes da PR #362, estas actions lançavam Error
+// (mascarado pelo Next 16 em produção) e o client fazia escrita otimista antes
+// de aguardar o resultado. Hoje retornam `{ error? }`; estes testes travam
+// esse contrato — nenhuma das três pode voltar a lançar em vez de retornar.
+import {
+  makeSupabaseMock,
+  type TableResults,
+  type WriteCall,
+} from "./supabase-mock";
+
+let writeCalls: WriteCall[];
+let serverTableResults: TableResults | undefined;
+
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "reviewer1" }),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () =>
+    makeSupabaseMock({ tableResults: serverTableResults, writeCalls }),
+}));
+// syncCompareAssignment é best-effort e teria seu próprio teste dedicado
+// (compare-sync.ts); aqui só interessa não deixá-lo derrubar a action.
+vi.mock("@/lib/compare-sync", () => ({
+  syncCompareAssignment: async () => {},
+}));
+
+beforeEach(() => {
+  writeCalls = [];
+  serverTableResults = undefined;
+});
+
+async function loadActions() {
+  return await import("@/actions/equivalences");
+}
+
+function upsertsOn(table: string) {
+  return writeCalls.filter((c) => c.op === "upsert" && c.table === table);
+}
+
+describe("confirmEquivalentVerdict", () => {
+  it("upsert em response_equivalences falha → retorna { error }, não lança, e não tenta gravar reviews", async () => {
+    serverTableResults = {
+      response_equivalences: { error: { message: "pair upsert boom" } },
+    };
+    const { confirmEquivalentVerdict } = await loadActions();
+
+    const result = await confirmEquivalentVerdict(
+      "p1",
+      "doc1",
+      "q1",
+      ["r1", "r2"],
+      "r1",
+      "resposta fundida",
+    );
+
+    expect(result).toEqual({ error: "pair upsert boom" });
+    expect(upsertsOn("response_equivalences")).toHaveLength(1);
+    expect(upsertsOn("reviews")).toHaveLength(0);
+  });
+
+  it("upsert em reviews falha após response_equivalences já gravado → retorna { error }, não lança", async () => {
+    serverTableResults = {
+      response_equivalences: { error: null },
+      reviews: { error: { message: "review upsert boom" } },
+    };
+    const { confirmEquivalentVerdict } = await loadActions();
+
+    const result = await confirmEquivalentVerdict(
+      "p1",
+      "doc1",
+      "q1",
+      ["r1", "r2"],
+      "r1",
+      "resposta fundida",
+    );
+
+    // Documenta o comportamento atual: o par de equivalência já foi
+    // persistido quando o upsert de reviews falha (não há rollback), mesmo
+    // com a action reportando erro ao client.
+    expect(result).toEqual({ error: "review upsert boom" });
+    expect(upsertsOn("response_equivalences")).toHaveLength(1);
+    expect(upsertsOn("reviews")).toHaveLength(1);
+  });
+
+  it("caminho feliz → retorna {} e grava o par canônico (a < b) e o chosen_response_id do gabarito", async () => {
+    serverTableResults = {
+      response_equivalences: { error: null },
+      reviews: { error: null },
+    };
+    const { confirmEquivalentVerdict } = await loadActions();
+
+    const result = await confirmEquivalentVerdict(
+      "p1",
+      "doc1",
+      "q1",
+      ["r2", "r1"],
+      "r2",
+      "resposta fundida",
+    );
+
+    expect(result).toEqual({});
+    expect(upsertsOn("response_equivalences")[0]?.payload).toEqual([
+      {
+        project_id: "p1",
+        document_id: "doc1",
+        field_name: "q1",
+        response_a_id: "r1",
+        response_b_id: "r2",
+        reviewer_id: "reviewer1",
+      },
+    ]);
+    expect(upsertsOn("reviews")[0]?.payload).toMatchObject({
+      project_id: "p1",
+      document_id: "doc1",
+      field_name: "q1",
+      reviewer_id: "reviewer1",
+      verdict: "resposta fundida",
+      chosen_response_id: "r2",
+    });
+  });
+});
+
+describe("markLlmEquivalent", () => {
+  it("upsert falha → retorna { error }, não lança", async () => {
+    serverTableResults = {
+      response_equivalences: { error: { message: "llm pair boom" } },
+    };
+    const { markLlmEquivalent } = await loadActions();
+
+    const result = await markLlmEquivalent("p1", "doc1", "q1", "llm1", "human1");
+
+    expect(result).toEqual({ error: "llm pair boom" });
+  });
+
+  it("caminho feliz → retorna {}", async () => {
+    serverTableResults = { response_equivalences: { error: null } };
+    const { markLlmEquivalent } = await loadActions();
+
+    const result = await markLlmEquivalent("p1", "doc1", "q1", "llm1", "human1");
+
+    expect(result).toEqual({});
+    expect(upsertsOn("response_equivalences")).toHaveLength(1);
+  });
+});
+
+describe("unmarkEquivalencePair", () => {
+  it("delete falha → retorna { error }, não lança", async () => {
+    serverTableResults = {
+      response_equivalences: [
+        { data: { document_id: "doc1", field_name: "q1" } },
+        { error: { message: "delete pair boom" } },
+      ],
+    };
+    const { unmarkEquivalencePair } = await loadActions();
+
+    const result = await unmarkEquivalencePair("p1", "eq1");
+
+    expect(result).toEqual({ error: "delete pair boom" });
+  });
+
+  it("caminho feliz → retorna {} e limpa o review do revisor atual para o par", async () => {
+    serverTableResults = {
+      response_equivalences: [
+        { data: { document_id: "doc1", field_name: "q1" } },
+        { error: null },
+      ],
+      reviews: { error: null },
+    };
+    const { unmarkEquivalencePair } = await loadActions();
+
+    const result = await unmarkEquivalencePair("p1", "eq1");
+
+    expect(result).toEqual({});
+    expect(
+      writeCalls.some((c) => c.op === "delete" && c.table === "reviews"),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/actions/__tests__/equivalences.test.ts
+++ b/frontend/src/actions/__tests__/equivalences.test.ts
@@ -41,27 +41,67 @@ function upsertsOn(table: string) {
   return writeCalls.filter((c) => c.op === "upsert" && c.table === table);
 }
 
-describe("confirmEquivalentVerdict", () => {
-  it("upsert em response_equivalences falha → retorna { error }, não lança, e não tenta gravar reviews", async () => {
-    serverTableResults = {
+type Actions = Awaited<ReturnType<typeof loadActions>>;
+
+// As 3 actions de equivalences.ts falham do mesmo jeito (upsert/delete
+// retorna erro → `{ error }`, nunca lança); um caso por action evita repetir
+// o esqueleto "seta serverTableResults, chama a action, confere o retorno".
+describe.each([
+  {
+    action: "confirmEquivalentVerdict",
+    tableResults: {
       response_equivalences: { error: { message: "pair upsert boom" } },
-    };
-    const { confirmEquivalentVerdict } = await loadActions();
+    },
+    call: (fns: Actions) =>
+      fns.confirmEquivalentVerdict(
+        "p1",
+        "doc1",
+        "q1",
+        ["r1", "r2"],
+        "r1",
+        "resposta fundida",
+      ),
+    expectedError: "pair upsert boom",
+    extraChecks: () => {
+      expect(upsertsOn("response_equivalences")).toHaveLength(1);
+      expect(upsertsOn("reviews")).toHaveLength(0);
+    },
+  },
+  {
+    action: "markLlmEquivalent",
+    tableResults: {
+      response_equivalences: { error: { message: "llm pair boom" } },
+    },
+    call: (fns: Actions) =>
+      fns.markLlmEquivalent("p1", "doc1", "q1", "llm1", "human1"),
+    expectedError: "llm pair boom",
+    extraChecks: undefined,
+  },
+  {
+    action: "unmarkEquivalencePair",
+    tableResults: {
+      response_equivalences: [
+        { data: { document_id: "doc1", field_name: "q1" } },
+        { error: { message: "delete pair boom" } },
+      ],
+    },
+    call: (fns: Actions) => fns.unmarkEquivalencePair("p1", "eq1"),
+    expectedError: "delete pair boom",
+    extraChecks: undefined,
+  },
+])("$action — falha no upsert/delete", ({ tableResults, call, expectedError, extraChecks }) => {
+  it("retorna { error }, não lança", async () => {
+    serverTableResults = tableResults;
+    const fns = await loadActions();
 
-    const result = await confirmEquivalentVerdict(
-      "p1",
-      "doc1",
-      "q1",
-      ["r1", "r2"],
-      "r1",
-      "resposta fundida",
-    );
+    const result = await call(fns);
 
-    expect(result).toEqual({ error: "pair upsert boom" });
-    expect(upsertsOn("response_equivalences")).toHaveLength(1);
-    expect(upsertsOn("reviews")).toHaveLength(0);
+    expect(result).toEqual({ error: expectedError });
+    extraChecks?.();
   });
+});
 
+describe("confirmEquivalentVerdict", () => {
   it("upsert em reviews falha após response_equivalences já gravado → retorna { error }, não lança", async () => {
     serverTableResults = {
       response_equivalences: { error: null },
@@ -125,17 +165,6 @@ describe("confirmEquivalentVerdict", () => {
 });
 
 describe("markLlmEquivalent", () => {
-  it("upsert falha → retorna { error }, não lança", async () => {
-    serverTableResults = {
-      response_equivalences: { error: { message: "llm pair boom" } },
-    };
-    const { markLlmEquivalent } = await loadActions();
-
-    const result = await markLlmEquivalent("p1", "doc1", "q1", "llm1", "human1");
-
-    expect(result).toEqual({ error: "llm pair boom" });
-  });
-
   it("caminho feliz → retorna {}", async () => {
     serverTableResults = { response_equivalences: { error: null } };
     const { markLlmEquivalent } = await loadActions();
@@ -148,20 +177,6 @@ describe("markLlmEquivalent", () => {
 });
 
 describe("unmarkEquivalencePair", () => {
-  it("delete falha → retorna { error }, não lança", async () => {
-    serverTableResults = {
-      response_equivalences: [
-        { data: { document_id: "doc1", field_name: "q1" } },
-        { error: { message: "delete pair boom" } },
-      ],
-    };
-    const { unmarkEquivalencePair } = await loadActions();
-
-    const result = await unmarkEquivalencePair("p1", "eq1");
-
-    expect(result).toEqual({ error: "delete pair boom" });
-  });
-
   it("caminho feliz → retorna {} e limpa o review do revisor atual para o par", async () => {
     serverTableResults = {
       response_equivalences: [

--- a/frontend/src/actions/__tests__/supabase-mock.ts
+++ b/frontend/src/actions/__tests__/supabase-mock.ts
@@ -11,7 +11,7 @@
 
 export type WriteCall = {
   table: string;
-  op: "update" | "insert" | "delete";
+  op: "update" | "insert" | "delete" | "upsert";
   payload: unknown;
 };
 
@@ -65,6 +65,10 @@ export function makeSupabaseMock(opts?: {
       };
       builder.insert = (payload: unknown) => {
         writeCalls?.push({ table, op: "insert", payload });
+        return builder;
+      };
+      builder.upsert = (payload: unknown) => {
+        writeCalls?.push({ table, op: "upsert", payload });
         return builder;
       };
       builder.delete = () => {

--- a/frontend/src/components/compare/__tests__/compare-test-helpers.ts
+++ b/frontend/src/components/compare/__tests__/compare-test-helpers.ts
@@ -1,0 +1,15 @@
+import type { CompareDocument } from "@/components/compare/compare-types";
+
+/**
+ * Fixture de `CompareDocument` compartilhada entre os testes de hooks de
+ * compare/ — evita reimplementar a mesma forma em cada arquivo (useStableDocOrder,
+ * useCompareNavigation, useCompareVerdicts).
+ */
+export function doc(id: string, title?: string, text = ""): CompareDocument {
+  return {
+    id,
+    title: title ?? `Doc ${id}`,
+    external_id: null,
+    text,
+  };
+}

--- a/frontend/src/components/compare/__tests__/useCompareNavigation.test.ts
+++ b/frontend/src/components/compare/__tests__/useCompareNavigation.test.ts
@@ -7,13 +7,7 @@ vi.mock("sonner", () => ({ toast: { info: toastInfo } }));
 
 import { useCompareNavigation } from "@/components/compare/useCompareNavigation";
 import type { CompareDocument } from "@/components/compare/compare-types";
-
-const doc = (id: string): CompareDocument => ({
-  id,
-  title: `Doc ${id}`,
-  external_id: null,
-  text: "",
-});
+import { doc } from "./compare-test-helpers";
 
 function renderNav(documents: CompareDocument[]) {
   return renderHook(

--- a/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
+++ b/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
@@ -15,7 +15,9 @@ import {
   unmarkEquivalencePair,
 } from "@/actions/equivalences";
 import { useCompareVerdicts } from "../useCompareVerdicts";
-import type { CompareDocument, FieldResponse } from "../compare-types";
+import type { FieldResponse } from "../compare-types";
+import type { VerdictInfo } from "@/lib/compare-reviews";
+import { doc } from "./compare-test-helpers";
 
 const { toastError, toastSuccess } = vi.hoisted(() => ({
   toastError: vi.fn(),
@@ -39,17 +41,35 @@ const mockMarkReviewed = vi.mocked(markCompareDocReviewed);
 const mockConfirmEquivalent = vi.mocked(confirmEquivalentVerdict);
 const mockUnmarkPair = vi.mocked(unmarkEquivalencePair);
 
-const DOC: CompareDocument = {
-  id: "doc1",
-  title: "Doc 1",
-  external_id: null,
-  text: "texto",
-};
+const DOC = doc("doc1", "Doc 1", "texto");
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 afterEach(cleanup);
+
+/** Nenhuma escrita otimista: a Server Action retornou `{ error }`. */
+function expectNoOptimisticWrite(
+  recordReview: ReturnType<typeof vi.fn>,
+  goNextField: ReturnType<typeof vi.fn>,
+  message: string,
+) {
+  expect(recordReview).not.toHaveBeenCalled();
+  expect(goNextField).not.toHaveBeenCalled();
+  expect(toastError).toHaveBeenCalledWith(message);
+}
+
+/** Escrita otimista após sucesso da Server Action + avanço de campo. */
+function expectOptimisticWrite(
+  recordReview: ReturnType<typeof vi.fn>,
+  goNextField: ReturnType<typeof vi.fn>,
+  docId: string,
+  fieldName: string,
+  info: VerdictInfo,
+) {
+  expect(recordReview).toHaveBeenCalledWith(docId, fieldName, info);
+  expect(goNextField).toHaveBeenCalledTimes(1);
+}
 
 function setup() {
   const recordReview = vi.fn();
@@ -80,9 +100,7 @@ describe("handleVerdict", () => {
       await result.current.handleVerdict("concordo", "r1");
     });
 
-    expect(recordReview).not.toHaveBeenCalled();
-    expect(goNextField).not.toHaveBeenCalled();
-    expect(toastError).toHaveBeenCalledWith("falhou");
+    expectNoOptimisticWrite(recordReview, goNextField, "falhou");
   });
 
   it("sucesso → grava o veredito otimista e avança de campo", async () => {
@@ -93,12 +111,11 @@ describe("handleVerdict", () => {
       await result.current.handleVerdict("concordo", "r1");
     });
 
-    expect(recordReview).toHaveBeenCalledWith("doc1", "q1", {
+    expectOptimisticWrite(recordReview, goNextField, "doc1", "q1", {
       verdict: "concordo",
       chosenResponseId: "r1",
       comment: null,
     });
-    expect(goNextField).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -111,9 +128,7 @@ describe("handleConfirmEquivalent — o caminho da issue #366", () => {
       await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
     });
 
-    expect(recordReview).not.toHaveBeenCalled();
-    expect(goNextField).not.toHaveBeenCalled();
-    expect(toastError).toHaveBeenCalledWith("não foi");
+    expectNoOptimisticWrite(recordReview, goNextField, "não foi");
   });
 
   it("sucesso → grava o gabarito como veredito otimista e avança de campo", async () => {
@@ -124,12 +139,11 @@ describe("handleConfirmEquivalent — o caminho da issue #366", () => {
       await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
     });
 
-    expect(recordReview).toHaveBeenCalledWith("doc1", "q1", {
+    expectOptimisticWrite(recordReview, goNextField, "doc1", "q1", {
       verdict: "fundida",
       chosenResponseId: "r1",
       comment: null,
     });
-    expect(goNextField).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
+++ b/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
@@ -1,0 +1,172 @@
+// @vitest-environment jsdom
+//
+// Cobertura de regressão para a issue #366 ("não tá indo a resposta da
+// equivalencia"): antes da PR #362, os handlers deste hook chamavam
+// `recordReview`/`goNextField` (escrita otimista) sem antes checar se a
+// Server Action tinha de fato falhado — e a Action lançava Error, mascarado
+// pelo Next 16 em produção, então o handler nunca chegava a ver o erro. Hoje
+// as três actions retornam `{ error? }`; estes testes travam que a escrita
+// otimista só ocorre quando `result.error` é ausente.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, cleanup } from "@testing-library/react";
+import { submitVerdict, markCompareDocReviewed } from "@/actions/reviews";
+import {
+  confirmEquivalentVerdict,
+  unmarkEquivalencePair,
+} from "@/actions/equivalences";
+import { useCompareVerdicts } from "../useCompareVerdicts";
+import type { CompareDocument, FieldResponse } from "../compare-types";
+
+const { toastError, toastSuccess } = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/actions/reviews", () => ({
+  submitVerdict: vi.fn(),
+  markCompareDocReviewed: vi.fn(),
+}));
+vi.mock("@/actions/equivalences", () => ({
+  confirmEquivalentVerdict: vi.fn(),
+  unmarkEquivalencePair: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess, error: toastError },
+}));
+
+const mockSubmitVerdict = vi.mocked(submitVerdict);
+const mockMarkReviewed = vi.mocked(markCompareDocReviewed);
+const mockConfirmEquivalent = vi.mocked(confirmEquivalentVerdict);
+const mockUnmarkPair = vi.mocked(unmarkEquivalencePair);
+
+const DOC: CompareDocument = {
+  id: "doc1",
+  title: "Doc 1",
+  external_id: null,
+  text: "texto",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(cleanup);
+
+function setup() {
+  const recordReview = vi.fn();
+  const goNextField = vi.fn();
+  const { result } = renderHook(() =>
+    useCompareVerdicts({
+      projectId: "p1",
+      currentDoc: DOC,
+      currentFieldName: "q1",
+      isCurrentFieldDivergent: true,
+      allDocDivergent: ["q1", "q2"],
+      localReviews: {},
+      fieldResponses: [] as FieldResponse[],
+      comment: "",
+      recordReview,
+      goNextField,
+    }),
+  );
+  return { result, recordReview, goNextField };
+}
+
+describe("handleVerdict", () => {
+  it("submitVerdict retorna { error } → não grava otimista, não avança, mostra toast.error", async () => {
+    mockSubmitVerdict.mockResolvedValue({ error: "falhou" });
+    const { result, recordReview, goNextField } = setup();
+
+    await act(async () => {
+      await result.current.handleVerdict("concordo", "r1");
+    });
+
+    expect(recordReview).not.toHaveBeenCalled();
+    expect(goNextField).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith("falhou");
+  });
+
+  it("sucesso → grava o veredito otimista e avança de campo", async () => {
+    mockSubmitVerdict.mockResolvedValue({});
+    const { result, recordReview, goNextField } = setup();
+
+    await act(async () => {
+      await result.current.handleVerdict("concordo", "r1");
+    });
+
+    expect(recordReview).toHaveBeenCalledWith("doc1", "q1", {
+      verdict: "concordo",
+      chosenResponseId: "r1",
+      comment: null,
+    });
+    expect(goNextField).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleConfirmEquivalent — o caminho da issue #366", () => {
+  it("confirmEquivalentVerdict retorna { error } → não grava otimista, não avança, mostra toast.error", async () => {
+    mockConfirmEquivalent.mockResolvedValue({ error: "não foi" });
+    const { result, recordReview, goNextField } = setup();
+
+    await act(async () => {
+      await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
+    });
+
+    expect(recordReview).not.toHaveBeenCalled();
+    expect(goNextField).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith("não foi");
+  });
+
+  it("sucesso → grava o gabarito como veredito otimista e avança de campo", async () => {
+    mockConfirmEquivalent.mockResolvedValue({});
+    const { result, recordReview, goNextField } = setup();
+
+    await act(async () => {
+      await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
+    });
+
+    expect(recordReview).toHaveBeenCalledWith("doc1", "q1", {
+      verdict: "fundida",
+      chosenResponseId: "r1",
+      comment: null,
+    });
+    expect(goNextField).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("handleUnmarkPair", () => {
+  it("unmarkEquivalencePair retorna { error } → mostra toast.error", async () => {
+    mockUnmarkPair.mockResolvedValue({ error: "não desfez" });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleUnmarkPair("pair1");
+    });
+
+    expect(toastError).toHaveBeenCalledWith("não desfez");
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("sucesso → mostra toast.success", async () => {
+    mockUnmarkPair.mockResolvedValue({});
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleUnmarkPair("pair1");
+    });
+
+    expect(toastSuccess).toHaveBeenCalledWith("Equivalência removida.");
+  });
+});
+
+describe("handleMarkReviewed", () => {
+  it("markCompareDocReviewed retorna { error } → mostra toast.error", async () => {
+    mockMarkReviewed.mockResolvedValue({ error: "não marcou" });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleMarkReviewed();
+    });
+
+    expect(toastError).toHaveBeenCalledWith("não marcou");
+  });
+});

--- a/frontend/src/components/compare/__tests__/useStableDocOrder.test.ts
+++ b/frontend/src/components/compare/__tests__/useStableDocOrder.test.ts
@@ -4,13 +4,7 @@ import { renderHook, cleanup } from "@testing-library/react";
 
 import { useStableDocOrder } from "@/components/compare/useStableDocOrder";
 import type { CompareDocument } from "@/components/compare/compare-types";
-
-const doc = (id: string, title?: string): CompareDocument => ({
-  id,
-  title: title ?? `Doc ${id}`,
-  external_id: null,
-  text: "",
-});
+import { doc } from "./compare-test-helpers";
 
 const ids = (docs: CompareDocument[]) => docs.map((d) => d.id);
 


### PR DESCRIPTION
## Contexto

A issue #366 reportou (comentário da Mari, 2026-07-02T21:07:12Z): "não tá indo a resposta da equivalencia" — o fluxo de marcar respostas equivalentes na Comparação (`AgreementGroup`) não estava persistindo o veredito.

Investigação (código + dados de produção, autorizados pelo Bruno em sessão):

- **Causa raiz**: antes da PR #362 (mergeada `2026-07-02T21:33:12-03:00`, ~3h26 depois do comentário), `confirmEquivalentVerdict` (`frontend/src/actions/equivalences.ts`) lançava `Error` — mascarado pelo Next 16 em produção — e `useCompareVerdicts.ts` fazia a escrita otimista (`recordReview`) **antes** de aguardar a confirmação da Server Action. A UI avançava como se tivesse salvo mesmo quando a escrita falhava silenciosamente.
- **Evidência em produção**: no projeto Zolgensma, a reviewer teve uma sequência de merges de equivalência bem-sucedidos até `20:19:16Z` e depois nenhuma escrita em `reviews`/`response_equivalences` até o comentário às `21:07:12Z` — consistente com uma tentativa que falhou silenciosamente nesse intervalo.
- A #362 já corrigiu o padrão (as 3 actions de `equivalences.ts` retornam `{ error? }`; `useCompareVerdicts.ts` só grava otimista após checar `result.error`) e está em produção. Não encontrei um segundo bug de escrita independente nesse fluxo.

## O que este PR faz

Fecha o gap de cobertura que deixou essa regressão passar despercebida: nenhum teste hoje simula a Server Action retornando `{ error }` e verifica que a UI **não** avança otimisticamente — os mocks existentes (`ComparePage.test.tsx`, `AgreementGroup.markAll.test.tsx`) sempre resolvem com sucesso.

- `frontend/src/actions/__tests__/equivalences.test.ts` (novo): `confirmEquivalentVerdict`/`markLlmEquivalent`/`unmarkEquivalencePair` retornam `{ error }` em vez de lançar, nos pontos de falha reais (upsert de `response_equivalences`, upsert de `reviews`, delete em `unmarkEquivalencePair`); mais o caminho feliz, checando o par canônico (`a < b`) e o `chosen_response_id` do gabarito.
- `frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts` (novo): trava que `recordReview`/`goNextField` só disparam quando a action **não** retorna erro, nos quatro handlers do hook — esse é o teste que teria pego a regressão antes de ir para produção.
- `frontend/src/actions/__tests__/supabase-mock.ts`: adiciona suporte a `upsert()` no mock chainable compartilhado (só tinha `insert`/`update`/`delete`).

Nenhum código de produção foi alterado — a correção já está em `main` via #362.

Ref #366

## Test plan

- [x] `npx vitest run` — 880/880 (nenhuma regressão)
- [x] `npx tsc --noEmit -p .` — 0 erros
- [x] `npx eslint` nos arquivos novos — limpo
- [x] hooks de pre-push (typecheck, vitest full, lint:types, fallow, semgrep) — todos verdes no push

🤖 Generated with [Claude Code](https://claude.com/claude-code)