### PR TITLE
ci: bloqueia exports inválidos em módulos use server

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,7 @@ repos:
         name: react-doctor (changed lines, fail on new errors)
         entry: bash -c 'cd frontend && test -x ./node_modules/.bin/react-doctor && exec ./node_modules/.bin/react-doctor . --scope changed --base HEAD --blocking error || { echo "react-doctor ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }'
         language: system
-        files: ^frontend/.*\.(ts|tsx)$
+        files: ^frontend/.*\.(mts|ts|tsx)$
         pass_filenames: false
         require_serial: true
 
@@ -86,7 +86,7 @@ repos:
         name: typecheck (tsc --noEmit, pre-push)
         entry: bash -c 'cd frontend && test -x ./node_modules/.bin/tsc && exec ./node_modules/.bin/tsc --noEmit || { echo "tsc ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }'
         language: system
-        files: ^frontend/.*\.(ts|tsx)$
+        files: ^frontend/.*\.(mts|ts|tsx)$
         pass_filenames: false
         require_serial: true
         stages: [pre-push]
@@ -95,13 +95,13 @@ repos:
       # roda full sem grandfathering — qualquer teste que quebre barra o push.
       # E o gate de regressao de teste que nem o build da Vercel nem o `next
       # build` do deploy Fly pegavam. Falha fechado se o binario estiver ausente.
-      # Escopo por .ts/.tsx alterado (nao por arquivo de teste): mudar codigo de
-      # producao roda a suite inteira, que e o comportamento desejado.
+      # Toda fonte JS/TS em modulo ESM dispara a suite inteira, inclusive regras
+      # e configs ESLint. O glob por extensao nao acopla o hook a nomes de arquivo.
       - id: vitest
         name: vitest run (full suite, pre-push)
         entry: bash -c 'cd frontend && test -x ./node_modules/.bin/vitest && exec ./node_modules/.bin/vitest run || { echo "vitest ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }'
         language: system
-        files: ^frontend/.*\.(ts|tsx)$
+        files: ^frontend/.*\.(mjs|mts|ts|tsx)$
         pass_filenames: false
         require_serial: true
         stages: [pre-push]
@@ -128,7 +128,7 @@ repos:
         name: playwright e2e smoke (pre-push)
         entry: bash -c 'cd frontend && test -x ./node_modules/.bin/playwright && PLAYWRIGHT_PRE_PUSH=1 exec ./node_modules/.bin/playwright test || { echo "playwright ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }'
         language: system
-        files: ^(\.pre-commit-config\.yaml|CLAUDE\.md|docs/CODE_QUALITY_TOOLING\.md|frontend/(.*\.(ts|tsx)|package(-lock)?\.json|\.env\.e2e\.example))$
+        files: ^(\.pre-commit-config\.yaml|CLAUDE\.md|docs/CODE_QUALITY_TOOLING\.md|frontend/(.*\.(mts|ts|tsx)|package(-lock)?\.json|\.env\.e2e\.example))$
         pass_filenames: false
         require_serial: true
         stages: [pre-push]
@@ -140,7 +140,7 @@ repos:
         name: typescript-eslint type-checked (changed files, pre-push)
         entry: bash -c 'cd frontend && files=$(printf "%s\n" "$@" | sed "s|^frontend/||"); [ -z "$files" ] && exit 0; test -x ./node_modules/.bin/eslint && exec ./node_modules/.bin/eslint --config eslint.config.typed.mjs $files || { echo "eslint ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }' --
         language: system
-        files: ^frontend/.*\.(ts|tsx)$
+        files: ^frontend/.*\.(mts|ts|tsx)$
         pass_filenames: true
         require_serial: true
         stages: [pre-push]
@@ -154,7 +154,7 @@ repos:
         name: fallow audit (new findings block, pre-push)
         entry: bash -c 'cd frontend && test -x ./node_modules/.bin/fallow && exec ./node_modules/.bin/fallow audit || { echo "fallow ausente em frontend/node_modules; rode (cd frontend && npm install)" >&2; exit 1; }'
         language: system
-        files: ^frontend/.*\.(ts|tsx)$
+        files: ^frontend/.*\.(mts|ts|tsx)$
         pass_filenames: false
         require_serial: true
         stages: [pre-push]

--- a/docs/CODE_QUALITY_TOOLING.md
+++ b/docs/CODE_QUALITY_TOOLING.md
@@ -13,7 +13,7 @@ A regra de ouro é que tudo roda sozinho, via git hook ou automação de servido
 | Quem dispara | Quando | Ferramentas | Grandfathering |
 |---|---|---|---|
 | `pre-commit` | todo commit (leve, file-scoped) | gitleaks · ruff (lint+format) · actionlint · deploy notifier · react-doctor | só o arquivo/linha tocado é checado; o notifier roda quando seu workflow ou teste muda |
-| `pre-push` | todo `git push` (pesado, grafo/tipos) | typecheck · e2e-smoke (Playwright) · lint:types · fallow audit · semgrep · backend-pytest · mypy | new-only / file-scoped (ver cada um); pytest roda a suíte inteira; e2e-smoke falha fechado no pre-push se envs E2E/Clerk obrigatórias faltarem |
+| `pre-push` | todo `git push` (pesado, grafo/tipos) | typecheck · vitest · e2e-smoke (Playwright) · lint:types · fallow audit · semgrep · backend-pytest · mypy | new-only / file-scoped (ver cada um); Vitest e pytest rodam as suítes inteiras; e2e-smoke falha fechado no pre-push se envs E2E/Clerk obrigatórias faltarem |
 | GitHub (servidor) | automático | Dependabot | n/a — abre PRs de vuln sozinho |
 | on-demand | ao investigar performance | React Scan | n/a — ferramenta de diagnóstico, não gate |
 
@@ -42,6 +42,10 @@ A escolha se justificou empiricamente: o primeiro scan encontrou 59 errors em ce
 ### typecheck (tsc) — o prerequisito que faltava
 
 O projeto não tinha sequer um script `tsc --noEmit`. O `npm run typecheck` preenche isso e roda no pre-push (projeto inteiro, sem grandfathering — hoje passa com **0 erros**, então qualquer erro de tipo novo barra o push). O compilador nativo em Go (tsgo / TypeScript 7) está em RC mas ainda não foi adotado (ver "Monitorar"); quando o GA sair, basta trocar `tsc` por `tsgo` nesse script.
+
+### Exports de Server Actions — contrato do projeto
+
+O Next.js exige que cada export de valor de um arquivo cuja diretiva é `"use server"` seja uma função `async`; `tsc --noEmit` não detecta essa restrição, e a ausência desse gate causou os três deploys quebrados registrados na [#413](https://github.com/bdcdo/dataframeitGUI/issues/413). A regra local aplicada pelo ESLint permite funções async exportadas diretamente — declaração nomeada, arrow ou function expression em `const`, e default async — e exports exclusivamente de tipo. Valores puros, generators, aliases e reexports de valor ficam bloqueados; a regra não resolve bindings indiretos para manter o gate sintático e file-scoped.
 
 ### ruff — lint, format e complexidade do backend
 

--- a/docs/CODE_QUALITY_TOOLING.md
+++ b/docs/CODE_QUALITY_TOOLING.md
@@ -45,7 +45,9 @@ O projeto não tinha sequer um script `tsc --noEmit`. O `npm run typecheck` pree
 
 ### Exports de Server Actions — contrato do projeto
 
-O Next.js exige que cada export de valor de um arquivo cuja diretiva é `"use server"` seja uma função `async`; `tsc --noEmit` não detecta essa restrição, e a ausência desse gate causou os três deploys quebrados registrados na [#413](https://github.com/bdcdo/dataframeitGUI/issues/413). A regra local aplicada pelo ESLint permite funções async exportadas diretamente — declaração nomeada, arrow ou function expression em `const`, e default async — e exports exclusivamente de tipo. Valores puros, generators, aliases e reexports de valor ficam bloqueados; a regra não resolve bindings indiretos para manter o gate sintático e file-scoped.
+O Next.js exige que cada export de valor de um arquivo cuja diretiva é `"use server"` seja uma função `async`; `tsc --noEmit` não detecta essa restrição, e a ausência desse gate causou os três deploys quebrados registrados na [#413](https://github.com/bdcdo/dataframeitGUI/issues/413). A regra local aplicada pelo ESLint permite funções async exportadas diretamente — declaração nomeada, arrow ou function expression em `const`, e default async — e exports exclusivamente de tipo. Valores puros, generators, aliases e reexports de valor ficam bloqueados; a regra não resolve bindings indiretos para manter o gate sintático e file-scoped. Assinaturas de overload e declarações ambientes (`declare function`) passam porque são apagadas na compilação e não exportam valor — a implementação do overload continua sujeita à regra.
+
+Quem aplica a regra é o hook **`lint-types`** (pre-push, arquivos alterados), e não o `npm run lint`, que nenhum hook executa: a regra mora em `eslint.config.mjs` e chega ao hook porque `eslint.config.typed.mjs` faz `...base`. Essa dependência é o único caminho de enforcement — desacoplar as duas configs removeria o gate da #413 em silêncio, sem nenhum teste falhando.
 
 ### ruff — lint, format e complexidade do backend
 

--- a/frontend/eslint-rules/server-action-exports.mjs
+++ b/frontend/eslint-rules/server-action-exports.mjs
@@ -20,10 +20,16 @@ function hasUseServerDirective(program) {
   );
 }
 
-function isAsyncFunction(node) {
+function unwrapTypeScript(node) {
   while (TRANSPARENT_TYPESCRIPT_EXPRESSIONS.has(node?.type)) {
     node = node.expression;
   }
+
+  return node;
+}
+
+function isAsyncFunction(node) {
+  node = unwrapTypeScript(node);
 
   return (
     ASYNC_FUNCTION_TYPES.has(node?.type) &&
@@ -32,9 +38,14 @@ function isAsyncFunction(node) {
   );
 }
 
+function isGeneratorFunction(node) {
+  node = unwrapTypeScript(node);
+
+  return ASYNC_FUNCTION_TYPES.has(node?.type) && node.generator === true;
+}
+
 function isAsyncVariableDeclaration(declaration) {
   return (
-    declaration.type === "VariableDeclaration" &&
     declaration.kind === "const" &&
     declaration.declarations.every(
       (declarator) =>
@@ -44,29 +55,52 @@ function isAsyncVariableDeclaration(declaration) {
   );
 }
 
-function exportIsAllowed(statement) {
-  if (statement.exportKind === "type") return true;
+// Devolve o messageId da violacao, ou null quando o export e valido.
+function declarationViolation(declaration) {
+  // `TSDeclareFunction` cobre assinaturas de overload e declaracoes ambientes:
+  // ambas somem na compilacao e nao exportam valor algum. A implementacao do
+  // overload e um statement proprio e e verificada por conta dela.
+  if (declaration.type === "TSDeclareFunction") return null;
 
-  if (statement.type === "ExportAllDeclaration") return false;
+  if (isAsyncFunction(declaration)) return null;
+  if (isGeneratorFunction(declaration)) return "generatorExport";
 
-  if (statement.type === "ExportDefaultDeclaration") {
-    return (
-      statement.declaration.type === "TSInterfaceDeclaration" ||
-      isAsyncFunction(statement.declaration)
-    );
+  if (declaration.type === "VariableDeclaration") {
+    if (
+      declaration.declarations.some((declarator) =>
+        isGeneratorFunction(declarator.init),
+      )
+    ) {
+      return "generatorExport";
+    }
+    if (isAsyncVariableDeclaration(declaration)) return null;
   }
 
-  if (statement.type !== "ExportNamedDeclaration") return true;
+  return "valueExport";
+}
+
+function exportViolation(statement) {
+  if (statement.exportKind === "type") return null;
+
+  if (statement.type === "ExportAllDeclaration") return "indirectExport";
+
+  if (statement.type === "ExportDefaultDeclaration") {
+    if (statement.declaration.type === "TSInterfaceDeclaration") return null;
+    return declarationViolation(statement.declaration);
+  }
+
+  if (statement.type !== "ExportNamedDeclaration") return null;
 
   const declaration = statement.declaration;
   if (!declaration) {
     return statement.specifiers.every(
       (specifier) => specifier.exportKind === "type",
-    );
+    )
+      ? null
+      : "indirectExport";
   }
 
-  if (isAsyncFunction(declaration)) return true;
-  return isAsyncVariableDeclaration(declaration);
+  return declarationViolation(declaration);
 }
 
 const asyncValueExports = {
@@ -80,6 +114,10 @@ const asyncValueExports = {
     messages: {
       valueExport:
         'Módulos "use server" só podem exportar funções async diretas ou tipos. Mova valores puros para um módulo sem a diretiva.',
+      indirectExport:
+        'Módulos "use server" não podem exportar aliases nem reexports: o gate é sintático e não resolve bindings. Declare a função async diretamente neste módulo.',
+      generatorExport:
+        'Server Actions precisam devolver uma Promise, e generators não são exports válidos em módulos "use server".',
     },
   },
   create(context) {
@@ -88,8 +126,9 @@ const asyncValueExports = {
         if (!hasUseServerDirective(program)) return;
 
         for (const statement of program.body) {
-          if (!exportIsAllowed(statement)) {
-            context.report({ node: statement, messageId: "valueExport" });
+          const messageId = exportViolation(statement);
+          if (messageId) {
+            context.report({ node: statement, messageId });
           }
         }
       },

--- a/frontend/eslint-rules/server-action-exports.mjs
+++ b/frontend/eslint-rules/server-action-exports.mjs
@@ -1,0 +1,106 @@
+const RULE_NAME = "async-value-exports";
+
+const ASYNC_FUNCTION_TYPES = new Set([
+  "ArrowFunctionExpression",
+  "FunctionDeclaration",
+  "FunctionExpression",
+]);
+
+const TRANSPARENT_TYPESCRIPT_EXPRESSIONS = new Set([
+  "TSAsExpression",
+  "TSInstantiationExpression",
+  "TSNonNullExpression",
+  "TSSatisfiesExpression",
+  "TSTypeAssertion",
+]);
+
+function hasUseServerDirective(program) {
+  return program.body.some(
+    (statement) => statement.directive === "use server",
+  );
+}
+
+function isAsyncFunction(node) {
+  while (TRANSPARENT_TYPESCRIPT_EXPRESSIONS.has(node?.type)) {
+    node = node.expression;
+  }
+
+  return (
+    ASYNC_FUNCTION_TYPES.has(node?.type) &&
+    node.async === true &&
+    node.generator !== true
+  );
+}
+
+function isAsyncVariableDeclaration(declaration) {
+  return (
+    declaration.type === "VariableDeclaration" &&
+    declaration.kind === "const" &&
+    declaration.declarations.every(
+      (declarator) =>
+        declarator.id.type === "Identifier" &&
+        isAsyncFunction(declarator.init),
+    )
+  );
+}
+
+function exportIsAllowed(statement) {
+  if (statement.exportKind === "type") return true;
+
+  if (statement.type === "ExportAllDeclaration") return false;
+
+  if (statement.type === "ExportDefaultDeclaration") {
+    return (
+      statement.declaration.type === "TSInterfaceDeclaration" ||
+      isAsyncFunction(statement.declaration)
+    );
+  }
+
+  if (statement.type !== "ExportNamedDeclaration") return true;
+
+  const declaration = statement.declaration;
+  if (!declaration) {
+    return statement.specifiers.every(
+      (specifier) => specifier.exportKind === "type",
+    );
+  }
+
+  if (isAsyncFunction(declaration)) return true;
+  return isAsyncVariableDeclaration(declaration);
+}
+
+const asyncValueExports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        'Exige funções async diretas nos exports de módulos "use server".',
+    },
+    schema: [],
+    messages: {
+      valueExport:
+        'Módulos "use server" só podem exportar funções async diretas ou tipos. Mova valores puros para um módulo sem a diretiva.',
+    },
+  },
+  create(context) {
+    return {
+      Program(program) {
+        if (!hasUseServerDirective(program)) return;
+
+        for (const statement of program.body) {
+          if (!exportIsAllowed(statement)) {
+            context.report({ node: statement, messageId: "valueExport" });
+          }
+        }
+      },
+    };
+  },
+};
+
+export const serverActionExportsPlugin = {
+  rules: {
+    [RULE_NAME]: asyncValueExports,
+  },
+};
+
+export { RULE_NAME };

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,10 +1,23 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import {
+  RULE_NAME,
+  serverActionExportsPlugin,
+} from "./eslint-rules/server-action-exports.mjs";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  {
+    files: ["src/**/*.{mts,ts,tsx}"],
+    plugins: {
+      "server-actions": serverActionExportsPlugin,
+    },
+    rules: {
+      [`server-actions/${RULE_NAME}`]: "error",
+    },
+  },
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/frontend/eslint.config.typed.mjs
+++ b/frontend/eslint.config.typed.mjs
@@ -14,7 +14,7 @@ import base from "./eslint.config.mjs";
 const typedConfig = defineConfig([
   ...base,
   {
-    files: ["src/**/*.{ts,tsx}"],
+    files: ["src/**/*.{mts,ts,tsx}"],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {

--- a/frontend/src/tooling/__tests__/server-action-exports.test.ts
+++ b/frontend/src/tooling/__tests__/server-action-exports.test.ts
@@ -1,0 +1,97 @@
+import { fileURLToPath } from "node:url";
+
+import { ESLint } from "eslint";
+import { describe, expect, it } from "vitest";
+
+import { RULE_NAME } from "../../../eslint-rules/server-action-exports.mjs";
+
+const frontendRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const ruleId = `server-actions/${RULE_NAME}`;
+const eslint = new ESLint({
+  cwd: frontendRoot,
+  overrideConfigFile: "eslint.config.mjs",
+});
+
+async function messagesFor(
+  code: string,
+  filePath = "src/actions/example.ts",
+) {
+  const [result] = await eslint.lintText(code, { filePath });
+  return result?.messages.filter((message) => message.ruleId === ruleId) ?? [];
+}
+
+describe('regra de exports em módulos "use server"', () => {
+  it("permite funções async diretas e exports de tipo", async () => {
+    await expect(
+      messagesFor(`
+        "use server";
+        export async function declared() { return 1; }
+        export const arrow = async () => 2;
+        export const expression = async function () { return 3; };
+        export const satisfying = (async () => 4) satisfies () => Promise<number>;
+        export const instantiated = (async <T>(value: T) => value)<string>;
+        export const asserted = (async () => 6) as () => Promise<number>;
+        export const nonNull = (async () => 7)!;
+        export const typeAsserted = <() => Promise<number>>(async () => 8);
+        export default async function defaultAction() { return 5; }
+        export type Result = { ok: boolean };
+        export interface Options { enabled: boolean }
+        export { type Result as PublicResult };
+        export type { RemoteResult } from "./other";
+        export type * from "./types";
+      `),
+    ).resolves.toEqual([]);
+
+    await expect(
+      messagesFor(`"use server"; export default interface Options {}`),
+    ).resolves.toEqual([]);
+  });
+
+  it("aplica a regra a módulos .mts", async () => {
+    await expect(
+      messagesFor(
+        `"use server";\nexport function syncAction() {}`,
+        "src/actions/example.mts",
+      ),
+    ).resolves.toHaveLength(1);
+  });
+
+  it("ignora módulos sem a diretiva", async () => {
+    await expect(
+      messagesFor("export function ordinaryFunction() {}"),
+    ).resolves.toEqual([]);
+  });
+
+  it.each([
+    ["função síncrona", "export function sync() { return 1; }"],
+    ["constante", "export const value = 1;"],
+    ["arrow síncrona", "export const sync = () => 1;"],
+    ["binding mutável", "export let action = async () => 1;"],
+    ["async generator", "export async function* stream() { yield 1; }"],
+    [
+      "declarators mistos",
+      "export const valid = async () => 1, invalid = () => 2;",
+    ],
+  ])("bloqueia %s", async (caseName, exported) => {
+    const messages = await messagesFor(`"use server";\n${exported}`);
+
+    expect(messages).toHaveLength(1);
+    if (caseName === "função síncrona") {
+      expect(messages[0]?.message).toContain(
+        'Módulos "use server" só podem exportar funções async diretas ou tipos',
+      );
+    }
+  });
+
+  it("bloqueia aliases, reexports e default de valor", async () => {
+    const messages = await messagesFor(`
+      "use server";
+      const internal = async () => true;
+      export { internal as publicAction };
+      export * from "./other";
+      export default 1;
+    `);
+
+    expect(messages).toHaveLength(3);
+  });
+});

--- a/frontend/src/tooling/__tests__/server-action-exports.test.ts
+++ b/frontend/src/tooling/__tests__/server-action-exports.test.ts
@@ -47,6 +47,23 @@ describe('regra de exports em módulos "use server"', () => {
     ).resolves.toEqual([]);
   });
 
+  // Assinaturas de overload e declaracoes ambientes sao `TSDeclareFunction`:
+  // nao emitem valor, entao nao ha export de valor a bloquear. A implementacao
+  // do overload e um statement proprio e continua sujeita a regra.
+  it("permite overloads async e declarações ambientes", async () => {
+    await expect(
+      messagesFor(`
+        "use server";
+        export declare function ambient(): Promise<void>;
+        export async function overloaded(value: string): Promise<number>;
+        export async function overloaded(value: number): Promise<number>;
+        export async function overloaded(value: string | number): Promise<number> {
+          return Number(value);
+        }
+      `),
+    ).resolves.toEqual([]);
+  });
+
   it("aplica a regra a módulos .mts", async () => {
     await expect(
       messagesFor(
@@ -63,24 +80,31 @@ describe('regra de exports em módulos "use server"', () => {
   });
 
   it.each([
-    ["função síncrona", "export function sync() { return 1; }"],
-    ["constante", "export const value = 1;"],
-    ["arrow síncrona", "export const sync = () => 1;"],
-    ["binding mutável", "export let action = async () => 1;"],
-    ["async generator", "export async function* stream() { yield 1; }"],
+    ["função síncrona", "export function sync() { return 1; }", "valueExport"],
+    ["constante", "export const value = 1;", "valueExport"],
+    ["arrow síncrona", "export const sync = () => 1;", "valueExport"],
+    ["enum", "export enum Mode { Draft }", "valueExport"],
+    ["binding mutável", "export let action = async () => 1;", "valueExport"],
     [
       "declarators mistos",
       "export const valid = async () => 1, invalid = () => 2;",
+      "valueExport",
     ],
-  ])("bloqueia %s", async (caseName, exported) => {
+    [
+      "async generator",
+      "export async function* stream() { yield 1; }",
+      "generatorExport",
+    ],
+    [
+      "generator em const",
+      "export const stream = async function* () { yield 1; };",
+      "generatorExport",
+    ],
+  ])("bloqueia %s", async (_caseName, exported, expectedMessageId) => {
     const messages = await messagesFor(`"use server";\n${exported}`);
 
     expect(messages).toHaveLength(1);
-    if (caseName === "função síncrona") {
-      expect(messages[0]?.message).toContain(
-        'Módulos "use server" só podem exportar funções async diretas ou tipos',
-      );
-    }
+    expect(messages[0]?.messageId).toBe(expectedMessageId);
   });
 
   it("bloqueia aliases, reexports e default de valor", async () => {
@@ -92,6 +116,24 @@ describe('regra de exports em módulos "use server"', () => {
       export default 1;
     `);
 
-    expect(messages).toHaveLength(3);
+    expect(messages.map((message) => message.messageId)).toEqual([
+      "indirectExport",
+      "indirectExport",
+      "valueExport",
+    ]);
+  });
+
+  it("orienta a correção conforme o tipo de export inválido", async () => {
+    const [pureValue] = await messagesFor(`"use server";\nexport const n = 1;`);
+    expect(pureValue?.message).toContain(
+      "Mova valores puros para um módulo sem a diretiva",
+    );
+
+    const [alias] = await messagesFor(
+      `"use server";\nconst internal = async () => 1;\nexport { internal };`,
+    );
+    expect(alias?.message).toContain(
+      "Declare a função async diretamente neste módulo",
+    );
   });
 });


### PR DESCRIPTION
## Resumo

- integra uma regra local à configuração ESLint canônica para módulos com diretiva `"use server"`;
- permite funções async exportadas diretamente: declaração nomeada, arrow ou function expression em `const`, default async e wrappers TypeScript transparentes;
- permite exports exclusivamente de tipo e bloqueia valores puros, generators, aliases e reexports de valor;
- cobre `.mts` na regra, no lint tipado e nos gates TypeScript;
- usa um glob estável no hook Vitest, sem acoplamento aos nomes da regra ou das configurações;
- mantém uma única decisão de export e um predicado separado para declarações `const async`, sem resolvedor parcial de bindings;
- emite um diagnóstico por declaração inválida e mantém 10 casos focados nos ramos públicos do contrato.

## Verificação

- 10 casos focados da regra
- 25 probes AST pela configuração ESLint real
- Vitest completo: 133 arquivos e 1.270 testes
- `npm run lint` — 0 errors; 1 warning legado fora do diff
- `npm run lint:types`
- `npm run typecheck`
- `npm run fallow:audit`
- `pre-commit validate-config .pre-commit-config.yaml`
- hooks de pre-push: typecheck, Vitest, lint tipado, Fallow, Semgrep, pytest e mypy
- E2E omitido explicitamente com `SKIP=e2e-smoke`: a worktree não contém as variáveis Clerk e fixtures autenticadas, e a mudança não altera runtime

Closes #413