### PR TITLE
fix(build): move funções puras para fora dos arquivos "use server"

### DIFF
--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -5,14 +5,18 @@ import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { getAuthUser, getEffectiveMemberId, requireCoordinator } from "@/lib/auth";
 import { buildLoadMap } from "@/lib/load-balancing";
 import { errorMessage } from "@/lib/utils";
-import { computeDivergentFieldNames } from "@/lib/compare-divergence";
-import { isCodingComplete } from "@/lib/coding-completeness";
 import { canonicalPair } from "@/lib/equivalence";
+import { buildEquivalenceMap, type EquivalenceRow } from "@/lib/compare-queue";
 import {
-  buildEquivalenceMap,
-  type EquivalenceByDocField,
-  type EquivalenceRow,
-} from "@/lib/compare-queue";
+  computeBacklogRows,
+  compositeKeySet,
+  diffReviewsToRemove,
+  type AssignmentRow,
+  type ExistingFieldReviewRow,
+  type FieldReviewRow,
+  type HumanResponseRow,
+  type LlmResponseRow,
+} from "@/lib/auto-review-backlog";
 import { resolveBlindVerdict } from "@/lib/arbitration-order";
 import { verdictRequiresJustification } from "@/lib/auto-review-decided";
 import { formatAnswerTechnical } from "@/lib/format-answer";
@@ -20,7 +24,6 @@ import { syncAutoRevisaoAssignmentStatus } from "@/lib/auto-revisao-sync";
 import { syncArbitragemAssignmentStatus } from "@/lib/arbitragem-sync";
 import { revalidatePath } from "next/cache";
 import type {
-  AnswerFieldHashes,
   PydanticField,
   SelfVerdict,
   ArbitrationVerdict,
@@ -802,45 +805,6 @@ export async function submitFinalVerdicts(
 // numero de respostas.
 type SupabaseAdminClient = ReturnType<typeof createSupabaseAdmin>;
 
-export interface HumanResponseRow {
-  id: string;
-  document_id: string;
-  respondent_id: string;
-  answers: Record<string, unknown>;
-  answer_field_hashes: AnswerFieldHashes;
-}
-
-export interface LlmResponseRow {
-  id: string;
-  document_id: string;
-  answers: Record<string, unknown>;
-  answer_field_hashes: AnswerFieldHashes;
-}
-
-export interface ExistingFieldReviewRow {
-  id: string;
-  document_id: string;
-  field_name: string;
-  self_verdict: string | null;
-}
-
-export interface AssignmentRow {
-  project_id: string;
-  document_id: string;
-  user_id: string;
-  type: "auto_revisao";
-  status: "pendente";
-}
-
-export interface FieldReviewRow {
-  project_id: string;
-  document_id: string;
-  field_name: string;
-  human_response_id: string;
-  llm_response_id: string;
-  self_reviewer_id: string;
-}
-
 interface BacklogInputs {
   fields: PydanticField[];
   humanResponses: HumanResponseRow[];
@@ -907,112 +871,9 @@ async function fetchBacklogInputs(
   };
 }
 
-// Varre as respostas humanas completas e calcula quais divergem do LLM —
-// puro, sem I/O (opera só sobre dados já pré-carregados por fetchBacklogInputs).
-export function computeBacklogRows(
-  projectId: string,
-  humanResponses: HumanResponseRow[],
-  llmByDocId: Map<string, LlmResponseRow>,
-  equivByDoc: EquivalenceByDocField,
-  fields: PydanticField[],
-): { assignmentRows: AssignmentRow[]; fieldReviewRows: FieldReviewRow[]; regenerated: number } {
-  const assignmentRows: AssignmentRow[] = [];
-  const fieldReviewRows: FieldReviewRow[] = [];
-  let regenerated = 0;
-
-  for (const human of humanResponses) {
-    const llm = llmByDocId.get(human.document_id);
-    if (!llm) continue;
-
-    // #174: só arbitrar codificações completas. is_partial é sinal inútil de
-    // completude para o humano (quase sempre false), então o filtro de query
-    // não basta: aqui pulamos respostas humanas cuja codificação não está
-    // completa. Espelha o gate inline de saveResponse (allAnswered) via o
-    // mesmo helper. Sem isto, codificações em andamento eram varridas para a
-    // arbitragem e apareciam como "(vazio)" em diversos campos.
-    //
-    // Staleness-aware: passamos answer_field_hashes porque a avaliação é
-    // RETROATIVA (schema atual vs. codificações antigas). Sem isto, um campo
-    // obrigatório adicionado depois (ex.: `medicamento`) tornaria toda
-    // codificação anterior "incompleta", varrendo arbitragens legítimas.
-    if (!isCodingComplete(fields, human.answers ?? {}, human.answer_field_hashes)) {
-      continue;
-    }
-
-    const divergent = computeDivergentFieldNames(
-      fields,
-      [
-        {
-          id: human.id,
-          answers: human.answers ?? {},
-          answerFieldHashes: human.answer_field_hashes,
-        },
-        {
-          id: llm.id,
-          answers: llm.answers ?? {},
-          answerFieldHashes: llm.answer_field_hashes,
-        },
-      ],
-      equivByDoc.get(human.document_id),
-    );
-    if (divergent.length === 0) continue;
-
-    regenerated++;
-    assignmentRows.push({
-      project_id: projectId,
-      document_id: human.document_id,
-      user_id: human.respondent_id,
-      type: "auto_revisao",
-      status: "pendente",
-    });
-    for (const fieldName of divergent) {
-      fieldReviewRows.push({
-        project_id: projectId,
-        document_id: human.document_id,
-        field_name: fieldName,
-        human_response_id: human.id,
-        llm_response_id: llm.id,
-        self_reviewer_id: human.respondent_id,
-      });
-    }
-  }
-
-  return { assignmentRows, fieldReviewRows, regenerated };
-}
-
-// Compartilhado entre diffReviewsToRemove e removeOrphanAssignments: as duas
-// reconciliam uma coleção recém-computada contra uma existente via chave
-// composta document_id+algo. Puro.
-function compositeKeySet<T>(rows: T[], keyFn: (row: T) => string): Set<string> {
-  return new Set(rows.map(keyFn));
-}
-
-// --- Reconcile: quais field_reviews não deveriam mais existir ---
-// O conjunto correto é o que acabou de ser computado em fieldReviewRows.
-// Linhas pendentes (self_verdict IS NULL) fora desse conjunto sao espurias
-// — tipicamente campos que ficaram "stale" apos edicao de schema — e podem
-// ser apagadas. Linhas ja resolvidas pelo pesquisador sao preservadas. Puro.
-export function diffReviewsToRemove(
-  existingReviews: ExistingFieldReviewRow[],
-  fieldReviewRows: FieldReviewRow[],
-): { idsToDelete: string[]; keptResolved: number } {
-  const correctKeys = compositeKeySet(
-    fieldReviewRows,
-    (r) => `${r.document_id}|${r.field_name}`,
-  );
-
-  const idsToDelete: string[] = [];
-  let keptResolved = 0;
-  for (const fr of existingReviews) {
-    if (correctKeys.has(`${fr.document_id}|${fr.field_name}`)) continue;
-    if (fr.self_verdict == null) {
-      idsToDelete.push(fr.id);
-    } else {
-      keptResolved++;
-    }
-  }
-  return { idsToDelete, keptResolved };
-}
+// As etapas puras (computeBacklogRows, diffReviewsToRemove, compositeKeySet)
+// vivem em @/lib/auto-review-backlog — "use server" só pode exportar funções
+// async (regra do Next), então o que é puro e testável fica fora deste arquivo.
 
 // Remove assignments auto_revisao orfaos: sem nenhum field_review restante
 // para o doc+pesquisador e ainda `pendente`. Assignments ja iniciados ou

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -5,16 +5,20 @@ import { getAuthUser } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { fetchFastAPIServer } from "@/lib/api-server";
 import type { PydanticField } from "@/lib/types";
-import {
-  computeFieldHash,
-  bumpVersion,
-  fieldDiffIsStructural,
-  planSchemaPersistence,
-  type ChangeType,
-} from "@/lib/schema-utils";
+import { bumpVersion, planSchemaPersistence } from "@/lib/schema-utils";
 import { updateOrThrow } from "@/lib/supabase/rls-guard";
 import { errorMessage } from "@/lib/utils";
-import type { SchemaVersion } from "@/lib/compare-version";
+import {
+  classifyLogEntries,
+  reconstructSnapshotsByVersion,
+  matchResponsesToVersions,
+  computeHashesFromSnapshot,
+  type BackfillStats,
+  type EnrichedEntry,
+  type LogEntryRow,
+  type ResponseRow,
+  type UpdateBucket,
+} from "@/lib/schema-backfill";
 import crypto from "crypto";
 
 interface RecoverResponse {
@@ -223,51 +227,10 @@ export async function saveSchemaFromGUI(
 //   cai em created_at quando não (responses pré-hash).
 // - Rastreia o método em responses.version_inferred_from.
 // Idempotente.
-
-export type FieldSnapshot = Partial<PydanticField> & { name: string };
-
-function cloneFieldSnapshot(f: FieldSnapshot): FieldSnapshot {
-  return {
-    ...f,
-    options: f.options ? [...f.options] : f.options,
-  };
-}
-
-function cloneSnapshotMap(snap: Map<string, FieldSnapshot>): Map<string, FieldSnapshot> {
-  const out = new Map<string, FieldSnapshot>();
-  for (const [k, v] of snap) out.set(k, cloneFieldSnapshot(v));
-  return out;
-}
-
-function versionKey(v: { major: number; minor: number; patch: number }) {
-  return `${v.major}.${v.minor}.${v.patch}`;
-}
-
-function computeHashesFromSnapshot(snap: Map<string, FieldSnapshot>): Record<string, string> {
-  const hashes: Record<string, string> = {};
-  for (const [name, field] of snap) {
-    if (!field.type || field.description == null) continue;
-    hashes[name] = computeFieldHash(
-      name,
-      field.type,
-      field.options ?? null,
-      field.description,
-    );
-  }
-  return hashes;
-}
-
-type BackfillStats = {
-  finalVersion: { major: number; minor: number; patch: number };
-  logEntriesUpdated: number;
-  responsesProcessed: number;
-  byMethod: {
-    hashes: number;
-    created_at: number;
-    fallback_created_at: number;
-    live_save: number;
-  };
-};
+//
+// As etapas puras (classificação, snapshots, matching) vivem em
+// @/lib/schema-backfill — "use server" só pode exportar funções async, então
+// o que é puro e testável fica fora deste arquivo.
 
 // Fronteira da action: runBackfill lança nos vários pontos de falha (leituras,
 // updates filtrados, permissões) e aqui o throw vira { error } para a copy
@@ -283,73 +246,6 @@ export async function backfillSchemaVersionHistory(
 }
 
 type SupabaseServerClient = Awaited<ReturnType<typeof createSupabaseServer>>;
-
-export type Version = SchemaVersion;
-
-export type EnrichedEntry = {
-  id: string;
-  field_name: string;
-  before: Record<string, unknown>;
-  after: Record<string, unknown>;
-  createdAt: number;
-  changeType: ChangeType;
-  version: Version;
-};
-
-export type LogEntryRow = {
-  id: string;
-  field_name: string;
-  before_value: Record<string, unknown> | null;
-  after_value: Record<string, unknown> | null;
-  created_at: string;
-  change_type: string | null;
-};
-
-export type ResponseRow = {
-  id: string;
-  created_at: string;
-  answer_field_hashes: Record<string, string> | null;
-  version_inferred_from: string | null;
-};
-
-export type UpdateBucket = { version: Version; method: string; ids: string[] };
-
-// Puro, sem I/O — exportada para teste unitário direto (schema.test.ts).
-// Classifica cada entry (major/minor/patch) e acumula a versão corrente:
-// `current` acumula sequencialmente porque a versão de uma entry depende de
-// todas as anteriores (semver é cumulativo).
-export function classifyLogEntries(log: LogEntryRow[]): {
-  enriched: EnrichedEntry[];
-  finalVersion: Version;
-} {
-  let current: Version = { major: 0, minor: 1, patch: 0 };
-  const enriched: EnrichedEntry[] = [];
-
-  for (const entry of log) {
-    const before = entry.before_value ?? {};
-    const after = entry.after_value ?? {};
-
-    const type: ChangeType =
-      entry.change_type === "major"
-        ? "major"
-        : fieldDiffIsStructural(before, after)
-          ? "minor"
-          : "patch";
-
-    current = bumpVersion(current, type);
-    enriched.push({
-      id: entry.id,
-      field_name: entry.field_name,
-      before,
-      after,
-      createdAt: new Date(entry.created_at).getTime(),
-      changeType: type,
-      version: { ...current },
-    });
-  }
-
-  return { enriched, finalVersion: current };
-}
 
 async function persistLogClassification(
   supabase: SupabaseServerClient,
@@ -381,83 +277,6 @@ async function persistLogClassification(
   }
 }
 
-// Puro, sem I/O — exportada para teste unitário direto (schema.test.ts).
-// Reconstrói o snapshot de campos em cada versão, andando o log de trás para
-// frente (revertendo diffs a partir do estado atual).
-export function reconstructSnapshotsByVersion(
-  pydanticFields: PydanticField[],
-  enriched: EnrichedEntry[],
-  finalVersion: Version,
-): Map<string, Map<string, FieldSnapshot>> {
-  const currentSnap = new Map<string, FieldSnapshot>();
-  for (const f of pydanticFields) {
-    currentSnap.set(f.name, cloneFieldSnapshot({ ...f }));
-  }
-
-  // Map: versionKey -> snapshot map (fieldName -> snapshot)
-  const snapByVersion = new Map<string, Map<string, FieldSnapshot>>();
-  snapByVersion.set(versionKey(finalVersion), cloneSnapshotMap(currentSnap));
-
-  // Group entries by version so we revert all at once per version-change
-  const versionsDesc: Array<{ key: string; version: Version }> = [];
-  const entriesByVersion = new Map<string, EnrichedEntry[]>();
-  for (const e of enriched) {
-    const k = versionKey(e.version);
-    if (!entriesByVersion.has(k)) {
-      entriesByVersion.set(k, []);
-      versionsDesc.push({ key: k, version: e.version });
-    }
-    entriesByVersion.get(k)!.push(e);
-  }
-  // Sort desc so we revert from latest → earliest
-  versionsDesc.sort((a, b) => {
-    if (a.version.major !== b.version.major) return b.version.major - a.version.major;
-    if (a.version.minor !== b.version.minor) return b.version.minor - a.version.minor;
-    return b.version.patch - a.version.patch;
-  });
-
-  const workingSnap = cloneSnapshotMap(currentSnap);
-  for (let idx = 0; idx < versionsDesc.length; idx++) {
-    const { key } = versionsDesc[idx];
-    // Snapshot at version `version` (before reverting) — if not already stored
-    if (!snapByVersion.has(key)) {
-      snapByVersion.set(key, cloneSnapshotMap(workingSnap));
-    }
-    // Revert all entries at this version
-    const group = entriesByVersion.get(key)!;
-    for (const e of group) {
-      // Skip project-level entries (publishMajorVersion)
-      if (e.field_name === "(projeto)") continue;
-      const isAdd = Object.keys(e.before).length === 0;
-      const isRemove = Object.keys(e.after).length === 0;
-      if (isAdd) {
-        // Pré-E: o campo não existia
-        workingSnap.delete(e.field_name);
-      } else if (isRemove) {
-        // Pré-E: o campo existia como `before`
-        const snap = { name: e.field_name, ...(e.before as Partial<PydanticField>) };
-        workingSnap.set(e.field_name, snap);
-      } else {
-        // Campo modificado: reverte atributos listados em `before`
-        const existing = workingSnap.get(e.field_name) ?? { name: e.field_name };
-        workingSnap.set(e.field_name, {
-          ...existing,
-          ...(e.before as Partial<PydanticField>),
-          name: e.field_name,
-        });
-      }
-    }
-    // Após reverter, workingSnap representa a versão anterior
-    const prev = versionsDesc[idx + 1];
-    if (!prev) {
-      // 0.1.0 inicial (pré-primeira entry)
-      snapByVersion.set(versionKey({ major: 0, minor: 1, patch: 0 }), cloneSnapshotMap(workingSnap));
-    }
-  }
-
-  return snapByVersion;
-}
-
 async function fetchAllResponses(
   supabase: SupabaseServerClient,
   projectId: string,
@@ -479,106 +298,6 @@ async function fetchAllResponses(
     if (page.length < RESPONSES_PAGE) break;
   }
   return responses;
-}
-
-// Puro, sem I/O — exportada para teste unitário direto (schema.test.ts).
-// Escolhe a versão de cada response (por hash de campos, com fallback em
-// created_at) e agrupa em buckets por (versão, método).
-export function matchResponsesToVersions(
-  responses: ResponseRow[],
-  hashesByVersion: Map<string, Record<string, string>>,
-  enriched: EnrichedEntry[],
-): { updates: Map<string, UpdateBucket>; byMethod: BackfillStats["byMethod"] } {
-  const versionByKey = new Map<string, Version>();
-  for (const k of hashesByVersion.keys()) {
-    const [mj, mn, pt] = k.split(".").map((n) => Number.parseInt(n, 10));
-    versionByKey.set(k, { major: mj, minor: mn, patch: pt });
-  }
-  // Timestamp of each version (from entries; initial version = 0)
-  const versionTs = new Map<string, number>();
-  for (const e of enriched) {
-    const k = versionKey(e.version);
-    if (!versionTs.has(k)) versionTs.set(k, e.createdAt);
-  }
-  versionTs.set(versionKey({ major: 0, minor: 1, patch: 0 }), 0);
-
-  // Bucket updates by (version, method)
-  const updates = new Map<string, UpdateBucket>();
-  let countLiveSave = 0;
-  let countHashes = 0;
-  let countCreatedAt = 0;
-  let countFallback = 0;
-
-  for (const r of responses) {
-    // Preserve live_save entries as-is (precisão total)
-    if (r.version_inferred_from === "live_save") {
-      countLiveSave++;
-      continue;
-    }
-
-    const rHashes = r.answer_field_hashes ?? null;
-    const ts = new Date(r.created_at).getTime();
-
-    let chosenKey: string | null = null;
-    let chosenMethod: "hashes" | "created_at" | "fallback_created_at" = "created_at";
-
-    if (rHashes && Object.keys(rHashes).length > 0) {
-      // Score each version
-      let bestScore = -1;
-      let bestKey: string | null = null;
-      let bestTieTs = Infinity;
-      for (const [k, vHashes] of hashesByVersion) {
-        let score = 0;
-        for (const [fn, h] of Object.entries(rHashes)) {
-          if (vHashes[fn] === h) score++;
-        }
-        if (score === 0) continue;
-        const kTs = versionTs.get(k) ?? 0;
-        const tieMetric = Math.abs(kTs - ts);
-        if (score > bestScore || (score === bestScore && tieMetric < bestTieTs)) {
-          bestScore = score;
-          bestKey = k;
-          bestTieTs = tieMetric;
-        }
-      }
-      if (bestKey) {
-        chosenKey = bestKey;
-        chosenMethod = "hashes";
-      }
-    }
-
-    if (!chosenKey) {
-      // Fallback timestamp
-      const candidates = [...versionTs.entries()]
-        .filter(([, t]) => t <= ts)
-        .sort((a, b) => b[1] - a[1]);
-      chosenKey =
-        candidates.length > 0 ? candidates[0][0] : versionKey({ major: 0, minor: 1, patch: 0 });
-      chosenMethod =
-        rHashes && Object.keys(rHashes).length > 0 ? "fallback_created_at" : "created_at";
-    }
-
-    const v = versionByKey.get(chosenKey) ?? { major: 0, minor: 1, patch: 0 };
-    const bucketKey = `${chosenKey}|${chosenMethod}`;
-    if (!updates.has(bucketKey)) {
-      updates.set(bucketKey, { version: v, method: chosenMethod, ids: [] });
-    }
-    updates.get(bucketKey)!.ids.push(r.id);
-
-    if (chosenMethod === "hashes") countHashes++;
-    else if (chosenMethod === "created_at") countCreatedAt++;
-    else if (chosenMethod === "fallback_created_at") countFallback++;
-  }
-
-  return {
-    updates,
-    byMethod: {
-      hashes: countHashes,
-      created_at: countCreatedAt,
-      fallback_created_at: countFallback,
-      live_save: countLiveSave,
-    },
-  };
 }
 
 async function persistResponseVersionUpdates(

--- a/frontend/src/lib/__tests__/auto-review-backlog.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-backlog.test.ts
@@ -6,7 +6,7 @@ import {
   type LlmResponseRow,
   type ExistingFieldReviewRow,
   type FieldReviewRow,
-} from "@/actions/field-reviews";
+} from "@/lib/auto-review-backlog";
 import type { PydanticField } from "@/lib/types";
 
 // Testes das funções puras extraídas de regenerateAutoReviewBacklog (issue

--- a/frontend/src/lib/__tests__/schema-backfill.test.ts
+++ b/frontend/src/lib/__tests__/schema-backfill.test.ts
@@ -6,7 +6,7 @@ import {
   type LogEntryRow,
   type EnrichedEntry,
   type ResponseRow,
-} from "@/actions/schema";
+} from "@/lib/schema-backfill";
 import type { PydanticField } from "@/lib/types";
 
 // Testes das funções puras extraídas de runBackfill (issue #392) — sem

--- a/frontend/src/lib/auto-review-backlog.ts
+++ b/frontend/src/lib/auto-review-backlog.ts
@@ -1,0 +1,155 @@
+// Funções puras da regeneração do backlog de auto-revisão. Extraídas de
+// actions/field-reviews.ts: arquivos "use server" só podem exportar funções
+// async (regra do Next), então o que é puro e testável vive aqui e a action
+// importa.
+
+import { computeDivergentFieldNames } from "@/lib/compare-divergence";
+import { isCodingComplete } from "@/lib/coding-completeness";
+import type { EquivalenceByDocField } from "@/lib/compare-queue";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
+
+export interface HumanResponseRow {
+  id: string;
+  document_id: string;
+  respondent_id: string;
+  answers: Record<string, unknown>;
+  answer_field_hashes: AnswerFieldHashes;
+}
+
+export interface LlmResponseRow {
+  id: string;
+  document_id: string;
+  answers: Record<string, unknown>;
+  answer_field_hashes: AnswerFieldHashes;
+}
+
+export interface ExistingFieldReviewRow {
+  id: string;
+  document_id: string;
+  field_name: string;
+  self_verdict: string | null;
+}
+
+export interface AssignmentRow {
+  project_id: string;
+  document_id: string;
+  user_id: string;
+  type: "auto_revisao";
+  status: "pendente";
+}
+
+export interface FieldReviewRow {
+  project_id: string;
+  document_id: string;
+  field_name: string;
+  human_response_id: string;
+  llm_response_id: string;
+  self_reviewer_id: string;
+}
+
+// Varre as respostas humanas completas e calcula quais divergem do LLM —
+// puro, sem I/O (opera só sobre dados já pré-carregados por fetchBacklogInputs).
+export function computeBacklogRows(
+  projectId: string,
+  humanResponses: HumanResponseRow[],
+  llmByDocId: Map<string, LlmResponseRow>,
+  equivByDoc: EquivalenceByDocField,
+  fields: PydanticField[],
+): { assignmentRows: AssignmentRow[]; fieldReviewRows: FieldReviewRow[]; regenerated: number } {
+  const assignmentRows: AssignmentRow[] = [];
+  const fieldReviewRows: FieldReviewRow[] = [];
+  let regenerated = 0;
+
+  for (const human of humanResponses) {
+    const llm = llmByDocId.get(human.document_id);
+    if (!llm) continue;
+
+    // #174: só arbitrar codificações completas. is_partial é sinal inútil de
+    // completude para o humano (quase sempre false), então o filtro de query
+    // não basta: aqui pulamos respostas humanas cuja codificação não está
+    // completa. Espelha o gate inline de saveResponse (allAnswered) via o
+    // mesmo helper. Sem isto, codificações em andamento eram varridas para a
+    // arbitragem e apareciam como "(vazio)" em diversos campos.
+    //
+    // Staleness-aware: passamos answer_field_hashes porque a avaliação é
+    // RETROATIVA (schema atual vs. codificações antigas). Sem isto, um campo
+    // obrigatório adicionado depois (ex.: `medicamento`) tornaria toda
+    // codificação anterior "incompleta", varrendo arbitragens legítimas.
+    if (!isCodingComplete(fields, human.answers ?? {}, human.answer_field_hashes)) {
+      continue;
+    }
+
+    const divergent = computeDivergentFieldNames(
+      fields,
+      [
+        {
+          id: human.id,
+          answers: human.answers ?? {},
+          answerFieldHashes: human.answer_field_hashes,
+        },
+        {
+          id: llm.id,
+          answers: llm.answers ?? {},
+          answerFieldHashes: llm.answer_field_hashes,
+        },
+      ],
+      equivByDoc.get(human.document_id),
+    );
+    if (divergent.length === 0) continue;
+
+    regenerated++;
+    assignmentRows.push({
+      project_id: projectId,
+      document_id: human.document_id,
+      user_id: human.respondent_id,
+      type: "auto_revisao",
+      status: "pendente",
+    });
+    for (const fieldName of divergent) {
+      fieldReviewRows.push({
+        project_id: projectId,
+        document_id: human.document_id,
+        field_name: fieldName,
+        human_response_id: human.id,
+        llm_response_id: llm.id,
+        self_reviewer_id: human.respondent_id,
+      });
+    }
+  }
+
+  return { assignmentRows, fieldReviewRows, regenerated };
+}
+
+// Compartilhado entre diffReviewsToRemove e removeOrphanAssignments (na
+// action): as duas reconciliam uma coleção recém-computada contra uma
+// existente via chave composta document_id+algo. Puro.
+export function compositeKeySet<T>(rows: T[], keyFn: (row: T) => string): Set<string> {
+  return new Set(rows.map(keyFn));
+}
+
+// --- Reconcile: quais field_reviews não deveriam mais existir ---
+// O conjunto correto é o que acabou de ser computado em fieldReviewRows.
+// Linhas pendentes (self_verdict IS NULL) fora desse conjunto sao espurias
+// — tipicamente campos que ficaram "stale" apos edicao de schema — e podem
+// ser apagadas. Linhas ja resolvidas pelo pesquisador sao preservadas. Puro.
+export function diffReviewsToRemove(
+  existingReviews: ExistingFieldReviewRow[],
+  fieldReviewRows: FieldReviewRow[],
+): { idsToDelete: string[]; keptResolved: number } {
+  const correctKeys = compositeKeySet(
+    fieldReviewRows,
+    (r) => `${r.document_id}|${r.field_name}`,
+  );
+
+  const idsToDelete: string[] = [];
+  let keptResolved = 0;
+  for (const fr of existingReviews) {
+    if (correctKeys.has(`${fr.document_id}|${fr.field_name}`)) continue;
+    if (fr.self_verdict == null) {
+      idsToDelete.push(fr.id);
+    } else {
+      keptResolved++;
+    }
+  }
+  return { idsToDelete, keptResolved };
+}

--- a/frontend/src/lib/schema-backfill.ts
+++ b/frontend/src/lib/schema-backfill.ts
@@ -1,0 +1,299 @@
+// Funções puras do backfill retroativo de versão de schema
+// (schema_change_log). Extraídas de actions/schema.ts: arquivos "use server"
+// só podem exportar funções async (regra do Next), então o que é puro e
+// testável vive aqui e a action importa.
+
+import type { PydanticField } from "@/lib/types";
+import {
+  computeFieldHash,
+  bumpVersion,
+  fieldDiffIsStructural,
+  type ChangeType,
+} from "@/lib/schema-utils";
+import type { SchemaVersion } from "@/lib/compare-version";
+
+export type FieldSnapshot = Partial<PydanticField> & { name: string };
+
+export type Version = SchemaVersion;
+
+export type EnrichedEntry = {
+  id: string;
+  field_name: string;
+  before: Record<string, unknown>;
+  after: Record<string, unknown>;
+  createdAt: number;
+  changeType: ChangeType;
+  version: Version;
+};
+
+export type LogEntryRow = {
+  id: string;
+  field_name: string;
+  before_value: Record<string, unknown> | null;
+  after_value: Record<string, unknown> | null;
+  created_at: string;
+  change_type: string | null;
+};
+
+export type ResponseRow = {
+  id: string;
+  created_at: string;
+  answer_field_hashes: Record<string, string> | null;
+  version_inferred_from: string | null;
+};
+
+export type UpdateBucket = { version: Version; method: string; ids: string[] };
+
+export type BackfillStats = {
+  finalVersion: { major: number; minor: number; patch: number };
+  logEntriesUpdated: number;
+  responsesProcessed: number;
+  byMethod: {
+    hashes: number;
+    created_at: number;
+    fallback_created_at: number;
+    live_save: number;
+  };
+};
+
+function cloneFieldSnapshot(f: FieldSnapshot): FieldSnapshot {
+  return {
+    ...f,
+    options: f.options ? [...f.options] : f.options,
+  };
+}
+
+function cloneSnapshotMap(snap: Map<string, FieldSnapshot>): Map<string, FieldSnapshot> {
+  const out = new Map<string, FieldSnapshot>();
+  for (const [k, v] of snap) out.set(k, cloneFieldSnapshot(v));
+  return out;
+}
+
+function versionKey(v: { major: number; minor: number; patch: number }) {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+export function computeHashesFromSnapshot(snap: Map<string, FieldSnapshot>): Record<string, string> {
+  const hashes: Record<string, string> = {};
+  for (const [name, field] of snap) {
+    if (!field.type || field.description == null) continue;
+    hashes[name] = computeFieldHash(
+      name,
+      field.type,
+      field.options ?? null,
+      field.description,
+    );
+  }
+  return hashes;
+}
+
+// Classifica cada entry (major/minor/patch) e acumula a versão corrente:
+// `current` acumula sequencialmente porque a versão de uma entry depende de
+// todas as anteriores (semver é cumulativo).
+export function classifyLogEntries(log: LogEntryRow[]): {
+  enriched: EnrichedEntry[];
+  finalVersion: Version;
+} {
+  let current: Version = { major: 0, minor: 1, patch: 0 };
+  const enriched: EnrichedEntry[] = [];
+
+  for (const entry of log) {
+    const before = entry.before_value ?? {};
+    const after = entry.after_value ?? {};
+
+    const type: ChangeType =
+      entry.change_type === "major"
+        ? "major"
+        : fieldDiffIsStructural(before, after)
+          ? "minor"
+          : "patch";
+
+    current = bumpVersion(current, type);
+    enriched.push({
+      id: entry.id,
+      field_name: entry.field_name,
+      before,
+      after,
+      createdAt: new Date(entry.created_at).getTime(),
+      changeType: type,
+      version: { ...current },
+    });
+  }
+
+  return { enriched, finalVersion: current };
+}
+
+// Reconstrói o snapshot de campos em cada versão, andando o log de trás para
+// frente (revertendo diffs a partir do estado atual).
+export function reconstructSnapshotsByVersion(
+  pydanticFields: PydanticField[],
+  enriched: EnrichedEntry[],
+  finalVersion: Version,
+): Map<string, Map<string, FieldSnapshot>> {
+  const currentSnap = new Map<string, FieldSnapshot>();
+  for (const f of pydanticFields) {
+    currentSnap.set(f.name, cloneFieldSnapshot({ ...f }));
+  }
+
+  // Map: versionKey -> snapshot map (fieldName -> snapshot)
+  const snapByVersion = new Map<string, Map<string, FieldSnapshot>>();
+  snapByVersion.set(versionKey(finalVersion), cloneSnapshotMap(currentSnap));
+
+  // Group entries by version so we revert all at once per version-change
+  const versionsDesc: Array<{ key: string; version: Version }> = [];
+  const entriesByVersion = new Map<string, EnrichedEntry[]>();
+  for (const e of enriched) {
+    const k = versionKey(e.version);
+    if (!entriesByVersion.has(k)) {
+      entriesByVersion.set(k, []);
+      versionsDesc.push({ key: k, version: e.version });
+    }
+    entriesByVersion.get(k)!.push(e);
+  }
+  // Sort desc so we revert from latest → earliest
+  versionsDesc.sort((a, b) => {
+    if (a.version.major !== b.version.major) return b.version.major - a.version.major;
+    if (a.version.minor !== b.version.minor) return b.version.minor - a.version.minor;
+    return b.version.patch - a.version.patch;
+  });
+
+  const workingSnap = cloneSnapshotMap(currentSnap);
+  for (let idx = 0; idx < versionsDesc.length; idx++) {
+    const { key } = versionsDesc[idx];
+    // Snapshot at version `version` (before reverting) — if not already stored
+    if (!snapByVersion.has(key)) {
+      snapByVersion.set(key, cloneSnapshotMap(workingSnap));
+    }
+    // Revert all entries at this version
+    const group = entriesByVersion.get(key)!;
+    for (const e of group) {
+      // Skip project-level entries (publishMajorVersion)
+      if (e.field_name === "(projeto)") continue;
+      const isAdd = Object.keys(e.before).length === 0;
+      const isRemove = Object.keys(e.after).length === 0;
+      if (isAdd) {
+        // Pré-E: o campo não existia
+        workingSnap.delete(e.field_name);
+      } else if (isRemove) {
+        // Pré-E: o campo existia como `before`
+        const snap = { name: e.field_name, ...(e.before as Partial<PydanticField>) };
+        workingSnap.set(e.field_name, snap);
+      } else {
+        // Campo modificado: reverte atributos listados em `before`
+        const existing = workingSnap.get(e.field_name) ?? { name: e.field_name };
+        workingSnap.set(e.field_name, {
+          ...existing,
+          ...(e.before as Partial<PydanticField>),
+          name: e.field_name,
+        });
+      }
+    }
+    // Após reverter, workingSnap representa a versão anterior
+    const prev = versionsDesc[idx + 1];
+    if (!prev) {
+      // 0.1.0 inicial (pré-primeira entry)
+      snapByVersion.set(versionKey({ major: 0, minor: 1, patch: 0 }), cloneSnapshotMap(workingSnap));
+    }
+  }
+
+  return snapByVersion;
+}
+
+// Escolhe a versão de cada response (por hash de campos, com fallback em
+// created_at) e agrupa em buckets por (versão, método).
+export function matchResponsesToVersions(
+  responses: ResponseRow[],
+  hashesByVersion: Map<string, Record<string, string>>,
+  enriched: EnrichedEntry[],
+): { updates: Map<string, UpdateBucket>; byMethod: BackfillStats["byMethod"] } {
+  const versionByKey = new Map<string, Version>();
+  for (const k of hashesByVersion.keys()) {
+    const [mj, mn, pt] = k.split(".").map((n) => Number.parseInt(n, 10));
+    versionByKey.set(k, { major: mj, minor: mn, patch: pt });
+  }
+  // Timestamp of each version (from entries; initial version = 0)
+  const versionTs = new Map<string, number>();
+  for (const e of enriched) {
+    const k = versionKey(e.version);
+    if (!versionTs.has(k)) versionTs.set(k, e.createdAt);
+  }
+  versionTs.set(versionKey({ major: 0, minor: 1, patch: 0 }), 0);
+
+  // Bucket updates by (version, method)
+  const updates = new Map<string, UpdateBucket>();
+  let countLiveSave = 0;
+  let countHashes = 0;
+  let countCreatedAt = 0;
+  let countFallback = 0;
+
+  for (const r of responses) {
+    // Preserve live_save entries as-is (precisão total)
+    if (r.version_inferred_from === "live_save") {
+      countLiveSave++;
+      continue;
+    }
+
+    const rHashes = r.answer_field_hashes ?? null;
+    const ts = new Date(r.created_at).getTime();
+
+    let chosenKey: string | null = null;
+    let chosenMethod: "hashes" | "created_at" | "fallback_created_at" = "created_at";
+
+    if (rHashes && Object.keys(rHashes).length > 0) {
+      // Score each version
+      let bestScore = -1;
+      let bestKey: string | null = null;
+      let bestTieTs = Infinity;
+      for (const [k, vHashes] of hashesByVersion) {
+        let score = 0;
+        for (const [fn, h] of Object.entries(rHashes)) {
+          if (vHashes[fn] === h) score++;
+        }
+        if (score === 0) continue;
+        const kTs = versionTs.get(k) ?? 0;
+        const tieMetric = Math.abs(kTs - ts);
+        if (score > bestScore || (score === bestScore && tieMetric < bestTieTs)) {
+          bestScore = score;
+          bestKey = k;
+          bestTieTs = tieMetric;
+        }
+      }
+      if (bestKey) {
+        chosenKey = bestKey;
+        chosenMethod = "hashes";
+      }
+    }
+
+    if (!chosenKey) {
+      // Fallback timestamp
+      const candidates = [...versionTs.entries()]
+        .filter(([, t]) => t <= ts)
+        .sort((a, b) => b[1] - a[1]);
+      chosenKey =
+        candidates.length > 0 ? candidates[0][0] : versionKey({ major: 0, minor: 1, patch: 0 });
+      chosenMethod =
+        rHashes && Object.keys(rHashes).length > 0 ? "fallback_created_at" : "created_at";
+    }
+
+    const v = versionByKey.get(chosenKey) ?? { major: 0, minor: 1, patch: 0 };
+    const bucketKey = `${chosenKey}|${chosenMethod}`;
+    if (!updates.has(bucketKey)) {
+      updates.set(bucketKey, { version: v, method: chosenMethod, ids: [] });
+    }
+    updates.get(bucketKey)!.ids.push(r.id);
+
+    if (chosenMethod === "hashes") countHashes++;
+    else if (chosenMethod === "created_at") countCreatedAt++;
+    else if (chosenMethod === "fallback_created_at") countFallback++;
+  }
+
+  return {
+    updates,
+    byMethod: {
+      hashes: countHashes,
+      created_at: countCreatedAt,
+      fallback_created_at: countFallback,
+      live_save: countLiveSave,
+    },
+  };
+}


### PR DESCRIPTION
## Resumo

- **O deploy do frontend no Fly está quebrado desde o merge do #404** (`f6c1af2`): 3 merges consecutivos (#404, #182/PR do sorteio, #407) falharam no workflow "Deploy frontend (Fly.io)" e não chegaram em produção. O último deploy bem-sucedido é `5e97cbc` (14:48 de 2026-07-03). Sintoma visível: o toggle "Meus atribuídos"/"Todos" do #407 não aparece em produção.
- Causa raiz: o #404 exportou **5 funções puras síncronas** de arquivos com diretiva `"use server"` (`actions/schema.ts` e `actions/field-reviews.ts`) para testá-las diretamente. O Next.js exige que todo export de *valor* nesses arquivos seja função async — cada export vira endpoint RPC invocável pelo cliente — e o `next build` falha com "Server Actions must be async functions". `tsc` não valida essa regra, e `next build` não roda em nenhum gate local, então nada barrou antes do Docker do Fly.
- Fix: extrai as etapas puras para módulos em `lib/` (padrão do projeto — puro em `lib`, actions só orquestram I/O). Nenhuma mudança de comportamento; corpo das funções movido verbatim. De quebra, elimina o risco latente de expor funções sem checagem de auth como endpoints RPC.

## Arquivos

- `frontend/src/lib/schema-backfill.ts` (novo): `classifyLogEntries`, `reconstructSnapshotsByVersion`, `matchResponsesToVersions` + helpers privados (`cloneFieldSnapshot`, `cloneSnapshotMap`, `versionKey`), `computeHashesFromSnapshot` e os tipos do backfill (`FieldSnapshot`, `Version`, `EnrichedEntry`, `LogEntryRow`, `ResponseRow`, `UpdateBucket`, `BackfillStats`).
- `frontend/src/lib/auto-review-backlog.ts` (novo): `computeBacklogRows`, `diffReviewsToRemove`, `compositeKeySet` (ainda usado por `removeOrphanAssignments`, que fica na action) + row-types do backlog.
- `frontend/src/actions/schema.ts` e `frontend/src/actions/field-reviews.ts`: importam de lib; só actions async permanecem exportadas.
- Testes movidos junto: `lib/__tests__/schema-backfill.test.ts` e `lib/__tests__/auto-review-backlog.test.ts` (ex-`actions/__tests__/`), imports atualizados.

## Test plan

- [x] `npm run build` — **passa** (era exatamente o que falhava no deploy)
- [x] `npm run typecheck` — limpo
- [x] `npx vitest run` — 1089/1089
- [x] Pre-push: typecheck, vitest full, lint:types e semgrep Passed
- [ ] Pós-merge: acompanhar "Deploy frontend (Fly.io)" até success e confirmar o toggle do #407 na Comparação em produção

Nota: `fallow-audit` pulado (`SKIP=fallow-audit`) por falso-positivo documentado — a complexidade de `reconstructSnapshotsByVersion` foi transplantada verbatim, mas o gate new-only a conta como nova (mesmo padrão dos PRs #334, #396, #402).

🤖 Generated with [Claude Code](https://claude.com/claude-code)