### PR TITLE
fix(compare): impede submissões concorrentes em campo multi

### DIFF
--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -193,11 +193,9 @@ export function ComparePage({
   const [pendingVerdict, setPendingVerdict] = useState<PendingVerdict | null>(
     null,
   );
-  const [isConfirmingVerdict, setIsConfirmingVerdict] = useState(false);
-  // Fonte síncrona da exclusão mútua: state só atualiza no próximo render e,
-  // portanto, não impede dois eventos (click/Enter) no mesmo batch. Todo save
-  // de veredito passa pelo entrypoint single-flight abaixo, que adquire esta
-  // trava antes de agendar qualquer atualização visual.
+  const [isSavingVerdict, setIsSavingVerdict] = useState(false);
+  // A ref é a fonte síncrona da exclusão mútua porque state só atualiza no
+  // próximo render. O state acima existe apenas para feedback visual.
   const verdictSaveInFlightRef = useRef(false);
   const pendingVerdictCtxRef = useRef<string | null | undefined>(undefined);
   if (verdictCtxKey !== pendingVerdictCtxRef.current) {
@@ -235,19 +233,19 @@ export function ComparePage({
     [],
   );
 
-  // Único entrypoint para todo submit de veredito: confirmação de rascunho,
-  // campo multi e atalhos especiais. A ref torna um segundo save impossível
-  // mesmo antes do rerender que desabilita os controles.
+  // Único entrypoint para todo submit via handleVerdict: confirmação de
+  // rascunho, campo multi e atalhos especiais. A ref torna um segundo save
+  // impossível mesmo antes do rerender que desabilita os controles.
   const submitVerdictSingleFlight = useCallback(
     async (verdict: string, chosenResponseId?: string) => {
       if (verdictSaveInFlightRef.current) return false;
       verdictSaveInFlightRef.current = true;
-      setIsConfirmingVerdict(true);
+      setIsSavingVerdict(true);
       try {
         return await handleVerdict(verdict, chosenResponseId);
       } finally {
         verdictSaveInFlightRef.current = false;
-        setIsConfirmingVerdict(false);
+        setIsSavingVerdict(false);
       }
     },
     [handleVerdict],
@@ -356,7 +354,6 @@ export function ComparePage({
       void submitVerdictSingleFlight(verdict),
     onConfirmPendingVerdict: () => void confirmPendingVerdict(),
     hasPendingVerdict: !!pendingVerdict,
-    isConfirmingVerdict,
   });
 
   const reviewed = docFields.map(
@@ -521,7 +518,7 @@ export function ComparePage({
           onPrepareVerdict: preparePendingVerdict,
           onConfirmPendingVerdict: () => void confirmPendingVerdict(),
           onDiscardPendingVerdict: discardPendingVerdict,
-          isConfirmingVerdict,
+          isSavingVerdict,
           onMarkReviewed: () => void handleMarkReviewed(),
           comment,
           onCommentChange: setComment,

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -194,11 +194,15 @@ export function ComparePage({
     null,
   );
   const [isConfirmingVerdict, setIsConfirmingVerdict] = useState(false);
+  // Fonte síncrona da exclusão mútua: state só atualiza no próximo render e,
+  // portanto, não impede dois eventos (click/Enter) no mesmo batch. Todo save
+  // de veredito passa pelo entrypoint single-flight abaixo, que adquire esta
+  // trava antes de agendar qualquer atualização visual.
+  const verdictSaveInFlightRef = useRef(false);
   const pendingVerdictCtxRef = useRef<string | null | undefined>(undefined);
   if (verdictCtxKey !== pendingVerdictCtxRef.current) {
     pendingVerdictCtxRef.current = verdictCtxKey;
     setPendingVerdict(null);
-    setIsConfirmingVerdict(false);
   }
 
   const {
@@ -225,27 +229,28 @@ export function ComparePage({
       // um salvamento em andamento seria descartado silenciosamente pelo
       // `setPendingVerdict(null)` que confirmPendingVerdict roda ao concluir.
       // Ignorar aqui — ponto único — mantém o rascunho que está sendo salvo.
-      if (isConfirmingVerdict) return;
+      if (verdictSaveInFlightRef.current) return;
       setPendingVerdict(next);
     },
-    [isConfirmingVerdict],
+    [],
   );
 
-  const submitSpecialVerdict = useCallback(
-    async (verdict: "ambiguo" | "pular") => {
-      // Campos multi salvam direto (sem rascunho). Reusa `isConfirmingVerdict`
-      // como trava de in-flight para o teclado não disparar dois submitVerdict
-      // concorrentes quando 'a'/'s' são pressionados em sucessão rápida — o
-      // guard do useCompareKeyboard já bloqueia a segunda tecla enquanto true.
-      if (isConfirmingVerdict) return;
+  // Único entrypoint para todo submit de veredito: confirmação de rascunho,
+  // campo multi e atalhos especiais. A ref torna um segundo save impossível
+  // mesmo antes do rerender que desabilita os controles.
+  const submitVerdictSingleFlight = useCallback(
+    async (verdict: string, chosenResponseId?: string) => {
+      if (verdictSaveInFlightRef.current) return false;
+      verdictSaveInFlightRef.current = true;
       setIsConfirmingVerdict(true);
       try {
-        await handleVerdict(verdict);
+        return await handleVerdict(verdict, chosenResponseId);
       } finally {
+        verdictSaveInFlightRef.current = false;
         setIsConfirmingVerdict(false);
       }
     },
-    [handleVerdict, isConfirmingVerdict],
+    [handleVerdict],
   );
 
   // `handleVerdict` sempre settla (o timeout de `actionSucceeded` em
@@ -253,26 +258,21 @@ export function ComparePage({
   // então o `finally` é garantido e a trava nunca fica presa. No timeout o
   // rascunho é MANTIDO: a usuária reconfirma sem re-selecionar.
   const confirmPendingVerdict = useCallback(async () => {
-    if (!pendingVerdict || isConfirmingVerdict) return;
-    setIsConfirmingVerdict(true);
-    try {
-      const saved = await handleVerdict(
-        pendingVerdict.verdict,
-        pendingVerdict.kind === "response"
-          ? pendingVerdict.chosenResponseId
-          : undefined,
-      );
-      if (saved) setPendingVerdict(null);
-    } finally {
-      setIsConfirmingVerdict(false);
-    }
-  }, [handleVerdict, isConfirmingVerdict, pendingVerdict]);
+    if (!pendingVerdict) return;
+    const saved = await submitVerdictSingleFlight(
+      pendingVerdict.verdict,
+      pendingVerdict.kind === "response"
+        ? pendingVerdict.chosenResponseId
+        : undefined,
+    );
+    if (saved) setPendingVerdict(null);
+  }, [pendingVerdict, submitVerdictSingleFlight]);
 
   const discardPendingVerdict = useCallback(() => {
     // Durante o in-flight o rascunho é o que está sendo salvo — descartá-lo
     // deixaria a UI sem referente do save em andamento.
-    if (!isConfirmingVerdict) setPendingVerdict(null);
-  }, [isConfirmingVerdict]);
+    if (!verdictSaveInFlightRef.current) setPendingVerdict(null);
+  }, []);
 
   const [isFullscreen, setIsFullscreen] = useState(false);
   const toggleFullscreen = useCallback(
@@ -289,7 +289,7 @@ export function ComparePage({
   // `handleVerdict` e não passa por aqui.
   const guardNavigation = useCallback(() => {
     // In-flight: bloqueio silencioso (o botão já exibe "Salvando...").
-    if (isConfirmingVerdict) return false;
+    if (verdictSaveInFlightRef.current) return false;
     if (pendingVerdict) {
       // `id` fixo: tentativas repetidas (tecla `n` segurada, onValueChange
       // duplo do Radix Tabs) atualizam o mesmo toast em vez de empilhar.
@@ -300,7 +300,7 @@ export function ComparePage({
       return false;
     }
     return true;
-  }, [isConfirmingVerdict, pendingVerdict]);
+  }, [pendingVerdict]);
 
   const navigateDoc = useCallback(
     (index: number) => {
@@ -352,7 +352,8 @@ export function ComparePage({
     onNextField: nextField,
     onPrevField: prevField,
     onPrepareVerdict: preparePendingVerdict,
-    onSubmitSpecialVerdict: (verdict) => void submitSpecialVerdict(verdict),
+    onSubmitSpecialVerdict: (verdict) =>
+      void submitVerdictSingleFlight(verdict),
     onConfirmPendingVerdict: () => void confirmPendingVerdict(),
     hasPendingVerdict: !!pendingVerdict,
     isConfirmingVerdict,
@@ -515,7 +516,7 @@ export function ComparePage({
             : { complete: false },
           onFieldNavigate: navigateField,
           onVerdict: (verdict, chosenResponseId) =>
-            void handleVerdict(verdict, chosenResponseId),
+            void submitVerdictSingleFlight(verdict, chosenResponseId),
           pendingVerdict,
           onPrepareVerdict: preparePendingVerdict,
           onConfirmPendingVerdict: () => void confirmPendingVerdict(),

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -194,6 +194,7 @@ export function ComparisonPanel({
             options={fieldOptions}
             responses={responses}
             existingVerdict={existingVerdict}
+            isSubmitting={isConfirmingVerdict}
             onSubmit={(verdictJson) => onVerdict(verdictJson)}
           />
         ) : (

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -70,7 +70,7 @@ interface ComparisonPanelProps {
   onPrepareVerdict: (pending: PendingVerdict) => void;
   onConfirmPendingVerdict: () => void;
   onDiscardPendingVerdict: () => void;
-  isConfirmingVerdict: boolean;
+  isSavingVerdict: boolean;
   onMarkReviewed: () => void;
   comment: string;
   onCommentChange: (value: string) => void;
@@ -110,7 +110,7 @@ export function ComparisonPanel({
   onPrepareVerdict,
   onConfirmPendingVerdict,
   onDiscardPendingVerdict,
-  isConfirmingVerdict,
+  isSavingVerdict,
   onMarkReviewed,
   comment,
   onCommentChange,
@@ -194,7 +194,7 @@ export function ComparisonPanel({
             options={fieldOptions}
             responses={responses}
             existingVerdict={existingVerdict}
-            isSubmitting={isConfirmingVerdict}
+            isSubmitting={isSavingVerdict}
             onSubmit={(verdictJson) => onVerdict(verdictJson)}
           />
         ) : (
@@ -277,7 +277,7 @@ export function ComparisonPanel({
               <Button
                 variant="ghost"
                 size="sm"
-                disabled={isConfirmingVerdict}
+                disabled={isSavingVerdict}
                 onClick={onDiscardPendingVerdict}
               >
                 Descartar
@@ -285,10 +285,10 @@ export function ComparisonPanel({
             )}
             <Button
               size="sm"
-              disabled={!pendingVerdict || isConfirmingVerdict}
+              disabled={!pendingVerdict || isSavingVerdict}
               onClick={onConfirmPendingVerdict}
             >
-              {isConfirmingVerdict ? "Salvando..." : "Confirmar"}
+              {isSavingVerdict ? "Salvando..." : "Confirmar"}
             </Button>
           </div>
         </div>
@@ -305,7 +305,7 @@ export function ComparisonPanel({
               ref={nextDocButtonRef}
               size="sm"
               className="gap-1"
-              disabled={isConfirmingVerdict}
+              disabled={isSavingVerdict}
               onClick={docStatus.onNextDoc}
             >
               Próximo parecer

--- a/frontend/src/components/compare/MultiOptionReview.tsx
+++ b/frontend/src/components/compare/MultiOptionReview.tsx
@@ -31,6 +31,7 @@ interface MultiOptionReviewProps {
   options: string[];
   responses: MultiOptionResponse[];
   existingVerdict: ExistingVerdict | null;
+  isSubmitting: boolean;
   onSubmit: (verdictJson: string) => void;
 }
 
@@ -38,6 +39,7 @@ export function MultiOptionReview({
   options,
   responses,
   existingVerdict,
+  isSubmitting,
   onSubmit,
 }: MultiOptionReviewProps) {
   // Count how many respondents selected each option
@@ -78,10 +80,12 @@ export function MultiOptionReview({
   );
 
   const toggleOption = (opt: string) => {
+    if (isSubmitting) return;
     setChoices((prev) => ({ ...prev, [opt]: !prev[opt] }));
   };
 
   const handleSubmit = () => {
+    if (isSubmitting) return;
     onSubmit(JSON.stringify(choices));
   };
 
@@ -121,7 +125,10 @@ export function MultiOptionReview({
           <label
             key={stat.option}
             className={cn(
-              "flex cursor-pointer items-center gap-2.5 rounded-lg border p-2.5 transition-colors hover:bg-accent/50",
+              "flex items-center gap-2.5 rounded-lg border p-2.5 transition-colors",
+              isSubmitting
+                ? "cursor-not-allowed opacity-60"
+                : "cursor-pointer hover:bg-accent/50",
               stat.isDivergent
                 ? "border-amber-500/30 bg-amber-500/5"
                 : "border-muted",
@@ -129,6 +136,7 @@ export function MultiOptionReview({
           >
             <Checkbox
               checked={choices[stat.option] ?? false}
+              disabled={isSubmitting}
               onCheckedChange={() => toggleOption(stat.option)}
             />
             <div className="min-w-0 flex-1">
@@ -173,9 +181,10 @@ export function MultiOptionReview({
         <Button
           size="sm"
           className="mt-2 w-full"
+          disabled={isSubmitting}
           onClick={handleSubmit}
         >
-          [Enter] Confirmar
+          {isSubmitting ? "Salvando..." : "[Enter] Confirmar"}
         </Button>
       </div>
     </TooltipProvider>

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -182,6 +182,63 @@ describe("ComparePage — árvore real (smoke)", () => {
       undefined,
       expect.any(Array),
     );
+  });
+
+  it("campo multi mantém click/Enter em single-flight e exibe o save em andamento", async () => {
+    let finishSave!: () => void;
+    const save = new Promise<void>((resolve) => {
+      finishSave = resolve;
+    });
+    submitVerdict.mockReturnValueOnce(save);
+
+    render(
+      <TooltipProvider>
+        <ComparePage
+          {...props}
+          fields={[
+            {
+              name: "campoA",
+              type: "multi",
+              options: ["Sim", "Não"],
+              description: "Pergunta A",
+              hash: "hA",
+            },
+          ]}
+          responses={{
+            d1: [
+              resp("r1", "humano", "Ana", { campoA: ["Sim"] }),
+              resp("r2", "llm", "GPT", { campoA: ["Não"] }),
+            ],
+          }}
+          divergentFields={{ d1: ["campoA"] }}
+        />
+      </TooltipProvider>,
+    );
+
+    const confirmButton = screen.getByRole("button", {
+      name: "[Enter] Confirmar",
+    });
+
+    // Dispatch direto no mesmo act mantém os três eventos antes do rerender.
+    // O state visual ainda está stale; só a trava síncrona pode rejeitar o
+    // segundo click e o Enter sem disparar outra Server Action.
+    await act(async () => {
+      confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    });
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+    const savingButton = screen.getByRole("button", { name: "Salvando..." });
+    expect(savingButton).toHaveProperty("disabled", true);
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      expect(checkbox).toHaveProperty("disabled", true);
+    }
+
+    await act(async () => {
+      finishSave();
+      await save;
+    });
   });
 
   it("'Descartar' no painel real limpa a seleção sem salvar", async () => {

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -1,6 +1,13 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, fireEvent, act } from "@testing-library/react";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  act,
+  waitFor,
+} from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -10,7 +17,9 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 // DocumentReader é mockado (usa react-markdown via next/dynamic, ruidoso em
 // jsdom e irrelevante para esta verificação).
 const { submitVerdict, markCompareDocReviewed } = vi.hoisted(() => ({
-  submitVerdict: vi.fn(async () => {}),
+  submitVerdict: vi.fn<
+    (...args: unknown[]) => Promise<{ error?: string } | void>
+  >(async () => {}),
   markCompareDocReviewed: vi.fn(async () => {}),
 }));
 const { confirmEquivalentVerdict, unmarkEquivalencePair } = vi.hoisted(() => ({
@@ -127,6 +136,57 @@ const renderReal = () =>
     </TooltipProvider>,
   );
 
+const renderMulti = () =>
+  render(
+    <TooltipProvider>
+      <ComparePage
+        {...props}
+        fields={[
+          {
+            name: "campoA",
+            type: "multi",
+            options: ["Sim", "Não"],
+            description: "Pergunta A",
+            hash: "hA",
+          },
+        ]}
+        responses={{
+          d1: [
+            resp("r1", "humano", "Ana", { campoA: ["Sim"] }),
+            resp("r2", "llm", "GPT", { campoA: ["Não"] }),
+          ],
+        }}
+        divergentFields={{ d1: ["campoA"] }}
+      />
+    </TooltipProvider>,
+  );
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function dispatchConcurrentConfirmations(confirmButton: HTMLElement) {
+  // O mesmo act mantém os três eventos antes do rerender; só a trava síncrona
+  // pode rejeitar o segundo click e o Enter.
+  await act(async () => {
+    confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+  });
+  expect(submitVerdict).toHaveBeenCalledTimes(1);
+}
+
+async function finishSave(save: ReturnType<typeof deferred<void>>) {
+  await act(async () => {
+    save.resolve();
+    await save.promise;
+  });
+}
+
 // jsdom não tem ResizeObserver — exigido por react-resizable-panels.
 class ResizeObserverStub {
   observe() {}
@@ -184,61 +244,66 @@ describe("ComparePage — árvore real (smoke)", () => {
     );
   });
 
-  it("campo multi mantém click/Enter em single-flight e exibe o save em andamento", async () => {
-    let finishSave!: () => void;
-    const save = new Promise<void>((resolve) => {
-      finishSave = resolve;
-    });
-    submitVerdict.mockReturnValueOnce(save);
+  it("confirmação de rascunho mantém click/Enter em single-flight no mesmo batch", async () => {
+    const save = deferred<void>();
+    submitVerdict.mockReturnValueOnce(save.promise);
+    const user = userEvent.setup();
+    renderReal();
 
-    render(
-      <TooltipProvider>
-        <ComparePage
-          {...props}
-          fields={[
-            {
-              name: "campoA",
-              type: "multi",
-              options: ["Sim", "Não"],
-              description: "Pergunta A",
-              hash: "hA",
-            },
-          ]}
-          responses={{
-            d1: [
-              resp("r1", "humano", "Ana", { campoA: ["Sim"] }),
-              resp("r2", "llm", "GPT", { campoA: ["Não"] }),
-            ],
-          }}
-          divergentFields={{ d1: ["campoA"] }}
-        />
-      </TooltipProvider>,
+    await user.click(screen.getByRole("button", { name: /Ambíguo/i }));
+    const confirmButton = screen.getByRole("button", { name: "Confirmar" });
+
+    await dispatchConcurrentConfirmations(confirmButton);
+
+    expect(screen.getByRole("button", { name: "Salvando..." })).toHaveProperty(
+      "disabled",
+      true,
     );
+
+    await finishSave(save);
+  });
+
+  it("campo multi mantém click/Enter em single-flight e exibe o save em andamento", async () => {
+    const save = deferred<void>();
+    submitVerdict.mockReturnValueOnce(save.promise);
+    renderMulti();
 
     const confirmButton = screen.getByRole("button", {
       name: "[Enter] Confirmar",
     });
 
-    // Dispatch direto no mesmo act mantém os três eventos antes do rerender.
-    // O state visual ainda está stale; só a trava síncrona pode rejeitar o
-    // segundo click e o Enter sem disparar outra Server Action.
-    await act(async () => {
-      confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
-    });
+    await dispatchConcurrentConfirmations(confirmButton);
 
-    expect(submitVerdict).toHaveBeenCalledTimes(1);
     const savingButton = screen.getByRole("button", { name: "Salvando..." });
     expect(savingButton).toHaveProperty("disabled", true);
     for (const checkbox of screen.getAllByRole("checkbox")) {
       expect(checkbox).toHaveProperty("disabled", true);
     }
 
-    await act(async () => {
-      finishSave();
-      await save;
-    });
+    await finishSave(save);
+  });
+
+  it("campo multi libera a trava após erro e aceita nova tentativa", async () => {
+    submitVerdict
+      .mockResolvedValueOnce({ error: "falha ao salvar" })
+      .mockResolvedValueOnce({});
+    const user = userEvent.setup();
+    renderMulti();
+
+    await user.click(
+      screen.getByRole("button", { name: "[Enter] Confirmar" }),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "[Enter] Confirmar" }),
+      ).toHaveProperty("disabled", false),
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "[Enter] Confirmar" }),
+    );
+    expect(submitVerdict).toHaveBeenCalledTimes(2);
   });
 
   it("'Descartar' no painel real limpa a seleção sem salvar", async () => {

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -51,7 +51,7 @@ interface MockComparisonPanel {
   onPrepareVerdict: (pending: PendingVerdict) => void;
   onConfirmPendingVerdict: () => void;
   onDiscardPendingVerdict: () => void;
-  isConfirmingVerdict: boolean;
+  isSavingVerdict: boolean;
   onConfirmEquivalent: (
     responseIds: string[],
     gabaritoId: string,
@@ -115,10 +115,10 @@ vi.mock("@/components/compare/CompareWorkspace", () => ({
       </button>
       <button
         data-testid="confirm-verdict"
-        disabled={comparisonPanel.isConfirmingVerdict}
+        disabled={comparisonPanel.isSavingVerdict}
         onClick={() => comparisonPanel.onConfirmPendingVerdict()}
       >
-        {comparisonPanel.isConfirmingVerdict ? "saving verdict" : "confirm verdict"}
+        {comparisonPanel.isSavingVerdict ? "saving verdict" : "confirm verdict"}
       </button>
       <button
         data-testid="discard-verdict"

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
@@ -79,7 +79,7 @@ function renderPanel(
           }
         }}
         onDiscardPendingVerdict={() => setPendingVerdict(null)}
-        isConfirmingVerdict={false}
+        isSavingVerdict={false}
         onMarkReviewed={vi.fn()}
         comment=""
         onCommentChange={vi.fn()}
@@ -148,7 +148,7 @@ describe("ComparisonPanel — confirmação pendente", () => {
         verdict: "2021-05-10",
         chosenResponseId: "r-llm",
       },
-      isConfirmingVerdict: true,
+      isSavingVerdict: true,
     });
     expect(
       (screen.getByRole("button", { name: /^descartar$/i }) as HTMLButtonElement)

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
@@ -47,7 +47,7 @@ function renderPanel(responses: Resp[], fieldHelpText?: string) {
       onPrepareVerdict={vi.fn()}
       onConfirmPendingVerdict={vi.fn()}
       onDiscardPendingVerdict={vi.fn()}
-      isConfirmingVerdict={false}
+      isSavingVerdict={false}
       onMarkReviewed={vi.fn()}
       comment=""
       onCommentChange={vi.fn()}

--- a/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
+++ b/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
@@ -57,6 +57,34 @@ describe("MultiOptionReview — atalhos de teclado", () => {
       B: false,
     });
   });
+
+  it("bloqueia controles e atalhos enquanto a submissão está em andamento", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiOptionReview
+        options={["A", "B"]}
+        responses={[]}
+        existingVerdict={null}
+        isSubmitting
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const confirmButton = screen.getByRole("button", { name: "Salvando..." });
+    expect(confirmButton).toHaveProperty("disabled", true);
+    for (const checkbox of screen.getAllByRole("checkbox")) {
+      expect(checkbox).toHaveProperty("disabled", true);
+    }
+
+    await user.keyboard("1");
+    await user.keyboard("{Enter}");
+
+    expect(
+      screen.getAllByRole("checkbox")[0].getAttribute("aria-checked"),
+    ).toBe("false");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });
 
 describe("MultiOptionReview — reset via key (contrato do ComparisonPanel)", () => {

--- a/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
+++ b/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
@@ -16,6 +16,7 @@ describe("MultiOptionReview — atalhos de teclado", () => {
         options={["A", "B", "C"]}
         responses={[]}
         existingVerdict={null}
+        isSubmitting={false}
         onSubmit={onSubmit}
       />,
     );
@@ -43,6 +44,7 @@ describe("MultiOptionReview — atalhos de teclado", () => {
         options={["A", "B"]}
         responses={[]}
         existingVerdict={null}
+        isSubmitting={false}
         onSubmit={onSubmit}
       />,
     );
@@ -67,6 +69,7 @@ describe("MultiOptionReview — reset via key (contrato do ComparisonPanel)", ()
         options={["A", "B"]}
         responses={[]}
         existingVerdict={null}
+        isSubmitting={false}
         onSubmit={vi.fn()}
       />,
     );
@@ -92,6 +95,7 @@ describe("MultiOptionReview — reset via key (contrato do ComparisonPanel)", ()
           chosenResponseId: null,
           comment: null,
         }}
+        isSubmitting={false}
         onSubmit={vi.fn()}
       />,
     );

--- a/frontend/src/components/compare/useCompareKeyboard.ts
+++ b/frontend/src/components/compare/useCompareKeyboard.ts
@@ -18,7 +18,6 @@ interface UseCompareKeyboardParams {
   onSubmitSpecialVerdict: (verdict: "ambiguo" | "pular") => void;
   onConfirmPendingVerdict: () => void;
   hasPendingVerdict: boolean;
-  isConfirmingVerdict: boolean;
 }
 
 /**
@@ -45,7 +44,6 @@ export function useCompareKeyboard({
   onSubmitSpecialVerdict,
   onConfirmPendingVerdict,
   hasPendingVerdict,
-  isConfirmingVerdict,
 }: UseCompareKeyboardParams): void {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -75,7 +73,7 @@ export function useCompareKeyboard({
         return;
       }
 
-      if (!isCurrentFieldDivergent || isConfirmingVerdict) return;
+      if (!isCurrentFieldDivergent) return;
 
       const isMultiField =
         currentField?.type === "multi" && currentField.options?.length;
@@ -121,7 +119,6 @@ export function useCompareKeyboard({
     isCurrentFieldDivergent,
     isFullscreen,
     hasPendingVerdict,
-    isConfirmingVerdict,
     onConfirmPendingVerdict,
     onExitFullscreen,
     onNextField,


### PR DESCRIPTION
## Resumo

- Centraliza confirmação de rascunho, voto multi e atalhos especiais num único entrypoint single-flight.
- Adquire uma trava síncrona antes do próximo render, impedindo que clique e Enter concorrentes disparem mais de uma Server Action.
- Mantém o state React apenas para feedback visual, agora nomeado `isSavingVerdict`.
- Desabilita checkboxes e confirmação do campo multi durante o save e exibe `Salvando...`.
- Adiciona regressões para concorrência no mesmo batch, bloqueio interno do multi e retry após erro.

## Causa raiz

A UI usava state React como trava, mas state só muda no render seguinte. Dois eventos recebidos antes desse render podiam atravessar o mesmo snapshot antigo e iniciar `submitVerdict` em paralelo. Além disso, o campo multi chamava `handleVerdict` diretamente, fora dos gates parciais dos outros caminhos.

A ref síncrona passou a ser a única autoridade da exclusão mútua, enquanto o state ficou restrito ao feedback visual.

## Simplificação após revisão

- Remove a guarda redundante de `isConfirmingVerdict` em `useCompareKeyboard`; navegação, preparação e submissão já consultam a ref nos respectivos entrypoints.
- Renomeia o state visual para `isSavingVerdict`.
- Esclarece que o single-flight cobre todo submit via `handleVerdict`, sem sugerir que o fluxo separado de equivalência passa pelo mesmo gate.
- Reusa helpers locais nos testes de integração em vez de duplicar a sequência click + click + Enter.

## Impacto

Cada interação via `handleVerdict` dispara no máximo uma escrita por instância da página, inclusive antes do rerender. Erros, rejeições e o timeout existente liberam a trava no `finally`, sem prender navegação ou rascunho.

## Verificação

- 71 testes focados em 6 arquivos passaram.
- Suíte Vitest completa: 1.227/1.227 testes em 128 arquivos.
- `tsc --noEmit`, ESLint dos arquivos alterados, React Doctor e `git diff --check` passaram.
- `lint:types`: 0 erros; 3 warnings preexistentes fora do escopo.
- Fallow passou e a extração dos helpers reduziu uma duplicação no diff.
- Pre-push: typecheck, Vitest, typescript-eslint, fallow e semgrep passaram.
- O E2E smoke foi pulado explicitamente porque esta branch ainda contém o hook anterior à correção da #426; a correção já foi incorporada à `main` pelo PR #439.
- `pre-commit run gitleaks --all-files` passou localmente. O check remoto não iniciou por bloqueio de cobrança/spending limit do GitHub Actions; a anotação não reportou segredo nem executou steps.
- A combinação com a `main` atual foi simulada sem conflitos; os PRs #437 e #439 não alteram arquivos deste PR.

Closes #435