### PR TITLE
refactor(test): extrai fixtures compartilhadas do cluster retry/comparison

### DIFF
--- a/frontend/src/actions/__tests__/arbitration-retry.test.ts
+++ b/frontend/src/actions/__tests__/arbitration-retry.test.ts
@@ -1,53 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  callsOf,
+  makeSimpleSupabaseMock,
+  type WriteCall,
+} from "@/test-utils/supabase-mock";
+import { authModuleMock } from "@/test-utils/auth-mock";
 
 // Mock supabase chainable — mesmo padrão de field-reviews.test.ts. Captura
 // payloads de write para validar o comportamento de retryPendingArbitrations
 // e assignArbitrator sem subir Postgres.
-type WriteCall = { table: string; op: string; payload: unknown };
 let writeCalls: WriteCall[];
 let tableData: Record<string, unknown>;
 
-const updateCallsOf = (table?: string) =>
-  writeCalls.filter((c) => c.op === "update" && (!table || c.table === table));
-const upsertCallsOf = (table?: string) =>
-  writeCalls.filter((c) => c.op === "upsert" && (!table || c.table === table));
+const updateCallsOf = (table?: string) => callsOf(writeCalls, "update", table);
+const upsertCallsOf = (table?: string) => callsOf(writeCalls, "upsert", table);
+const deleteCallsOf = (table?: string) => callsOf(writeCalls, "delete", table);
 
 function makeClient() {
-  return {
-    from: (table: string) => {
-      const builder: Record<string, unknown> = {};
-      let op = "select";
-      for (const m of ["select", "eq", "is", "in", "neq", "limit"]) {
-        builder[m] = () => builder;
-      }
-      builder.update = (payload: unknown) => {
-        writeCalls.push({ table, op: "update", payload });
-        op = "update";
-        return builder;
-      };
-      builder.upsert = (payload: unknown) => {
-        writeCalls.push({ table, op: "upsert", payload });
-        op = "upsert";
-        return builder;
-      };
-      builder.insert = (payload: unknown) => {
-        writeCalls.push({ table, op: "insert", payload });
-        op = "insert";
-        return builder;
-      };
-      builder.delete = () => {
-        writeCalls.push({ table, op: "delete", payload: null });
-        op = "delete";
-        return builder;
-      };
-      builder.then = (resolve: (v: unknown) => unknown) =>
-        resolve({
-          data: tableData[`${table}:${op}`] ?? tableData[table] ?? null,
-          error: tableData[`__error:${table}:${op}`] ?? null,
-        });
-      return builder;
-    },
-  };
+  return makeSimpleSupabaseMock({ tableData, writeCalls });
 }
 
 // isProjectCoordinator: hoisted para permitir override por teste.
@@ -56,10 +26,7 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
-vi.mock("@/lib/auth", () => ({
-  getAuthUser: async () => ({ id: "userCoord" }),
-  isProjectCoordinator: () => hoisted.isCoord(),
-}));
+vi.mock("@/lib/auth", () => authModuleMock(hoisted.isCoord));
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServer: async () => makeClient(),
 }));
@@ -242,9 +209,6 @@ describe("retryPendingArbitrations — exclui codificadores do documento", () =>
 async function loadRelease() {
   return (await import("@/actions/field-reviews")).releaseArbitrationsFromUser;
 }
-
-const deleteCallsOf = (table?: string) =>
-  writeCalls.filter((c) => c.op === "delete" && (!table || c.table === table));
 
 describe("releaseArbitrationsFromUser", () => {
   it("sem field_reviews afetados → released 0, nenhum write", async () => {

--- a/frontend/src/actions/__tests__/comparisons-retry.test.ts
+++ b/frontend/src/actions/__tests__/comparisons-retry.test.ts
@@ -1,61 +1,24 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { PydanticField } from "@/lib/types";
+import {
+  callsOf,
+  makeFilterAwareSupabaseMock,
+  type WriteCall,
+} from "@/test-utils/supabase-mock";
+import { authModuleMock } from "@/test-utils/auth-mock";
+import {
+  makeHumanResponse,
+  makeProjectMember,
+  makeProjectRow,
+} from "@/test-utils/comparison-fixtures";
 
 // Mock supabase filter-aware (mesmo padrão de lib/__tests__/auto-comparison.test.ts).
-type WriteCall = { table: string; op: string; payload: unknown };
 let writeCalls: WriteCall[];
 let tableData: Record<string, unknown[]>;
 
-const upsertCallsOf = (table?: string) =>
-  writeCalls.filter((c) => c.op === "upsert" && (!table || c.table === table));
+const upsertCallsOf = (table?: string) => callsOf(writeCalls, "upsert", table);
 
 function makeClient() {
-  return {
-    from: (table: string) => {
-      const eqs: Array<[string, unknown]> = [];
-      const neqs: Array<[string, unknown]> = [];
-      const ins: Array<[string, unknown[]]> = [];
-      let op = "select";
-      let limitN: number | null = null;
-      const builder: Record<string, unknown> = {};
-      builder.select = () => builder;
-      builder.eq = (c: string, v: unknown) => (eqs.push([c, v]), builder);
-      builder.neq = (c: string, v: unknown) => (neqs.push([c, v]), builder);
-      builder.is = (c: string, v: unknown) => (eqs.push([c, v]), builder);
-      builder.in = (c: string, v: unknown[]) => (ins.push([c, v]), builder);
-      builder.limit = (n: number) => ((limitN = n), builder);
-      builder.upsert = (payload: unknown) => {
-        writeCalls.push({ table, op: "upsert", payload });
-        op = "upsert";
-        return builder;
-      };
-      builder.update = (payload: unknown) => {
-        writeCalls.push({ table, op: "update", payload });
-        op = "update";
-        return builder;
-      };
-      builder.delete = () => {
-        writeCalls.push({ table, op: "delete", payload: null });
-        op = "delete";
-        return builder;
-      };
-      const rows = () => {
-        const data = (tableData[table] ?? []) as Array<Record<string, unknown>>;
-        const filtered = data.filter((r) => {
-          for (const [c, v] of eqs) if (r[c] !== v) return false;
-          for (const [c, v] of neqs) if (r[c] === v) return false;
-          for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
-          return true;
-        });
-        return limitN != null ? filtered.slice(0, limitN) : filtered;
-      };
-      const err = () => tableData[`__error:${table}:${op}`] ?? null;
-      builder.single = () => Promise.resolve({ data: rows()[0] ?? null, error: err() });
-      builder.maybeSingle = () => Promise.resolve({ data: rows()[0] ?? null, error: err() });
-      builder.then = (resolve: (v: unknown) => unknown) => resolve({ data: rows(), error: err() });
-      return builder;
-    },
-  };
+  return makeFilterAwareSupabaseMock({ tableData, writeCalls });
 }
 
 const hoisted = vi.hoisted(() => ({
@@ -63,56 +26,15 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
-vi.mock("@/lib/auth", () => ({
-  getAuthUser: async () => ({ id: "userCoord" }),
-  isProjectCoordinator: () => hoisted.isCoord(),
-}));
+vi.mock("@/lib/auth", () => authModuleMock(hoisted.isCoord));
 vi.mock("@/lib/supabase/admin", () => ({
   createSupabaseAdmin: () => makeClient(),
 }));
 
-const FIELDS: PydanticField[] = [
-  { name: "q1", type: "text", options: null, description: "", required: true },
-];
-// Hash do schema corrente: o backlog (scanComparisonBacklog) aplica o piso vivo
-// `latest_major` (#247), então as respostas precisam qualificar — usam o hash
-// atual com semver NULL (caminho de fallback por hash em responseQualifiesForVersion).
-const CURRENT_HASH = "hash-atual";
-const human = (respondent_id: string, q1: string, document_id = "doc1") => ({
-  id: `r-${respondent_id}-${document_id}`,
-  project_id: "p1",
-  document_id,
-  respondent_id,
-  respondent_type: "humano",
-  is_latest: true,
-  answers: { q1 },
-  answer_field_hashes: null,
-  pydantic_hash: CURRENT_HASH,
-  schema_version_major: null,
-  schema_version_minor: null,
-  schema_version_patch: null,
-  // Chaves do filtro de embed `documents!inner` (fora-de-escopo): o mock
-  // filter-aware compara r["documents.excluded_at"] literalmente.
-  "documents.excluded_at": null,
-  "documents.exclusion_pending_at": null,
-});
-const projectRow = (over: Record<string, unknown> = {}) => ({
-  id: "p1",
-  pydantic_fields: FIELDS,
-  pydantic_hash: CURRENT_HASH,
-  min_responses_for_comparison: 2,
-  comparison_includes_llm: true,
-  automation_mode: "compare_humans",
-  schema_version_major: null,
-  schema_version_minor: null,
-  schema_version_patch: null,
-  ...over,
-});
-
 beforeEach(() => {
   writeCalls = [];
   tableData = {
-    projects: [projectRow()],
+    projects: [makeProjectRow()],
     project_members: [],
     assignments: [],
     responses: [],
@@ -141,9 +63,9 @@ describe("retryPendingComparisons — guards", () => {
   });
 
   it("modo não-comparação → no-op", async () => {
-    tableData.projects = [projectRow({ automation_mode: "auto_review_llm" })];
-    tableData.responses = [human("userA", "A"), human("userB", "B")];
-    tableData.project_members = [{ user_id: "userC", project_id: "p1", can_compare: true }];
+    tableData.projects = [makeProjectRow({ automation_mode: "auto_review_llm" })];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "B")];
+    tableData.project_members = [makeProjectMember("userC")];
     const retry = await loadRetry();
     const r = await retry("p1");
     expect(r.success).toBe(true);
@@ -154,8 +76,8 @@ describe("retryPendingComparisons — guards", () => {
 
 describe("retryPendingComparisons — atribui backlog divergente", () => {
   it("doc divergente sem comparacao ativa → atribui 1", async () => {
-    tableData.responses = [human("userA", "A"), human("userB", "B")];
-    tableData.project_members = [{ user_id: "userC", project_id: "p1", can_compare: true }];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "B")];
+    tableData.project_members = [makeProjectMember("userC")];
     const retry = await loadRetry();
     const r = await retry("p1");
     expect(r.success).toBe(true);
@@ -169,7 +91,7 @@ describe("retryPendingComparisons — atribui backlog divergente", () => {
   });
 
   it("doc divergente sem revisor elegível → stillNoPool", async () => {
-    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "B")];
     tableData.project_members = []; // ninguém can_compare
     const retry = await loadRetry();
     const r = await retry("p1");
@@ -179,8 +101,8 @@ describe("retryPendingComparisons — atribui backlog divergente", () => {
   });
 
   it("doc em consenso → nada a atribuir", async () => {
-    tableData.responses = [human("userA", "A"), human("userB", "A")];
-    tableData.project_members = [{ user_id: "userC", project_id: "p1", can_compare: true }];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "A")];
+    tableData.project_members = [makeProjectMember("userC")];
     const retry = await loadRetry();
     const r = await retry("p1");
     expect(r.success).toBe(true);

--- a/frontend/src/lib/__tests__/auto-comparison.test.ts
+++ b/frontend/src/lib/__tests__/auto-comparison.test.ts
@@ -1,145 +1,39 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { PydanticField } from "@/lib/types";
+import {
+  callsOf,
+  makeFilterAwareSupabaseMock,
+  type WriteCall,
+} from "@/test-utils/supabase-mock";
+import {
+  CURRENT_HASH,
+  makeHumanResponse,
+  makeProjectMember,
+  makeProjectRow,
+} from "@/test-utils/comparison-fixtures";
 
 // Mock supabase chainable e FILTER-AWARE: diferente do mock de
 // arbitration-retry.test.ts, aplica os filtros .eq/.neq/.in às linhas, porque a
 // comparação consulta `responses` duas vezes na mesma chamada (humano vs LLM) —
 // um mock que ignora filtros devolveria o mesmo array para ambas.
-type WriteCall = { table: string; op: string; payload: unknown };
 let writeCalls: WriteCall[];
 let tableData: Record<string, unknown[]>;
 
-const upsertCallsOf = (table?: string) =>
-  writeCalls.filter((c) => c.op === "upsert" && (!table || c.table === table));
-const deleteCallsOf = (table?: string) =>
-  writeCalls.filter((c) => c.op === "delete" && (!table || c.table === table));
+const upsertCallsOf = (table?: string) => callsOf(writeCalls, "upsert", table);
+const deleteCallsOf = (table?: string) => callsOf(writeCalls, "delete", table);
 
 function makeClient() {
-  return {
-    from: (table: string) => {
-      const eqs: Array<[string, unknown]> = [];
-      const neqs: Array<[string, unknown]> = [];
-      const ins: Array<[string, unknown[]]> = [];
-      let op = "select";
-      let limitN: number | null = null;
-
-      const builder: Record<string, unknown> = {};
-      builder.select = () => builder;
-      builder.eq = (c: string, v: unknown) => {
-        eqs.push([c, v]);
-        return builder;
-      };
-      builder.neq = (c: string, v: unknown) => {
-        neqs.push([c, v]);
-        return builder;
-      };
-      builder.is = (c: string, v: unknown) => {
-        eqs.push([c, v]);
-        return builder;
-      };
-      builder.in = (c: string, v: unknown[]) => {
-        ins.push([c, v]);
-        return builder;
-      };
-      builder.limit = (n: number) => {
-        limitN = n;
-        return builder;
-      };
-      builder.update = (payload: unknown) => {
-        writeCalls.push({ table, op: "update", payload });
-        op = "update";
-        return builder;
-      };
-      builder.upsert = (payload: unknown) => {
-        writeCalls.push({ table, op: "upsert", payload });
-        op = "upsert";
-        return builder;
-      };
-      builder.insert = (payload: unknown) => {
-        writeCalls.push({ table, op: "insert", payload });
-        op = "insert";
-        return builder;
-      };
-      builder.delete = () => {
-        writeCalls.push({ table, op: "delete", payload: null });
-        op = "delete";
-        return builder;
-      };
-
-      const rows = () => {
-        const data = (tableData[table] ?? []) as Array<Record<string, unknown>>;
-        const filtered = data.filter((r) => {
-          for (const [c, v] of eqs) if (r[c] !== v) return false;
-          for (const [c, v] of neqs) if (r[c] === v) return false;
-          for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
-          return true;
-        });
-        return limitN != null ? filtered.slice(0, limitN) : filtered;
-      };
-      const err = () => tableData[`__error:${table}:${op}`] ?? null;
-
-      builder.single = () =>
-        Promise.resolve({ data: rows()[0] ?? null, error: err() });
-      builder.maybeSingle = () =>
-        Promise.resolve({ data: rows()[0] ?? null, error: err() });
-      builder.then = (resolve: (v: unknown) => unknown) =>
-        resolve({ data: rows(), error: err() });
-      return builder;
-    },
-  };
+  return makeFilterAwareSupabaseMock({ tableData, writeCalls });
 }
 
-const hoisted = vi.hoisted(() => ({
-  isCoord: vi.fn<() => Promise<boolean>>(async () => true),
-}));
-
 vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
-vi.mock("@/lib/auth", () => ({
-  getAuthUser: async () => ({ id: "userCoord" }),
-  isProjectCoordinator: () => hoisted.isCoord(),
-}));
 vi.mock("@/lib/supabase/admin", () => ({
   createSupabaseAdmin: () => makeClient(),
 }));
 
-const FIELDS: PydanticField[] = [
-  { name: "q1", type: "text", options: null, description: "", required: true },
-];
+// `@/lib/auto-comparison.ts` não importa `@/lib/auth` — o mock de
+// `@/lib/auth`/`isCoord` que existia antes era boilerplate copiado sem
+// efeito (nenhum teste deste arquivo exercitava o guard) — removido no #387.
 
-// Hash do schema corrente do projeto. As fixtures default usam-no como
-// `pydantic_hash`, com semver NULL, para qualificar pelo fallback de hash em
-// `responseQualifiesForVersion` sob o piso vivo `latest_major` (#247). Casos de
-// versão antiga passam `pydantic_hash: "hash-antigo"` ou um semver < piso.
-const CURRENT_HASH = "hash-atual";
-
-// Helpers de fixture. Campos de versão (pydantic_hash, schema_version_*) entram
-// no shape porque o gatilho agora aplica o piso `latest_major` antes de medir
-// divergência (#247). Default = versão corrente (qualifica); `extra` sobrescreve
-// para emular rodadas antigas. Semver explícito como NULL (não undefined) para
-// espelhar o que o Postgres devolve em respostas pré-versionamento.
-const human = (
-  respondent_id: string,
-  q1: string,
-  extra: Record<string, unknown> = {},
-) => ({
-  id: `r-${respondent_id}`,
-  project_id: "p1",
-  document_id: "doc1",
-  respondent_id,
-  respondent_type: "humano",
-  is_latest: true,
-  answers: { q1 },
-  answer_field_hashes: null,
-  pydantic_hash: CURRENT_HASH,
-  schema_version_major: null,
-  schema_version_minor: null,
-  schema_version_patch: null,
-  // Chaves do filtro de embed `documents!inner` (fora-de-escopo): o mock
-  // filter-aware compara r["documents.excluded_at"] literalmente.
-  "documents.excluded_at": null,
-  "documents.exclusion_pending_at": null,
-  ...extra,
-});
 const llm = (q1: string, extra: Record<string, unknown> = {}) => ({
   id: "r-llm",
   project_id: "p1",
@@ -154,31 +48,11 @@ const llm = (q1: string, extra: Record<string, unknown> = {}) => ({
   schema_version_patch: null,
   ...extra,
 });
-const member = (user_id: string) => ({
-  user_id,
-  project_id: "p1",
-  can_compare: true,
-});
-const projectRow = (over: Record<string, unknown> = {}) => ({
-  id: "p1",
-  pydantic_fields: FIELDS,
-  pydantic_hash: CURRENT_HASH,
-  min_responses_for_comparison: 2,
-  comparison_includes_llm: true,
-  automation_mode: "compare_humans",
-  // Sem semver explícito: cai nos fallbacks {0,1,0} (como page.tsx/compare-sync),
-  // e o piso `latest_major` ancora em {0,1,0}. Casos que exercitam o caminho
-  // semver passam schema_version_* aqui.
-  schema_version_major: null,
-  schema_version_minor: null,
-  schema_version_patch: null,
-  ...over,
-});
 
 beforeEach(() => {
   writeCalls = [];
   tableData = {
-    projects: [projectRow()],
+    projects: [makeProjectRow()],
     project_members: [],
     assignments: [],
     responses: [],
@@ -194,7 +68,6 @@ beforeEach(() => {
       },
     ],
   };
-  hoisted.isCoord.mockResolvedValue(true);
 });
 
 async function loadLib() {
@@ -204,7 +77,7 @@ async function loadLib() {
 describe("assignComparisonReviewer — pool e balanceamento", () => {
   it("exclui TODOS os codificadores do pool", async () => {
     const { assignComparisonReviewer } = await loadLib();
-    tableData.project_members = [member("userA"), member("userB"), member("userC")];
+    tableData.project_members = [makeProjectMember("userA"), makeProjectMember("userB"), makeProjectMember("userC")];
     const r = await assignComparisonReviewer(
       makeClient() as never,
       "p1",
@@ -223,7 +96,7 @@ describe("assignComparisonReviewer — pool e balanceamento", () => {
 
   it("pool vazio (todos codificaram) → noPool, sem upsert", async () => {
     const { assignComparisonReviewer } = await loadLib();
-    tableData.project_members = [member("userA"), member("userB")];
+    tableData.project_members = [makeProjectMember("userA"), makeProjectMember("userB")];
     const r = await assignComparisonReviewer(
       makeClient() as never,
       "p1",
@@ -249,7 +122,7 @@ describe("assignComparisonReviewer — pool e balanceamento", () => {
 
   it("escolhe o revisor de menor carga de comparações abertas", async () => {
     const { assignComparisonReviewer } = await loadLib();
-    tableData.project_members = [member("userB"), member("userC")];
+    tableData.project_members = [makeProjectMember("userB"), makeProjectMember("userC")];
     // userB já tem 2 comparações abertas; userC nenhuma → escolhe userC.
     tableData.assignments = [
       { user_id: "userB", project_id: "p1", type: "comparacao", status: "pendente" },
@@ -271,8 +144,8 @@ describe("assignComparisonReviewer — pool e balanceamento", () => {
 describe("createAutoComparisonIfDiverges — compare_humans", () => {
   it("2 humanos divergentes → atribui comparacao", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.responses = [human("userA", "A"), human("userB", "B")];
-    tableData.project_members = [member("userC")];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "B")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(true);
     expect(upsertCallsOf("assignments")).toHaveLength(1);
@@ -284,8 +157,8 @@ describe("createAutoComparisonIfDiverges — compare_humans", () => {
 
   it("2 humanos em consenso → não atribui", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.responses = [human("userA", "A"), human("userB", "A")];
-    tableData.project_members = [member("userC")];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "A")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(false);
     expect(upsertCallsOf("assignments")).toHaveLength(0);
@@ -293,8 +166,8 @@ describe("createAutoComparisonIfDiverges — compare_humans", () => {
 
   it("abaixo do mínimo (1 humano) → não dispara", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.responses = [human("userA", "A")];
-    tableData.project_members = [member("userC")];
+    tableData.responses = [makeHumanResponse("userA", "A")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(false);
     expect(upsertCallsOf("assignments")).toHaveLength(0);
@@ -304,18 +177,18 @@ describe("createAutoComparisonIfDiverges — compare_humans", () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
     // userB tem resposta vazia (incompleta) → só 1 humano completo.
     tableData.responses = [
-      human("userA", "A"),
-      { ...human("userB", "B"), answers: {} },
+      makeHumanResponse("userA", "A"),
+      { ...makeHumanResponse("userB", "B"), answers: {} },
     ];
-    tableData.project_members = [member("userC")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(false);
   });
 
   it("já existe comparacao ativa → idempotente, não re-sorteia", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.responses = [human("userA", "A"), human("userB", "B")];
-    tableData.project_members = [member("userC")];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "B")];
+    tableData.project_members = [makeProjectMember("userC")];
     tableData.assignments = [
       { document_id: "doc1", project_id: "p1", type: "comparacao", status: "pendente" },
     ];
@@ -326,18 +199,18 @@ describe("createAutoComparisonIfDiverges — compare_humans", () => {
 
   it("comparison_includes_llm=true: humanos concordam mas LLM diverge → dispara", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.projects = [projectRow({ comparison_includes_llm: true })];
-    tableData.responses = [human("userA", "A"), human("userB", "A"), llm("Z")];
-    tableData.project_members = [member("userC")];
+    tableData.projects = [makeProjectRow({ comparison_includes_llm: true })];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "A"), llm("Z")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(true);
   });
 
   it("comparison_includes_llm=false: humanos concordam e só LLM diverge → NÃO dispara", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.projects = [projectRow({ comparison_includes_llm: false })];
-    tableData.responses = [human("userA", "A"), human("userB", "A"), llm("Z")];
-    tableData.project_members = [member("userC")];
+    tableData.projects = [makeProjectRow({ comparison_includes_llm: false })];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "A"), llm("Z")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(false);
   });
@@ -346,9 +219,9 @@ describe("createAutoComparisonIfDiverges — compare_humans", () => {
 describe("createAutoComparisonIfDiverges — compare_llm", () => {
   it("1 humano + LLM divergentes → atribui comparacao", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
-    tableData.responses = [human("userA", "A"), llm("B")];
-    tableData.project_members = [member("userC")];
+    tableData.projects = [makeProjectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [makeHumanResponse("userA", "A"), llm("B")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
     expect(r.assigned).toBe(true);
     expect(upsertCallsOf("assignments")[0].payload).toMatchObject({
@@ -359,28 +232,28 @@ describe("createAutoComparisonIfDiverges — compare_llm", () => {
 
   it("1 humano + LLM em consenso → não dispara", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
-    tableData.responses = [human("userA", "A"), llm("A")];
-    tableData.project_members = [member("userC")];
+    tableData.projects = [makeProjectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [makeHumanResponse("userA", "A"), llm("A")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
     expect(r.assigned).toBe(false);
   });
 
   it("sem resposta do LLM → não dispara", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
-    tableData.responses = [human("userA", "A")];
-    tableData.project_members = [member("userC")];
+    tableData.projects = [makeProjectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [makeHumanResponse("userA", "A")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
     expect(r.assigned).toBe(false);
   });
 
   it("codificador do doc não entra no pool (LLM compara, mas humano que codificou não revisa)", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
-    tableData.responses = [human("userA", "A"), llm("B")];
+    tableData.projects = [makeProjectRow({ automation_mode: "compare_llm" })];
+    tableData.responses = [makeHumanResponse("userA", "A"), llm("B")];
     // userA é o único can_compare, mas codificou o doc → noPool.
-    tableData.project_members = [member("userA")];
+    tableData.project_members = [makeProjectMember("userA")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
     expect(r.assigned).toBe(false);
     expect(r.noPool).toBe(true);
@@ -397,10 +270,10 @@ describe("createAutoComparisonIfDiverges — piso de versão latest_major (#247)
     // Dois humanos completos que DIVERGEM, mas ambos de um schema anterior
     // (pydantic_hash != atual, semver NULL) → descartados pelo piso → 0 < 2.
     tableData.responses = [
-      human("userA", "A", { pydantic_hash: "hash-antigo" }),
-      human("userB", "B", { pydantic_hash: "hash-antigo" }),
+      makeHumanResponse("userA", "A", { pydantic_hash: "hash-antigo" }),
+      makeHumanResponse("userB", "B", { pydantic_hash: "hash-antigo" }),
     ];
-    tableData.project_members = [member("userC")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(false);
     expect(upsertCallsOf("assignments")).toHaveLength(0);
@@ -415,13 +288,13 @@ describe("createAutoComparisonIfDiverges — piso de versão latest_major (#247)
     // o fallback por hash também recusaria (hash != atual) — não depende da ordem
     // dos branches em responseQualifiesForVersion.
     tableData.projects = [
-      projectRow({ schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+      makeProjectRow({ schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
     ];
     tableData.responses = [
-      human("userA", "A", { pydantic_hash: "hash-antigo", schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
-      human("userB", "B", { pydantic_hash: "hash-antigo", schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
+      makeHumanResponse("userA", "A", { pydantic_hash: "hash-antigo", schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
+      makeHumanResponse("userB", "B", { pydantic_hash: "hash-antigo", schema_version_major: 1, schema_version_minor: 0, schema_version_patch: 0 }),
     ];
-    tableData.project_members = [member("userC")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(false);
     expect(upsertCallsOf("assignments")).toHaveLength(0);
@@ -430,13 +303,13 @@ describe("createAutoComparisonIfDiverges — piso de versão latest_major (#247)
   it("divergência na MAJOR corrente ainda materializa (semver)", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
     tableData.projects = [
-      projectRow({ schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+      makeProjectRow({ schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
     ];
     tableData.responses = [
-      human("userA", "A", { schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
-      human("userB", "B", { schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+      makeHumanResponse("userA", "A", { schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
+      makeHumanResponse("userB", "B", { schema_version_major: 2, schema_version_minor: 0, schema_version_patch: 0 }),
     ];
-    tableData.project_members = [member("userC")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(true);
     expect(upsertCallsOf("assignments")).toHaveLength(1);
@@ -445,10 +318,10 @@ describe("createAutoComparisonIfDiverges — piso de versão latest_major (#247)
   it("mistura: 1 corrente + 1 antiga divergem → antiga descartada, sobra 1 < mínimo", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
     tableData.responses = [
-      human("userA", "A"), // corrente (hash atual)
-      human("userB", "B", { pydantic_hash: "hash-antigo" }), // antiga
+      makeHumanResponse("userA", "A"), // corrente (hash atual)
+      makeHumanResponse("userB", "B", { pydantic_hash: "hash-antigo" }), // antiga
     ];
-    tableData.project_members = [member("userC")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_humans");
     expect(r.assigned).toBe(false);
     expect(upsertCallsOf("assignments")).toHaveLength(0);
@@ -456,12 +329,12 @@ describe("createAutoComparisonIfDiverges — piso de versão latest_major (#247)
 
   it("compare_llm: humano corrente diverge de LLM de schema antigo → LLM descartado, sem 2ª resposta", async () => {
     const { createAutoComparisonIfDiverges } = await loadLib();
-    tableData.projects = [projectRow({ automation_mode: "compare_llm" })];
+    tableData.projects = [makeProjectRow({ automation_mode: "compare_llm" })];
     tableData.responses = [
-      human("userA", "A"),
+      makeHumanResponse("userA", "A"),
       llm("B", { pydantic_hash: "hash-antigo" }),
     ];
-    tableData.project_members = [member("userC")];
+    tableData.project_members = [makeProjectMember("userC")];
     const r = await createAutoComparisonIfDiverges("p1", "doc1", "compare_llm");
     // LLM antigo não qualifica → falta a 2ª resposta → não dispara.
     expect(r.assigned).toBe(false);
@@ -473,8 +346,8 @@ describe("scanComparisonBacklog — piso de versão latest_major (#247)", () => 
   it("doc cuja divergência só existe em versão antiga fica fora do backlog", async () => {
     const { scanComparisonBacklog } = await loadLib();
     tableData.responses = [
-      human("userA", "A", { pydantic_hash: "hash-antigo" }),
-      human("userB", "B", { pydantic_hash: "hash-antigo" }),
+      makeHumanResponse("userA", "A", { pydantic_hash: "hash-antigo" }),
+      makeHumanResponse("userB", "B", { pydantic_hash: "hash-antigo" }),
     ];
     const backlog = await scanComparisonBacklog(
       makeClient() as never,
@@ -486,7 +359,7 @@ describe("scanComparisonBacklog — piso de versão latest_major (#247)", () => 
 
   it("doc divergente na versão corrente entra no backlog", async () => {
     const { scanComparisonBacklog } = await loadLib();
-    tableData.responses = [human("userA", "A"), human("userB", "B")];
+    tableData.responses = [makeHumanResponse("userA", "A"), makeHumanResponse("userB", "B")];
     const backlog = await scanComparisonBacklog(
       makeClient() as never,
       "p1",

--- a/frontend/src/lib/__tests__/compare-sync.test.ts
+++ b/frontend/src/lib/__tests__/compare-sync.test.ts
@@ -1,67 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import type { PydanticField } from "@/lib/types";
+import {
+  callsOf,
+  makeFilterAwareSupabaseMock,
+  type WriteCall,
+} from "@/test-utils/supabase-mock";
+import { CURRENT_HASH } from "@/test-utils/comparison-fixtures";
 
 // compare-sync.ts abre com `import "server-only"`, que LANÇA fora de um Server
 // Component. Mocká-lo para no-op deixa o módulo importável no Vitest (node).
 vi.mock("server-only", () => ({}));
 
-// Mock supabase chainable e FILTER-AWARE (mesmo padrão de auto-comparison.test.ts):
-// aplica .eq/.neq/.in às linhas e registra os writes (.update) para asserção.
-// syncCompareAssignment recebe o client como argumento, então basta passá-lo.
-type WriteCall = { table: string; op: string; payload: unknown };
 let writeCalls: WriteCall[];
 let tableData: Record<string, unknown[]>;
 
-const updateCallsOf = (table?: string) =>
-  writeCalls.filter((c) => c.op === "update" && (!table || c.table === table));
+const updateCallsOf = (table?: string) => callsOf(writeCalls, "update", table);
 
 function makeClient() {
-  return {
-    from: (table: string) => {
-      const eqs: Array<[string, unknown]> = [];
-      const neqs: Array<[string, unknown]> = [];
-      const ins: Array<[string, unknown[]]> = [];
-      let op = "select";
-
-      const builder: Record<string, unknown> = {};
-      builder.select = () => builder;
-      builder.eq = (c: string, v: unknown) => {
-        eqs.push([c, v]);
-        return builder;
-      };
-      builder.neq = (c: string, v: unknown) => {
-        neqs.push([c, v]);
-        return builder;
-      };
-      builder.in = (c: string, v: unknown[]) => {
-        ins.push([c, v]);
-        return builder;
-      };
-      builder.update = (payload: unknown) => {
-        writeCalls.push({ table, op: "update", payload });
-        op = "update";
-        return builder;
-      };
-
-      const rows = () => {
-        const data = (tableData[table] ?? []) as Array<Record<string, unknown>>;
-        return data.filter((r) => {
-          for (const [c, v] of eqs) if (r[c] !== v) return false;
-          for (const [c, v] of neqs) if (r[c] === v) return false;
-          for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
-          return true;
-        });
-      };
-
-      builder.single = () =>
-        Promise.resolve({ data: rows()[0] ?? null, error: null });
-      builder.maybeSingle = () =>
-        Promise.resolve({ data: rows()[0] ?? null, error: null });
-      builder.then = (resolve: (v: unknown) => unknown) =>
-        resolve({ data: op === "update" ? null : rows(), error: null });
-      return builder;
-    },
-  };
+  return makeFilterAwareSupabaseMock({ tableData, writeCalls });
 }
 
 const FIELDS: PydanticField[] = [
@@ -73,8 +29,6 @@ const FIELDS: PydanticField[] = [
     target: "all",
   },
 ];
-
-const CURRENT_HASH = "hash-atual";
 
 // Resposta da MAJOR corrente (qualifica sob o piso latest_major). `extra`
 // sobrescreve para emular rodadas antigas / pré-versionamento.

--- a/frontend/src/test-utils/auth-mock.ts
+++ b/frontend/src/test-utils/auth-mock.ts
@@ -1,0 +1,20 @@
+// Fábrica do corpo do mock de @/lib/auth usada por testes de Server Actions
+// que exigem coordenador de projeto (#387). A chamada
+// `vi.mock("@/lib/auth", () => ...)` precisa continuar escrita no corpo de
+// cada arquivo de teste (restrição de hoisting estático do Vitest).
+//
+// IMPORTANTE: `vi.hoisted(fn)` executa `fn` IMEDIATAMENTE na posição
+// hoisted, acima dos bindings de import transpilados — chamar uma função
+// importada de dentro de `vi.hoisted(() => ...)` quebra com
+// "Cannot access '...' before initialization". Por isso `isCoord` continua
+// sendo criado inline com `vi.fn(...)` dentro de `vi.hoisted()` em cada
+// arquivo de teste; só o corpo (lazy) da factory de `vi.mock` é delegado
+// para `authModuleMock`, chamado de dentro do callback de `vi.mock`, que
+// SÓ roda quando o módulo mockado é de fato importado (bem depois de todo o
+// topo do arquivo, imports inclusive, já ter executado).
+export function authModuleMock(isCoord: () => Promise<boolean>, userId = "userCoord") {
+  return {
+    getAuthUser: async () => ({ id: userId }),
+    isProjectCoordinator: () => isCoord(),
+  };
+}

--- a/frontend/src/test-utils/auth-mock.ts
+++ b/frontend/src/test-utils/auth-mock.ts
@@ -12,6 +12,15 @@
 // para `authModuleMock`, chamado de dentro do callback de `vi.mock`, que
 // SÓ roda quando o módulo mockado é de fato importado (bem depois de todo o
 // topo do arquivo, imports inclusive, já ter executado).
+//
+// Um mock GLOBAL via `vitest.config.ts` (setupFiles) foi cogitado e
+// descartado: `src/lib/__tests__/auth-effective-member.test.ts` testa a
+// implementação REAL de `getEffectiveMemberId`/`getAuthUser` (só mocka as
+// dependências transitivas — Clerk, supabase/admin — não `@/lib/auth` em
+// si); um `vi.mock("@/lib/auth", ...)` em setupFiles substituiria esse
+// módulo incondicionalmente para TODOS os arquivos, quebrando esse teste.
+// A duplicação do par vi.hoisted/vi.mock nos poucos arquivos que precisam de
+// override por teste é o preço de não ter um mock global de auth no repo.
 export function authModuleMock(isCoord: () => Promise<boolean>, userId = "userCoord") {
   return {
     getAuthUser: async () => ({ id: userId }),

--- a/frontend/src/test-utils/comparison-fixtures.ts
+++ b/frontend/src/test-utils/comparison-fixtures.ts
@@ -1,0 +1,61 @@
+import type { PydanticField } from "@/lib/types";
+
+// Hash do schema corrente. scanComparisonBacklog/createAutoComparisonIfDiverges/
+// syncCompareAssignment aplicam o piso vivo `latest_major` (#247): respostas de
+// versão antiga (hash != atual, semver abaixo do piso) são descartadas da
+// contagem de divergência. Fixtures default usam este hash com semver NULL
+// para qualificar pelo caminho de fallback por hash em
+// responseQualifiesForVersion.
+export const CURRENT_HASH = "hash-atual";
+
+const DEFAULT_FIELDS: PydanticField[] = [
+  { name: "q1", type: "text", options: null, description: "", required: true },
+];
+
+export function makeProjectRow(over: Record<string, unknown> = {}) {
+  return {
+    id: "p1",
+    pydantic_fields: DEFAULT_FIELDS,
+    pydantic_hash: CURRENT_HASH,
+    min_responses_for_comparison: 2,
+    comparison_includes_llm: true,
+    automation_mode: "compare_humans",
+    schema_version_major: null,
+    schema_version_minor: null,
+    schema_version_patch: null,
+    ...over,
+  };
+}
+
+// Resposta humana qualificada na versão corrente (hash atual, semver NULL).
+// `extra` sobrescreve qualquer campo — incluindo document_id/pydantic_hash/
+// schema_version_* — para emular rodadas antigas ou docs alternativos.
+export function makeHumanResponse(
+  respondentId: string,
+  q1: string,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    id: `r-${respondentId}`,
+    project_id: "p1",
+    document_id: "doc1",
+    respondent_id: respondentId,
+    respondent_type: "humano",
+    is_latest: true,
+    answers: { q1 },
+    answer_field_hashes: null,
+    pydantic_hash: CURRENT_HASH,
+    schema_version_major: null,
+    schema_version_minor: null,
+    schema_version_patch: null,
+    // Chaves do filtro de embed `documents!inner` (fora-de-escopo): o mock
+    // filter-aware compara r["documents.excluded_at"] literalmente.
+    "documents.excluded_at": null,
+    "documents.exclusion_pending_at": null,
+    ...extra,
+  };
+}
+
+export function makeProjectMember(userId: string) {
+  return { user_id: userId, project_id: "p1", can_compare: true };
+}

--- a/frontend/src/test-utils/supabase-mock.ts
+++ b/frontend/src/test-utils/supabase-mock.ts
@@ -1,0 +1,144 @@
+// Mocks chainable do client Supabase compartilhados entre os testes do
+// cluster retry/comparison (arbitration-retry, comparisons-retry,
+// auto-comparison, compare-sync). Extraído dos mocks duplicados desses 4
+// arquivos (#387). Não é coletado pelo vitest (include cobre apenas
+// *.test.ts). Não confundir com `actions/__tests__/supabase-mock.ts`
+// (`makeSupabaseMock`), que serve outro conjunto de testes e não é
+// filter-aware — mantido separado de propósito.
+
+export type WriteCall = { table: string; op: string; payload: unknown };
+
+export function callsOf(
+  writeCalls: WriteCall[],
+  op: string,
+  table?: string,
+): WriteCall[] {
+  return writeCalls.filter((c) => c.op === op && (!table || c.table === table));
+}
+
+// Mock filter-aware: aplica eq/neq/is/in/limit às linhas de state.tableData[table]
+// e registra writes em state.writeCalls. Usado por comparisons-retry.test.ts,
+// auto-comparison.test.ts e compare-sync.test.ts. `state` deve ser passado como
+// objeto fresco a cada chamada de makeClient() local (não memoizar), para
+// sempre refletir os valores atuais de `let tableData`/`let writeCalls` do
+// arquivo de teste — que são reatribuídos por inteiro no beforeEach.
+export function makeFilterAwareSupabaseMock(state: {
+  tableData: Record<string, unknown[]>;
+  writeCalls: WriteCall[];
+}) {
+  return {
+    from: (table: string) => {
+      const eqs: Array<[string, unknown]> = [];
+      const neqs: Array<[string, unknown]> = [];
+      const ins: Array<[string, unknown[]]> = [];
+      let op = "select";
+      let limitN: number | null = null;
+      const builder: Record<string, unknown> = {};
+      builder.select = () => builder;
+      builder.eq = (c: string, v: unknown) => {
+        eqs.push([c, v]);
+        return builder;
+      };
+      builder.neq = (c: string, v: unknown) => {
+        neqs.push([c, v]);
+        return builder;
+      };
+      builder.is = (c: string, v: unknown) => {
+        eqs.push([c, v]);
+        return builder;
+      };
+      builder.in = (c: string, v: unknown[]) => {
+        ins.push([c, v]);
+        return builder;
+      };
+      builder.limit = (n: number) => {
+        limitN = n;
+        return builder;
+      };
+      builder.update = (payload: unknown) => {
+        state.writeCalls.push({ table, op: "update", payload });
+        op = "update";
+        return builder;
+      };
+      builder.upsert = (payload: unknown) => {
+        state.writeCalls.push({ table, op: "upsert", payload });
+        op = "upsert";
+        return builder;
+      };
+      builder.insert = (payload: unknown) => {
+        state.writeCalls.push({ table, op: "insert", payload });
+        op = "insert";
+        return builder;
+      };
+      builder.delete = () => {
+        state.writeCalls.push({ table, op: "delete", payload: null });
+        op = "delete";
+        return builder;
+      };
+      const rows = () => {
+        const data = (state.tableData[table] ?? []) as Array<
+          Record<string, unknown>
+        >;
+        const filtered = data.filter((r) => {
+          for (const [c, v] of eqs) if (r[c] !== v) return false;
+          for (const [c, v] of neqs) if (r[c] === v) return false;
+          for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
+          return true;
+        });
+        return limitN != null ? filtered.slice(0, limitN) : filtered;
+      };
+      const err = () => state.tableData[`__error:${table}:${op}`] ?? null;
+      builder.single = () =>
+        Promise.resolve({ data: rows()[0] ?? null, error: err() });
+      builder.maybeSingle = () =>
+        Promise.resolve({ data: rows()[0] ?? null, error: err() });
+      builder.then = (resolve: (v: unknown) => unknown) =>
+        resolve({ data: rows(), error: err() });
+      return builder;
+    },
+  };
+}
+
+// Variante simples (ignora filtros .eq/.is/.in/.neq/.limit — resolve por
+// chave de tabela inteira, com fallback para chave sufixada pela operação).
+// Usada só por arbitration-retry.test.ts.
+export function makeSimpleSupabaseMock(state: {
+  tableData: Record<string, unknown>;
+  writeCalls: WriteCall[];
+}) {
+  return {
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      let op = "select";
+      for (const m of ["select", "eq", "is", "in", "neq", "limit"]) {
+        builder[m] = () => builder;
+      }
+      builder.update = (payload: unknown) => {
+        state.writeCalls.push({ table, op: "update", payload });
+        op = "update";
+        return builder;
+      };
+      builder.upsert = (payload: unknown) => {
+        state.writeCalls.push({ table, op: "upsert", payload });
+        op = "upsert";
+        return builder;
+      };
+      builder.insert = (payload: unknown) => {
+        state.writeCalls.push({ table, op: "insert", payload });
+        op = "insert";
+        return builder;
+      };
+      builder.delete = () => {
+        state.writeCalls.push({ table, op: "delete", payload: null });
+        op = "delete";
+        return builder;
+      };
+      builder.then = (resolve: (v: unknown) => unknown) =>
+        resolve({
+          data: state.tableData[`${table}:${op}`] ?? state.tableData[table] ?? null,
+          error: state.tableData[`__error:${table}:${op}`] ?? null,
+        });
+      return builder;
+    },
+  };
+}

--- a/frontend/src/test-utils/supabase-mock.ts
+++ b/frontend/src/test-utils/supabase-mock.ts
@@ -16,6 +16,40 @@ export function callsOf(
   return writeCalls.filter((c) => c.op === op && (!table || c.table === table));
 }
 
+// Rastreia a última operação de escrita (update/upsert/insert/delete) por
+// referência mutável, para que os dois mocks abaixo possam expor o `op`
+// corrente ao restante do builder (chave de erro, fallback de leitura) sem
+// duplicar os quatro métodos de escrita entre si.
+type OpRef = { current: string };
+
+function attachWriteOps(
+  builder: Record<string, unknown>,
+  table: string,
+  writeCalls: WriteCall[],
+  opRef: OpRef,
+) {
+  builder.update = (payload: unknown) => {
+    writeCalls.push({ table, op: "update", payload });
+    opRef.current = "update";
+    return builder;
+  };
+  builder.upsert = (payload: unknown) => {
+    writeCalls.push({ table, op: "upsert", payload });
+    opRef.current = "upsert";
+    return builder;
+  };
+  builder.insert = (payload: unknown) => {
+    writeCalls.push({ table, op: "insert", payload });
+    opRef.current = "insert";
+    return builder;
+  };
+  builder.delete = () => {
+    writeCalls.push({ table, op: "delete", payload: null });
+    opRef.current = "delete";
+    return builder;
+  };
+}
+
 // Mock filter-aware: aplica eq/neq/is/in/limit às linhas de state.tableData[table]
 // e registra writes em state.writeCalls. Usado por comparisons-retry.test.ts,
 // auto-comparison.test.ts e compare-sync.test.ts. `state` deve ser passado como
@@ -31,7 +65,7 @@ export function makeFilterAwareSupabaseMock(state: {
       const eqs: Array<[string, unknown]> = [];
       const neqs: Array<[string, unknown]> = [];
       const ins: Array<[string, unknown[]]> = [];
-      let op = "select";
+      const opRef: OpRef = { current: "select" };
       let limitN: number | null = null;
       const builder: Record<string, unknown> = {};
       builder.select = () => builder;
@@ -55,26 +89,7 @@ export function makeFilterAwareSupabaseMock(state: {
         limitN = n;
         return builder;
       };
-      builder.update = (payload: unknown) => {
-        state.writeCalls.push({ table, op: "update", payload });
-        op = "update";
-        return builder;
-      };
-      builder.upsert = (payload: unknown) => {
-        state.writeCalls.push({ table, op: "upsert", payload });
-        op = "upsert";
-        return builder;
-      };
-      builder.insert = (payload: unknown) => {
-        state.writeCalls.push({ table, op: "insert", payload });
-        op = "insert";
-        return builder;
-      };
-      builder.delete = () => {
-        state.writeCalls.push({ table, op: "delete", payload: null });
-        op = "delete";
-        return builder;
-      };
+      attachWriteOps(builder, table, state.writeCalls, opRef);
       const rows = () => {
         const data = (state.tableData[table] ?? []) as Array<
           Record<string, unknown>
@@ -87,7 +102,7 @@ export function makeFilterAwareSupabaseMock(state: {
         });
         return limitN != null ? filtered.slice(0, limitN) : filtered;
       };
-      const err = () => state.tableData[`__error:${table}:${op}`] ?? null;
+      const err = () => state.tableData[`__error:${table}:${opRef.current}`] ?? null;
       builder.single = () =>
         Promise.resolve({ data: rows()[0] ?? null, error: err() });
       builder.maybeSingle = () =>
@@ -109,34 +124,18 @@ export function makeSimpleSupabaseMock(state: {
   return {
     from: (table: string) => {
       const builder: Record<string, unknown> = {};
-      let op = "select";
+      const opRef: OpRef = { current: "select" };
       for (const m of ["select", "eq", "is", "in", "neq", "limit"]) {
         builder[m] = () => builder;
       }
-      builder.update = (payload: unknown) => {
-        state.writeCalls.push({ table, op: "update", payload });
-        op = "update";
-        return builder;
-      };
-      builder.upsert = (payload: unknown) => {
-        state.writeCalls.push({ table, op: "upsert", payload });
-        op = "upsert";
-        return builder;
-      };
-      builder.insert = (payload: unknown) => {
-        state.writeCalls.push({ table, op: "insert", payload });
-        op = "insert";
-        return builder;
-      };
-      builder.delete = () => {
-        state.writeCalls.push({ table, op: "delete", payload: null });
-        op = "delete";
-        return builder;
-      };
+      attachWriteOps(builder, table, state.writeCalls, opRef);
       builder.then = (resolve: (v: unknown) => unknown) =>
         resolve({
-          data: state.tableData[`${table}:${op}`] ?? state.tableData[table] ?? null,
-          error: state.tableData[`__error:${table}:${op}`] ?? null,
+          data:
+            state.tableData[`${table}:${opRef.current}`] ??
+            state.tableData[table] ??
+            null,
+          error: state.tableData[`__error:${table}:${opRef.current}`] ?? null,
         });
       return builder;
     },


### PR DESCRIPTION
## Resumo

Parte da epic #376 (onda duplicação do `fallow`). Extrai os mocks/fixtures duplicados entre os 4 testes do cluster retry/comparison para `frontend/src/test-utils/`:

- **`supabase-mock.ts`**: `makeFilterAwareSupabaseMock` (usado por `comparisons-retry`, `auto-comparison`, `compare-sync`) e `makeSimpleSupabaseMock` (usado só por `arbitration-retry`), mais `callsOf`/`WriteCall` compartilhados.
- **`auth-mock.ts`**: `authModuleMock`, o corpo do mock de `@/lib/auth` para checagem de coordenador.
- **`comparison-fixtures.ts`**: `CURRENT_HASH`, `makeProjectRow`, `makeHumanResponse`, `makeProjectMember`.

Não toca em `frontend/src/actions/__tests__/supabase-mock.ts` (helper existente, usado por 6 outros testes — não é filter-aware, semântica diferente, fora de escopo).

## Achado extra

Durante a migração de `auto-comparison.test.ts`, identifiquei que o bloco de mock de `@/lib/auth` (`vi.hoisted(isCoord)` + `vi.mock("@/lib/auth", ...)`) era código morto: `auto-comparison.ts` nunca importa `@/lib/auth` (é lib pura, recebe o client Supabase por parâmetro) e nenhum teste do arquivo exercitava o guard de coordenador. Removido nesta mesma PR.

## Resultado no fallow

Os 2 maiores clusters apontados na issue desaparecem do relatório:
- `comparisons-retry.test.ts` × `auto-comparison.test.ts` (4 grupos, 126 linhas — o maior)
- `comparisons-retry.test.ts` × `auto-comparison.test.ts` × `compare-sync.test.ts` (2 grupos, 16 linhas)

O cluster menor (`arbitration-retry.test.ts` × `comparisons-retry.test.ts`, ~45-49 linhas — boilerplate de `vi.hoisted`/`vi.mock` do auth mock + wrappers `callsOf`) permanece: confirmei durante a implementação que `vi.hoisted(() => algumaFuncaoImportada())` quebra em runtime (`Cannot access '...' before initialization`), porque `vi.hoisted` executa seu callback imediatamente na posição hoisted do Vitest, acima dos bindings de import transpilados — só o corpo da factory (lazy, dentro de `vi.mock`) pode delegar para um helper importado com segurança. Documentado como decisão consciente de escopo (issue já pedia reduzir o pior, não zerar tudo).

## Test plan

- [x] `npx vitest run` — suíte completa (96 arquivos / 948 testes) verde
- [x] `npm run typecheck` limpo
- [x] `npm run lint` sem novos erros (os 9 problemas remanescentes são débito pré-existente em `useStableListIds.ts`/#382, `schema.ts`, `useCachedResource.test.ts` — nenhum arquivo tocado por esta PR)
- [x] `npm run fallow` confirmando a eliminação dos 2 maiores clusters
- [x] Pre-push hooks (typecheck, vitest full suite, lint:types, fallow audit new-only, semgrep) passaram no `git push`

Closes #387