### PR TITLE
Consolida specs abertas

### DIFF
--- a/specs/002-preregister-members/plan.md
+++ b/specs/002-preregister-members/plan.md
@@ -32,14 +32,16 @@ Coordenadores passam a poder (1) adicionar e-mails sem conta a um projeto — o 
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-`.specify/memory/constitution.md` é o template não ratificado — sem gates formais. Gates de fato adotados (CLAUDE.md do projeto):
+`.specify/memory/constitution.md` está ratificada na versão 1.0.1 e prevalece sobre práticas ad hoc. Gates aplicáveis:
 
-- ✅ Server Actions para mutations, RSC para reads — todas as operações novas são actions em `actions/members.ts`.
-- ✅ Queries com colunas explícitas, sem `select("*")`; agregações via `count`/join; `Promise.all` para independentes.
-- ✅ Tabela nova em RLS com index nas colunas usadas pelas funções de auth (`linked_user_id`, `project_id`).
-- ✅ UI com shadcn/ui, pt-BR nos labels, código em inglês.
-- ✅ Migrations manuais (memória do projeto): `db push` nunca roda sozinho no merge.
-- ✅ Pydantic/schema não é tocado — regras de round-trip não se aplicam.
+- ✅ I. Usabilidade primeiro — a feature vive na tela de membros, usa labels/toasts em pt-BR, status visível de pendente e confirmação explícita para unificação.
+- ✅ II. Velocidade — resolução de identidade efetiva e lista de membros devem evitar N+1; queries novas usam colunas explícitas, índices e `Promise.all` quando independentes.
+- ✅ III. Segurança da informação — aliases por projeto preservam isolamento cross-project; service key fica restrita a Server Actions/webhook.
+- ✅ IV. RLS-por-padrão — `member_email_links` nasce com RLS, policies por projeto/papel e índices em `project_id`/`linked_user_id`.
+- ✅ V. Robustez via testes — mudanças em `frontend/src/lib` e `frontend/src/actions` exigem Vitest; fluxos Clerk/signup ficam no quickstart manual.
+- ✅ VI. Acessibilidade WCAG 2.1 AA — dialogs e ações novas devem manter shadcn/ui, labels associados, foco visível e contraste AA.
+- ✅ VII. Fonte única de verdade do schema — Pydantic/schema não é tocado; regras de round-trip não se aplicam.
+- ✅ VIII. Simplicidade de stack — tudo permanece em Next.js Server Actions/RSC + Supabase; FastAPI não participa de CRUD.
 
 **Pós-Phase 1**: sem violações; nenhuma entrada em Complexity Tracking.
 

--- a/specs/003-auth-render-path/checklists/requirements.md
+++ b/specs/003-auth-render-path/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Auth Render Path
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on 2026-07-06.
+- The spec names the existing identity-provider/data-authorization boundary in the input and assumptions because that boundary is part of the approved product scope; functional requirements remain focused on user-visible behavior, security outcomes, and measurable performance.
+- No `[NEEDS CLARIFICATION]`, `TODO`, or `TBD` markers remain in `spec.md`.

--- a/specs/003-auth-render-path/spec.md
+++ b/specs/003-auth-render-path/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: Caminho de autenticação rápido e recuperável
+
+**Feature Branch**: `003-auth-render-path`
+
+**Created**: 2026-07-06
+
+**Status**: Draft
+
+**Input**: User description: "Melhorar a autenticação após a issue #187: reduzir a latência de páginas autenticadas causada por verificações remotas durante a renderização, manter o caminho oficial Clerk/Supabase como padrão, incluir cache por request na mesma spec, preservar RLS e evitar que pesquisadores fiquem bloqueados quando o vínculo de conta ainda não estiver pronto."
+
+## Clarifications
+
+### Session 2026-07-06
+
+- Q: Quando uma página protegida encontra sessão válida, mas vínculo interno ausente ou divergente, ela deve tentar reparo silencioso no render ou encaminhar o usuário para conclusão de acesso? → A: Redirecionar para conclusão de acesso/reparo; páginas protegidas não fazem reparo silencioso.
+- Q: `viewAs`/impersonação deve afetar também escritas ou apenas leitura, navegação e escopo visual? → A: `viewAs`/impersonação só afeta leitura, navegação e escopo visual; escritas continuam proibidas ou feitas como ator real quando já permitido.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Acessar projeto sem espera perceptível de autenticação (Priority: P1)
+
+O coordenador ou pesquisador já autenticado abre o dashboard ou uma página de projeto e consegue começar a trabalhar sem que a plataforma refaça verificações remotas de identidade durante cada renderização protegida. A experiência esperada é que autenticação e permissão já estejam preparadas quando a página protegida carrega, de modo que o tempo de espera percebido seja dominado pelo carregamento dos dados do projeto, não por uma nova rodada de autenticação.
+
+**Why this priority**: Esta é a motivação central da issue #187. Depois da melhoria de região do PR #185, o custo restante mais visível passou a ser a autenticação no caminho crítico de páginas protegidas.
+
+**Independent Test**: Pode ser testado com uma conta autenticada e com vínculo interno já preparado, acessando uma página de projeto sem cache de navegador e medindo se a página fica utilizável dentro do orçamento definido, sem múltiplas resoluções de identidade na mesma solicitação.
+
+**Acceptance Scenarios**:
+
+1. **Given** um usuário autenticado com vínculo de acesso já preparado, **When** ele abre uma página de projeto protegida, **Then** a página carrega dentro da meta de tempo definida e mostra o conteúdo autorizado sem etapa intermediária de autenticação.
+2. **Given** uma mesma renderização protegida que precisa consultar várias informações do projeto, **When** essas informações são carregadas, **Then** a identidade autenticada é reutilizada dentro da própria solicitação em vez de ser recalculada repetidamente.
+3. **Given** um usuário autenticado que alterna entre páginas protegidas do mesmo projeto, **When** ele navega para uma página de análise, configuração ou progresso, **Then** a plataforma mantém a mesma experiência de acesso rápido e autorizado.
+
+---
+
+### User Story 2 - Concluir acesso quando o vínculo de conta ainda não está pronto (Priority: P2)
+
+O usuário que acabou de entrar, ou cuja conta ainda não foi vinculada ao perfil interno da plataforma, recebe uma tela clara de conclusão de acesso. A tela explica que a sessão existe, mas que a plataforma ainda está preparando o vínculo necessário para acessar dados protegidos; oferece uma nova tentativa segura e orienta o usuário a procurar suporte apenas quando a recuperação automática não resolver.
+
+**Why this priority**: A melhoria de performance não pode transformar falhas de sincronização em bloqueio silencioso. Pesquisadores e coordenadores precisam entender se devem aguardar, tentar novamente ou pedir suporte.
+
+**Independent Test**: Pode ser testado com uma sessão autenticada sem vínculo interno confirmado, verificando se o usuário é conduzido a um estado recuperável, com mensagem compreensível e sem exposição de ferramentas técnicas.
+
+**Acceptance Scenarios**:
+
+1. **Given** uma sessão autenticada sem vínculo interno confirmado, **When** o usuário conclui o login, **Then** a plataforma mostra um estado de conclusão de acesso com explicação clara e ação de nova tentativa.
+2. **Given** uma página protegida encontra sessão válida, mas vínculo interno ausente ou divergente, **When** a página verifica o acesso, **Then** o usuário é redirecionado para conclusão de acesso/reparo sem reparo silencioso dentro da renderização protegida.
+3. **Given** uma falha temporária ao preparar o vínculo de acesso, **When** o usuário tenta novamente após a recuperação, **Then** ele é redirecionado para o dashboard sem precisar sair da conta manualmente.
+4. **Given** uma conta autenticada que não tem acesso a nenhum projeto, **When** o usuário chega ao dashboard, **Then** a plataforma distingue ausência de projetos de falha técnica de autenticação.
+
+---
+
+### User Story 3 - Preservar permissões, aliases e impersonação (Priority: P3)
+
+O coordenador, pesquisador, pesquisador vinculado por e-mail alternativo ou usuário master em modo de visualização continuam vendo e alterando apenas aquilo que já lhes era permitido. A melhoria de autenticação não muda a regra de negócio de quem pode acessar cada projeto, nem confunde a pessoa autenticada de fato com a identidade efetiva usada para trabalho dentro de um projeto.
+
+**Why this priority**: A plataforma depende de autorização por projeto, papéis, vínculos de e-mail e fluxos de visualização como outro usuário. Qualquer mudança no caminho de autenticação precisa preservar essa separação.
+
+**Independent Test**: Pode ser testado com contas representativas de cada papel acessando os mesmos projetos e ações antes e depois da mudança, confirmando que cada uma vê e altera somente o que já era permitido.
+
+**Acceptance Scenarios**:
+
+1. **Given** um pesquisador atribuído diretamente a um projeto, **When** ele acessa filas e formulários protegidos, **Then** ele vê somente os documentos e ações permitidos para sua identidade efetiva.
+2. **Given** um pesquisador que acessa o projeto por vínculo de e-mail alternativo, **When** ele codifica ou revisa documentos, **Then** a plataforma preserva a identidade efetiva do membro canônico sem perder o ator autenticado real.
+3. **Given** um usuário master ou coordenador usando visualização como outro usuário, **When** ele navega por páginas protegidas, **Then** a plataforma mantém a distinção entre quem está autenticado e qual identidade está sendo visualizada ou usada para escopo de trabalho.
+4. **Given** um usuário master ou coordenador usando visualização como outro usuário, **When** uma ação de escrita é apresentada ou executada, **Then** a visualização como outro usuário não concede permissão de escrita em nome da identidade visualizada; a ação permanece proibida ou atribuída ao ator real quando ele já tiver permissão própria.
+5. **Given** um usuário autenticado sem permissão para um projeto, **When** ele tenta acessar a URL desse projeto, **Then** o acesso é negado sem revelar dados do projeto.
+
+---
+
+### Edge Cases
+
+- Sessão autenticada existe, mas o vínculo interno ainda não foi criado ou ainda não foi refletido nos dados disponíveis para a sessão.
+- Dados de sessão carregam uma identidade interna antiga ou divergente do vínculo persistido.
+- Usuário mudou o e-mail principal no provedor de identidade depois de já ter acesso a projetos.
+- Vínculo por e-mail alternativo existe para um projeto, mas o usuário também tem acesso direto a outro projeto.
+- Usuário master visualiza filas como pesquisador, mas executa ações que precisam registrar o ator real.
+- Provedor de identidade ou serviço de sincronização fica temporariamente indisponível durante o login.
+- Página protegida faz múltiplas leituras independentes de dados do mesmo projeto durante uma única solicitação.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST reduce repeated authentication work within a single protected page request by reusing the resolved authenticated identity for all reads that belong to that request.
+- **FR-002**: The system MUST support authenticated access to dashboards and project pages without requiring a remote identity-provider lookup during the critical rendering path when the user's account link is already prepared.
+- **FR-003**: The system MUST use the official supported integration path between the identity provider and the data authorization layer as the default approach for authenticated data access.
+- **FR-004**: The system MUST NOT replace per-user authorization controls with a general privileged data-access path for ordinary authenticated pages.
+- **FR-005**: The system MUST preserve project-level authorization for coordinators, direct researchers, linked-email researchers, master users, and users without project access.
+- **FR-006**: The system MUST preserve the distinction between the authenticated actor, the effective project member identity, and any visualized or impersonated user context; visualized or impersonated context MUST NOT grant write permission as the viewed identity.
+- **FR-007**: The system MUST provide a user-facing access-completion state when an authenticated account has not yet been linked to an internal profile.
+- **FR-008**: Protected pages MUST fail closed and redirect to access completion or repair when the internal account link is absent or divergent; they MUST NOT silently repair the link inside the protected rendering flow.
+- **FR-009**: The access-completion state MUST explain the situation in non-technical language and offer a recovery action that can be retried safely.
+- **FR-010**: The system MUST avoid exposing diagnostic-only links or token-debugging instructions in ordinary user-facing authentication failure states.
+- **FR-011**: The system MUST distinguish at least these outcomes: signed out, signed in but link pending, signed in without project access, and signed in with a technical synchronization failure.
+- **FR-012**: The system MUST keep account-link preparation idempotent so retrying access completion does not create duplicate user records or duplicate project memberships.
+- **FR-013**: The system MUST define a measured contingency process for any non-default token path: it can only be considered after the official supported path fails the performance target in measurement, and it must require explicit security review before implementation.
+- **FR-014**: The system MUST provide a regression check that flags reintroduction of the legacy custom-token path or full remote user lookup in protected rendering flows.
+- **FR-015**: The system MUST provide observability or test evidence sufficient to show whether authentication work is still contributing materially to protected-page latency.
+- **FR-016**: The system MUST keep existing login and sign-out behavior recognizable to current users, except for clearer completion and error states after login.
+
+### Key Entities *(include if feature involves data)*
+
+- **Authenticated Actor**: The real signed-in account controlling the session; used for accountability, master checks, and security decisions that must refer to who is actually logged in.
+- **Internal User Profile**: The platform identity used by project membership, ownership, assignments, responses, reviews, and row-level access controls.
+- **Account Link**: The durable association between the authenticated actor and the internal user profile, including links created during first login, webhook synchronization, or recovery.
+- **Effective Project Member**: The internal identity used for project work when aliases or linked e-mails cause a signed-in account to act as a canonical project member.
+- **Project Access Context**: The user's relationship to a project, including creator, coordinator, researcher, master visibility, or no access.
+- **Access Completion State**: A temporary state shown after login when the session exists but the platform cannot yet confirm the internal account link required for protected data access.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For an authenticated user with a prepared account link, protected project pages become usable within 300 ms at the 95th percentile under no-browser-cache measurement, with 150–250 ms treated as the target range.
+- **SC-002**: In a representative protected page request with multiple independent data reads, authentication identity resolution happens once for the request rather than once per data read.
+- **SC-003**: 100% of tested roles — coordinator, direct researcher, linked-email researcher, master user, and authenticated user without access — retain their expected project visibility and permissions after the change.
+- **SC-004**: 100% of tested account-link failure cases show a non-technical completion or recovery state instead of a raw error, loop, blank page, or diagnostic-token instruction.
+- **SC-005**: No ordinary protected page uses a general privileged data-access path to bypass per-user authorization in the standard authenticated flow.
+- **SC-006**: A regression check fails if the legacy custom-token path or full remote user lookup is reintroduced into the protected rendering path.
+- **SC-007**: Retrying access completion for the same signed-in account produces at most one internal profile link and does not duplicate project membership records.
+
+## Assumptions
+
+- The existing identity provider remains the login system for this feature; replacing it is out of scope.
+- The existing per-user data authorization model remains the security boundary for protected project data; replacing it with application-only authorization is out of scope.
+- The first release may include an immediate request-scoped caching slice before the deeper migration, as long as the full feature still targets removal of remote identity work from the critical render path.
+- The official supported integration path between the identity provider and the data authorization layer is the default path unless measurement proves it cannot meet the performance target.
+- A locally issued database-access token is not part of the default solution; it is a contingency that requires separate security review if measurement justifies it.
+- Existing users, project memberships, account links, aliases, and master-user behavior must continue working through the migration.

--- a/specs/003-export-original-metadata/checklists/requirements.md
+++ b/specs/003-export-original-metadata/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Documentos com exportação completa
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validação revisada após decisão de juntar Documentos e Exportar na mesma experiência.
+- A especificação registra que todos os membros podem acessar Documentos em modo leitura/exportação, enquanto ações de gestão seguem restritas a coordenadores.
+- A especificação registra explicitamente que ZIP, geração assíncrona, jobs de exportação, backfill completo e migration obrigatória estão fora da primeira versão.

--- a/specs/003-export-original-metadata/spec.md
+++ b/specs/003-export-original-metadata/spec.md
@@ -1,0 +1,151 @@
+# Feature Specification: Documentos com exportação completa
+
+**Feature Branch**: `003-export-original-metadata`
+
+**Created**: 2026-07-06
+
+**Status**: Draft
+
+**Input**: User description: "Melhorar a experiência de Documentos e Exportar no dataframeitGUI. A plataforma deve preservar a linha original inteira do CSV importado junto a cada documento, inclusive colunas que também são mapeadas para texto, título e ID externo. A área de Documentos deve reunir lista, preview e exportação de forma mais intuitiva: a exportação fica no topo de Documentos em um card simples, usando o preview existente como base quando aplicável. Todos os membros do projeto devem poder acessar Documentos em modo leitura e baixar exportações; ações de gestão, como importar, excluir, restaurar ou apagar documentos, continuam restritas a coordenadores. A exportação deve priorizar simplicidade técnica: exportar sempre o conjunto completo equivalente ao modo atual “Ambos”, removendo a escolha de dataset e mantendo apenas a escolha de formato CSV/XLSX. Para CSV, manter um arquivo unificado com colunas combinadas; para XLSX, reaproveitar múltiplas abas. Não criar ZIP de CSVs, geração server-side nem jobs assíncronos nesta primeira versão. Documentos antigos sem linha original preservada continuam exportáveis, com colunas originais vazias. Não há requisito de migration nesta fase, salvo descoberta técnica posterior. O objetivo é facilitar análises posteriores preservando todos os campos da base original fornecida e tornando a exportação mais fácil de encontrar."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preservar a base original importada (Priority: P1)
+
+Como coordenador que importa documentos por CSV, quero que todas as colunas da planilha original sejam preservadas junto a cada documento para que eu possa recuperar variáveis auxiliares em análises futuras, mesmo quando elas não são usadas diretamente na codificação.
+
+**Why this priority**: Sem preservar a linha original, a exportação não consegue entregar os campos que o usuário forneceu na base inicial; depois do upload, essas informações ficam indisponíveis para auditoria e análise.
+
+**Independent Test**: Importar um CSV com colunas extras além das colunas mapeadas para texto, título e ID externo; depois exportar os dados e verificar que todas as colunas da linha original aparecem no arquivo baixado.
+
+**Acceptance Scenarios**:
+
+1. **Given** um CSV com colunas `id_original`, `titulo`, `texto`, `tribunal` e `classe`, **When** o coordenador importa os documentos mapeando `texto` como conteúdo, `titulo` como título e `id_original` como ID externo, **Then** cada documento preserva também `tribunal`, `classe` e todas as demais colunas da linha original para exportação futura.
+2. **Given** uma coluna do CSV que foi usada como título, texto ou ID externo, **When** qualquer membro autorizado exporta a base, **Then** essa coluna ainda aparece como parte da linha original preservada, sem depender apenas do campo normalizado da plataforma.
+
+---
+
+### User Story 2 - Encontrar exportação no topo de Documentos (Priority: P2)
+
+Como membro do projeto que quer analisar os dados fora da plataforma, quero acessar Documentos e encontrar a exportação logo no topo da tela para não precisar saber que ela ficava escondida em outra área.
+
+**Why this priority**: Exportar é uma ação natural do fluxo de Documentos: o usuário primeiro entende quais documentos compõem a base e depois baixa o conjunto completo para análise. Colocar a exportação no topo reduz descoberta por tentativa e erro.
+
+**Independent Test**: Acessar a área Documentos de um projeto com documentos importados; verificar que há um card de exportação antes da lista, com escolha de formato e preview curto; baixar CSV e XLSX sem escolher dataset.
+
+**Acceptance Scenarios**:
+
+1. **Given** um projeto com documentos importados, **When** o usuário abre Documentos, **Then** a primeira seção de conteúdo apresenta um card simples de exportação com escolha entre CSV e XLSX.
+2. **Given** que o usuário baixa a exportação, **When** o arquivo é aberto, **Then** ele contém o conjunto completo equivalente ao modo “Ambos”, com identificação suficiente para distinguir a origem de cada linha.
+3. **Given** que o usuário visualiza o preview no card de exportação, **When** existem documentos e respostas suficientes para prévia, **Then** o preview mostra uma amostra coerente do arquivo que será baixado, reaproveitando o padrão de preview já usado em Documentos quando fizer sentido.
+
+---
+
+### User Story 3 - Consultar Documentos como membro do projeto (Priority: P3)
+
+Como pesquisador ou outro membro do projeto, quero acessar Documentos em modo leitura para conferir a base que estou codificando ou revisando, sem receber permissões de coordenação.
+
+**Why this priority**: A leitura dos documentos é parte do trabalho de todos os membros, enquanto importação e ações destrutivas continuam sendo responsabilidade de coordenação. Separar leitura de gestão simplifica permissões sem abrir configurações sensíveis.
+
+**Independent Test**: Entrar como membro não coordenador de um projeto; acessar Documentos; confirmar que lista, preview e exportação estão disponíveis, enquanto importação, exclusão, restauração e apagamento não aparecem ou não são acionáveis.
+
+**Acceptance Scenarios**:
+
+1. **Given** um membro não coordenador com acesso ao projeto, **When** ele abre Documentos, **Then** ele vê a lista de documentos, consegue abrir preview e consegue baixar exportações.
+2. **Given** esse mesmo membro não coordenador, **When** ele visualiza Documentos, **Then** ações de importação, exclusão, restauração e apagamento não ficam disponíveis.
+3. **Given** um coordenador do projeto, **When** ele abre Documentos, **Then** ele continua podendo importar, excluir, restaurar e apagar documentos conforme as regras já existentes.
+
+---
+
+### User Story 4 - Exportar documentos antigos sem quebrar o fluxo (Priority: P4)
+
+Como usuário de um projeto já existente, quero que documentos importados antes dessa melhoria continuem exportáveis para que a nova experiência de Documentos não bloqueie análises de bases antigas.
+
+**Why this priority**: Projetos existentes podem não ter a linha original preservada. A melhoria deve ser incremental e não pode transformar dados antigos em erro de exportação.
+
+**Independent Test**: Abrir Documentos em um projeto com documentos antigos sem linha original preservada; baixar CSV e XLSX; verificar que os arquivos são gerados normalmente e que as colunas da base original ficam vazias quando não existem para aqueles documentos.
+
+**Acceptance Scenarios**:
+
+1. **Given** um documento antigo sem linha original preservada, **When** o usuário exporta os dados do projeto, **Then** a linha correspondente continua aparecendo com os campos disponíveis da plataforma.
+2. **Given** um projeto que mistura documentos antigos e novos, **When** o usuário baixa a exportação, **Then** documentos novos exibem colunas da base original e documentos antigos deixam essas colunas vazias sem impedir o download.
+
+---
+
+### Edge Cases
+
+- CSVs com colunas vazias devem preservar a existência da coluna no conjunto exportado, mesmo quando uma linha específica não tem valor.
+- CSVs com nomes de colunas repetidos ou incompatíveis com a exportação devem gerar nomes de coluna estáveis e distinguíveis no arquivo baixado.
+- Projetos sem respostas individuais ou sem gabarito devem continuar baixando a exportação completa com os dados disponíveis e sem erro.
+- Campos da base original com o mesmo nome de campos de controle da exportação devem ser diferenciados para evitar ambiguidade no arquivo final.
+- Valores complexos de respostas ou gabarito devem continuar sendo representados de forma legível na exportação, como ocorre hoje.
+- Usuários sem acesso ao projeto não devem conseguir visualizar Documentos nem baixar exportações.
+- Um membro não coordenador não deve conseguir acionar ações de gestão de documentos por navegação direta, atalho ou estado residual da interface.
+- Em reimportações que substituem documentos existentes, a linha original preservada deve refletir a nova linha importada; em duplicatas ignoradas, os dados preservados anteriormente devem permanecer inalterados.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: O sistema deve preservar, para cada documento importado por CSV, a linha original completa fornecida pelo usuário.
+- **FR-002**: A preservação da linha original deve incluir também as colunas usadas para alimentar texto, título e ID externo do documento.
+- **FR-003**: A importação por CSV deve continuar permitindo que o coordenador escolha quais colunas alimentam texto, título e ID externo do documento.
+- **FR-004**: A área Documentos deve reunir lista, preview e exportação na mesma experiência de navegação.
+- **FR-005**: A área Documentos deve exibir um card simples de exportação no topo da página, antes da lista de documentos.
+- **FR-006**: O card de exportação deve permitir escolher apenas o formato do arquivo, entre CSV e XLSX.
+- **FR-007**: A exportação deve incluir as colunas preservadas da base original nos arquivos baixados.
+- **FR-008**: A exportação deve exportar sempre o conjunto completo equivalente ao modo atual “Ambos”, sem exigir escolha entre respostas individuais, gabarito ou ambos.
+- **FR-009**: O CSV deve ser gerado como arquivo único com colunas combinadas e identificação da origem de cada linha.
+- **FR-010**: O XLSX deve separar respostas individuais e gabarito em abas distintas quando ambos existirem.
+- **FR-011**: Documentos sem linha original preservada devem continuar exportáveis, com células vazias nas colunas da base original que não existirem para esses documentos.
+- **FR-012**: A exportação deve diferenciar colunas da base original quando seus nomes colidirem com colunas de controle, respostas ou gabarito.
+- **FR-013**: A exportação deve manter informações suficientes para o usuário distinguir respostas individuais, registros de gabarito e a origem de cada linha no arquivo final.
+- **FR-014**: Todos os membros do projeto devem poder acessar Documentos em modo leitura, visualizar preview de documentos e baixar exportações.
+- **FR-015**: Ações de importação, exclusão, restauração e apagamento de documentos devem continuar restritas a coordenadores.
+- **FR-016**: A experiência de Documentos deve deixar claro para membros não coordenadores quais ações são apenas de coordenação, preferindo ocultar ações indisponíveis a exibir controles inertes.
+- **FR-017**: A melhoria não deve introduzir nesta versão exportação em ZIP, geração assíncrona, jobs de exportação ou novo fluxo de seleção de recortes.
+- **FR-018**: A melhoria não deve exigir reconstrução retroativa da linha original para documentos já importados antes da preservação.
+
+### Data and Export Rules
+
+- A linha original preservada deve representar os valores textuais da linha do CSV conforme lidos na importação.
+- A linha original preservada deve manter colunas mapeadas e não mapeadas.
+- Campos vazios da linha original devem continuar distinguíveis como campos existentes sem valor, em vez de serem tratados como coluna inexistente.
+- Colunas originais devem aparecer na exportação em ordem estável e previsível.
+- Quando uma coluna original tiver o mesmo nome de uma coluna de controle, resposta ou gabarito, o arquivo exportado deve diferenciar os nomes de modo consistente.
+- O CSV unificado deve repetir os dados originais do documento nas linhas associadas a esse documento, inclusive nas linhas de resposta individual e gabarito quando aplicável.
+- O XLSX deve incluir as colunas originais nas abas em que elas ajudam a relacionar resposta/gabarito ao documento correspondente.
+
+### Key Entities
+
+- **Documento importado**: Unidade de análise criada a partir de uma linha do CSV, com conteúdo textual, título opcional, ID externo opcional e a linha original preservada.
+- **Linha original do CSV**: Conjunto completo de pares coluna-valor fornecido pelo usuário na importação, preservado para auditoria e exportação posterior.
+- **Área Documentos**: Experiência unificada para consultar documentos, visualizar preview, importar documentos quando o usuário for coordenador e baixar exportações.
+- **Resposta individual**: Codificação humana ou gerada por LLM associada a um documento e a um conjunto de campos do schema do projeto.
+- **Gabarito do revisor**: Resultado consolidado da revisão/comparação para um documento, exportado junto com as respostas individuais quando disponível.
+- **Arquivo exportado**: Saída baixada pelo usuário em CSV ou XLSX contendo dados da base original preservada, respostas e gabarito disponível.
+- **Membro do projeto**: Usuário com acesso ao projeto, autorizado a consultar documentos e exportações.
+- **Coordenador do projeto**: Usuário com permissões de gestão sobre documentos, incluindo importação e ações destrutivas.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Em um CSV de teste com pelo menos 5 colunas originais, incluindo 2 colunas não mapeadas para campos operacionais, 100% das colunas aparecem na exportação após o upload.
+- **SC-002**: Usuários conseguem baixar a exportação completa a partir do topo de Documentos escolhendo apenas o formato do arquivo.
+- **SC-003**: Um membro não coordenador consegue acessar Documentos, visualizar preview e baixar exportação sem ver ações de importação, exclusão, restauração ou apagamento.
+- **SC-004**: Um coordenador mantém acesso às ações de gestão de documentos já existentes após a reorganização da experiência.
+- **SC-005**: Projetos com documentos antigos sem linha original preservada geram CSV e XLSX sem erro e mantêm visíveis os dados disponíveis da plataforma.
+- **SC-006**: Em um projeto com respostas individuais e gabarito, o arquivo exportado permite distinguir a origem de 100% das linhas.
+- **SC-007**: A exportação de um projeto pequeno de validação, com até 50 documentos e respostas correspondentes, é concluída em até 10 segundos em uma conexão e máquina de desenvolvimento usuais.
+
+## Assumptions
+
+- A primeira versão prioriza simplicidade técnica e reaproveita o comportamento existente de exportação completa, em vez de criar ZIP, fila de exportação ou geração em segundo plano.
+- A exportação completa é preferível a filtros na plataforma; o usuário fará recortes posteriores em ferramenta externa de análise.
+- Colunas da base original são tratadas como dados do usuário e devem aparecer no export exatamente para fins de análise e auditoria, salvo ajustes necessários de nome para evitar colisão de cabeçalhos.
+- A melhoria vale para novas importações por CSV; documentos antigos sem linha original preservada não serão retroativamente enriquecidos.
+- Todos os membros do projeto podem consultar documentos, mas apenas coordenadores podem alterar a composição da base de documentos.
+- A experiência unificada permanece em Configurações > Documentos nesta versão, mas deixa de tratar a leitura de Documentos como uma área exclusiva de coordenadores.
+- Não há requisito de migration nesta especificação. A fase de planejamento técnico deve apenas verificar se a persistência e as permissões existentes já suportam o comportamento descrito; se descobrir lacuna real, a migration passa a ser consequência técnica, não premissa da feature.
+- O alvo principal continua sendo uso em desktop, com foco em clareza e densidade de informação para análise.


### PR DESCRIPTION
## Summary
- Agrupa specs abertas numa branch dedicada de curadoria.
- Preserva a atualização local de `specs/002-preregister-members/plan.md`.
- Adiciona specs `003-auth-render-path` e `003-export-original-metadata` sem trazer código de implementação dos branches originais.

## Test plan
- [x] `git diff --name-status origin/main...HEAD` restrito a `specs/**`
- [x] Hooks de pre-push aplicáveis passaram

🤖 Generated with [Claude Code](https://claude.com/claude-code)