### PR TITLE
fix(compare): filas pessoais honram impersonação master e contas-alias

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/arbitragem/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/arbitragem/page.tsx
@@ -1,5 +1,5 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, resolveEffectiveUserId } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { ArbitrationPage } from "@/components/arbitration/ArbitrationPage";
 import { assignOrder } from "@/lib/arbitration-order";
@@ -12,15 +12,23 @@ import type { ArbitrationVerdict, PydanticField } from "@/lib/types";
 
 export default async function ArbitrationRoute({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ viewAsUser?: string }>;
 }) {
-  const [{ id }, user, supabase] = await Promise.all([
+  const [{ id }, sp, user, supabase] = await Promise.all([
     params,
+    searchParams,
     getAuthUser(),
     createSupabaseServer(),
   ]);
   if (!user) redirect("/auth/login");
+
+  // Fila 100% pessoal: pertence à identidade EFETIVA (impersonação master via
+  // ?viewAsUser= ou conta-alias da spec 002), como no Codificar/Comparação.
+  // Com user.id cru, o master "visualizando como" via a própria fila (vazia).
+  const { effectiveUserId } = await resolveEffectiveUserId(id, user, sp.viewAsUser);
 
   const [{ data: project }, { data: assignments }] = await Promise.all([
     supabase
@@ -32,7 +40,7 @@ export default async function ArbitrationRoute({
       .from("assignments")
       .select("document_id, status")
       .eq("project_id", id)
-      .eq("user_id", user.id)
+      .eq("user_id", effectiveUserId)
       .eq("type", "arbitragem")
       .neq("status", "concluido"),
   ]);
@@ -63,7 +71,7 @@ export default async function ArbitrationRoute({
         "id, document_id, field_name, human_response_id, llm_response_id, blind_verdict, final_verdict, self_justification",
       )
       .in("document_id", docIds)
-      .eq("arbitrator_id", user.id)
+      .eq("arbitrator_id", effectiveUserId)
       .eq("self_verdict", "contesta_llm")
       .is("final_verdict", null),
   ]);

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -2,8 +2,8 @@ import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import {
   getAuthUser,
-  getEffectiveMemberId,
   isProjectCoordinator,
+  resolveEffectiveUserId,
 } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { CodingPage } from "@/components/coding/CodingPage";
@@ -43,10 +43,13 @@ export default async function CodePage({
 
   // Impersonação master (viewAsUser) tem precedência; sem ela, contas
   // vinculadas trabalham como o membro canônico do projeto (spec 002).
-  const isImpersonating = !!(user.isMaster && sp.viewAsUser);
-  const effectiveUserId = isImpersonating
-    ? sp.viewAsUser!
-    : await getEffectiveMemberId(id);
+  // resolveEffectiveUserId é a fonte única dessa precedência, compartilhada
+  // com Comparação e Arbitragem.
+  const { effectiveUserId, isImpersonating } = await resolveEffectiveUserId(
+    id,
+    user,
+    sp.viewAsUser,
+  );
   const roundParam = sp.round ?? CURRENT_FILTER_VALUE;
 
   const supabase = await createSupabaseServer();

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
+import { getAuthUser, getProjectAccessContext, resolveEffectiveUserId } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { ComparePage } from "@/components/compare/ComparePage";
 import { coordinatorGate } from "@/lib/project-access";
@@ -48,6 +48,16 @@ export default async function ComparePageRoute({
     createSupabaseServer(),
   ]);
   if (!user) redirect("/auth/login");
+
+  // Fila pessoal pertence à identidade EFETIVA: impersonação master
+  // (?viewAsUser=, mesmo param do Codificar) ou conta-alias (spec 002).
+  // Filtrar por user.id cru mostrava a fila do master (vazia) durante a
+  // impersonação — foi o "não tem documento atribuído" da Mariana.
+  const { effectiveUserId, isImpersonating } = await resolveEffectiveUserId(
+    id,
+    user,
+    sp.viewAsUser,
+  );
 
   const [
     { data: project },
@@ -152,7 +162,11 @@ export default async function ComparePageRoute({
   const latestMajorLabel = formatVersion(latestMajorAnchor(projectVersion));
 
   // Compare-type assignments filter (ver assignedCompareDocIds).
-  const compareAssignedDocIds = assignedCompareDocIds(showAllQueue, allAssignments, user.id);
+  const compareAssignedDocIds = assignedCompareDocIds(
+    showAllQueue,
+    allAssignments,
+    effectiveUserId,
+  );
 
   // Distingue "sem nada atribuído" de "tem atribuído, mas foi filtrado por
   // cobertura/divergência" — usado só pela mensagem de estado vazio em
@@ -168,7 +182,7 @@ export default async function ComparePageRoute({
   const compareAssignmentStatusByDoc = buildCompareAssignmentStatusByDoc(
     allAssignments,
     showAllQueue,
-    user.id,
+    effectiveUserId,
   );
 
   const { responsesByDoc, docsMetaMap } = indexResponsesByDoc(allResponses);
@@ -223,10 +237,11 @@ export default async function ComparePageRoute({
   // completo, nao apenas com texto vazio.
   const documentsForCompareUnsorted = buildDocumentsForCompare(qualifiedDocIds, textMap, docsMetaMap);
 
-  // Track reviews do user atual para preencher reviewedCount
+  // Track reviews da identidade efetiva para preencher reviewedCount — na
+  // impersonação, o progresso exibido é o do dono da fila, não o do master.
   const { existingReviews, reviewedCountByDoc } = buildReviewsAndReviewedCounts(
     reviews,
-    user.id,
+    effectiveUserId,
     qualifiedDocIds,
     divergentFields,
   );
@@ -271,6 +286,7 @@ export default async function ComparePageRoute({
         currentProjectVersion={`${projectVersion.major}.${projectVersion.minor}.${projectVersion.patch}`}
         equivalencesByDocField={equivalencesByDocField}
         currentUserId={user.id}
+        isImpersonating={isImpersonating}
         canManageAnyPair={isCoordinator}
         isCoordinator={isCoordinator}
         showingAllQueue={showAllQueue}

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -64,6 +64,11 @@ interface ComparePageProps {
   // pra diferenciar a mensagem de estado vazio: "sem nada atribuído" (trocar
   // de aba resolve) vs. "atribuído mas filtrado" (trocar de aba não resolve).
   hasAssignedDocs: boolean;
+  // Master visualizando como outro membro (?viewAsUser=): a fila exibida é a
+  // do membro impersonado, então a copy do estado vazio muda pra 3ª pessoa —
+  // o "você não tem documentos atribuídos" desta tela já foi lido como sendo
+  // sobre o membro quando era sobre o master.
+  isImpersonating: boolean;
 }
 
 export function ComparePage({
@@ -89,6 +94,7 @@ export function ComparePage({
   isCoordinator,
   showingAllQueue,
   hasAssignedDocs,
+  isImpersonating,
 }: ComparePageProps) {
   // Ordem estável de montagem: o re-sort por pendências do servidor (a cada
   // veredito) não remexe a fila nem a sidebar — só mudança de composição
@@ -262,12 +268,21 @@ export function ComparePage({
     // — trocar de aba não muda nada, o filtro de cobertura é ortogonal ao
     // de assignment. `hasAssignedDocs` (calculado em page.tsx a partir do
     // mesmo Set que já filtra a fila) diferencia os dois casos.
+    // Na impersonação a fila exibida é a do membro, então o sujeito da copy
+    // muda pra 3ª pessoa — "você" aqui já foi lido como sendo sobre o membro
+    // quando descrevia a fila (vazia) do próprio master.
+    const filteredOutMessage = isImpersonating
+      ? "Os documentos atribuídos a este membro não atendem aos filtros atuais (respostas mínimas, versão, etc.). Ajuste os filtros ou use a aba \"Todos\" para ver a fila completa."
+      : "Seus documentos atribuídos não atendem aos filtros atuais (respostas mínimas, versão, etc.). Ajuste os filtros ou use a aba \"Todos\" para ver a fila completa.";
+    const nothingAssignedMessage = isImpersonating
+      ? 'Este membro não tem documentos atribuídos para comparação. Use a aba "Todos" acima para ver a fila completa do projeto.'
+      : 'Você não tem documentos atribuídos para comparação. Use a aba "Todos" acima para ver a fila completa do projeto.';
     const emptyMessage =
       documents.length === 0
         ? isCoordinator && !showingAllQueue
           ? hasAssignedDocs
-            ? "Seus documentos atribuídos não atendem aos filtros atuais (respostas mínimas, versão, etc.). Ajuste os filtros ou use a aba \"Todos\" para ver a fila completa."
-            : 'Você não tem documentos atribuídos para comparação. Use a aba "Todos" acima para ver a fila completa do projeto.'
+            ? filteredOutMessage
+            : nothingAssignedMessage
           : "Nenhum documento na fila com os filtros atuais."
         : "Nenhuma divergência neste documento.";
 

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -116,6 +116,7 @@ const props = {
   isCoordinator: false,
   showingAllQueue: false,
   hasAssignedDocs: false,
+  isImpersonating: false,
 };
 
 const renderReal = () =>

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -218,6 +218,7 @@ function makeProps(existingReviews: ReviewsByDoc = {}) {
     isCoordinator: false,
     showingAllQueue: false,
     hasAssignedDocs: false,
+    isImpersonating: false,
   };
 }
 
@@ -567,6 +568,42 @@ describe("ComparePage — toggle de fila (só coordenador)", () => {
     expect(
       screen.queryByText(/Você não tem documentos atribuídos/),
     ).toBeNull();
+  });
+
+  it("impersonando sem documentos atribuídos: copy em 3ª pessoa (fila é do membro)", () => {
+    render(
+      <ComparePage
+        {...emptyProps({
+          isCoordinator: true,
+          showingAllQueue: false,
+          hasAssignedDocs: false,
+          isImpersonating: true,
+        })}
+      />,
+    );
+    expect(
+      screen.getByText(/Este membro não tem documentos atribuídos.*aba "Todos"/),
+    ).not.toBeNull();
+    expect(
+      screen.queryByText(/Você não tem documentos atribuídos/),
+    ).toBeNull();
+  });
+
+  it("impersonando com atribuídos filtrados por cobertura: copy em 3ª pessoa", () => {
+    render(
+      <ComparePage
+        {...emptyProps({
+          isCoordinator: true,
+          showingAllQueue: false,
+          hasAssignedDocs: true,
+          isImpersonating: true,
+        })}
+      />,
+    );
+    expect(
+      screen.getByText(/atribuídos a este membro não atendem aos filtros atuais/),
+    ).not.toBeNull();
+    expect(screen.queryByText(/Seus documentos atribuídos/)).toBeNull();
   });
 
   it("na aba 'Todos', a mensagem genérica não menciona assignment", () => {

--- a/frontend/src/lib/__tests__/auth-effective-member.test.ts
+++ b/frontend/src/lib/__tests__/auth-effective-member.test.ts
@@ -64,6 +64,10 @@ async function loadGetEffective() {
   return (await import("@/lib/auth")).getEffectiveMemberId;
 }
 
+async function loadResolveEffective() {
+  return (await import("@/lib/auth")).resolveEffectiveUserId;
+}
+
 describe("getEffectiveMemberId", () => {
   it("com alias no projeto → retorna o member_user_id canônico", async () => {
     aliasByProject = { pA: { member_user_id: "canonico1" } };
@@ -81,5 +85,35 @@ describe("getEffectiveMemberId", () => {
     aliasByProject = { pC: { member_user_id: "canonico1" }, pD: null };
     const getEffectiveMemberId = await loadGetEffective();
     await expect(getEffectiveMemberId("pD")).resolves.toBe("acc1");
+  });
+});
+
+// resolveEffectiveUserId: fonte única da precedência entre impersonação
+// master (?viewAsUser=) e conta-alias, compartilhada por Codificar,
+// Comparação e Arbitragem. Sem ela, Comparação/Arbitragem filtravam a fila
+// pessoal pelo id do master logado e mostravam fila vazia na impersonação.
+describe("resolveEffectiveUserId", () => {
+  it("master + viewAsUser → impersona (precedência sobre alias)", async () => {
+    aliasByProject = { pE: { member_user_id: "canonico1" } };
+    const resolveEffectiveUserId = await loadResolveEffective();
+    await expect(
+      resolveEffectiveUserId("pE", { id: "acc1", isMaster: true }, "membro9"),
+    ).resolves.toEqual({ effectiveUserId: "membro9", isImpersonating: true });
+  });
+
+  it("não-master ignora viewAsUser e resolve alias", async () => {
+    aliasByProject = { pF: { member_user_id: "canonico1" } };
+    const resolveEffectiveUserId = await loadResolveEffective();
+    await expect(
+      resolveEffectiveUserId("pF", { id: "acc1", isMaster: false }, "membro9"),
+    ).resolves.toEqual({ effectiveUserId: "canonico1", isImpersonating: false });
+  });
+
+  it("master sem viewAsUser cai na resolução de alias/si próprio", async () => {
+    aliasByProject = { pG: null };
+    const resolveEffectiveUserId = await loadResolveEffective();
+    await expect(
+      resolveEffectiveUserId("pG", { id: "acc1", isMaster: true }, undefined),
+    ).resolves.toEqual({ effectiveUserId: "acc1", isImpersonating: false });
   });
 });

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -120,6 +120,27 @@ export const getEffectiveMemberId = cache(
   },
 );
 
+// Identidade efetiva das páginas de fila pessoal (Codificar, Comparação,
+// Arbitragem, Meus vereditos): a impersonação master (?viewAsUser=) tem
+// precedência; sem ela, contas vinculadas resolvem para o membro canônico do
+// projeto via getEffectiveMemberId (spec 002). Fonte única da precedência —
+// antes cada página reimplementava o par isMaster && viewAsUser, e as que não
+// o fizeram (Comparação/Arbitragem) filtravam a fila pelo id do master logado,
+// mostrando fila vazia durante a impersonação.
+export async function resolveEffectiveUserId(
+  projectId: string,
+  user: Pick<AuthUser, "id" | "isMaster">,
+  viewAsUser: string | undefined,
+): Promise<{ effectiveUserId: string; isImpersonating: boolean }> {
+  if (user.isMaster && viewAsUser) {
+    return { effectiveUserId: viewAsUser, isImpersonating: true };
+  }
+  return {
+    effectiveUserId: await getEffectiveMemberId(projectId),
+    isImpersonating: false,
+  };
+}
+
 interface ProjectAccessContext {
   project: { id: string; name: string; created_by: string } | null;
   membershipRole: string | null;


### PR DESCRIPTION
## Resumo

- **Sintoma**: Bruno (master), "visualizando como" a Mariana, viu na Comparação do Zolgensma a mensagem "Você não tem documentos atribuídos para comparação" — enquanto a matriz de Atribuições mostra dezenas de pendências dela.
- **Diagnóstico (verificado nos dados de produção)**: a fila da Mariana não está vazia — ela tem 45 comparações pendentes + 2 em andamento, e ~44 docs passam nos gates da fila (versão 0.20.0, compare_llm). A fila vazia era a do **master**: `analyze/compare/page.tsx` filtrava assignments por `user.id` cru, ignorando a impersonação (`?viewAsUser=`, honrada pelo Codificar) e a resolução de conta-alias (spec 002). Antes do #407 o furo era invisível (coordenador via tudo sem filtro); o default "Meus atribuídos" o expôs. A Arbitragem tinha o mesmo furo latente.
- **Nota**: a Mariana logada diretamente já via a fila dela normalmente — o vazio era artefato da impersonação.

## Mudanças

- `lib/auth.ts`: `resolveEffectiveUserId(projectId, user, viewAsUser)` — fonte única da precedência (master+viewAsUser → impersona; senão alias/si próprio via `getEffectiveMemberId`).
- `analyze/compare/page.tsx`: identidade efetiva no filtro de assignments (`assignedCompareDocIds`), no status por doc e no `reviewedCount`; `currentUserId` (autoria/escrita no client) segue o usuário real.
- `ComparePage.tsx`: copy do estado vazio em 3ª pessoa durante impersonação ("Este membro não tem documentos atribuídos...") — evita exatamente a leitura errada desta sessão.
- `analyze/arbitragem/page.tsx`: mesma resolução nas queries de `assignments` e `field_reviews` (fila 100% pessoal).
- `analyze/code/page.tsx`: refatorado para consumir o helper (comportamento idêntico — é a origem do padrão).
- Testes: 3 casos do helper em `auth-effective-member.test.ts` + 2 casos de copy em `ComparePage.test.tsx`.

## Test plan

- [x] `npm run typecheck` — limpo
- [x] `npm run build` — passa (gate do deploy)
- [x] `npx vitest run` — 1094/1094
- [x] Pre-push: typecheck, vitest, lint:types, fallow, semgrep — todos Passed
- [ ] Pós-deploy: como master, Comparação do Zolgensma impersonando a Mariana → fila com ~44 docs; Arbitragem idem; sem impersonação → fila própria com copy em 1ª pessoa

🤖 Generated with [Claude Code](https://claude.com/claude-code)