### PR TITLE
fix(compare): fila de coordenador passa a ser "meus atribuídos" por padrão

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -99,12 +99,19 @@ export default async function ComparePageRoute({
   // detection on the server and for fusing answer cards on the client.
   const equivByDocField = buildEquivalenceMap(allEquivalences);
 
-  // Fail-CLOSED (ao contrario de comments/llm-insights): isCoordinator decide
-  // quais documentos aparecem na fila — um nao-coordenador ve so os atribuidos a
-  // si (compareAssignedDocIds). A policy RLS deixa qualquer membro ler todas as
-  // responses, entao esse recorte e so aplicacional; fail-open exporia
-  // documentos/respostas de terceiros em erro transitorio.
+  // Fail-CLOSED (ao contrario de comments/llm-insights): showAllQueue decide
+  // quais documentos aparecem na fila — quem não pediu "todos" ve so os
+  // atribuidos a si (compareAssignedDocIds). A policy RLS deixa qualquer
+  // membro ler todas as responses, entao esse recorte e so aplicacional;
+  // fail-open exporia documentos/respostas de terceiros em erro transitorio.
   const isCoordinator = coordinatorGate(access, { failOpen: false });
+
+  // Coordenador também compara documentos (não só supervisiona) — por isso o
+  // padrão é a fila pessoal dele, igual pesquisador. "Todos" é uma escolha
+  // explícita via aba/param `queue=all`, só alcançável por coordenador (um
+  // não-coordenador nunca chega a showAllQueue=true, mesmo editando a URL).
+  const queueParam = sp.queue;
+  const showAllQueue = isCoordinator && queueParam === "all";
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];
 
@@ -142,8 +149,8 @@ export default async function ComparePageRoute({
   const availableVersions = buildAvailableVersions(versionLog, allResponses);
   const latestMajorLabel = formatVersion(latestMajorAnchor(projectVersion));
 
-  // Compare-type assignments filter for researchers (ver assignedCompareDocIds).
-  const compareAssignedDocIds = assignedCompareDocIds(isCoordinator, allAssignments, user.id);
+  // Compare-type assignments filter (ver assignedCompareDocIds).
+  const compareAssignedDocIds = assignedCompareDocIds(showAllQueue, allAssignments, user.id);
 
   // Coding-type assignments map per doc (denominator for % atribuídos)
   const codingAssignedByDoc = buildCodingAssignedByDoc(allAssignments);
@@ -151,7 +158,7 @@ export default async function ComparePageRoute({
   // Status per user-doc for compare assignment (used in list and panel)
   const compareAssignmentStatusByDoc = buildCompareAssignmentStatusByDoc(
     allAssignments,
-    isCoordinator,
+    showAllQueue,
     user.id,
   );
 
@@ -256,6 +263,8 @@ export default async function ComparePageRoute({
         equivalencesByDocField={equivalencesByDocField}
         currentUserId={user.id}
         canManageAnyPair={isCoordinator}
+        isCoordinator={isCoordinator}
+        showingAllQueue={showAllQueue}
       />
     </Suspense>
   );

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -8,6 +8,7 @@ import {
   readCompareFilters,
   compareDefaultsForMode,
   assignedCompareDocIds,
+  resolveShowAllQueue,
 } from "@/lib/compare-filters";
 import {
   deriveProjectVersionContext,
@@ -110,8 +111,9 @@ export default async function ComparePageRoute({
   // padrão é a fila pessoal dele, igual pesquisador. "Todos" é uma escolha
   // explícita via aba/param `queue=all`, só alcançável por coordenador (um
   // não-coordenador nunca chega a showAllQueue=true, mesmo editando a URL).
-  const queueParam = sp.queue;
-  const showAllQueue = isCoordinator && queueParam === "all";
+  // resolveShowAllQueue é testada isoladamente (ver compare-filters.test.ts) —
+  // é a mesma classe de expressão que já causou o bug original desta página.
+  const showAllQueue = resolveShowAllQueue(isCoordinator, sp.queue);
 
   const fields = (project?.pydantic_fields || []) as PydanticField[];
 
@@ -151,6 +153,13 @@ export default async function ComparePageRoute({
 
   // Compare-type assignments filter (ver assignedCompareDocIds).
   const compareAssignedDocIds = assignedCompareDocIds(showAllQueue, allAssignments, user.id);
+
+  // Distingue "sem nada atribuído" de "tem atribuído, mas foi filtrado por
+  // cobertura/divergência" — usado só pela mensagem de estado vazio em
+  // ComparePage (trocar de aba não resolve o segundo caso). Só é não-null
+  // quando showAllQueue=false (aba "Meus"), que é justamente quando a
+  // mensagem é exibida.
+  const hasAssignedDocs = (compareAssignedDocIds?.size ?? 0) > 0;
 
   // Coding-type assignments map per doc (denominator for % atribuídos)
   const codingAssignedByDoc = buildCodingAssignedByDoc(allAssignments);
@@ -265,6 +274,7 @@ export default async function ComparePageRoute({
         canManageAnyPair={isCoordinator}
         isCoordinator={isCoordinator}
         showingAllQueue={showAllQueue}
+        hasAssignedDocs={hasAssignedDocs}
       />
     </Suspense>
   );

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 import { FullscreenNav } from "../coding/FullscreenNav";
 import { CompareNav } from "./CompareNav";
-import { CompareQueueTabs } from "./CompareQueueTabs";
+import { CompareQueueTabs, type CompareQueueScope } from "./CompareQueueTabs";
 import { CompareDocList, type DocListEntry } from "./CompareDocList";
 import { CompareWorkspace } from "./CompareWorkspace";
 import { useCompareReviews } from "./useCompareReviews";
@@ -12,6 +12,7 @@ import { useStableDocOrder } from "./useStableDocOrder";
 import { useCompareFieldData } from "./useCompareFieldData";
 import { useCompareVerdicts } from "./useCompareVerdicts";
 import { useCompareKeyboard } from "./useCompareKeyboard";
+import { useUrlState } from "@/hooks/useUrlState";
 import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import type { DocCoverage } from "@/app/(app)/projects/[id]/analyze/compare/page";
@@ -54,10 +55,15 @@ interface ComparePageProps {
   // "Meus atribuídos" / "Todos" — coordenador também compara documentos, por
   // isso o padrão é a fila pessoal dele, igual pesquisador.
   isCoordinator: boolean;
-  // Valor efetivo (resolvido no servidor) da aba de fila atual — usado só
-  // para escolher a mensagem do estado vazio; a aba em si é controlada pela
-  // própria CompareQueueTabs via URL.
+  // Valor efetivo (resolvido no servidor) da aba de fila atual — fonte única
+  // pro valor exibido em CompareQueueTabs (evita reler a URL no cliente) e
+  // pra mensagem do estado vazio.
   showingAllQueue: boolean;
+  // Se o coordenador TEM documentos atribuídos a ele para comparação (mesmo
+  // que nenhum tenha passado nos filtros de cobertura/divergência) — usado só
+  // pra diferenciar a mensagem de estado vazio: "sem nada atribuído" (trocar
+  // de aba resolve) vs. "atribuído mas filtrado" (trocar de aba não resolve).
+  hasAssignedDocs: boolean;
 }
 
 export function ComparePage({
@@ -82,13 +88,28 @@ export function ComparePage({
   canManageAnyPair,
   isCoordinator,
   showingAllQueue,
+  hasAssignedDocs,
 }: ComparePageProps) {
   // Ordem estável de montagem: o re-sort por pendências do servidor (a cada
   // veredito) não remexe a fila nem a sidebar — só mudança de composição
-  // (filtro/exclusão) altera a ordem. Ver useStableDocOrder.
-  const documents = useStableDocOrder(serverDocuments);
+  // (filtro/exclusão) altera a ordem. `showingAllQueue` como resetKey: ao
+  // trocar de ESCOPO de fila (Meus↔Todos), a ordem nasce do zero em vez de
+  // manter os docs da fila pessoal presos no topo. Ver useStableDocOrder.
+  const documents = useStableDocOrder(serverDocuments, showingAllQueue);
 
   const { localReviews, recordReview } = useCompareReviews(existingReviews);
+
+  // Única leitura/escrita da URL pro toggle de fila — CompareQueueTabs é só
+  // JSX controlado (mesmo padrão de CodingHeader). O valor exibido vem
+  // direto de `showingAllQueue` (já resolvido no servidor, fail-closed) em
+  // vez de re-derivar `queue === "all"` no cliente.
+  const { set: setUrlState } = useUrlState();
+  const queueValue: CompareQueueScope = showingAllQueue ? "all" : "mine";
+  const handleQueueChange = useCallback(
+    (value: CompareQueueScope) =>
+      setUrlState({ queue: value === "all" ? "all" : null }),
+    [setUrlState],
+  );
 
   const {
     docIndex,
@@ -109,7 +130,13 @@ export function ComparePage({
     handleNextDoc,
     goNextField,
     goPrevField,
-  } = useCompareNavigation({ documents, divergentFields, fields, localReviews });
+  } = useCompareNavigation({
+    documents,
+    divergentFields,
+    fields,
+    localReviews,
+    resetKey: showingAllQueue,
+  });
 
   const {
     fieldResponses,
@@ -219,14 +246,34 @@ export function ComparePage({
     };
   });
 
+  // Bar do toggle de fila, compartilhada pelos dois branches de return
+  // abaixo (estado vazio e visão completa) — só coordenador vê.
+  const queueTabsBar = isCoordinator ? (
+    <div className="flex h-9 shrink-0 items-center gap-2 border-b px-3">
+      <CompareQueueTabs value={queueValue} onValueChange={handleQueueChange} />
+    </div>
+  ) : null;
+
   if (!currentDoc || docFields.length === 0) {
+    // documents.length===0 na aba "Meus" pode ter duas causas bem diferentes:
+    // (a) o coordenador não tem NENHUM documento atribuído — trocar pra
+    // "Todos" resolve; (b) ele TEM documentos atribuídos, mas nenhum passou
+    // nos filtros de cobertura/divergência (minHumans/minTotal/versão/etc.)
+    // — trocar de aba não muda nada, o filtro de cobertura é ortogonal ao
+    // de assignment. `hasAssignedDocs` (calculado em page.tsx a partir do
+    // mesmo Set que já filtra a fila) diferencia os dois casos.
+    const emptyMessage =
+      documents.length === 0
+        ? isCoordinator && !showingAllQueue
+          ? hasAssignedDocs
+            ? "Seus documentos atribuídos não atendem aos filtros atuais (respostas mínimas, versão, etc.). Ajuste os filtros ou use a aba \"Todos\" para ver a fila completa."
+            : 'Você não tem documentos atribuídos para comparação. Use a aba "Todos" acima para ver a fila completa do projeto.'
+          : "Nenhum documento na fila com os filtros atuais."
+        : "Nenhuma divergência neste documento.";
+
     return (
       <div className="flex h-[calc(100vh-96px)] flex-col">
-        {isCoordinator && (
-          <div className="flex h-9 shrink-0 items-center gap-2 border-b px-3">
-            <CompareQueueTabs />
-          </div>
-        )}
+        {queueTabsBar}
         <div className="flex flex-1 w-full">
           <CompareDocList
             docs={docListEntries}
@@ -236,11 +283,7 @@ export function ComparePage({
             onToggle={toggleList}
           />
           <div className="flex flex-1 items-center justify-center text-muted-foreground">
-            {documents.length === 0
-              ? isCoordinator && !showingAllQueue
-                ? 'Você não tem documentos atribuídos para comparação. Use a aba "Todos" acima para ver a fila completa do projeto.'
-                : "Nenhum documento na fila com os filtros atuais."
-              : "Nenhuma divergência neste documento."}
+            {emptyMessage}
           </div>
         </div>
       </div>
@@ -264,11 +307,7 @@ export function ComparePage({
           : "flex h-[calc(100vh-96px)] flex-col"
       }
     >
-      {!isFullscreen && isCoordinator && (
-        <div className="flex h-9 shrink-0 items-center gap-2 border-b px-3">
-          <CompareQueueTabs />
-        </div>
-      )}
+      {!isFullscreen && queueTabsBar}
 
       {isFullscreen ? (
         <FullscreenNav

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 import { FullscreenNav } from "../coding/FullscreenNav";
 import { CompareNav } from "./CompareNav";
+import { CompareQueueTabs } from "./CompareQueueTabs";
 import { CompareDocList, type DocListEntry } from "./CompareDocList";
 import { CompareWorkspace } from "./CompareWorkspace";
 import { useCompareReviews } from "./useCompareReviews";
@@ -48,6 +49,15 @@ interface ComparePageProps {
   >;
   currentUserId: string;
   canManageAnyPair: boolean;
+  // Distinto de canManageAnyPair (permissão de ação sobre pares de
+  // equivalência): isCoordinator só gateia a exibição do toggle de fila
+  // "Meus atribuídos" / "Todos" — coordenador também compara documentos, por
+  // isso o padrão é a fila pessoal dele, igual pesquisador.
+  isCoordinator: boolean;
+  // Valor efetivo (resolvido no servidor) da aba de fila atual — usado só
+  // para escolher a mensagem do estado vazio; a aba em si é controlada pela
+  // própria CompareQueueTabs via URL.
+  showingAllQueue: boolean;
 }
 
 export function ComparePage({
@@ -70,6 +80,8 @@ export function ComparePage({
   equivalencesByDocField,
   currentUserId,
   canManageAnyPair,
+  isCoordinator,
+  showingAllQueue,
 }: ComparePageProps) {
   // Ordem estável de montagem: o re-sort por pendências do servidor (a cada
   // veredito) não remexe a fila nem a sidebar — só mudança de composição
@@ -209,18 +221,27 @@ export function ComparePage({
 
   if (!currentDoc || docFields.length === 0) {
     return (
-      <div className="flex h-[calc(100vh-96px)] w-full">
-        <CompareDocList
-          docs={docListEntries}
-          currentIndex={docIndex}
-          onSelect={handleDocNavigate}
-          collapsed={listCollapsed}
-          onToggle={toggleList}
-        />
-        <div className="flex flex-1 items-center justify-center text-muted-foreground">
-          {documents.length === 0
-            ? "Nenhum documento na fila com os filtros atuais."
-            : "Nenhuma divergência neste documento."}
+      <div className="flex h-[calc(100vh-96px)] flex-col">
+        {isCoordinator && (
+          <div className="flex h-9 shrink-0 items-center gap-2 border-b px-3">
+            <CompareQueueTabs />
+          </div>
+        )}
+        <div className="flex flex-1 w-full">
+          <CompareDocList
+            docs={docListEntries}
+            currentIndex={docIndex}
+            onSelect={handleDocNavigate}
+            collapsed={listCollapsed}
+            onToggle={toggleList}
+          />
+          <div className="flex flex-1 items-center justify-center text-muted-foreground">
+            {documents.length === 0
+              ? isCoordinator && !showingAllQueue
+                ? 'Você não tem documentos atribuídos para comparação. Use a aba "Todos" acima para ver a fila completa do projeto.'
+                : "Nenhum documento na fila com os filtros atuais."
+              : "Nenhuma divergência neste documento."}
+          </div>
         </div>
       </div>
     );
@@ -243,6 +264,12 @@ export function ComparePage({
           : "flex h-[calc(100vh-96px)] flex-col"
       }
     >
+      {!isFullscreen && isCoordinator && (
+        <div className="flex h-9 shrink-0 items-center gap-2 border-b px-3">
+          <CompareQueueTabs />
+        </div>
+      )}
+
       {isFullscreen ? (
         <FullscreenNav
           title={docTitle}

--- a/frontend/src/components/compare/CompareQueueTabs.tsx
+++ b/frontend/src/components/compare/CompareQueueTabs.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useUrlState } from "@/hooks/useUrlState";
+
+/**
+ * Alterna a fila de Comparação entre "Meus atribuídos" (padrão) e "Todos" —
+ * só renderizado para coordenador (gate no caller). "Meus" é o valor
+ * ausente/default na URL para manter o link limpo; "Todos" só é alcançado
+ * com `?queue=all` explícito, mesmo padrão de RoundSelect (CodingHeader).
+ */
+export function CompareQueueTabs() {
+  const { get, set } = useUrlState();
+  const queue = get("queue") === "all" ? "all" : "mine";
+
+  return (
+    <Tabs
+      value={queue}
+      onValueChange={(v) => set({ queue: v === "all" ? "all" : null })}
+    >
+      <TabsList className="h-7">
+        <TabsTrigger value="mine" className="h-6 text-xs">
+          Meus atribuídos
+        </TabsTrigger>
+        <TabsTrigger value="all" className="h-6 text-xs">
+          Todos
+        </TabsTrigger>
+      </TabsList>
+    </Tabs>
+  );
+}

--- a/frontend/src/components/compare/CompareQueueTabs.tsx
+++ b/frontend/src/components/compare/CompareQueueTabs.tsx
@@ -1,23 +1,24 @@
 "use client";
 
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { useUrlState } from "@/hooks/useUrlState";
+
+export type CompareQueueScope = "mine" | "all";
+
+interface CompareQueueTabsProps {
+  value: CompareQueueScope;
+  onValueChange: (value: CompareQueueScope) => void;
+}
 
 /**
  * Alterna a fila de Comparação entre "Meus atribuídos" (padrão) e "Todos" —
- * só renderizado para coordenador (gate no caller). "Meus" é o valor
- * ausente/default na URL para manter o link limpo; "Todos" só é alcançado
- * com `?queue=all` explícito, mesmo padrão de RoundSelect (CodingHeader).
+ * só renderizado para coordenador (gate no caller). Controlado pelo pai
+ * (ComparePage), que detém a leitura/escrita da URL via useUrlState — mesmo
+ * padrão de CodingHeader (`mode`/`onModeChange` como props puras), em vez de
+ * cada instância deste componente (é montado 2x) ler a URL por conta própria.
  */
-export function CompareQueueTabs() {
-  const { get, set } = useUrlState();
-  const queue = get("queue") === "all" ? "all" : "mine";
-
+export function CompareQueueTabs({ value, onValueChange }: CompareQueueTabsProps) {
   return (
-    <Tabs
-      value={queue}
-      onValueChange={(v) => set({ queue: v === "all" ? "all" : null })}
-    >
+    <Tabs value={value} onValueChange={(v) => onValueChange(v as CompareQueueScope)}>
       <TabsList className="h-7">
         <TabsTrigger value="mine" className="h-6 text-xs">
           Meus atribuídos

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -115,6 +115,7 @@ const props = {
   canManageAnyPair: false,
   isCoordinator: false,
   showingAllQueue: false,
+  hasAssignedDocs: false,
 };
 
 const renderReal = () =>
@@ -162,5 +163,15 @@ describe("ComparePage — árvore real (smoke)", () => {
       undefined,
       expect.any(Array),
     );
+  });
+
+  it("coordenador vê o toggle de fila real (CompareQueueTabs) montado", () => {
+    render(
+      <TooltipProvider>
+        <ComparePage {...props} isCoordinator canManageAnyPair />
+      </TooltipProvider>,
+    );
+    expect(screen.getByRole("tab", { name: "Meus atribuídos" })).not.toBeNull();
+    expect(screen.getByRole("tab", { name: "Todos" })).not.toBeNull();
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -113,6 +113,8 @@ const props = {
   equivalencesByDocField: {},
   currentUserId: "u1",
   canManageAnyPair: false,
+  isCoordinator: false,
+  showingAllQueue: false,
 };
 
 const renderReal = () =>

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -22,6 +22,11 @@ vi.mock("@/actions/equivalences", () => ({
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
 }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/analyze/compare",
+}));
 
 // Mock das views: expõem só os controles necessários para dirigir a lógica do
 // container. NÃO testam o render dos filhos reais (CompareNav/ComparisonPanel/
@@ -212,6 +217,7 @@ function makeProps(existingReviews: ReviewsByDoc = {}) {
     canManageAnyPair: false,
     isCoordinator: false,
     showingAllQueue: false,
+    hasAssignedDocs: false,
   };
 }
 
@@ -501,5 +507,76 @@ describe("ComparePage — vereditos e equivalências (useCompareVerdicts)", () =
     await user.click(screen.getByTestId("mark-reviewed"));
 
     expect(markCompareDocReviewed).toHaveBeenCalledWith("p1", "d1");
+  });
+});
+
+// Antes deste PR, nenhum teste deste arquivo exercitava isCoordinator: true —
+// a bar do toggle e a diferenciação da mensagem de estado vazio ficavam sem
+// cobertura direta.
+describe("ComparePage — toggle de fila (só coordenador)", () => {
+  function emptyProps(overrides: Partial<ReturnType<typeof makeProps>> = {}) {
+    return {
+      ...makeProps(),
+      documents: [],
+      divergentFields: {},
+      responses: {},
+      coverageByDoc: {},
+      ...overrides,
+    };
+  }
+
+  it("não-coordenador nunca vê o toggle de fila", () => {
+    render(<ComparePage {...emptyProps({ isCoordinator: false })} />);
+    expect(screen.queryByRole("tab", { name: "Meus atribuídos" })).toBeNull();
+  });
+
+  it("coordenador vê o toggle de fila", () => {
+    render(<ComparePage {...emptyProps({ isCoordinator: true })} />);
+    expect(screen.getByRole("tab", { name: "Meus atribuídos" })).not.toBeNull();
+    expect(screen.getByRole("tab", { name: "Todos" })).not.toBeNull();
+  });
+
+  it("sem nenhum documento atribuído: mensagem sugere a aba 'Todos'", () => {
+    render(
+      <ComparePage
+        {...emptyProps({
+          isCoordinator: true,
+          showingAllQueue: false,
+          hasAssignedDocs: false,
+        })}
+      />,
+    );
+    expect(
+      screen.getByText(/Você não tem documentos atribuídos.*aba "Todos"/),
+    ).not.toBeNull();
+  });
+
+  it("com documentos atribuídos filtrados por cobertura: mensagem não sugere trocar de aba", () => {
+    render(
+      <ComparePage
+        {...emptyProps({
+          isCoordinator: true,
+          showingAllQueue: false,
+          hasAssignedDocs: true,
+        })}
+      />,
+    );
+    expect(
+      screen.getByText(/não atendem aos filtros atuais/),
+    ).not.toBeNull();
+    expect(
+      screen.queryByText(/Você não tem documentos atribuídos/),
+    ).toBeNull();
+  });
+
+  it("na aba 'Todos', a mensagem genérica não menciona assignment", () => {
+    render(
+      <ComparePage
+        {...emptyProps({ isCoordinator: true, showingAllQueue: true })}
+      />,
+    );
+    expect(
+      screen.getByText("Nenhum documento na fila com os filtros atuais."),
+    ).not.toBeNull();
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -210,6 +210,8 @@ function makeProps(existingReviews: ReviewsByDoc = {}) {
     equivalencesByDocField: {},
     currentUserId: "u1",
     canManageAnyPair: false,
+    isCoordinator: false,
+    showingAllQueue: false,
   };
 }
 

--- a/frontend/src/components/compare/__tests__/CompareQueueTabs.test.tsx
+++ b/frontend/src/components/compare/__tests__/CompareQueueTabs.test.tsx
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CompareQueueTabs } from "@/components/compare/CompareQueueTabs";
+
+afterEach(cleanup);
+
+describe("CompareQueueTabs — toggle controlado (sem estado próprio de URL)", () => {
+  it("reflete `value` na aba ativa", () => {
+    render(<CompareQueueTabs value="mine" onValueChange={vi.fn()} />);
+    expect(
+      screen.getByRole("tab", { name: "Meus atribuídos" }).getAttribute("aria-selected"),
+    ).toBe("true");
+    expect(
+      screen.getByRole("tab", { name: "Todos" }).getAttribute("aria-selected"),
+    ).toBe("false");
+  });
+
+  it("clicar em 'Todos' chama onValueChange('all') sem mexer na URL sozinho", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<CompareQueueTabs value="mine" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("tab", { name: "Todos" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("all");
+  });
+
+  it("clicar em 'Meus atribuídos' chama onValueChange('mine')", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(<CompareQueueTabs value="all" onValueChange={onValueChange} />);
+
+    await user.click(screen.getByRole("tab", { name: "Meus atribuídos" }));
+
+    expect(onValueChange).toHaveBeenCalledWith("mine");
+  });
+});

--- a/frontend/src/components/compare/__tests__/useCompareNavigation.test.ts
+++ b/frontend/src/components/compare/__tests__/useCompareNavigation.test.ts
@@ -9,16 +9,19 @@ import { useCompareNavigation } from "@/components/compare/useCompareNavigation"
 import type { CompareDocument } from "@/components/compare/compare-types";
 import { doc } from "./compare-test-helpers";
 
-function renderNav(documents: CompareDocument[]) {
+type NavHookProps = { documents: CompareDocument[]; resetKey?: boolean };
+
+function renderNav(documents: CompareDocument[], resetKey = false) {
   return renderHook(
-    (props: { documents: CompareDocument[] }) =>
+    (props: NavHookProps) =>
       useCompareNavigation({
         documents: props.documents,
         divergentFields: {},
         fields: [],
         localReviews: {},
+        resetKey: props.resetKey ?? false,
       }),
-    { initialProps: { documents } },
+    { initialProps: { documents, resetKey } as NavHookProps },
   );
 }
 
@@ -87,5 +90,36 @@ describe("useCompareNavigation — pin do doc exibido", () => {
     rerender({ documents: [B, A] });
     expect(result.current.currentDoc?.id).toBe("B");
     expect(result.current.docIndex).toBe(0);
+  });
+
+  // Regressão: alternar a fila de Comparação entre "Meus atribuídos" e
+  // "Todos" (resetKey) troca a composição de `documents` sem que o doc
+  // pinado tenha sido de fato excluído — ele só saiu do recorte que o
+  // usuário estava olhando (segue visível no outro escopo). O toast de
+  // "documento removido" não pode disparar nessa transição.
+  it("resetKey muda: re-pina sem toast, mesmo com o doc pinado sumindo da lista", () => {
+    const A = doc("A");
+    const B = doc("B");
+    const { result, rerender } = renderNav([A, B], false);
+
+    expect(result.current.currentDoc?.id).toBe("A");
+
+    // Troca de escopo: A (visível no escopo anterior) não está mais na lista.
+    rerender({ documents: [B], resetKey: true });
+    expect(result.current.currentDoc?.id).toBe("B");
+    expect(toastInfo).not.toHaveBeenCalled();
+  });
+
+  it("exclusão real dentro do MESMO resetKey continua disparando o toast", () => {
+    const A = doc("A");
+    const B = doc("B");
+    const { result, rerender } = renderNav([A, B], true);
+
+    expect(result.current.currentDoc?.id).toBe("A");
+
+    // Mesmo resetKey (sem troca de escopo) — A saiu de verdade da fila.
+    rerender({ documents: [B], resetKey: true });
+    expect(result.current.currentDoc?.id).toBe("B");
+    expect(toastInfo).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/compare/__tests__/useStableDocOrder.test.ts
+++ b/frontend/src/components/compare/__tests__/useStableDocOrder.test.ts
@@ -8,11 +8,13 @@ import { doc } from "./compare-test-helpers";
 
 const ids = (docs: CompareDocument[]) => docs.map((d) => d.id);
 
-function renderOrder(documents: CompareDocument[]) {
+type OrderHookProps = { documents: CompareDocument[]; resetKey?: boolean };
+
+function renderOrder(documents: CompareDocument[], resetKey = false) {
   return renderHook(
-    (props: { documents: CompareDocument[] }) =>
-      useStableDocOrder(props.documents),
-    { initialProps: { documents } },
+    (props: OrderHookProps) =>
+      useStableDocOrder(props.documents, props.resetKey ?? false),
+    { initialProps: { documents, resetKey } as OrderHookProps },
   );
 }
 
@@ -78,5 +80,30 @@ describe("useStableDocOrder — ordem estável da fila", () => {
 
     rerender({ documents: [B, A] });
     expect(ids(result.current)).toEqual(["B", "A"]);
+  });
+
+  // Regressão: alternar a fila de Comparação entre "Meus atribuídos" e
+  // "Todos" (mesmo componente, sem remount) não pode deixar os docs da fila
+  // pessoal presos no topo da fila "Todos", fora da ordem de prioridade do
+  // servidor — resetKey trata essa troca como composição totalmente nova.
+  it("resetKey muda: ordem nasce do zero, mesmo com docs sobrepostos", () => {
+    const [A, B, C] = [doc("A"), doc("B"), doc("C")];
+    const { result, rerender } = renderOrder([A, B, C], false);
+
+    // Servidor devolve os ~500 docs do projeto (aqui simulados por D, E),
+    // com A-C espalhados fora do topo — a troca de resetKey (mesma composição
+    // OU não) não deve preservar a ordem antiga.
+    rerender({ documents: [doc("D"), A, doc("E"), C, B], resetKey: true });
+
+    expect(ids(result.current)).toEqual(["D", "A", "E", "C", "B"]);
+  });
+
+  it("resetKey igual: comportamento normal de composição é preservado", () => {
+    const [A, B, C] = [doc("A"), doc("B"), doc("C")];
+    const { result, rerender } = renderOrder([A, B, C], true);
+
+    // Mesmo resetKey, servidor reordenou (revalidate) — não deve remexer.
+    rerender({ documents: [C, A, B], resetKey: true });
+    expect(ids(result.current)).toEqual(["A", "B", "C"]);
   });
 });

--- a/frontend/src/components/compare/useCompareNavigation.ts
+++ b/frontend/src/components/compare/useCompareNavigation.ts
@@ -13,6 +13,11 @@ interface UseCompareNavigationParams {
   divergentFields: Record<string, string[]>;
   fields: PydanticField[];
   localReviews: ReviewsByDoc;
+  // Muda quando o usuário troca deliberadamente de ESCOPO de fila (ex.:
+  // "Meus atribuídos" ↔ "Todos" na Comparação), não quando um doc some por
+  // exclusão/filtro real. Usado só para silenciar o toast de "documento
+  // removido" nessa transição específica — ver o useEffect abaixo.
+  resetKey: boolean;
 }
 
 export interface CompareNavigation {
@@ -46,6 +51,7 @@ export function useCompareNavigation({
   divergentFields,
   fields,
   localReviews,
+  resetKey,
 }: UseCompareNavigationParams): CompareNavigation {
   // O pin nasce já apontando para o doc exibido: se ficasse `null` até a
   // primeira navegação explícita (bug #73, caso residual), o fallback
@@ -88,10 +94,21 @@ export function useCompareNavigation({
   // só aqui) guarda o último pin válido do render anterior: se ele deixou de
   // existir em `documents` e o pin corrente já é outro (a re-pinagem acima
   // aconteceu), houve a transição "estava lá → sumiu" — toast uma vez.
+  //
+  // Exceção: se a transição coincide com uma troca de `resetKey` (o usuário
+  // trocou de ESCOPO de fila, ex. "Meus atribuídos" → "Todos"), o doc pinado
+  // não foi excluído/filtrado de verdade — só saiu do recorte que o usuário
+  // estava olhando, e continua visível no outro escopo. `prevResetKeyRef`
+  // rastreia essa troca pra silenciar o toast só nesse ciclo específico; uma
+  // exclusão real dentro do MESMO escopo continua avisando normalmente.
   const lastValidPinnedRef = useRef<string | null>(null);
+  const prevResetKeyRef = useRef(resetKey);
   useEffect(() => {
     const prev = lastValidPinnedRef.current;
+    const scopeChanged = prevResetKeyRef.current !== resetKey;
+    prevResetKeyRef.current = resetKey;
     if (
+      !scopeChanged &&
       prev !== null &&
       prev !== pinnedDocId &&
       documents.length > 0 &&
@@ -100,7 +117,7 @@ export function useCompareNavigation({
       toast.info("Documento removido da fila — voltando ao topo.");
     }
     lastValidPinnedRef.current = pinnedDocId;
-  }, [pinnedDocId, documents]);
+  }, [pinnedDocId, documents, resetKey]);
 
   const currentDoc = documents[docIndex];
   const allDocDivergent = useMemo(

--- a/frontend/src/components/compare/useStableDocOrder.ts
+++ b/frontend/src/components/compare/useStableDocOrder.ts
@@ -16,22 +16,41 @@ import type { CompareDocument } from "./compare-types";
  * (mesmo padrão da re-pinagem em `useCompareNavigation`; `set-state-in-effect`
  * proíbe o setState síncrono em effect) — converge porque, com a composição
  * igual, não há setState.
+ *
+ * `resetKey` cobre o caso em que a composição muda DRASTICAMENTE por uma
+ * escolha deliberada do usuário (ex.: alternar a fila de Comparação entre
+ * "Meus atribuídos" e "Todos" — mesma instância de componente, sem remount).
+ * Sem isso, os poucos docs da fila pessoal ficariam presos no topo da fila
+ * "Todos" na ordem antiga, fora da prioridade por pendência que o servidor
+ * calculou para o projeto inteiro. Quando `resetKey` muda, a ordem nasce do
+ * zero (igual à ordem de `documents`) em vez de mesclar com a anterior.
+ * `prevResetKey` é `useState` (não `useRef`): `react-hooks/refs` proíbe ler/
+ * escrever `ref.current` fora de effect/handler, então o espelho do valor
+ * anterior precisa ser estado, ajustado durante o render como `orderIds`.
  */
 export function useStableDocOrder(
   documents: CompareDocument[],
+  resetKey: boolean,
 ): CompareDocument[] {
   const [orderIds, setOrderIds] = useState<string[]>(() =>
     documents.map((d) => d.id),
   );
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+  const scopeChanged = prevResetKey !== resetKey;
+  if (scopeChanged) {
+    setPrevResetKey(resetKey);
+  }
 
   const currentIdSet = new Set(documents.map((d) => d.id));
   const sameComposition =
+    !scopeChanged &&
     orderIds.length === currentIdSet.size &&
     orderIds.every((id) => currentIdSet.has(id));
   if (!sameComposition) {
-    const knownIdSet = new Set(orderIds);
+    const knownIdSet = scopeChanged ? new Set<string>() : new Set(orderIds);
+    const preserved = scopeChanged ? [] : orderIds.filter((id) => currentIdSet.has(id));
     setOrderIds([
-      ...orderIds.filter((id) => currentIdSet.has(id)),
+      ...preserved,
       ...documents.map((d) => d.id).filter((id) => !knownIdSet.has(id)),
     ]);
   }

--- a/frontend/src/lib/__tests__/compare-filters.test.ts
+++ b/frontend/src/lib/__tests__/compare-filters.test.ts
@@ -5,6 +5,7 @@ import {
   readCompareFilters,
   compareDefaultsForMode,
   assignedCompareDocIds,
+  resolveShowAllQueue,
 } from "@/lib/compare-filters";
 
 // Estes testes cobrem a peça que liga a Comparação de "1 humano + 1 LLM": o
@@ -132,5 +133,33 @@ describe("assignedCompareDocIds — showAll decide, não o papel sozinho", () =>
   it("showAll=false sem assignments → conjunto vazio (não vê nada)", () => {
     expect(assignedCompareDocIds(false, [], userId)).toEqual(new Set());
     expect(assignedCompareDocIds(false, null, userId)).toEqual(new Set());
+  });
+});
+
+// Regressão: showAllQueue nasceu inline em page.tsx (isCoordinator &&
+// queueParam === "all") — a mesma classe de expressão que já causou o bug
+// original desta página (tratar "é coordenador" como "vê tudo"). Extraída
+// aqui como função pura testada para que uma reescrita futura (ex.: trocar
+// `&&` por `||`, esquecer o `isCoordinator &&`) quebre o CI em vez de só
+// aparecer em produção.
+describe("resolveShowAllQueue — gate fail-closed do toggle de fila", () => {
+  it("coordenador + queue=all → true", () => {
+    expect(resolveShowAllQueue(true, "all")).toBe(true);
+  });
+
+  it("coordenador + param ausente → false (padrão é a fila pessoal)", () => {
+    expect(resolveShowAllQueue(true, undefined)).toBe(false);
+  });
+
+  it("coordenador + queue=mine → false", () => {
+    expect(resolveShowAllQueue(true, "mine")).toBe(false);
+  });
+
+  it("não-coordenador + queue=all → false (fail-closed, param sozinho não basta)", () => {
+    expect(resolveShowAllQueue(false, "all")).toBe(false);
+  });
+
+  it("não-coordenador + param ausente → false", () => {
+    expect(resolveShowAllQueue(false, undefined)).toBe(false);
   });
 });

--- a/frontend/src/lib/__tests__/compare-filters.test.ts
+++ b/frontend/src/lib/__tests__/compare-filters.test.ts
@@ -102,11 +102,13 @@ describe("readCompareFilters com defaults por modo", () => {
   });
 });
 
-// Invariante de segurança: na fila de Comparação, um não-coordenador só pode
-// ver os documentos atribuídos a ele. A policy RLS "Members view responses" não
-// restringe por linha, então este recorte é a única barreira — por isso o
-// `isCoordinator` que o alimenta é fail-closed.
-describe("assignedCompareDocIds — não-coordenador vê só os docs atribuídos", () => {
+// Invariante de segurança: na fila de Comparação, quem não pediu "todos" só
+// pode ver os documentos atribuídos a ele (vale tanto para coordenador na aba
+// "Meus atribuídos" quanto para não-coordenador, que nunca alcança showAll).
+// A policy RLS "Members view responses" não restringe por linha, então este
+// recorte é a única barreira — por isso `showAll` é resolvido fail-closed no
+// servidor (showAllQueue = isCoordinator && queueParam === "all").
+describe("assignedCompareDocIds — showAll decide, não o papel sozinho", () => {
   const userId = "user-self";
   const assignments = [
     { document_id: "doc-meu", user_id: userId, type: "comparacao" },
@@ -114,11 +116,11 @@ describe("assignedCompareDocIds — não-coordenador vê só os docs atribuídos
     { document_id: "doc-codificacao", user_id: userId, type: "codificacao" },
   ];
 
-  it("coordenador → null (sem restrição: vê todos os documentos)", () => {
+  it("showAll=true → null (sem restrição: vê todos os documentos)", () => {
     expect(assignedCompareDocIds(true, assignments, userId)).toBeNull();
   });
 
-  it("não-coordenador → só os docs de comparação atribuídos a ele", () => {
+  it("showAll=false → só os docs de comparação atribuídos ao usuário (coordenador ou não)", () => {
     const visible = assignedCompareDocIds(false, assignments, userId);
     expect(visible).toEqual(new Set(["doc-meu"]));
     // não vaza o doc de comparação atribuído a outro respondente...
@@ -127,7 +129,7 @@ describe("assignedCompareDocIds — não-coordenador vê só os docs atribuídos
     expect(visible!.has("doc-codificacao")).toBe(false);
   });
 
-  it("não-coordenador sem assignments → conjunto vazio (não vê nada)", () => {
+  it("showAll=false sem assignments → conjunto vazio (não vê nada)", () => {
     expect(assignedCompareDocIds(false, [], userId)).toEqual(new Set());
     expect(assignedCompareDocIds(false, null, userId)).toEqual(new Set());
   });

--- a/frontend/src/lib/__tests__/compare-queue.test.ts
+++ b/frontend/src/lib/__tests__/compare-queue.test.ts
@@ -169,11 +169,11 @@ describe("buildCodingAssignedByDoc / buildCompareAssignmentStatusByDoc", () => {
     expect(map.has("d2")).toBe(false);
   });
 
-  it("buildCompareAssignmentStatusByDoc: coordenador não tem assignment individual", () => {
+  it("buildCompareAssignmentStatusByDoc: showAll=true não tem assignment individual de referência", () => {
     expect(buildCompareAssignmentStatusByDoc(assignments, true, "u3").size).toBe(0);
   });
 
-  it("buildCompareAssignmentStatusByDoc: filtra por type=comparacao e pelo usuário", () => {
+  it("buildCompareAssignmentStatusByDoc: showAll=false filtra por type=comparacao e pelo usuário", () => {
     const map = buildCompareAssignmentStatusByDoc(assignments, false, "u3");
     expect(map.get("d1")).toBe("em_andamento");
     expect(map.get("d2")).toBe("concluido");

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -97,20 +97,21 @@ export function compareDefaultsForMode(
 }
 
 // Conjunto de document_ids que um usuário pode VER na fila de comparação.
-// Coordenador → null (sem restrição: vê todos os documentos). Não-coordenador
-// → apenas os docs com assignment de comparação atribuído a ele.
+// showAll → null (sem restrição: vê todos os documentos). false → apenas os
+// docs com assignment de comparação atribuído a ele (vale para coordenador
+// na aba "Meus atribuídos" e para não-coordenador, que nunca alcança showAll).
 // SEGURANÇA: a policy RLS "Members view responses" deixa qualquer membro ler
 // todas as responses do projeto, então este recorte é a única barreira de
-// visibilidade — por isso o `isCoordinator` que o alimenta é fail-closed (não
-// incorpora queryFailed). Ver analyze/compare/page.tsx.
+// visibilidade — por isso `showAll` (isCoordinator && aba/param "todos") é
+// resolvido no servidor de forma fail-closed. Ver analyze/compare/page.tsx.
 export function assignedCompareDocIds(
-  isCoordinator: boolean,
+  showAll: boolean,
   assignments:
     | ReadonlyArray<{ document_id: string; user_id: string; type: string }>
     | null,
   userId: string,
 ): Set<string> | null {
-  if (isCoordinator) return null;
+  if (showAll) return null;
   return new Set(
     (assignments ?? [])
       .filter((a) => a.type === "comparacao" && a.user_id === userId)

--- a/frontend/src/lib/compare-filters.ts
+++ b/frontend/src/lib/compare-filters.ts
@@ -96,6 +96,21 @@ export function compareDefaultsForMode(
   return { ...DEFAULT_COMPARE_FILTERS, minHumans, version: COMPARE_DEFAULT_VERSION };
 }
 
+// Resolve se a fila de Comparação mostra TODOS os documentos do projeto
+// (showAll=true) ou só os atribuídos ao usuário (showAll=false). SEGURANÇA:
+// mesma fronteira fail-closed de assignedCompareDocIds — só coordenador pode
+// pedir "todos"; o param de URL sozinho nunca basta, e um não-coordenador
+// nunca alcança showAll=true mesmo editando a URL. Extraída como função pura
+// testável (em vez de inline em page.tsx) porque é a MESMA classe de
+// expressão booleana que já causou o bug original desta página: tratar
+// "é coordenador" como sinônimo de "vê tudo".
+export function resolveShowAllQueue(
+  isCoordinator: boolean,
+  queueParam: string | undefined,
+): boolean {
+  return isCoordinator && queueParam === "all";
+}
+
 // Conjunto de document_ids que um usuário pode VER na fila de comparação.
 // showAll → null (sem restrição: vê todos os documentos). false → apenas os
 // docs com assignment de comparação atribuído a ele (vale para coordenador

--- a/frontend/src/lib/compare-queue.ts
+++ b/frontend/src/lib/compare-queue.ts
@@ -218,17 +218,19 @@ export function buildCodingAssignedByDoc(
 }
 
 // Status per user-doc for compare assignment (used in list and panel).
-// Coordenador não tem assignment individual de comparação — mapa vazio.
+// showAll (coordenador na aba "Todos") não tem um único assignment individual
+// de referência — mapa vazio. Na aba "Meus" (showAll=false), vale tanto para
+// coordenador quanto para não-coordenador: mesmo filtro por user_id.
 export function buildCompareAssignmentStatusByDoc(
   allAssignments: readonly AssignmentRow[] | null,
-  isCoordinator: boolean,
+  showAll: boolean,
   userId: string,
 ): Map<string, "pendente" | "em_andamento" | "concluido"> {
   const compareAssignmentStatusByDoc = new Map<
     string,
     "pendente" | "em_andamento" | "concluido"
   >();
-  if (isCoordinator) return compareAssignmentStatusByDoc;
+  if (showAll) return compareAssignmentStatusByDoc;
   for (const a of allAssignments ?? []) {
     if (a.type !== "comparacao" || a.user_id !== userId) continue;
     compareAssignmentStatusByDoc.set(


### PR DESCRIPTION
## Resumo

- Uma pesquisadora relatou que todos os documentos da fila de Comparação estavam vindo pra ela, enquanto outro pesquisador via corretamente só os dele. Investigação confirmou que ela é coordenadora de fato no projeto — não é bug de dado.
- O problema é de design: `assignedCompareDocIds(isCoordinator, ...)` retornava `null` (sem filtro) sempre que `isCoordinator === true`, mostrando literalmente todos os documentos do projeto. Isso pressupõe que coordenador só supervisiona — mas nesse projeto o coordenador também faz o trabalho de comparar documentos, igual pesquisador, e por isso quer ver só os seus por padrão.
- Adiciona um toggle **Tabs "Meus atribuídos" / "Todos"** (só visível para coordenador), no mesmo padrão visual/estado já usado em `CodingHeader.tsx` (Tabs + `useUrlState`). Param de URL `queue=all` alcança a visão ampla; ausente/`mine` é o padrão para todo mundo, coordenador incluso. Pesquisador comum nunca vê o toggle nem alcança `showAll`, mesmo editando a URL (gate resolvido no servidor).
- Estado vazio: se o coordenador está em "Meus atribuídos" e não tem nenhuma atribuição pessoal de comparação, a mensagem indica explicitamente o atalho para a aba "Todos" (que já fica visível ali ao lado).

## Escopo

Só a tela de Comparação. Arbitragem e Auto-revisão foram investigadas e já resolvem esse mesmo problema de forma adequada ao próprio fluxo (Arbitragem é 100% pessoal por padrão; Auto-revisão já tem `viewAs` para auditoria 1-a-1) — ficam de fora por decisão explícita, não é problema para elas.

## Arquivos

- `frontend/src/lib/compare-filters.ts`: `assignedCompareDocIds` — parâmetro renomeado de `isCoordinator` para `showAll` (decisão de mostrar tudo deixa de ser 1:1 com o papel).
- `frontend/src/lib/compare-queue.ts`: `buildCompareAssignmentStatusByDoc` — mesmo rename/semântica.
- `frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx`: lê `queue` da URL, calcula `showAllQueue = isCoordinator && queueParam === "all"`, plumba para as duas funções acima e para `<ComparePage>`.
- `frontend/src/components/compare/CompareQueueTabs.tsx` (novo): Tabs auto-contido via `useUrlState`.
- `frontend/src/components/compare/ComparePage.tsx`: renderiza o toggle (gated por `isCoordinator`) nas duas ramificações de render (estado vazio e visão completa); mensagem de estado vazio diferenciada.
- Testes atualizados: `compare-filters.test.ts`, `compare-queue.test.ts`, `ComparePage.test.tsx`, `ComparePage.integration.test.tsx`.

## Test plan

- [x] `npm run typecheck` — limpo
- [x] `npm run lint` — limpo (2 warnings pré-existentes não relacionados)
- [x] `npx vitest run` — 977/977 testes passando (suíte completa)
- [x] `npm run build` — build de produção passa
- [x] Dev server sobe e a rota de Comparação redireciona corretamente para login quando não-autenticado (smoke test, sem sessão real)
- [ ] Verificação manual em browser como coordenador logado com atribuições de comparação reais — não realizada nesta sessão (sem credenciais Clerk de um coordenador de teste disponíveis); recomendo esse passo antes do merge

Nota: o gate `fallow-audit` do pre-push bloqueou por complexidade/duplicação **pré-existentes** nos arquivos tocados (`ComparePage.tsx` já é CRITICAL em complexidade antes desta mudança; a duplicação de setup entre `ComparePage.test.tsx`/`ComparePage.integration.test.tsx` também é anterior). Push feito com `SKIP=fallow-audit`, validado manualmente por typecheck+lint+vitest — mesmo padrão já documentado em PRs anteriores desta campanha (#334, #396).