### PR TITLE
fix(export): preserva colunas auxiliares por documento

### DIFF
--- a/frontend/src/lib/__tests__/export-assemble.test.ts
+++ b/frontend/src/lib/__tests__/export-assemble.test.ts
@@ -416,6 +416,42 @@ describe("assembleExport — inteiro teor só na aba Documentos", () => {
     expect(docRow[idx(d.documents, "original_document_text")]).toBe("auxiliar");
   });
 
+  it("preserva coluna auxiliar homônima à coluna de texto de outro documento", () => {
+    const d = run({
+      documents: [
+        doc("A", {
+          external_id: "EXT-A",
+          columns: ["texto", "tribunal"],
+          row: { texto: "Inteiro teor de A", tribunal: "TJSP" },
+          textColumn: "texto",
+        }),
+        doc("B", {
+          external_id: "EXT-B",
+          columns: ["conteudo", "texto"],
+          row: { conteudo: "Inteiro teor de B", texto: "dado auxiliar" },
+          textColumn: "conteudo",
+        }),
+      ],
+    });
+
+    expect(d.documents.headers).toContain("texto");
+    expect(d.csv.headers).toContain("texto");
+
+    const docA = d.documents.rows.find((row) => row[0] === "EXT-A")!;
+    const docB = d.documents.rows.find((row) => row[0] === "EXT-B")!;
+    expect(docA[idx(d.documents, "texto")]).toBe("");
+    expect(docA[idx(d.documents, "document_text")]).toBe("Inteiro teor de A");
+    expect(docB[idx(d.documents, "texto")]).toBe("dado auxiliar");
+    expect(docB[idx(d.documents, "document_text")]).toBe("Inteiro teor de B");
+
+    const csvA = d.csv.rows.find((row) => row[0] === "EXT-A")!;
+    const csvB = d.csv.rows.find((row) => row[0] === "EXT-B")!;
+    expect(csvA[idx(d.csv, "texto")]).toBe("");
+    expect(csvB[idx(d.csv, "texto")]).toBe("dado auxiliar");
+    expect(d.csv.rows.some((row) => row.includes("Inteiro teor de A"))).toBe(false);
+    expect(d.csv.rows.some((row) => row.includes("Inteiro teor de B"))).toBe(false);
+  });
+
   it("doc sem text_column mantém comportamento antigo (toda coluna é auxiliar)", () => {
     // Guarda de retrocompatibilidade: metadata sem text_column (legado/NULL) não
     // cria document_text e não omite nenhuma coluna.

--- a/frontend/src/lib/export/assemble.ts
+++ b/frontend/src/lib/export/assemble.ts
@@ -260,17 +260,19 @@ export function assembleExport(input: AssembleInput): ExportDataset {
 
   // O inteiro teor sai APENAS na aba Documentos (coluna dedicada `document_text`,
   // uma linha por doc); as colunas auxiliares (tribunal, classe...) são leves e
-  // seguem repetidas por linha no CSV. `textColumns` reúne os nomes marcados como
-  // texto (metadata.text_column) — o cenário dominante é um único mapeamento por
-  // projeto (size === 1). Suposição: uma coluna cujo nome coincide com a coluna
-  // de texto de algum upload é tratada como texto globalmente.
-  const textColumns = new Set<string>();
+  // seguem repetidas por linha no CSV. `text_column` tem escopo por documento:
+  // um nome entra no header auxiliar se ao menos um documento o usa como coluna
+  // auxiliar, mesmo que outro documento use o mesmo nome como inteiro teor.
+  const auxiliaryColumns = new Set<string>();
+  let hasText = false;
   for (const d of baseDocs) {
-    const tc = d.metadata?.text_column;
-    if (tc) textColumns.add(tc);
+    const metadata = d.metadata;
+    if (metadata?.text_column) hasText = true;
+    for (const col of metadata?.original_columns ?? []) {
+      if (col !== metadata?.text_column) auxiliaryColumns.add(col);
+    }
   }
-  const hasText = textColumns.size > 0;
-  const auxRaw = unionRaw.filter((col) => !textColumns.has(col));
+  const auxRaw = unionRaw.filter((col) => auxiliaryColumns.has(col));
 
   const reserved = new Set<string>([
     ...CONTROL_COLUMNS,
@@ -284,8 +286,10 @@ export function assembleExport(input: AssembleInput): ExportDataset {
   const auxReserved = hasText ? new Set([...reserved, "document_text"]) : reserved;
   const auxHeaders = resolveOriginalHeaders(auxRaw, auxReserved);
   const auxCells = (docId: string): string[] => {
-    const row = docById.get(docId)?.metadata?.original_row ?? {};
-    return auxRaw.map((col) => row[col] ?? "");
+    const metadata = docById.get(docId)?.metadata;
+    return auxRaw.map((col) =>
+      col === metadata?.text_column ? "" : (metadata?.original_row[col] ?? "")
+    );
   };
   // Texto do documento (uma vez por doc, só na aba Documentos).
   const documentText = (docId: string): string => {

--- a/specs/004-export-original-metadata/data-model.md
+++ b/specs/004-export-original-metadata/data-model.md
@@ -21,7 +21,7 @@ Phase 1 do `/speckit-plan`. Sem migration: a única mudança de dados é passar 
 Regras e invariantes:
 
 - `original_row` contém **todas** as colunas da linha, inclusive as mapeadas para `text`/`title`/`external_id` (FR-002). Valores são os textuais do parse (`Record<string, string>`); células ausentes em linhas curtas normalizam para `""`.
-- `text_column` guarda o nome da coluna do CSV mapeada como texto (`mapping.text`). Serve **apenas** ao export, para separar o inteiro teor (coluna dedicada `document_text`, uma vez por documento) das colunas auxiliares (repetidas por linha no CSV) — ver §3. Opcional na leitura (fail-soft): `metadata IS NULL` ou legado sem o campo ⇒ todas as colunas tratadas como auxiliares (comportamento anterior).
+- `text_column` guarda, por documento, o nome da coluna do CSV mapeada como texto (`mapping.text`). Serve **apenas** ao export, para separar o inteiro teor (coluna dedicada `document_text`, uma vez por documento) das colunas auxiliares (repetidas por linha no CSV) — ver §3. Em uploads heterogêneos, o mesmo nome pode ser texto para um documento e auxiliar para outro. Opcional na leitura (fail-soft): `metadata IS NULL` ou legado sem o campo ⇒ todas as colunas tratadas como auxiliares (comportamento anterior).
 - `original_columns` existe porque jsonb não preserva ordem de chaves; é a fonte da ordenação no export. Invariante: `original_columns` ⊇ chaves de `original_row` na prática (ambos vêm de `results.meta.fields` e da própria linha); o export usa `original_columns` como ordem e `original_row` como valores.
 - **Cabeçalhos duplicados no CSV** (achado C2 do /speckit-analyze): verificado contra o pacote instalado (papaparse 5.5.4) em 2026-07-10 — o próprio parse com `header: true` renomeia duplicatas (`nome`, `nome_1`, …) preservando os valores de todas as colunas homônimas ("Duplicate headers found and renamed."). `buildDocs` confia nessa garantia e não normaliza de novo; um teste de regressão protege a dependência desse comportamento. Invariante resultante: `original_columns` não contém duplicatas.
 - `metadata IS NULL` ⇒ documento importado antes da feature (ou criado por caminho sem CSV). O export trata como "colunas originais vazias" (FR-011); nenhum backfill (FR-018).
@@ -55,7 +55,7 @@ Três visões montadas server-side por funções puras de `lib/export/`:
 |---|---|
 | `document_id` | `documents.external_id \|\| documents.id` (regra atual do export) |
 | `document_title` | `documents.title` |
-| `<colunas auxiliares...>` | `metadata.original_row` **exceto** a coluna de texto, ordenadas pela união de `original_columns` (docs por `created_at` asc, primeira aparição vence) |
+| `<colunas auxiliares...>` | `metadata.original_row`, ordenadas pela união de `original_columns` (docs por `created_at` asc, primeira aparição vence). Um nome entra no header se ao menos um documento o usa como auxiliar; a célula fica vazia nos documentos cujo `metadata.text_column` tem esse nome |
 | `document_text` | `metadata.original_row[metadata.text_column]` — o inteiro teor, uma vez por documento. Só existe se algum doc tiver `text_column`; é a **única** coluna do export que carrega o texto |
 
 ### 3.2 Visão Respostas individuais (estrutura atual preservada)
@@ -68,7 +68,7 @@ Três visões montadas server-side por funções puras de `lib/export/`:
 
 ### 3.4 Composição final
 
-- **CSV unificado**: cabeçalho = controle ∪ colunas auxiliares ∪ campos do schema ∪ `reviewer_comments`. Linhas: todas as respostas (3.2) + todos os gabaritos (3.3) + uma linha `source=documento` para cada documento sem resposta E sem gabarito. Colunas auxiliares (sem o texto) repetidas em toda linha do documento; **o inteiro teor NÃO entra no CSV** — vive só na coluna `document_text` da visão Documentos, evitando replicá-lo por linha. BOM `﻿` + escaping manual (herdados do ExportPanel).
+- **CSV unificado**: cabeçalho = controle ∪ colunas auxiliares ∪ campos do schema ∪ `reviewer_comments`. Linhas: todas as respostas (3.2) + todos os gabaritos (3.3) + uma linha `source=documento` para cada documento sem resposta E sem gabarito. Colunas auxiliares repetidas em toda linha do documento; quando um header auxiliar coincide com o `text_column` daquele documento, a célula fica vazia. **O inteiro teor NÃO entra no CSV** — vive só na coluna `document_text` da visão Documentos, evitando replicá-lo por linha. BOM `﻿` + escaping manual (herdados do ExportPanel).
 - **XLSX**: aba `Documentos` (3.1, sempre presente, inclui `document_text`), aba `Respostas` (3.2, se houver), aba `Gabarito` (3.3, se houver). Colunas originais e texto só na aba Documentos.
 
 ### 3.5 Colisão e ordenação (regras determinísticas)


### PR DESCRIPTION
## Resumo

- Trata `metadata.text_column` no escopo de cada documento, em vez de remover globalmente qualquer coluna homônima.
- Mantém o header auxiliar quando ao menos um upload usa o nome como dado auxiliar e deixa a célula vazia apenas no documento que usa esse nome como inteiro teor.
- Adiciona regressão para uploads heterogêneos e atualiza o modelo de dados da feature 004.

## Causa raiz

O export construía um conjunto global de nomes de colunas de texto. Assim, o nome usado como inteiro teor em um upload era descartado também nos documentos de outro upload que o usavam como coluna auxiliar. A nova derivação usa a união das colunas auxiliares por documento e impede que o inteiro teor volte a aparecer no CSV.

## Impacto

O valor auxiliar deixa de ser perdido em projetos com uploads de estruturas diferentes. O comportamento legado, a ordenação e as regras de colisão de headers permanecem preservados.

## Verificação

- 31 testes relacionados passaram.
- `tsc --noEmit` passou.
- ESLint dos arquivos alterados passou.
- Revisão adversarial independente sem achados acionáveis.
- Pre-push: typecheck, suíte Vitest completa, typescript-eslint, fallow e semgrep passaram; E2E smoke foi pulado pela limitação rastreada em #426.

Closes #436