### PR TITLE
fix(compare): vereditos de terceiros não mascaram mais a revisão nem travam o fecho

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -214,10 +214,15 @@ export default async function ComparePageRoute({
             .is("excluded_at", null)
             .is("exclusion_pending_at", null)
         : Promise.resolve({ data: [] as { id: string; text: string }[] }),
+      // Só os reviews da identidade efetiva: a revisão é por revisor e este
+      // fetch alimenta exclusivamente existingReviews/reviewedCount (ver
+      // buildReviewsAndReviewedCounts). Vereditos de terceiros contaminavam o
+      // estado "já revisado" da tela e travavam o fecho do parecer.
       supabase
         .from("reviews")
         .select("document_id, field_name, verdict, chosen_response_id, comment, reviewer_id")
-        .eq("project_id", id),
+        .eq("project_id", id)
+        .eq("reviewer_id", effectiveUserId),
       supabase
         .from("project_comments")
         .select("document_id, field_name")

--- a/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
+++ b/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
@@ -184,3 +184,68 @@ describe("handleMarkReviewed", () => {
     expect(toastError).toHaveBeenCalledWith("não marcou");
   });
 });
+
+describe("rejeição da Server Action (fora do try dela) → toast.error, sem escrita otimista", () => {
+  // Regressão do padrão do PR #417 estendido aos quatro handlers: uma
+  // rejeição (vs. retorno { error }) era descartada pelo `void` do call site
+  // — silêncio total. Cada handler precisa capturar e avisar.
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("handleVerdict", async () => {
+    mockSubmitVerdict.mockRejectedValue(new Error("rede caiu"));
+    const { result, recordReview, goNextField } = setup();
+
+    await act(async () => {
+      await result.current.handleVerdict("concordo", "r1");
+    });
+
+    expect(recordReview).not.toHaveBeenCalled();
+    expect(goNextField).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleConfirmEquivalent", async () => {
+    mockConfirmEquivalent.mockRejectedValue(new Error("rede caiu"));
+    const { result, recordReview, goNextField } = setup();
+
+    await act(async () => {
+      await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
+    });
+
+    expect(recordReview).not.toHaveBeenCalled();
+    expect(goNextField).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleMarkReviewed", async () => {
+    mockMarkReviewed.mockRejectedValue(new Error("rede caiu"));
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleMarkReviewed();
+    });
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+
+  it("handleUnmarkPair", async () => {
+    mockUnmarkPair.mockRejectedValue(new Error("rede caiu"));
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleUnmarkPair("pair1");
+    });
+
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/compare/useCompareVerdicts.ts
+++ b/frontend/src/components/compare/useCompareVerdicts.ts
@@ -174,9 +174,20 @@ export function useCompareVerdicts({
         verdictDisplay,
         verdictComment,
         buildSnapshot(fieldResponses),
-      );
+      ).catch((error: unknown) => {
+        // Mesmo padrão do handleVerdict: rejeição da server action (fora do
+        // try dela) seria descartada pelo `void` do call site — sem toast.
+        console.error("Failed to confirm equivalent verdict", {
+          error,
+          projectId,
+          documentId: docId,
+          fieldName,
+        });
+        toast.error("Não foi possível salvar a equivalência. Tente novamente antes de avançar.");
+        return { error: "unexpected" };
+      });
       if (result?.error) {
-        toast.error(result.error);
+        if (result.error !== "unexpected") toast.error(result.error);
         return;
       }
 
@@ -214,9 +225,19 @@ export function useCompareVerdicts({
 
   const handleMarkReviewed = useCallback(async () => {
     if (!currentDoc) return;
-    const result = await markCompareDocReviewed(projectId, currentDoc.id);
+    const result = await markCompareDocReviewed(projectId, currentDoc.id).catch(
+      (error: unknown) => {
+        console.error("Failed to mark compare doc reviewed", {
+          error,
+          projectId,
+          documentId: currentDoc.id,
+        });
+        toast.error("Não foi possível marcar o documento como revisado. Tente novamente.");
+        return { error: "unexpected" };
+      },
+    );
     if (result?.error) {
-      toast.error(result.error);
+      if (result.error !== "unexpected") toast.error(result.error);
       return;
     }
     toast.success("Documento marcado como revisado.");
@@ -224,9 +245,19 @@ export function useCompareVerdicts({
 
   const handleUnmarkPair = useCallback(
     async (pairId: string) => {
-      const result = await unmarkEquivalencePair(projectId, pairId);
+      const result = await unmarkEquivalencePair(projectId, pairId).catch(
+        (error: unknown) => {
+          console.error("Failed to unmark equivalence pair", {
+            error,
+            projectId,
+            pairId,
+          });
+          toast.error("Não foi possível remover a equivalência. Tente novamente.");
+          return { error: "unexpected" };
+        },
+      );
       if (result?.error) {
-        toast.error(result.error);
+        if (result.error !== "unexpected") toast.error(result.error);
         return;
       }
       toast.success("Equivalência removida.");

--- a/frontend/src/components/compare/useCompareVerdicts.ts
+++ b/frontend/src/components/compare/useCompareVerdicts.ts
@@ -38,6 +38,31 @@ export interface CompareVerdicts {
   handleUnmarkPair: (pairId: string) => Promise<void>;
 }
 
+/**
+ * Resolve a promise de uma server action em "salvou?", exibindo o toast
+ * adequado no caminho de erro. Ponto único para os dois modos de falha:
+ * rejeição da action (fora do try dela, que o `void` do call site
+ * descartaria em silêncio) vira log + mensagem genérica; `{ error }`
+ * retornado vira toast com a mensagem da própria action.
+ */
+async function actionSucceeded(
+  promise: Promise<{ error?: string }>,
+  logLabel: string,
+  logContext: Record<string, unknown>,
+  rejectionMessage: string,
+): Promise<boolean> {
+  const result = await promise.catch((error: unknown) => {
+    console.error(logLabel, { error, ...logContext });
+    toast.error(rejectionMessage);
+    return { error: "unexpected" as const };
+  });
+  if (result?.error) {
+    if (result.error !== "unexpected") toast.error(result.error);
+    return false;
+  }
+  return true;
+}
+
 /** Snapshot das respostas presentes no momento do veredito (auditoria). */
 function buildSnapshot(fieldResponses: FieldResponse[]): ResponseSnapshotEntry[] {
   return fieldResponses
@@ -87,30 +112,27 @@ export function useCompareVerdicts({
         chosenResponseId: chosenResponseId ?? null,
         comment: verdictComment ?? null,
       };
-      const result = await submitVerdict(
-        projectId,
-        currentDoc.id,
-        currentFieldName,
-        verdict,
-        chosenResponseId,
-        verdictComment,
-        buildSnapshot(fieldResponses),
-      ).catch((error: unknown) => {
-        console.error("Failed to submit compare verdict", {
-          error,
+      const saved = await actionSucceeded(
+        submitVerdict(
+          projectId,
+          currentDoc.id,
+          currentFieldName,
+          verdict,
+          chosenResponseId,
+          verdictComment,
+          buildSnapshot(fieldResponses),
+        ),
+        "Failed to submit compare verdict",
+        {
           projectId,
           documentId: currentDoc.id,
           fieldName: currentFieldName,
           verdict,
           chosenResponseId,
-        });
-        toast.error("Não foi possível salvar o veredito. Tente novamente antes de avançar.");
-        return { error: "unexpected" };
-      });
-      if (result?.error) {
-        if (result.error !== "unexpected") toast.error(result.error);
-        return false;
-      }
+        },
+        "Não foi possível salvar o veredito. Tente novamente antes de avançar.",
+      );
+      if (!saved) return false;
 
       // Escrita otimista só após o sucesso: `recordReview` grava em `overrides`
       // (estado da sessão, não auto-revertido). Gravar antes deixaria o campo
@@ -165,31 +187,22 @@ export function useCompareVerdicts({
         chosenResponseId: gabaritoId,
         comment: verdictComment ?? null,
       };
-      const result = await confirmEquivalentVerdict(
-        projectId,
-        docId,
-        fieldName,
-        responseIds,
-        gabaritoId,
-        verdictDisplay,
-        verdictComment,
-        buildSnapshot(fieldResponses),
-      ).catch((error: unknown) => {
-        // Mesmo padrão do handleVerdict: rejeição da server action (fora do
-        // try dela) seria descartada pelo `void` do call site — sem toast.
-        console.error("Failed to confirm equivalent verdict", {
-          error,
+      const saved = await actionSucceeded(
+        confirmEquivalentVerdict(
           projectId,
-          documentId: docId,
+          docId,
           fieldName,
-        });
-        toast.error("Não foi possível salvar a equivalência. Tente novamente antes de avançar.");
-        return { error: "unexpected" };
-      });
-      if (result?.error) {
-        if (result.error !== "unexpected") toast.error(result.error);
-        return;
-      }
+          responseIds,
+          gabaritoId,
+          verdictDisplay,
+          verdictComment,
+          buildSnapshot(fieldResponses),
+        ),
+        "Failed to confirm equivalent verdict",
+        { projectId, documentId: docId, fieldName },
+        "Não foi possível salvar a equivalência. Tente novamente antes de avançar.",
+      );
+      if (!saved) return;
 
       // Escrita otimista só após o sucesso (ver handleVerdict): não deixar o
       // campo/doc exibido como revisado quando a marcação de equivalência falha.
@@ -225,41 +238,25 @@ export function useCompareVerdicts({
 
   const handleMarkReviewed = useCallback(async () => {
     if (!currentDoc) return;
-    const result = await markCompareDocReviewed(projectId, currentDoc.id).catch(
-      (error: unknown) => {
-        console.error("Failed to mark compare doc reviewed", {
-          error,
-          projectId,
-          documentId: currentDoc.id,
-        });
-        toast.error("Não foi possível marcar o documento como revisado. Tente novamente.");
-        return { error: "unexpected" };
-      },
+    const saved = await actionSucceeded(
+      markCompareDocReviewed(projectId, currentDoc.id),
+      "Failed to mark compare doc reviewed",
+      { projectId, documentId: currentDoc.id },
+      "Não foi possível marcar o documento como revisado. Tente novamente.",
     );
-    if (result?.error) {
-      if (result.error !== "unexpected") toast.error(result.error);
-      return;
-    }
+    if (!saved) return;
     toast.success("Documento marcado como revisado.");
   }, [projectId, currentDoc]);
 
   const handleUnmarkPair = useCallback(
     async (pairId: string) => {
-      const result = await unmarkEquivalencePair(projectId, pairId).catch(
-        (error: unknown) => {
-          console.error("Failed to unmark equivalence pair", {
-            error,
-            projectId,
-            pairId,
-          });
-          toast.error("Não foi possível remover a equivalência. Tente novamente.");
-          return { error: "unexpected" };
-        },
+      const saved = await actionSucceeded(
+        unmarkEquivalencePair(projectId, pairId),
+        "Failed to unmark equivalence pair",
+        { projectId, pairId },
+        "Não foi possível remover a equivalência. Tente novamente.",
       );
-      if (result?.error) {
-        if (result.error !== "unexpected") toast.error(result.error);
-        return;
-      }
+      if (!saved) return;
       toast.success("Equivalência removida.");
     },
     [projectId],

--- a/frontend/src/lib/__tests__/compare-queue.test.ts
+++ b/frontend/src/lib/__tests__/compare-queue.test.ts
@@ -338,7 +338,7 @@ describe("buildDocumentsForCompare", () => {
 });
 
 describe("buildReviewsAndReviewedCounts", () => {
-  it("monta existingReviews por doc/campo e conta só os vereditos do usuário atual", () => {
+  it("monta existingReviews e reviewedCount só com os vereditos do usuário atual", () => {
     const { existingReviews, reviewedCountByDoc } = buildReviewsAndReviewedCounts(
       [
         {
@@ -363,9 +363,41 @@ describe("buildReviewsAndReviewedCounts", () => {
       { doc1: ["a", "b"] },
     );
     expect(existingReviews.doc1.a.verdict).toBe("resposta_a");
-    expect(existingReviews.doc1.b.verdict).toBe("resposta_b");
-    // só o campo "a" foi revisado pelo usuário logado ("me")
+    // veredito de outro revisor NÃO semeia a tela do usuário atual — a
+    // revisão da Comparação é por revisor (mesmo critério do reviewedCount)
+    expect(existingReviews.doc1.b).toBeUndefined();
     expect(reviewedCountByDoc.doc1).toBe(1);
+  });
+
+  it("doc coberto só por vereditos de terceiros continua inteiramente pendente para o usuário", () => {
+    // Regressão do bug de 2026-07-10: docs 100% revisados por OUTRO revisor
+    // apareciam como "Revisão concluída" para quem nunca os revisou — o
+    // teclado de voto era bloqueado e o assignment nunca fechava.
+    const { existingReviews, reviewedCountByDoc } = buildReviewsAndReviewedCounts(
+      [
+        {
+          document_id: "doc1",
+          field_name: "a",
+          verdict: "x",
+          chosen_response_id: null,
+          comment: null,
+          reviewer_id: "coordenador",
+        },
+        {
+          document_id: "doc1",
+          field_name: "b",
+          verdict: "y",
+          chosen_response_id: null,
+          comment: null,
+          reviewer_id: "coordenador",
+        },
+      ],
+      "me",
+      ["doc1"],
+      { doc1: ["a", "b"] },
+    );
+    expect(existingReviews.doc1).toBeUndefined();
+    expect(reviewedCountByDoc.doc1).toBe(0);
   });
 
   it("doc sem nenhum review do usuário atual conta 0", () => {

--- a/frontend/src/lib/compare-queue.ts
+++ b/frontend/src/lib/compare-queue.ts
@@ -437,20 +437,25 @@ export function buildReviewsAndReviewedCounts(
 ): { existingReviews: ReviewsByDoc; reviewedCountByDoc: Record<string, number> } {
   const existingReviews: ReviewsByDoc = {};
 
-  // Track reviews do user atual para preencher reviewedCount
+  // A revisão da Comparação é POR REVISOR (UNIQUE inclui reviewer_id, e
+  // syncCompareAssignment fecha o assignment contando só os reviews do
+  // usuário). Por isso `existingReviews` — que semeia `localReviews` e decide
+  // "campo/doc já revisado" na UI — considera SÓ a identidade efetiva, igual
+  // ao reviewedCount. Semear com vereditos de terceiros (comportamento antigo)
+  // marcava docs revisados por outro revisor como "Revisão concluída" na tela
+  // de quem nunca os revisou: o teclado de voto era bloqueado e o assignment
+  // nunca fechava — o parecer travava na fila (bug relatado em 2026-07-10).
   const myReviewsByDoc = new Map<string, Set<string>>();
   reviews?.forEach((r) => {
+    if (r.reviewer_id !== userId) return;
     if (!existingReviews[r.document_id]) existingReviews[r.document_id] = {};
-    // Sempre captura o veredito mais recente (se múltiplos reviewers, o da página é do user logado)
     existingReviews[r.document_id][r.field_name] = {
       verdict: r.verdict,
       chosenResponseId: r.chosen_response_id ?? null,
       comment: r.comment ?? null,
     };
-    if (r.reviewer_id === userId) {
-      if (!myReviewsByDoc.has(r.document_id)) myReviewsByDoc.set(r.document_id, new Set());
-      myReviewsByDoc.get(r.document_id)!.add(r.field_name);
-    }
+    if (!myReviewsByDoc.has(r.document_id)) myReviewsByDoc.set(r.document_id, new Set());
+    myReviewsByDoc.get(r.document_id)!.add(r.field_name);
   });
 
   const reviewedCountByDoc: Record<string, number> = {};


### PR DESCRIPTION
## Contexto

Bug relatado em 2026-07-10 (pesquisador Matheus): na aba Comparação, os pareceres restantes da fila não fechavam — "as respostas não querem salvar; fica como se eu não tivesse clicado em nada". Diagnóstico com dados de produção (projeto Zolgensma) confirmou a cadeia:

1. A página buscava os reviews **do projeto inteiro** e `buildReviewsAndReviewedCounts` semeava `existingReviews[doc][campo]` com veredito de **qualquer** revisor — o comentário no código ainda assumia "se múltiplos reviewers, o da página é do user logado", suposição quebrada desde que coordenadores passaram a revisar a fila inteira (#407).
2. Docs 100% revisados por **outro** revisor apareciam como "Revisão do documento concluída" para quem nunca os revisou; o `useCompareKeyboard` bloqueia as teclas de voto quando o doc parece completo → teclas 1–9 sem efeito, sem toast.
3. O fecho (`syncCompareAssignment`) conta só os reviews do próprio usuário → o assignment nunca fechava e o doc travava no topo da fila (mais "pendências").

Evidência: os 3 docs `pendente` do pesquisador estavam 100% cobertos por 259 vereditos que um coordenador emitiu em 2–4/jul (+1 doc parcial). Os vereditos do próprio pesquisador sempre salvaram (189 nos últimos 3 dias) — o que falhava era a tela mentir que não havia nada a votar.

## Mudanças

- **`compare-queue.ts`**: `existingReviews` passa a considerar só a identidade efetiva — o mesmo critério que `reviewedCount`, `isDocComplete` e `syncCompareAssignment` já usavam; o fix elimina a divergência interna em vez de criar semântica nova.
- **`compare/page.tsx`**: a query de reviews filtra `reviewer_id = effectiveUserId` na origem (correção + menos dados). Para usuário comum e conta-alias (spec 002) é a mesma identidade com que `submitVerdict` grava; sob impersonação master a leitura usa `viewAsUser` enquanto o write path segue gravando como o master — descompasso pré-existente, registrado na issue #428.
- **`useCompareVerdicts.ts`**: rejeições de server action nos handlers restantes (`confirmEquivalent`, `markReviewed`, `unmarkPair`) deixam de ser engolidas pelo `void` do call site — helper `actionSucceeded` unifica catch + `{ error }` com toast, estendendo o padrão que o #417 aplicou ao `handleVerdict`.
- **Testes**: regressão do doc 100% coberto por terceiros (tela inteiramente pendente para o usuário) + caminho de rejeição dos quatro handlers. O teste antigo que fixava o comportamento bugado foi substituído.

## Validação

- `vitest`: 1114 → 1123 testes, todos verdes; `tsc --noEmit` limpo.
- Playwright smoke E2E: 5 passed / 1 skipped (rodado na worktree com as mudanças; o spec de master pula sem `E2E_MASTER_EMAIL`).
- Revisão adversarial por subagente: nenhum achado bloqueante; a sugestão de cobrir o caminho de rejeição foi incorporada.
- Gates de pre-push: typecheck, vitest, lint:types, fallow audit e semgrep passaram. `SKIP=e2e-smoke` no push: o gate fail-closed (#410) exige `E2E_MASTER_EMAIL`, ausente também no checkout primário — pendência de ambiente a registrar em issue; o smoke em si rodou verde manualmente.

## Pós-merge

Nenhuma migração de dados: os docs mascarados voltam a exibir os campos abertos assim que a página recarrega. Vale avisar o Matheus que os pareceres travados voltarão a aceitar vereditos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
