### PR TITLE
fix(membros): confirma remoção e torna limpeza transacional

### DIFF
--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -811,9 +811,45 @@ type SupabaseDataClient = ReturnType<typeof createSupabaseAdmin>;
 interface BacklogInputs {
   fields: PydanticField[];
   humanResponses: HumanResponseRow[];
+  activeMemberIds: Set<string>;
   llmResponses: LlmResponseRow[];
   equivalences: EquivalenceRow[];
   existingReviews: ExistingFieldReviewRow[];
+}
+
+const ACTIVE_MEMBER_PAGE_SIZE = 1_000;
+
+// O PostgREST local limita cada resposta a 1.000 linhas. Paginação por chave
+// evita que esse teto transforme membros ativos, silenciosamente, em
+// ex-membros durante o reconcile.
+async function fetchActiveMemberIds(
+  admin: SupabaseDataClient,
+  projectId: string,
+): Promise<Set<string>> {
+  const activeMemberIds = new Set<string>();
+  let afterUserId: string | null = null;
+
+  for (;;) {
+    const baseQuery = admin
+      .from("project_members")
+      .select("user_id")
+      .eq("project_id", projectId)
+      .order("user_id", { ascending: true })
+      .limit(ACTIVE_MEMBER_PAGE_SIZE);
+    const result: {
+      data: { user_id: string }[] | null;
+      error: { message: string } | null;
+    } = afterUserId
+      ? await baseQuery.gt("user_id", afterUserId)
+      : await baseQuery;
+    if (result.error) throw new Error(result.error.message);
+
+    const page: { user_id: string }[] = result.data ?? [];
+    for (const member of page) activeMemberIds.add(member.user_id);
+    if (page.length < ACTIVE_MEMBER_PAGE_SIZE) return activeMemberIds;
+
+    afterUserId = page.at(-1)!.user_id;
+  }
 }
 
 // Batch de leitura inicial do backlog — lança em qualquer erro de query,
@@ -826,6 +862,7 @@ async function fetchBacklogInputs(
   const [
     { data: project, error: projErr },
     { data: humanResponses, error: humanErr },
+    activeMemberIds,
     { data: llmResponses, error: llmErr },
     { data: equivalences, error: equivErr },
     { data: existingReviews, error: existingErr },
@@ -841,6 +878,7 @@ async function fetchBacklogInputs(
       .eq("project_id", projectId)
       .eq("respondent_type", "humano")
       .eq("is_partial", false),
+    fetchActiveMemberIds(admin, projectId),
     admin
       .from("responses")
       .select("id, document_id, answers, answer_field_hashes")
@@ -868,6 +906,7 @@ async function fetchBacklogInputs(
   return {
     fields: (project?.pydantic_fields as PydanticField[]) ?? [],
     humanResponses: (humanResponses ?? []) as HumanResponseRow[],
+    activeMemberIds,
     llmResponses: (llmResponses ?? []) as LlmResponseRow[],
     equivalences: (equivalences ?? []) as EquivalenceRow[],
     existingReviews: (existingReviews ?? []) as ExistingFieldReviewRow[],
@@ -938,8 +977,14 @@ export async function regenerateAutoReviewBacklog(
     if (!gate.ok) return { success: false, error: gate.error };
 
     const supabase = await createSupabaseServer();
-    const { fields, humanResponses, llmResponses, equivalences, existingReviews } =
-      await fetchBacklogInputs(supabase, projectId);
+    const {
+      fields,
+      humanResponses,
+      activeMemberIds,
+      llmResponses,
+      equivalences,
+      existingReviews,
+    } = await fetchBacklogInputs(supabase, projectId);
 
     if (fields.length === 0) {
       return { success: true, scanned: 0, regenerated: 0 };
@@ -952,6 +997,7 @@ export async function regenerateAutoReviewBacklog(
     const { assignmentRows, fieldReviewRows, regenerated } = computeBacklogRows(
       projectId,
       humanResponses,
+      activeMemberIds,
       llmByDocId,
       equivByDoc,
       fields,

--- a/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/members/page.tsx
@@ -1,5 +1,5 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getEffectiveMemberId } from "@/lib/auth";
 import { scanComparisonBacklog } from "@/lib/auto-comparison";
 import { MemberList } from "@/components/members/MemberList";
 import { AddMemberDialog } from "@/components/members/AddMemberDialog";
@@ -10,9 +10,12 @@ export default async function MembersPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const [{ id }, user, supabase] = await Promise.all([
-    params,
-    getAuthUser(),
+  const projectContext = params.then(async ({ id }) => ({
+    id,
+    effectiveUserId: await getEffectiveMemberId(id),
+  }));
+  const [{ id, effectiveUserId }, supabase] = await Promise.all([
+    projectContext,
     createSupabaseServer(),
   ]);
 
@@ -74,7 +77,7 @@ export default async function MembersPage({
         projectId={id}
         members={typedMembers}
         emailLinks={(emailLinks || []) as MemberEmailLink[]}
-        currentUserId={user!.id}
+        effectiveUserId={effectiveUserId}
       />
     </div>
   );

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -26,15 +26,23 @@ interface MemberListProps {
   projectId: string;
   members: MemberRowData[];
   emailLinks: MemberEmailLink[];
-  currentUserId: string;
+  effectiveUserId: string;
 }
 
-async function removeMemberWithToast(memberId: string) {
-  const result = await removeMember(memberId);
-  if (result?.error) {
-    toast.error(result.error);
-  } else {
+async function removeMemberWithToast(memberId: string): Promise<boolean> {
+  try {
+    const result = await removeMember(memberId);
+    if (result?.error) {
+      toast.error(result.error);
+      return false;
+    }
+
     toast.success("Membro removido");
+    return true;
+  } catch (error) {
+    console.error("[MemberList] erro ao remover membro", error);
+    toast.error("Não foi possível remover o membro. Tente novamente.");
+    return false;
   }
 }
 
@@ -54,7 +62,7 @@ export function MemberList({
   projectId,
   members,
   emailLinks,
-  currentUserId,
+  effectiveUserId,
 }: MemberListProps) {
   const {
     editingEmailMemberId,
@@ -129,7 +137,7 @@ export function MemberList({
           key={m.id}
           member={m}
           projectId={projectId}
-          currentUserId={currentUserId}
+          effectiveUserId={effectiveUserId}
           links={linksByMember.get(m.user_id) ?? []}
           editingEmailMemberId={editingEmailMemberId}
           onEditingEmailChange={setEditingEmailMemberId}
@@ -144,7 +152,7 @@ export function MemberList({
           onChangeRole={(memberId, newRole) =>
             void changeRoleWithToast(memberId, newRole)
           }
-          onRemove={(memberId) => void removeMemberWithToast(memberId)}
+          onRemove={removeMemberWithToast}
         />
       ))}
       {linkingMember && (

--- a/frontend/src/components/members/MemberRoleControls.tsx
+++ b/frontend/src/components/members/MemberRoleControls.tsx
@@ -1,5 +1,18 @@
 "use client";
 
+import { useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -8,27 +21,49 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { MemberRow } from "./member-list-utils";
+import { memberDisplayName, type MemberRow } from "./member-list-utils";
 
 interface MemberRoleControlsProps {
   member: MemberRow;
-  currentUserId: string;
+  effectiveUserId: string;
   onChangeRole: (memberId: string, newRole: "coordenador" | "pesquisador") => void;
-  onRemove: (memberId: string) => void;
+  onRemove: (memberId: string) => Promise<boolean>;
 }
 
 export function MemberRoleControls({
   member,
-  currentUserId,
+  effectiveUserId,
   onChangeRole,
   onRemove,
 }: MemberRoleControlsProps) {
+  const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+  const removeInFlight = useRef(false);
+  const displayName = memberDisplayName(member);
+  const email = member.profiles?.email;
+
+  const handleConfirmRemove = async () => {
+    // O ref fecha a janela entre o clique e o primeiro rerender, durante a qual
+    // dois eventos poderiam iniciar a mesma Server Action.
+    if (removeInFlight.current) return;
+
+    removeInFlight.current = true;
+    setIsRemoving(true);
+    try {
+      const removed = await onRemove(member.id);
+      if (removed) setRemoveDialogOpen(false);
+    } finally {
+      removeInFlight.current = false;
+      setIsRemoving(false);
+    }
+  };
+
   return (
     <>
       <Select
         value={member.role}
         onValueChange={(v) => onChangeRole(member.id, v as "coordenador" | "pesquisador")}
-        disabled={member.user_id === currentUserId}
+        disabled={member.user_id === effectiveUserId}
       >
         <SelectTrigger className="h-8 w-[140px] text-xs">
           <SelectValue />
@@ -38,15 +73,54 @@ export function MemberRoleControls({
           <SelectItem value="pesquisador">Pesquisador</SelectItem>
         </SelectContent>
       </Select>
-      {member.user_id !== currentUserId && (
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onRemove(member.id)}
-          className="text-destructive"
+      {member.user_id !== effectiveUserId && (
+        <AlertDialog
+          open={removeDialogOpen}
+          onOpenChange={(open) => {
+            if (!isRemoving) setRemoveDialogOpen(open);
+          }}
         >
-          Remover
-        </Button>
+          <AlertDialogTrigger asChild>
+            <Button variant="ghost" size="sm" className="text-destructive">
+              Remover
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Remover membro?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Tem certeza de que deseja remover <strong>{displayName}</strong>
+                {email && email !== displayName ? <> ({email})</> : null} deste projeto?
+                As atribuições ainda não iniciadas voltarão ao conjunto disponível.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isRemoving}>
+                Cancelar
+              </AlertDialogCancel>
+              <AlertDialogAction
+                variant="destructive"
+                disabled={isRemoving}
+                aria-busy={isRemoving}
+                onClick={(event) => {
+                  // AlertDialogAction fecha por padrão. O resultado da action é
+                  // quem decide: sucesso fecha; erro preserva o diálogo para retry.
+                  event.preventDefault();
+                  void handleConfirmRemove();
+                }}
+              >
+                {isRemoving ? (
+                  <>
+                    <Loader2 aria-hidden="true" className="mr-1.5 size-3.5 animate-spin" />
+                    Removendo…
+                  </>
+                ) : (
+                  "Remover"
+                )}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       )}
     </>
   );

--- a/frontend/src/components/members/MemberRow.tsx
+++ b/frontend/src/components/members/MemberRow.tsx
@@ -12,7 +12,7 @@ import { memberDisplayName, type MemberRow as MemberRowData } from "./member-lis
 interface MemberRowProps {
   member: MemberRowData;
   projectId: string;
-  currentUserId: string;
+  effectiveUserId: string;
   links: MemberEmailLink[];
   editingEmailMemberId: string | null;
   onEditingEmailChange: (memberId: string | null) => void;
@@ -25,13 +25,13 @@ interface MemberRowProps {
   onToggleResolve: (memberId: string, value: boolean) => void;
   onToggleCompare: (memberId: string, value: boolean) => void;
   onChangeRole: (memberId: string, newRole: "coordenador" | "pesquisador") => void;
-  onRemove: (memberId: string) => void;
+  onRemove: (memberId: string) => Promise<boolean>;
 }
 
 export function MemberRow({
   member,
   projectId,
-  currentUserId,
+  effectiveUserId,
   links,
   editingEmailMemberId,
   onEditingEmailChange,
@@ -97,7 +97,7 @@ export function MemberRow({
         />
         <MemberRoleControls
           member={member}
-          currentUserId={currentUserId}
+          effectiveUserId={effectiveUserId}
           onChangeRole={onChangeRole}
           onRemove={onRemove}
         />

--- a/frontend/src/components/members/__tests__/MemberList.test.tsx
+++ b/frontend/src/components/members/__tests__/MemberList.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { MemberRow } from "../member-list-utils";
+
+const mocks = vi.hoisted(() => ({
+  removeMember: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/actions/members", () => ({
+  removeMember: mocks.removeMember,
+  changeRole: vi.fn(),
+  setCanArbitrate: vi.fn(),
+  setCanResolve: vi.fn(),
+  setCanCompare: vi.fn(),
+  unlinkMemberEmail: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}));
+
+import { MemberList } from "../MemberList";
+
+const targetMember: MemberRow = {
+  id: "member-target",
+  project_id: "project-1",
+  user_id: "user-target",
+  role: "pesquisador",
+  can_arbitrate: false,
+  can_resolve: false,
+  can_compare: false,
+  profiles: {
+    id: "user-target",
+    email: "ana@example.com",
+    first_name: "Ana",
+    last_name: "Silva",
+    created_at: "2026-01-01T00:00:00Z",
+    activated_at: "2026-01-02T00:00:00Z",
+  },
+};
+
+function renderList({
+  member = targetMember,
+  effectiveUserId = "coordinator-user",
+}: {
+  member?: MemberRow;
+  effectiveUserId?: string;
+} = {}) {
+  return render(
+    <MemberList
+      projectId="project-1"
+      members={[member]}
+      emailLinks={[]}
+      effectiveUserId={effectiveUserId}
+    />,
+  );
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.removeMember.mockResolvedValue(undefined);
+});
+
+describe("MemberList — confirmação de remoção", () => {
+  it("abre um alertdialog identificado e não chama a action no clique inicial", async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+    expect(dialog.getAttribute("aria-describedby")).toBeTruthy();
+    expect(dialog.textContent).toContain("Ana");
+    expect(dialog.textContent).toContain("ana@example.com");
+    expect(screen.getByRole("button", { name: "Cancelar" })).toBe(document.activeElement);
+    expect(mocks.removeMember).not.toHaveBeenCalled();
+  });
+
+  it("cancela sem remover o membro", async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    await user.click(await screen.findByRole("button", { name: "Cancelar" }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.removeMember).not.toHaveBeenCalled();
+  });
+
+  it("confirma uma única vez com o membro e bloqueia cliques concorrentes", async () => {
+    let finishRemoval: ((value: undefined) => void) | undefined;
+    mocks.removeMember.mockReturnValue(
+      new Promise<undefined>((resolve) => {
+        finishRemoval = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    const confirm = await screen.findByRole("button", { name: "Remover" });
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    expect(mocks.removeMember).toHaveBeenCalledTimes(1);
+    expect(mocks.removeMember).toHaveBeenCalledWith("member-target");
+    expect(screen.getByRole("button", { name: "Removendo…" }).hasAttribute("disabled")).toBe(true);
+
+    finishRemoval?.(undefined);
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Membro removido");
+  });
+
+  it("mantém o diálogo aberto após erro e permite tentar novamente sem falso sucesso", async () => {
+    mocks.removeMember
+      .mockResolvedValueOnce({ error: "Falha ao remover" })
+      .mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    await user.click(await screen.findByRole("button", { name: "Remover" }));
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalledWith("Falha ao remover"));
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+
+    await waitFor(() => expect(mocks.removeMember).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("mantém o diálogo aberto quando a action lança e permite tentar novamente", async () => {
+    mocks.removeMember
+      .mockRejectedValueOnce(new Error("rede indisponível"))
+      .mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    await user.click(await screen.findByRole("button", { name: "Remover" }));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Não foi possível remover o membro. Tente novamente.",
+      ),
+    );
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+
+    await waitFor(() => expect(mocks.removeMember).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("não oferece remoção para a identidade canônica exercida pela conta atual", () => {
+    renderList({ effectiveUserId: targetMember.user_id });
+
+    expect(screen.queryByRole("button", { name: "Remover" })).toBeNull();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+});

--- a/frontend/src/lib/__tests__/auto-review-backlog.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-backlog.test.ts
@@ -23,6 +23,8 @@ const field: PydanticField = {
 };
 
 describe("computeBacklogRows", () => {
+  const activeMemberIds = new Set(["user1"]);
+
   function human(overrides: Partial<HumanResponseRow>): HumanResponseRow {
     return {
       id: "human1",
@@ -48,6 +50,7 @@ describe("computeBacklogRows", () => {
     const { assignmentRows, fieldReviewRows, regenerated } = computeBacklogRows(
       "proj1",
       [human({})],
+      activeMemberIds,
       llmByDocId,
       new Map(),
       [field],
@@ -76,7 +79,14 @@ describe("computeBacklogRows", () => {
   });
 
   it("pula quando não há resposta LLM para o documento", () => {
-    const result = computeBacklogRows("proj1", [human({})], new Map(), new Map(), [field]);
+    const result = computeBacklogRows(
+      "proj1",
+      [human({})],
+      activeMemberIds,
+      new Map(),
+      new Map(),
+      [field],
+    );
     expect(result.regenerated).toBe(0);
     expect(result.fieldReviewRows).toEqual([]);
   });
@@ -86,6 +96,7 @@ describe("computeBacklogRows", () => {
     const result = computeBacklogRows(
       "proj1",
       [human({ answers: {} })],
+      activeMemberIds,
       llmByDocId,
       new Map(),
       [field],
@@ -110,6 +121,7 @@ describe("computeBacklogRows", () => {
     const result = computeBacklogRows(
       "proj1",
       [human({})],
+      activeMemberIds,
       llmByDocId,
       equivByDoc,
       [field],
@@ -117,6 +129,24 @@ describe("computeBacklogRows", () => {
 
     expect(result.regenerated).toBe(0);
     expect(result.fieldReviewRows).toEqual([]);
+  });
+
+  it("não recria trabalho pendente para ex-membro a partir de resposta histórica", () => {
+    const llmByDocId = new Map([["doc1", llm({})]]);
+    const result = computeBacklogRows(
+      "proj1",
+      [human({})],
+      new Set(),
+      llmByDocId,
+      new Map(),
+      [field],
+    );
+
+    expect(result).toEqual({
+      assignmentRows: [],
+      fieldReviewRows: [],
+      regenerated: 0,
+    });
   });
 });
 

--- a/frontend/src/lib/auto-review-backlog.ts
+++ b/frontend/src/lib/auto-review-backlog.ts
@@ -52,6 +52,7 @@ export interface FieldReviewRow {
 export function computeBacklogRows(
   projectId: string,
   humanResponses: HumanResponseRow[],
+  activeMemberIds: ReadonlySet<string>,
   llmByDocId: Map<string, LlmResponseRow>,
   equivByDoc: EquivalenceByDocField,
   fields: PydanticField[],
@@ -61,6 +62,10 @@ export function computeBacklogRows(
   let regenerated = 0;
 
   for (const human of humanResponses) {
+    // Respostas permanecem como histórico depois da saída do pesquisador, mas
+    // não podem recriar trabalho pendente para uma identidade sem membership.
+    if (!activeMemberIds.has(human.respondent_id)) continue;
+
     const llm = llmByDocId.get(human.document_id);
     if (!llm) continue;
 

--- a/frontend/supabase/migrations/20260715170000_remove_project_member_invariants.sql
+++ b/frontend/supabase/migrations/20260715170000_remove_project_member_invariants.sql
@@ -1,0 +1,278 @@
+-- Invariantes da remoção de membros (issue #177).
+--
+-- Alias concede acesso futuro e assignment pendente representa trabalho ainda
+-- não iniciado. Nenhum dos dois pode sobreviver sem a membership canônica. O
+-- saneamento permite instalar essas invariantes sobre bancos que passaram pelo
+-- fluxo best-effort anterior.
+DO $$
+DECLARE
+  v_orphan_aliases integer;
+  v_orphan_pending_assignments integer;
+BEGIN
+  DELETE FROM public.member_email_links AS mel
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.project_members AS pm
+    WHERE pm.project_id = mel.project_id
+      AND pm.user_id = mel.member_user_id
+  );
+  GET DIAGNOSTICS v_orphan_aliases = ROW_COUNT;
+
+  DELETE FROM public.assignments AS a
+  WHERE a.status = 'pendente'
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.project_members AS pm
+      WHERE pm.project_id = a.project_id
+        AND pm.user_id = a.user_id
+    );
+  GET DIAGNOSTICS v_orphan_pending_assignments = ROW_COUNT;
+
+  RAISE NOTICE
+    'Saneamento: % alias(es) órfão(s) e % assignment(s) pendente(s) órfão(s) removido(s).',
+    v_orphan_aliases,
+    v_orphan_pending_assignments;
+END;
+$$;
+
+-- Um alias sempre referencia a membership canônica do mesmo projeto. A FK
+-- também serializa a criação do alias com a remoção da membership.
+ALTER TABLE public.member_email_links
+  ADD CONSTRAINT member_email_links_project_member_fkey
+  FOREIGN KEY (project_id, member_user_id)
+  REFERENCES public.project_members (project_id, user_id)
+  ON DELETE CASCADE;
+
+-- Histórico iniciado ou concluído pode sobreviver à saída do membro. Uma
+-- pendência, por outro lado, só existe enquanto há membership ativa. O lock de
+-- chave serializa writers de pendências com o DELETE da membership.
+CREATE OR REPLACE FUNCTION public.enforce_pending_assignment_membership()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM 1
+  FROM public.project_members AS pm
+  WHERE pm.project_id = NEW.project_id
+    AND pm.user_id = NEW.user_id
+  FOR KEY SHARE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Assignment pendente exige membro ativo no mesmo projeto.'
+      USING ERRCODE = '23503';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enforce_pending_assignment_membership()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE TRIGGER enforce_pending_assignment_membership
+  BEFORE INSERT OR UPDATE ON public.assignments
+  FOR EACH ROW
+  WHEN (NEW.status = 'pendente')
+  EXECUTE FUNCTION public.enforce_pending_assignment_membership();
+
+-- Toda remoção de membership libera suas pendências na mesma transação. A FK
+-- composta acima cuida dos aliases; trabalho iniciado/concluído é preservado.
+CREATE OR REPLACE FUNCTION public.release_pending_assignments_before_member_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  DELETE FROM public.assignments AS a
+  WHERE a.project_id = OLD.project_id
+    AND a.user_id = OLD.user_id
+    AND a.status = 'pendente';
+
+  RETURN OLD;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.release_pending_assignments_before_member_delete()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE TRIGGER release_pending_assignments_before_member_delete
+  BEFORE DELETE ON public.project_members
+  FOR EACH ROW
+  EXECUTE FUNCTION public.release_pending_assignments_before_member_delete();
+
+-- Ao substituir documentos, somente assignments de memberships ainda ativas
+-- podem voltar a pendente. O histórico de ex-membros permanece no estado em
+-- que foi produzido.
+CREATE OR REPLACE FUNCTION public.replace_and_add_documents(
+  p_project_id uuid,
+  p_existing_doc_ids uuid[],
+  p_delete_responses boolean,
+  p_duplicate_updates jsonb,
+  p_new_documents jsonb
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_inserted integer := 0;
+BEGIN
+  IF p_delete_responses
+     AND p_existing_doc_ids IS NOT NULL
+     AND array_length(p_existing_doc_ids, 1) > 0 THEN
+    DELETE FROM public.reviews
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids);
+
+    DELETE FROM public.responses
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids);
+
+    UPDATE public.assignments AS a
+    SET status = 'pendente'
+    WHERE a.project_id = p_project_id
+      AND a.document_id = ANY(p_existing_doc_ids)
+      AND EXISTS (
+        SELECT 1
+        FROM public.project_members AS pm
+        WHERE pm.project_id = a.project_id
+          AND pm.user_id = a.user_id
+      );
+  END IF;
+
+  IF p_duplicate_updates IS NOT NULL
+     AND jsonb_array_length(p_duplicate_updates) > 0 THEN
+    UPDATE public.documents AS d
+    SET text = u."text",
+        title = u.title,
+        external_id = u.external_id,
+        text_hash = u.text_hash,
+        metadata = u.metadata
+    FROM jsonb_to_recordset(p_duplicate_updates)
+      AS u(
+        id uuid,
+        "text" text,
+        title text,
+        external_id text,
+        text_hash text,
+        metadata jsonb
+      )
+    WHERE d.id = u.id
+      AND d.project_id = p_project_id;
+  END IF;
+
+  IF p_new_documents IS NOT NULL
+     AND jsonb_array_length(p_new_documents) > 0 THEN
+    INSERT INTO public.documents (
+      project_id,
+      external_id,
+      title,
+      text,
+      text_hash,
+      metadata
+    )
+    SELECT
+      p_project_id,
+      n.external_id,
+      n.title,
+      n."text",
+      n.text_hash,
+      n.metadata
+    FROM jsonb_to_recordset(p_new_documents)
+      AS n(
+        external_id text,
+        title text,
+        "text" text,
+        text_hash text,
+        metadata jsonb
+      );
+    GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  END IF;
+
+  RETURN v_inserted;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.replace_and_add_documents(
+  uuid,
+  uuid[],
+  boolean,
+  jsonb,
+  jsonb
+) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.replace_and_add_documents(
+  uuid,
+  uuid[],
+  boolean,
+  jsonb,
+  jsonb
+) TO authenticated;
+
+-- A autoidentidade não pode ser removida nem por DELETE direto no PostgREST.
+-- Como policy restritiva, esta condição complementa todos os caminhos
+-- permissivos atuais e futuros de administração de membros.
+DROP POLICY IF EXISTS "Members cannot remove their own identity"
+  ON public.project_members;
+CREATE POLICY "Members cannot remove their own identity"
+  ON public.project_members
+  AS RESTRICTIVE
+  FOR DELETE
+  TO authenticated
+  USING (
+    NOT (
+      user_id IN (
+        SELECT public.auth_user_member_identity_ids(project_id)
+      )
+    )
+  );
+
+-- A PK global é a única entrada da RPC. project_id e user_id vêm da linha que
+-- a RLS permite enxergar e remover. O lock também impede que um alias novo seja
+-- ligado ao alvo entre a checagem de autoidentidade e o DELETE.
+CREATE OR REPLACE FUNCTION public.remove_project_member(
+  p_member_id uuid
+) RETURNS TABLE(project_id uuid)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_project_id uuid;
+  v_user_id uuid;
+BEGIN
+  SELECT pm.project_id, pm.user_id
+  INTO v_project_id, v_user_id
+  FROM public.project_members AS pm
+  WHERE pm.id = p_member_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF v_user_id IN (
+    SELECT public.auth_user_member_identity_ids(v_project_id)
+  ) THEN
+    RAISE EXCEPTION 'Você não pode remover sua própria associação ao projeto.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM public.project_members AS pm
+  WHERE pm.id = p_member_id
+  RETURNING pm.project_id INTO v_project_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY SELECT v_project_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.remove_project_member(uuid)
+  FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.remove_project_member(uuid)
+  TO authenticated;

--- a/frontend/supabase/tests/atomic_replace_rpcs.test.sql
+++ b/frontend/supabase/tests/atomic_replace_rpcs.test.sql
@@ -11,14 +11,25 @@
 -- blocos roda como owner (o objeto é a transação); o bloco "RLS" abaixo troca
 -- para o role `authenticated` com um JWT forjado para provar que, sob SECURITY
 -- INVOKER, a RLS continua filtrando dentro da função (um não-coordenador não
--- apaga dados via a RPC). Sem dependência de profiles/auth.users: os FKs
--- created_by / respondent_id / reviewer_id / user_id são todos nuláveis.
+-- apaga dados via a RPC). created_by / respondent_id / reviewer_id continuam
+-- nuláveis; assignments pendentes usam profile + membership reais porque essa
+-- relação agora é uma invariante do banco.
 
 BEGIN;
 
 -- ----- Fixtures -----
+INSERT INTO auth.users (id, email) VALUES
+  ('77777777-7777-7777-7777-777777777777', 'atomic-member@example.test'),
+  ('88888888-8888-8888-8888-888888888888', 'atomic-outsider@example.test');
+
 INSERT INTO public.projects (id, name) VALUES
   ('11111111-1111-1111-1111-111111111111', 'proj atomic test');
+
+INSERT INTO public.project_members (id, project_id, user_id, role) VALUES
+  ('99999999-9999-9999-9999-999999999991',
+   '11111111-1111-1111-1111-111111111111',
+   '77777777-7777-7777-7777-777777777777',
+   'pesquisador');
 
 -- D1 = doc alvo do "replace"; D2 = doc ativo cujo external_id 'EXISTING' será
 -- colidido pelo INSERT do caminho de falha.
@@ -32,8 +43,10 @@ INSERT INTO public.responses (id, project_id, document_id, respondent_type, answ
 INSERT INTO public.reviews (id, project_id, document_id, field_name, verdict) VALUES
   ('55555555-5555-5555-5555-555555555555', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'campo', 'concordo');
 
-INSERT INTO public.assignments (id, project_id, document_id, status, type) VALUES
-  ('66666666-6666-6666-6666-666666666666', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'concluido', 'codificacao');
+INSERT INTO public.assignments (id, project_id, document_id, user_id, status, type) VALUES
+  ('66666666-6666-6666-6666-666666666666', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '77777777-7777-7777-7777-777777777777', 'concluido', 'codificacao'),
+  -- Histórico do mesmo documento para profile que já não é membro.
+  ('66666666-6666-6666-6666-666666666667', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '88888888-8888-8888-8888-888888888888', 'concluido', 'codificacao');
 
 -- ----- RLS: authenticated não-coordenador não apaga dados via a RPC -----
 -- A decisão central do PR é SECURITY INVOKER justamente para manter a RLS valendo
@@ -50,6 +63,7 @@ INSERT INTO public.assignments (id, project_id, document_id, status, type) VALUE
 GRANT SELECT, INSERT, UPDATE, DELETE
   ON public.responses, public.reviews, public.assignments, public.documents
   TO authenticated;
+GRANT SELECT ON public.project_members TO authenticated;
 SELECT set_config('request.jwt.claims',
   '{"supabase_uid":"99999999-9999-9999-9999-999999999999"}', true);
 SET LOCAL ROLE authenticated;
@@ -63,13 +77,15 @@ SELECT public.replace_and_add_documents(
 RESET ROLE;
 
 DO $$
-DECLARE n_resp int; n_rev int; a_status text;
+DECLARE n_resp int; n_rev int; n_inactive int; a_status text;
 BEGIN
   SELECT count(*) INTO n_resp   FROM public.responses   WHERE id = '44444444-4444-4444-4444-444444444444';
   SELECT count(*) INTO n_rev    FROM public.reviews     WHERE id = '55555555-5555-5555-5555-555555555555';
+  SELECT count(*) INTO n_inactive FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666667';
   SELECT status   INTO a_status FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666666';
   IF n_resp <> 1 THEN RAISE EXCEPTION 'FALHOU RLS: response apagada por nao-coordenador via RPC (n=%)', n_resp; END IF;
   IF n_rev  <> 1 THEN RAISE EXCEPTION 'FALHOU RLS: review apagada por nao-coordenador via RPC (n=%)', n_rev; END IF;
+  IF n_inactive <> 1 THEN RAISE EXCEPTION 'FALHOU RLS: histórico inativo apagado por nao-coordenador via RPC'; END IF;
   IF a_status <> 'concluido' THEN RAISE EXCEPTION 'FALHOU RLS: assignment resetado por nao-coordenador via RPC (status=%)', a_status; END IF;
   RAISE NOTICE 'OK RLS: authenticated nao-coordenador nao apagou responses/reviews/assignments via a RPC';
 END $$;
@@ -92,13 +108,15 @@ EXCEPTION
 END $$;
 
 DO $$
-DECLARE n_resp int; n_rev int; a_status text;
+DECLARE n_resp int; n_rev int; n_inactive int; a_status text;
 BEGIN
   SELECT count(*) INTO n_resp   FROM public.responses   WHERE id = '44444444-4444-4444-4444-444444444444';
   SELECT count(*) INTO n_rev    FROM public.reviews     WHERE id = '55555555-5555-5555-5555-555555555555';
+  SELECT count(*) INTO n_inactive FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666667';
   SELECT status   INTO a_status FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666666';
   IF n_resp <> 1   THEN RAISE EXCEPTION 'FALHOU #284: response apagada sem rollback (n=%)', n_resp; END IF;
   IF n_rev  <> 1   THEN RAISE EXCEPTION 'FALHOU #284: review apagada sem rollback (n=%)', n_rev; END IF;
+  IF n_inactive <> 1 THEN RAISE EXCEPTION 'FALHOU #284: histórico inativo apagado sem rollback'; END IF;
   IF a_status <> 'concluido' THEN RAISE EXCEPTION 'FALHOU #284: assignment resetado sem rollback (status=%)', a_status; END IF;
   RAISE NOTICE 'OK #284: responses/reviews/assignments preservados apos falha (rollback atomico)';
 END $$;
@@ -128,7 +146,7 @@ END $$;
 -- parcial DENTRO do passo UPDATE. Como há delete_responses=true, o DELETE roda
 -- antes; a exceção deve reverter inclusive esse DELETE (atomicidade no UPDATE).
 DO $$
-DECLARE n_resp int;
+DECLARE n_resp int; n_inactive int;
 BEGIN
   PERFORM public.replace_and_add_documents(
     '11111111-1111-1111-1111-111111111111'::uuid,
@@ -141,13 +159,15 @@ BEGIN
 EXCEPTION
   WHEN unique_violation THEN
     SELECT count(*) INTO n_resp FROM public.responses WHERE id = '44444444-4444-4444-4444-444444444444';
+    SELECT count(*) INTO n_inactive FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666667';
     IF n_resp <> 1 THEN RAISE EXCEPTION 'FALHOU #284: response apagada sem rollback na falha do UPDATE (n=%)', n_resp; END IF;
+    IF n_inactive <> 1 THEN RAISE EXCEPTION 'FALHOU #284: histórico inativo apagado sem rollback na falha do UPDATE'; END IF;
     RAISE NOTICE 'OK #284: falha no UPDATE reverteu o DELETE anterior (rollback atomico)';
 END $$;
 
 -- ----- #284: caminho feliz aplica deletes + insere o novo doc -----
 DO $$
-DECLARE n_new int; n_resp int;
+DECLARE n_new int; n_resp int; n_inactive int; active_status text;
 BEGIN
   PERFORM public.replace_and_add_documents(
     '11111111-1111-1111-1111-111111111111'::uuid,
@@ -157,9 +177,13 @@ BEGIN
   );
   SELECT count(*) INTO n_new  FROM public.documents WHERE project_id = '11111111-1111-1111-1111-111111111111' AND external_id = 'NEW-OK';
   SELECT count(*) INTO n_resp FROM public.responses WHERE id = '44444444-4444-4444-4444-444444444444';
+  SELECT count(*) INTO n_inactive FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666667';
+  SELECT status INTO active_status FROM public.assignments WHERE id = '66666666-6666-6666-6666-666666666666';
   IF n_new  <> 1 THEN RAISE EXCEPTION 'FALHOU: novo doc nao inserido no caminho feliz (n=%)', n_new; END IF;
   IF n_resp <> 0 THEN RAISE EXCEPTION 'FALHOU: deleteResponses nao apagou a response no caminho feliz (n=%)', n_resp; END IF;
-  RAISE NOTICE 'OK #284: caminho feliz inseriu o novo doc e aplicou os deletes';
+  IF n_inactive <> 1 THEN RAISE EXCEPTION 'FALHOU: histórico de ex-membro foi removido'; END IF;
+  IF active_status <> 'pendente' THEN RAISE EXCEPTION 'FALHOU: assignment de membro ativo não foi reaberto'; END IF;
+  RAISE NOTICE 'OK #284: histórico do ex-membro preservado e assignment do membro ativo reaberto';
 END $$;
 
 -- ----- #181: apply_lottery_assignments(replace) descarta pendentes do tipo + insere -----
@@ -167,17 +191,50 @@ DO $$
 DECLARE n_pend int;
 BEGIN
   -- Pendente antiga (em D2) que deve ser descartada pelo modo replace.
-  INSERT INTO public.assignments (project_id, document_id, status, type)
-    VALUES ('11111111-1111-1111-1111-111111111111', '33333333-3333-3333-3333-333333333333', 'pendente', 'codificacao');
+  INSERT INTO public.assignments (project_id, document_id, user_id, status, type)
+    VALUES ('11111111-1111-1111-1111-111111111111', '33333333-3333-3333-3333-333333333333', '77777777-7777-7777-7777-777777777777', 'pendente', 'codificacao');
   PERFORM public.apply_lottery_assignments(
     '11111111-1111-1111-1111-111111111111'::uuid, 'codificacao', NULL,
-    '[{"document_id":"22222222-2222-2222-2222-222222222222","user_id":null}]'::jsonb,
+    '[{"document_id":"22222222-2222-2222-2222-222222222222","user_id":"77777777-7777-7777-7777-777777777777"}]'::jsonb,
     true
   );
   SELECT count(*) INTO n_pend FROM public.assignments
     WHERE project_id = '11111111-1111-1111-1111-111111111111' AND type = 'codificacao' AND status = 'pendente';
   IF n_pend <> 1 THEN RAISE EXCEPTION 'FALHOU #181: esperava 1 pendente (a nova), achei %', n_pend; END IF;
   RAISE NOTICE 'OK #181: replace descartou a pendente antiga e inseriu a nova atomicamente';
+END $$;
+
+-- O trigger também cobre o writer em lote. A função primeiro apaga a pendente
+-- válida do modo replace, mas o INSERT para um profile sem membership falha;
+-- como tudo é um statement, a pendência anterior precisa voltar no rollback.
+DO $$
+DECLARE n_original int;
+BEGIN
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '11111111-1111-1111-1111-111111111111'::uuid, 'codificacao', NULL,
+      '[{"document_id":"33333333-3333-3333-3333-333333333333","user_id":"88888888-8888-8888-8888-888888888888"}]'::jsonb,
+      true
+    );
+    RAISE EXCEPTION 'FALHOU #181: lote criou pendência sem membership';
+  EXCEPTION
+    WHEN foreign_key_violation THEN
+      IF SQLERRM <> 'Assignment pendente exige membro ativo no mesmo projeto.' THEN
+        RAISE;
+      END IF;
+  END;
+
+  SELECT count(*) INTO n_original
+  FROM public.assignments
+  WHERE project_id = '11111111-1111-1111-1111-111111111111'
+    AND document_id = '22222222-2222-2222-2222-222222222222'
+    AND user_id = '77777777-7777-7777-7777-777777777777'
+    AND status = 'pendente';
+
+  IF n_original <> 1 THEN
+    RAISE EXCEPTION 'FALHOU #181: erro do trigger não restaurou a pendência substituída';
+  END IF;
+  RAISE NOTICE 'OK #181: trigger bloqueou lote órfão e o replace sofreu rollback';
 END $$;
 
 ROLLBACK;

--- a/frontend/supabase/tests/remove_project_member_invariants.test.sql
+++ b/frontend/supabase/tests/remove_project_member_invariants.test.sql
@@ -1,0 +1,232 @@
+-- Regressão da autoidentidade na remoção de membros (issue #177).
+--
+-- Como rodar depois de `npx supabase start` e `npx supabase db reset`:
+--   docker exec -i supabase_db_frontend psql -U postgres -d postgres \
+--     -X -v ON_ERROR_STOP=1 < supabase/tests/remove_project_member_invariants.test.sql
+
+BEGIN;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('17710000-0000-0000-0000-000000000001', 'issue177-coordinator@example.test'),
+  ('17710000-0000-0000-0000-000000000002', 'issue177-coordinator-alias@example.test'),
+  ('17710000-0000-0000-0000-000000000004', 'issue177-creator@example.test'),
+  ('17710000-0000-0000-0000-000000000005', 'issue177-creator-target@example.test'),
+  ('17710000-0000-0000-0000-000000000006', 'issue177-master@example.test'),
+  ('17710000-0000-0000-0000-000000000007', 'issue177-master-target@example.test'),
+  ('17710000-0000-0000-0000-000000000008', 'issue177-direct-target@example.test');
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('17700000-0000-0000-0000-000000000001', 'Issue 177 - coordinator',
+   '17710000-0000-0000-0000-000000000001'),
+  ('17700000-0000-0000-0000-000000000002', 'Issue 177 - creator',
+   '17710000-0000-0000-0000-000000000004'),
+  ('17700000-0000-0000-0000-000000000003', 'Issue 177 - master',
+   '17710000-0000-0000-0000-000000000001');
+
+INSERT INTO public.project_members (id, project_id, user_id, role) VALUES
+  ('17730000-0000-0000-0000-000000000001',
+   '17700000-0000-0000-0000-000000000001',
+   '17710000-0000-0000-0000-000000000001', 'coordenador'),
+  ('17730000-0000-0000-0000-000000000003',
+   '17700000-0000-0000-0000-000000000002',
+   '17710000-0000-0000-0000-000000000004', 'pesquisador'),
+  ('17730000-0000-0000-0000-000000000004',
+   '17700000-0000-0000-0000-000000000002',
+   '17710000-0000-0000-0000-000000000005', 'pesquisador'),
+  ('17730000-0000-0000-0000-000000000005',
+   '17700000-0000-0000-0000-000000000003',
+   '17710000-0000-0000-0000-000000000006', 'pesquisador'),
+  ('17730000-0000-0000-0000-000000000006',
+   '17700000-0000-0000-0000-000000000003',
+   '17710000-0000-0000-0000-000000000007', 'pesquisador'),
+  ('17730000-0000-0000-0000-000000000007',
+   '17700000-0000-0000-0000-000000000001',
+   '17710000-0000-0000-0000-000000000008', 'pesquisador');
+
+INSERT INTO public.master_users (user_id) VALUES
+  ('17710000-0000-0000-0000-000000000002'),
+  ('17710000-0000-0000-0000-000000000006');
+
+INSERT INTO public.member_email_links (
+  project_id,
+  member_user_id,
+  email,
+  linked_user_id,
+  created_by
+) VALUES (
+  '17700000-0000-0000-0000-000000000001',
+  '17710000-0000-0000-0000-000000000001',
+  'issue177-coordinator-alias@example.test',
+  '17710000-0000-0000-0000-000000000002',
+  '17710000-0000-0000-0000-000000000001'
+);
+
+GRANT SELECT, UPDATE, DELETE ON public.project_members TO authenticated;
+
+-- A RPC permanece SECURITY INVOKER e a autoidentidade vive numa policy
+-- restritiva aplicável também a DELETE direto.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc AS p
+    WHERE p.oid = 'public.remove_project_member(uuid)'::regprocedure
+      AND p.prosecdef
+  ) THEN
+    RAISE EXCEPTION 'FALHOU contrato: remove_project_member deve ser SECURITY INVOKER';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policy AS p
+    JOIN pg_class AS c ON c.oid = p.polrelid
+    JOIN pg_namespace AS n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'project_members'
+      AND p.polname = 'Members cannot remove their own identity'
+      AND p.polcmd = 'd'
+      AND NOT p.polpermissive
+  ) THEN
+    RAISE EXCEPTION 'FALHOU contrato: auto-remoção exige policy DELETE restritiva';
+  END IF;
+END;
+$$;
+
+-- Coordenador direto não remove sua própria membership.
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"17710000-0000-0000-0000-000000000001"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.remove_project_member(
+      '17730000-0000-0000-0000-000000000001'
+    );
+    RAISE EXCEPTION 'FALHOU: coordenador removeu a própria membership';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+END;
+$$;
+DELETE FROM public.project_members
+WHERE id = '17730000-0000-0000-0000-000000000001';
+DELETE FROM public.project_members
+WHERE id = '17730000-0000-0000-0000-000000000007';
+RESET ROLE;
+
+-- A conta-alias também é master nesta fixture. Assim ela tem uma rota
+-- permissiva própria para o DELETE, sem depender da autorização geral de
+-- aliases que pertence à issue #427, e ainda não pode remover a identidade
+-- canônica que exerce.
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"17710000-0000-0000-0000-000000000002"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.remove_project_member(
+      '17730000-0000-0000-0000-000000000001'
+    );
+    RAISE EXCEPTION 'FALHOU: alias removeu a identidade canônica';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+END;
+$$;
+DELETE FROM public.project_members
+WHERE id = '17730000-0000-0000-0000-000000000001';
+RESET ROLE;
+
+-- Criador e master também não podem remover a identidade própria, mas mantêm
+-- a autorização para remover terceiros.
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"17710000-0000-0000-0000-000000000004"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.remove_project_member(
+      '17730000-0000-0000-0000-000000000003'
+    );
+    RAISE EXCEPTION 'FALHOU: criador removeu a própria membership';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+END;
+$$;
+DELETE FROM public.project_members
+WHERE id = '17730000-0000-0000-0000-000000000003';
+SELECT * FROM public.remove_project_member(
+  '17730000-0000-0000-0000-000000000004'
+);
+RESET ROLE;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"17710000-0000-0000-0000-000000000006"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.remove_project_member(
+      '17730000-0000-0000-0000-000000000005'
+    );
+    RAISE EXCEPTION 'FALHOU: master removeu a própria membership';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+END;
+$$;
+DELETE FROM public.project_members
+WHERE id = '17730000-0000-0000-0000-000000000005';
+SELECT * FROM public.remove_project_member(
+  '17730000-0000-0000-0000-000000000006'
+);
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.project_members
+    WHERE id IN (
+      '17730000-0000-0000-0000-000000000004',
+      '17730000-0000-0000-0000-000000000006',
+      '17730000-0000-0000-0000-000000000007'
+    )
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: uma remoção autorizada de terceiro não ocorreu';
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM public.project_members
+    WHERE id IN (
+      '17730000-0000-0000-0000-000000000001',
+      '17730000-0000-0000-0000-000000000003',
+      '17730000-0000-0000-0000-000000000005'
+    )
+  ) <> 3 THEN
+    RAISE EXCEPTION 'FALHOU: uma tentativa de auto-remoção alterou a membership';
+  END IF;
+
+  RAISE NOTICE 'OK: RPC e DELETE direto preservam autoidentidade e removem terceiros';
+END;
+$$;
+
+ROLLBACK;

--- a/frontend/supabase/tests/remove_project_member_invariants.upgrade.test.sql
+++ b/frontend/supabase/tests/remove_project_member_invariants.upgrade.test.sql
@@ -1,0 +1,276 @@
+-- Upgrade real da remoção transacional de membros (issue #177).
+--
+-- Este arquivo pressupõe exatamente o schema imediatamente anterior:
+--   npx supabase db reset --local --no-seed --version 20260715160000
+--   psql "$(npx supabase status -o env | grep DB_URL | cut -d= -f2- | tr -d '\"')" \
+--     -v ON_ERROR_STOP=1 -f supabase/tests/remove_project_member_invariants.upgrade.test.sql
+--
+-- As fixtures órfãs são válidas naquele schema. A migration real é incluída
+-- depois delas e precisa sanear o legado antes de instalar as invariantes.
+
+BEGIN;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('17790000-0000-0000-0000-000000000001', 'issue177-upgrade-owner@example.test'),
+  ('17790000-0000-0000-0000-000000000002', 'issue177-upgrade-orphan@example.test');
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('17790000-0000-0000-0000-000000000010',
+   'Issue 177 - legacy upgrade',
+   '17790000-0000-0000-0000-000000000001');
+
+INSERT INTO public.documents (id, project_id, external_id, title, text) VALUES
+  ('17790000-0000-0000-0000-000000000020',
+   '17790000-0000-0000-0000-000000000010', '177-UP-1', 'Pendente órfã', 'texto'),
+  ('17790000-0000-0000-0000-000000000021',
+   '17790000-0000-0000-0000-000000000010', '177-UP-2', 'Histórico órfão', 'texto'),
+  ('17790000-0000-0000-0000-000000000022',
+   '17790000-0000-0000-0000-000000000010', '177-UP-3', 'Novo teste', 'texto');
+
+-- O schema antigo aceita os três estados abaixo: alias e pendência sem linha
+-- em project_members, além de histórico sem membership.
+INSERT INTO public.member_email_links (
+  id,
+  project_id,
+  member_user_id,
+  email,
+  linked_user_id,
+  created_by
+) VALUES (
+  '17790000-0000-0000-0000-000000000030',
+  '17790000-0000-0000-0000-000000000010',
+  '17790000-0000-0000-0000-000000000002',
+  'issue177-upgrade-alias@example.test',
+  '17790000-0000-0000-0000-000000000002',
+  '17790000-0000-0000-0000-000000000001'
+);
+
+INSERT INTO public.assignments (
+  id,
+  project_id,
+  document_id,
+  user_id,
+  status,
+  type
+) VALUES
+  ('17790000-0000-0000-0000-000000000040',
+   '17790000-0000-0000-0000-000000000010',
+   '17790000-0000-0000-0000-000000000020',
+   '17790000-0000-0000-0000-000000000002',
+   'pendente',
+   'codificacao'),
+  ('17790000-0000-0000-0000-000000000041',
+   '17790000-0000-0000-0000-000000000010',
+   '17790000-0000-0000-0000-000000000021',
+   '17790000-0000-0000-0000-000000000002',
+   'em_andamento',
+   'codificacao');
+
+\ir ../migrations/20260715170000_remove_project_member_invariants.sql
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.member_email_links
+    WHERE id = '17790000-0000-0000-0000-000000000030'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: alias órfão não foi saneado';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.assignments
+    WHERE id = '17790000-0000-0000-0000-000000000040'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: pendência órfã não voltou ao pool';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.assignments
+    WHERE id = '17790000-0000-0000-0000-000000000041'
+      AND status = 'em_andamento'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: histórico iniciado foi removido';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.member_email_links'::regclass
+      AND conname = 'member_email_links_project_member_fkey'
+      AND convalidated
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: FK composta não foi criada e validada';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.assignments'::regclass
+      AND tgname = 'enforce_pending_assignment_membership'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: trigger de pendência não foi criado';
+  END IF;
+
+  RAISE NOTICE 'OK upgrade: legado saneado, histórico preservado e invariantes instaladas';
+END;
+$$;
+
+-- A FK precisa rejeitar a recriação do grant órfão.
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.member_email_links (
+      project_id,
+      member_user_id,
+      email,
+      created_by
+    ) VALUES (
+      '17790000-0000-0000-0000-000000000010',
+      '17790000-0000-0000-0000-000000000002',
+      'issue177-upgrade-alias-2@example.test',
+      '17790000-0000-0000-0000-000000000001'
+    );
+    RAISE EXCEPTION 'FALHOU upgrade: FK aceitou alias órfão';
+  EXCEPTION
+    WHEN foreign_key_violation THEN
+      NULL;
+  END;
+END;
+$$;
+
+-- O trigger precisa rejeitar uma pendência nova, mas aceitar histórico.
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.assignments (
+      project_id,
+      document_id,
+      user_id,
+      status,
+      type
+    ) VALUES (
+      '17790000-0000-0000-0000-000000000010',
+      '17790000-0000-0000-0000-000000000022',
+      '17790000-0000-0000-0000-000000000002',
+      'pendente',
+      'codificacao'
+    );
+    RAISE EXCEPTION 'FALHOU upgrade: trigger aceitou pendência órfã';
+  EXCEPTION
+    WHEN foreign_key_violation THEN
+      IF SQLERRM <> 'Assignment pendente exige membro ativo no mesmo projeto.' THEN
+        RAISE;
+      END IF;
+  END;
+
+  BEGIN
+    UPDATE public.assignments
+    SET status = 'pendente'
+    WHERE id = '17790000-0000-0000-0000-000000000041';
+    RAISE EXCEPTION 'FALHOU upgrade: UPDATE transformou histórico órfão em pendência';
+  EXCEPTION
+    WHEN foreign_key_violation THEN
+      IF SQLERRM <> 'Assignment pendente exige membro ativo no mesmo projeto.' THEN
+        RAISE;
+      END IF;
+  END;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.assignments
+    WHERE id = '17790000-0000-0000-0000-000000000041'
+      AND status = 'em_andamento'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: UPDATE rejeitado não preservou o histórico';
+  END IF;
+
+  INSERT INTO public.assignments (
+    project_id,
+    document_id,
+    user_id,
+    status,
+    type
+  ) VALUES (
+    '17790000-0000-0000-0000-000000000010',
+    '17790000-0000-0000-0000-000000000022',
+    '17790000-0000-0000-0000-000000000002',
+    'concluido',
+    'codificacao'
+  );
+
+  RAISE NOTICE 'OK upgrade: INSERT/UPDATE órfãos bloqueados e histórico sem membership permitido';
+END;
+$$;
+
+-- A limpeza vive na membership, não apenas na RPC: um DELETE direto também
+-- libera pendências e aliases, mas conserva os dois registros históricos.
+INSERT INTO public.project_members (id, project_id, user_id, role) VALUES (
+  '17790000-0000-0000-0000-000000000050',
+  '17790000-0000-0000-0000-000000000010',
+  '17790000-0000-0000-0000-000000000002',
+  'pesquisador'
+);
+
+INSERT INTO public.member_email_links (
+  project_id,
+  member_user_id,
+  email,
+  created_by
+) VALUES (
+  '17790000-0000-0000-0000-000000000010',
+  '17790000-0000-0000-0000-000000000002',
+  'issue177-upgrade-valid-alias@example.test',
+  '17790000-0000-0000-0000-000000000001'
+);
+
+INSERT INTO public.assignments (
+  id,
+  project_id,
+  document_id,
+  user_id,
+  status,
+  type
+) VALUES (
+  '17790000-0000-0000-0000-000000000042',
+  '17790000-0000-0000-0000-000000000010',
+  '17790000-0000-0000-0000-000000000020',
+  '17790000-0000-0000-0000-000000000002',
+  'pendente',
+  'codificacao'
+);
+
+DELETE FROM public.project_members
+WHERE id = '17790000-0000-0000-0000-000000000050';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.assignments
+    WHERE id = '17790000-0000-0000-0000-000000000042'
+  ) OR EXISTS (
+    SELECT 1
+    FROM public.member_email_links
+    WHERE email = 'issue177-upgrade-valid-alias@example.test'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: DELETE direto deixou pendência ou alias';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.assignments
+    WHERE id = '17790000-0000-0000-0000-000000000041'
+      AND status = 'em_andamento'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU upgrade: DELETE direto removeu histórico';
+  END IF;
+
+  RAISE NOTICE 'OK upgrade: DELETE direto obedeceu ao contrato da membership';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
> [!WARNING]
> **Migration com número já ocupado na `main` — renumerar no rebase.**
>
> Este PR adiciona `20260715170000_remove_project_member_invariants.sql`, mas **`20260715170000_llm_rate_limit.sql` já está na `main`** (veio do #455, commit `82f1453`). O git mergeia limpo — os nomes de arquivo diferem — mas o Supabase versiona pelo **prefixo numérico**, então nenhum gate pega e o conflito só aparece no histórico do remoto.
>
> Renumerar para depois da última migration da `main`, **pulando `20260715180000`** (ocupado pelo #454). Detalhe [neste comentário](https://github.com/bdcdo/dataframeitGUI/pull/450#issuecomment-4995115189).
>
> ⚠️ O corpo abaixo afirma que `82f1453` "tem como migration mais recente a `20260715160000`" — isso está incorreto: `82f1453` é justamente o commit que **adicionou** a `20260715170000`.

## Bloqueios

Este PR está bloqueado e não deve ser integrado antes de:

- #440 — consolida a identidade canônica e a FK de aliases que este PR deve reutilizar;
- #446 — recompõe os fluxos de equivalência sobre essa identidade e precisa preceder a migration deste PR.

O #446 também depende de #454. A recomposição, a implementação das correções da revisão e a validação final do #450 só serão feitas depois que #440 e #446 estiverem integrados à `main`.

## Resumo

- adiciona confirmação acessível antes da remoção, com foco inicial em Cancelar, estado de progresso, retry e bloqueio síncrono de duplo clique;
- usa somente o contrato canônico `remove_project_member(uuid)` e deriva projeto e usuário da membership visível pela RLS;
- bloqueia auto-remoção direta, por alias, criador ou master tanto na RPC quanto em `DELETE` direto, por uma policy restritiva da própria tabela;
- remove membership, aliases e pendências na mesma transação, torna aliases e assignments pendentes órfãos irrepresentáveis e preserva assignments iniciados ou concluídos como histórico;
- impede que substituição de documentos e regeneração do backlog recriem pendências para ex-membros.

## Simplificações aplicadas

- preservadas as actions atômicas e o hardening de service role da `main`, sem duplicar autorização ou decompor `members.ts` em helpers sem ganho de contrato;
- removida a redefinição de `auth_user_coordinator_or_creator_project_ids`, cuja fonte única permanece no PR #446;
- removidos o autofocus que o Radix já fornece, duas coberturas sem mudança de produção e o `DROP` de uma assinatura que nunca existiu na `main`;
- paginação de membros ativos feita por chave em lotes de 1.000, sem teto arbitrário, sentinela ou segundo caminho de leitura;
- cada mecanismo do banco cobre uma invariante distinta: FK para aliases, trigger para pendências e RLS para autoidentidade.

## Ordem de migrations

Este PR foi rebaseado sobre a `main` no commit `82f1453`, cuja migration mais recente é `20260715160000`, e adiciona `20260715170000`. O PR #446 ainda adiciona uma migration anterior (`20260715120000`) e deve entrar antes deste para preservar a ordem de aplicação no ambiente remoto; o código do #450 não duplica mais o helper daquele PR.

A migration foi validada apenas no Supabase local; nenhuma alteração foi aplicada ao banco remoto.

## Verificação

- 1.267 testes Vitest na suíte completa e 37 testes focados de membros;
- reset integral do Supabase local e três suítes SQL de invariantes, permissões e substituição atômica;
- upgrade real a partir de `20260715160000`, com saneamento de 1 alias e 1 pendência órfãos;
- testes de RPC e `DELETE` direto para coordenador, alias, criador e master;
- TypeScript, ESLint, lint tipado, React Doctor 100/100, Fallow sobre os 12 arquivos alterados e Semgrep;
- pre-push completo para os arquivos do PR;
- Playwright não coletou testes porque faltam as 6 variáveis do tenant E2E nesta worktree.

Closes #177
