### PR TITLE
feat: desliga LLM no alfa com kill-switch estrutural

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ fly deploy -c fly.toml -a gui-analise-sistematica-api   # fallback; o normal é 
 
 Verificar: `curl https://gui-analise-sistematica-api.fly.dev/health`
 
+O alfa público está configurado sem LLM por duas flags versionadas no Fly: `LLM_ENABLED=false` no backend bloqueia estruturalmente todo `/api/llm/*` com `403`, e `NEXT_PUBLIC_LLM_ENABLED=false` no build do frontend remove navegação, botões e páginas dedicadas. Ambas têm default `true` fora do Fly para preservar desenvolvimento e instalações existentes. Reativar exige alterar as duas configurações e fazer novo deploy; `/api/pydantic/*` não depende dessas flags. Com a flag desligada, novos projetos usam `none` por default e só aceitam `none` ou `compare_humans`; configurações e respostas LLM já existentes permanecem legíveis, sem reescrita automática. O editor de schema continua permitindo preparar campos `target="llm_only"` para uma reativação futura, pois salvar essa definição Pydantic não executa modelo nem gera custo.
+
 ### 3. Frontend (Fly.io — `gui-analise-sistematica-frontend`)
 
 Config em `frontend/fly.toml`. As `NEXT_PUBLIC_*` ficam em `[build.args]` (embutidas no bundle em build time, todas públicas por design); os secrets de runtime (`CLERK_SECRET_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `CLERK_WEBHOOK_SECRET`) via `fly secrets set`:
@@ -103,9 +105,11 @@ fly deploy -c fly.toml -a gui-analise-sistematica-frontend   # fallback; o norma
 | `SUPABASE_SERVICE_KEY` | Backend (Fly.io) | Service role key |
 | `CLERK_JWKS_URL` | Backend (Fly.io) | URL do JWKS do Clerk (verificação RS256 do JWT) |
 | `CORS_ORIGINS` | Backend (`fly.toml [env]`) | JSON array de origens permitidas |
+| `LLM_ENABLED` | Backend (`fly.toml [env]`) | Kill-switch de `/api/llm/*`; default `true`, alfa `false` |
 | `NEXT_PUBLIC_SUPABASE_URL` | Frontend (`fly.toml [build.args]`) | URL do projeto Supabase |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Frontend (`fly.toml [build.args]`) | Anon/publishable key |
 | `NEXT_PUBLIC_API_URL` | Frontend (`fly.toml [build.args]`) | URL do backend no Fly.io |
+| `NEXT_PUBLIC_LLM_ENABLED` | Frontend (`fly.toml [build.args]`) | Visibilidade das superfícies LLM; default `true`, alfa `false` |
 | `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | Frontend (`fly.toml [build.args]`) | Publishable key do Clerk |
 | `CLERK_SECRET_KEY` | Frontend (Fly secret) | Secret key do Clerk |
 | `SUPABASE_SERVICE_ROLE_KEY` | Frontend (Fly secret) | Service role (server actions) |

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,10 @@ SUPABASE_URL=http://127.0.0.1:54321
 SUPABASE_SERVICE_KEY=your-service-key-here
 CORS_ORIGINS=["http://localhost:3000"]
 
+# Kill-switch de todas as rotas /api/llm/* (default true). Quando false, o
+# router responde 403 antes de autorização, banco ou processamento pago.
+# LLM_ENABLED=false
+
 # Verificação do JWT do Clerk (template "supabase").
 # Configure pelo menos UM mecanismo — sem nenhum, as rotas autenticadas
 # rejeitam tudo (fail-closed).

--- a/backend/config.py
+++ b/backend/config.py
@@ -25,6 +25,11 @@ class Settings(BaseSettings):
     # do JWT. O token do template expira em ~60s e é pollado por minutos.
     jwt_leeway_seconds: int = 30
 
+    # Kill-switch operacional de todo o namespace /api/llm/*. Default ligado
+    # para compatibilidade com desenvolvimento/self-hosting; o alfa público
+    # desliga explicitamente no fly.toml.
+    llm_enabled: bool = True
+
     # Endpoints de documentação (/docs, /redoc, /openapi.json). Fechados por
     # padrão (fail-safe): num serviço internet-facing, /openapi.json anônimo
     # vaza o schema de todas as rotas protegidas. Ligar só em dev via

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -38,6 +38,9 @@ kill_timeout = "5m"
 
 [env]
   PORT = "8000"
+  # Alfa público: bloqueia estruturalmente todo /api/llm/* antes dos handlers.
+  # Não é secret; reativar exige remover/trocar este valor e fazer novo deploy.
+  LLM_ENABLED = "false"
   CORS_ORIGINS = '["https://dataframeit.com.br", "https://gui-analise-sistematica-frontend.fly.dev", "https://ac.brunodcdo.com.br", "http://localhost:3000"]'
   # ENABLE_DOCS ausente de propósito: o default fail-safe (config.py) mantém
   # /docs, /redoc e /openapi.json fechados em produção. NÃO adicionar aqui.

--- a/backend/main.py
+++ b/backend/main.py
@@ -110,6 +110,14 @@ async def health():
     return {"status": "ok"}
 
 
+def require_llm_enabled() -> None:
+    if not settings.llm_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="Funcionalidades de LLM estão desabilitadas.",
+        )
+
+
 # Docs (/docs, /redoc, /openapi.json) desligados por padrão — fail-safe. Num
 # serviço internet-facing, /openapi.json anônimo enumera o schema de todas as
 # rotas protegidas. Ligar só em dev com ENABLE_DOCS=true (ver config.py).
@@ -152,7 +160,10 @@ def create_app(*, enable_docs: bool = settings.enable_docs) -> FastAPI:
         llm_router,
         prefix="/api/llm",
         tags=["llm"],
-        dependencies=[Depends(require_authenticated_user)],
+        dependencies=[
+            Depends(require_llm_enabled),
+            Depends(require_authenticated_user),
+        ],
     )
     app.include_router(
         pydantic_router,

--- a/backend/tests/test_llm_feature_flag.py
+++ b/backend/tests/test_llm_feature_flag.py
@@ -15,6 +15,7 @@ from config import Settings, settings
 from main import create_app
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+VALID_PROJECT_ID = "00000000-0000-4000-8000-000000000001"
 
 
 def test_settings_defaults_to_llm_enabled(monkeypatch) -> None:
@@ -129,7 +130,7 @@ def test_disabled_switch_does_not_cover_pydantic_namespace(
 
     response = client.post(
         "/api/pydantic/recover-fields",
-        json={"project_id": "p1"},
+        json={"project_id": VALID_PROJECT_ID},
         headers=auth_headers,
     )
 

--- a/backend/tests/test_llm_feature_flag.py
+++ b/backend/tests/test_llm_feature_flag.py
@@ -1,0 +1,137 @@
+"""Contrato estrutural do kill-switch de /api/llm/* (issue #186)."""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import routes.llm_routes as llm_routes
+import routes.pydantic_routes as pydantic_routes
+from config import Settings, settings
+from main import create_app
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_settings_defaults_to_llm_enabled(monkeypatch) -> None:
+    monkeypatch.delenv("LLM_ENABLED", raising=False)
+    assert Settings(_env_file=None).llm_enabled is True
+
+
+def test_settings_parses_explicit_false(monkeypatch) -> None:
+    monkeypatch.setenv("LLM_ENABLED", "false")
+    assert Settings(_env_file=None).llm_enabled is False
+
+
+def test_fly_alpha_disables_frontend_and_backend() -> None:
+    backend_fly = tomllib.loads((REPOSITORY_ROOT / "backend/fly.toml").read_text())
+    frontend_fly = tomllib.loads((REPOSITORY_ROOT / "frontend/fly.toml").read_text())
+
+    assert backend_fly["env"]["LLM_ENABLED"] == "false"
+    assert frontend_fly["build"]["args"]["NEXT_PUBLIC_LLM_ENABLED"] == "false"
+
+
+def test_disabled_switch_covers_every_llm_route(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "llm_enabled", False)
+    app = create_app()
+    client = TestClient(app, raise_server_exceptions=False)
+    checked = 0
+
+    for path, operations in app.openapi()["paths"].items():
+        if not path.startswith("/api/llm/"):
+            continue
+        concrete_path = re.sub(r"\{[^}]+\}", "job-id", path)
+        for method in operations:
+            if method.upper() in {"HEAD", "OPTIONS", "PARAMETERS"}:
+                continue
+            response = client.request(
+                method.upper(),
+                concrete_path,
+                json={"project_id": "p1", "field_names": ["field"]},
+            )
+            assert response.status_code == 403, (
+                f"{method.upper()} {concrete_path} retornou {response.status_code}"
+            )
+            assert response.json() == {
+                "detail": "Funcionalidades de LLM estão desabilitadas."
+            }
+            checked += 1
+
+    assert checked >= 5
+
+
+def test_disabled_switch_runs_before_paid_handler_work(
+    monkeypatch, auth_headers
+) -> None:
+    monkeypatch.setattr(settings, "llm_enabled", False)
+
+    def fail_init_job(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("init_job não deveria executar")
+
+    monkeypatch.setattr(llm_routes, "init_job", fail_init_job)
+    client = TestClient(create_app(), raise_server_exceptions=False)
+
+    response = client.post(
+        "/api/llm/run",
+        json={"project_id": "p1"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 403
+
+
+class _StoredPydanticCode:
+    def select(self, *_args: object) -> "_StoredPydanticCode":
+        return self
+
+    def eq(self, *_args: object) -> "_StoredPydanticCode":
+        return self
+
+    def maybe_single(self) -> "_StoredPydanticCode":
+        return self
+
+    def execute(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            data={
+                "pydantic_code": (
+                    "from pydantic import BaseModel\n\n"
+                    "class Analysis(BaseModel):\n"
+                    "    answer: str"
+                )
+            }
+        )
+
+
+class _PydanticSupabase:
+    def table(self, _name: str) -> _StoredPydanticCode:
+        return _StoredPydanticCode()
+
+
+def test_disabled_switch_does_not_cover_pydantic_namespace(
+    monkeypatch, auth_headers
+) -> None:
+    monkeypatch.setattr(settings, "llm_enabled", False)
+    monkeypatch.setattr(
+        pydantic_routes,
+        "require_project_coordinator",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        pydantic_routes,
+        "get_supabase",
+        lambda: _PydanticSupabase(),
+    )
+    client = TestClient(create_app(), raise_server_exceptions=False)
+
+    response = client.post(
+        "/api/pydantic/recover-fields",
+        json={"project_id": "p1"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["valid"] is True

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,8 @@
 
 Base URL: `NEXT_PUBLIC_API_URL` (default: `http://localhost:8000`)
 
+Todas as rotas sob `/api/llm/*` herdam um kill-switch estrutural do router. Com `LLM_ENABLED=false`, elas retornam `403` antes de autenticação, banco ou processamento; o namespace `/api/pydantic/*` permanece disponível e continua sujeito apenas às próprias regras de autenticação e autorização.
+
 ## POST /api/pydantic/validate
 
 Compila codigo Pydantic e extrai campos tipados.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,6 +16,7 @@ COPY . .
 ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_LLM_ENABLED
 # Variaveis NEXT_PUBLIC_* sao embutidas no bundle em build time; sem as do
 # Clerk aqui, o cliente quebra em producao.
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -18,6 +18,9 @@ swap_size_mb = 512
     NEXT_PUBLIC_SUPABASE_URL = "https://nryebmwlmxuwvynfuzsv.supabase.co"
     NEXT_PUBLIC_SUPABASE_ANON_KEY = "sb_publishable_nqJGyzUd0ackkC9jSDTo3w_0xjg1hDd"
     NEXT_PUBLIC_API_URL = "https://gui-analise-sistematica-api.fly.dev"
+    # Alfa público sem execução/configuração LLM. Como NEXT_PUBLIC_*, o valor é
+    # embutido no bundle durante o build; reativar exige novo deploy.
+    NEXT_PUBLIC_LLM_ENABLED = "false"
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = "pk_test_aW5ub2NlbnQtZm94aG91bmQtODguY2xlcmsuYWNjb3VudHMuZGV2JA"
     NEXT_PUBLIC_CLERK_SIGN_IN_URL = "/auth/login"
     NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL = "/dashboard"

--- a/frontend/src/actions/__tests__/projects-feature-flags.test.ts
+++ b/frontend/src/actions/__tests__/projects-feature-flags.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  makeSupabaseMock,
+  type TableResults,
+  type WriteCall,
+} from "./supabase-mock";
+
+let tableResults: TableResults;
+let writeCalls: WriteCall[];
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: async () => ({ id: "user-coord" }),
+}));
+vi.mock("@/lib/supabase/server", () => ({
+  createSupabaseServer: async () =>
+    makeSupabaseMock({ tableResults, writeCalls }),
+}));
+
+import { createProject, updateProject } from "../projects";
+
+const originalFlag = process.env.NEXT_PUBLIC_LLM_ENABLED;
+
+function projectForm(mode?: string): FormData {
+  const formData = new FormData();
+  formData.set("name", "Projeto");
+  formData.set("description", "Descrição");
+  if (mode !== undefined) formData.set("automation_mode", mode);
+  return formData;
+}
+
+function projectInsert(): Record<string, unknown> | undefined {
+  return writeCalls.find(
+    ({ table, op }) => table === "projects" && op === "insert",
+  )?.payload as Record<string, unknown> | undefined;
+}
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_LLM_ENABLED = "false";
+  writeCalls = [];
+  tableResults = {
+    projects: { data: { id: "p1" }, error: null },
+    project_members: { data: null, error: null },
+  };
+  mocks.redirect.mockReset();
+});
+
+afterEach(() => {
+  if (originalFlag === undefined) {
+    delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+  } else {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = originalFlag;
+  }
+});
+
+describe("createProject sem LLM", () => {
+  it("usa none como default e persiste comparison_includes_llm=false", async () => {
+    const result = await createProject(null, projectForm());
+
+    expect(result).toBeUndefined();
+    expect(projectInsert()).toMatchObject({
+      automation_mode: "none",
+      comparison_includes_llm: false,
+    });
+  });
+
+  it("mantém compare_humans como opção permitida", async () => {
+    await createProject(null, projectForm("compare_humans"));
+
+    expect(projectInsert()).toMatchObject({
+      automation_mode: "compare_humans",
+      comparison_includes_llm: false,
+    });
+  });
+
+  it("preserva o default auto_review_llm quando a flag não está definida", async () => {
+    delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+
+    await createProject(null, projectForm());
+
+    expect(projectInsert()).toMatchObject({
+      automation_mode: "auto_review_llm",
+    });
+    expect(projectInsert()).not.toHaveProperty("comparison_includes_llm");
+  });
+
+  it("faz fallback para none diante de um valor desconhecido", async () => {
+    await createProject(null, projectForm("modo-inventado"));
+
+    expect(projectInsert()).toMatchObject({ automation_mode: "none" });
+  });
+
+  it.each(["auto_review_llm", "compare_llm"])(
+    "rejeita payload forjado com o modo %s",
+    async (mode) => {
+      const result = await createProject(null, projectForm(mode));
+
+      expect(result?.error).toMatch(/desabilitadas/i);
+      expect(projectInsert()).toBeUndefined();
+    },
+  );
+
+  it("rejeita comparison_includes_llm=true forjado na criação", async () => {
+    const formData = projectForm("compare_humans");
+    formData.set("comparison_includes_llm", "true");
+
+    const result = await createProject(null, formData);
+
+    expect(result?.error).toMatch(/desabilitadas/i);
+    expect(projectInsert()).toBeUndefined();
+  });
+});
+
+describe("updateProject sem LLM", () => {
+  it.each([
+    { automation_mode: "auto_review_llm" as const },
+    { automation_mode: "compare_llm" as const },
+    { comparison_includes_llm: true },
+  ])("rejeita payload forjado $automation_mode", async (payload) => {
+    const result = await updateProject("p1", payload);
+
+    expect(result.error).toMatch(/desabilitadas/i);
+    expect(writeCalls).toHaveLength(0);
+  });
+
+  it("aceita transição explícita para compare_humans sem LLM", async () => {
+    tableResults.projects = { data: [{ id: "p1" }], error: null };
+
+    const result = await updateProject("p1", {
+      automation_mode: "compare_humans",
+      comparison_includes_llm: false,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(writeCalls).toContainEqual({
+      table: "projects",
+      op: "update",
+      payload: {
+        automation_mode: "compare_humans",
+        comparison_includes_llm: false,
+      },
+    });
+  });
+});

--- a/frontend/src/actions/__tests__/schema.test.ts
+++ b/frontend/src/actions/__tests__/schema.test.ts
@@ -167,6 +167,35 @@ describe("saveSchemaFromGUI", () => {
     const r = await saveSchemaFromGUI("p1", []);
     expect(r.error).toBeUndefined();
   });
+
+  it("preserva campos llm_only com a execução LLM desligada", async () => {
+    const previousFlag = process.env.NEXT_PUBLIC_LLM_ENABLED;
+    process.env.NEXT_PUBLIC_LLM_ENABLED = "false";
+    serverTableResults = {
+      projects: [PROJECT_SELECT, { data: [{ id: "p1" }] }],
+      schema_change_log: { data: null, error: null },
+    };
+
+    try {
+      const r = await saveSchemaFromGUI("p1", [
+        { ...FIELD, target: "llm_only" },
+      ]);
+
+      expect(r.error).toBeUndefined();
+      const projectUpdate = writeCalls.find(
+        ({ table, op }) => table === "projects" && op === "update",
+      );
+      expect(projectUpdate?.payload).toMatchObject({
+        pydantic_fields: [expect.objectContaining({ target: "llm_only" })],
+      });
+    } finally {
+      if (previousFlag === undefined) {
+        delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+      } else {
+        process.env.NEXT_PUBLIC_LLM_ENABLED = previousFlag;
+      }
+    }
+  });
 });
 
 describe("recoverFieldsFromStoredCode", () => {

--- a/frontend/src/actions/projects.ts
+++ b/frontend/src/actions/projects.ts
@@ -5,33 +5,52 @@ import { getAuthUser } from "@/lib/auth";
 import { updateOrThrow } from "@/lib/supabase/rls-guard";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
-import type { AutomationMode } from "@/lib/types";
+import { isLlmEnabled } from "@/lib/feature-flags";
+import {
+  getDefaultAutomationMode,
+  isAutomationMode,
+  isAutomationModeAvailable,
+  type AutomationMode,
+} from "@/lib/automation-modes";
 
-const AUTOMATION_MODE_VALUES: ReadonlyArray<AutomationMode> = Object.freeze([
-  "none",
-  "auto_review_llm",
-  "compare_humans",
-  "compare_llm",
-]);
+const LLM_CONFIGURATION_DISABLED_ERROR =
+  "As configurações de LLM estão desabilitadas neste ambiente.";
 
 export async function createProject(_prev: unknown, formData: FormData) {
   const user = await getAuthUser();
   if (!user) return { error: "Não autenticado" };
 
-  const supabase = await createSupabaseServer();
-
   const name = formData.get("name") as string;
   const description = formData.get("description") as string;
-  const rawMode = formData.get("automation_mode") as string | null;
-  const automation_mode: AutomationMode = AUTOMATION_MODE_VALUES.includes(
-    rawMode as AutomationMode,
-  )
-    ? (rawMode as AutomationMode)
-    : "auto_review_llm";
+  const llmEnabled = isLlmEnabled();
+  const rawMode = formData.get("automation_mode");
+  const rawComparisonIncludesLlm = formData.get("comparison_includes_llm");
+  if (
+    !llmEnabled &&
+    ((isAutomationMode(rawMode) &&
+      !isAutomationModeAvailable(rawMode, llmEnabled)) ||
+      rawComparisonIncludesLlm === "true")
+  ) {
+    return { error: LLM_CONFIGURATION_DISABLED_ERROR };
+  }
+  const automationMode = isAutomationMode(rawMode)
+    ? rawMode
+    : getDefaultAutomationMode(llmEnabled);
+  const projectData = {
+    name,
+    description,
+    created_by: user.id,
+    automation_mode: automationMode,
+    // O default histórico do banco é true. No alfa sem LLM precisamos gravar
+    // false explicitamente para que novos projetos não nasçam com uma
+    // automação LLM latente; projetos existentes não são reescritos.
+    ...(!llmEnabled && { comparison_includes_llm: false }),
+  };
+  const supabase = await createSupabaseServer();
 
   const { data: project, error } = await supabase
     .from("projects")
-    .insert({ name, description, created_by: user.id, automation_mode })
+    .insert(projectData)
     .select()
     .single();
 
@@ -69,6 +88,28 @@ export async function updateProject(
     out_of_scope_enabled?: boolean;
   }
 ): Promise<{ error?: string }> {
+  const llmEnabled = isLlmEnabled();
+  if (
+    data.automation_mode !== undefined &&
+    (!isAutomationMode(data.automation_mode) ||
+      !isAutomationModeAvailable(data.automation_mode, llmEnabled))
+  ) {
+    return {
+      error: !isAutomationMode(data.automation_mode)
+        ? "Modo de automação inválido."
+        : LLM_CONFIGURATION_DISABLED_ERROR,
+    };
+  }
+  if (
+    data.comparison_includes_llm !== undefined &&
+    typeof data.comparison_includes_llm !== "boolean"
+  ) {
+    return { error: "Configuração de comparação LLM inválida." };
+  }
+  if (!llmEnabled && data.comparison_includes_llm === true) {
+    return { error: LLM_CONFIGURATION_DISABLED_ERROR };
+  }
+
   const supabase = await createSupabaseServer();
   try {
     await updateOrThrow(supabase, "projects", data, { id: projectId }, {

--- a/frontend/src/app/(app)/projects/[id]/__tests__/llm-feature-layouts.test.tsx
+++ b/frontend/src/app/(app)/projects/[id]/__tests__/llm-feature-layouts.test.tsx
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAuthUser: vi.fn(),
+  getProjectAccessContext: vi.fn(),
+  redirect: vi.fn((path: string): never => {
+    throw new Error(`REDIRECT:${path}`);
+  }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getAuthUser: mocks.getAuthUser,
+  getProjectAccessContext: mocks.getProjectAccessContext,
+}));
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(),
+  redirect: mocks.redirect,
+}));
+
+import LlmLayout from "@/app/(app)/projects/[id]/llm/layout";
+import LlmInsightsLayout from "@/app/(app)/projects/[id]/reviews/llm-insights/layout";
+
+const originalValue = process.env.NEXT_PUBLIC_LLM_ENABLED;
+
+afterEach(() => {
+  vi.clearAllMocks();
+  if (originalValue === undefined) {
+    delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+  } else {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = originalValue;
+  }
+});
+
+describe("layouts das páginas LLM", () => {
+  it("redireciona todo /llm/* antes de consultar autenticação", async () => {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = "false";
+
+    await expect(
+      LlmLayout({
+        children: <div>LLM</div>,
+        params: Promise.resolve({ id: "p1" }),
+      }),
+    ).rejects.toThrow("REDIRECT:/projects/p1/analyze/code");
+    expect(mocks.getAuthUser).not.toHaveBeenCalled();
+  });
+
+  it("redireciona o acesso direto a Erros LLM", async () => {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = "false";
+
+    await expect(
+      LlmInsightsLayout({
+        children: <div>Erros LLM</div>,
+        params: Promise.resolve({ id: "p1" }),
+      }),
+    ).rejects.toThrow("REDIRECT:/projects/p1/analyze/code");
+  });
+});

--- a/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/RulesForm.tsx
@@ -17,7 +17,16 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { AUTOMATION_MODES, type AutomationMode } from "@/lib/types";
+import { isLlmEnabled } from "@/lib/feature-flags";
+import {
+  AUTOMATION_MODES,
+  automationModeRequiresLlm,
+  getAutomationModeOption,
+  getAvailableAutomationModes,
+  isAutomationMode,
+  isAutomationModeAvailable,
+  type AutomationMode,
+} from "@/lib/automation-modes";
 
 interface RulesFormProps {
   projectId: string;
@@ -47,7 +56,8 @@ function useRulesFormState({
   automationMode,
   comparisonIncludesLlm,
   outOfScopeEnabled,
-}: RulesFormProps) {
+  llmEnabled,
+}: RulesFormProps & { llmEnabled: boolean }) {
   const { refresh } = useRouter();
   const [isPending, startTransition] = useTransition();
   const [rule, setRule] = useState(resolutionRule);
@@ -58,19 +68,43 @@ function useRulesFormState({
   const [outOfScope, setOutOfScope] = useState(outOfScopeEnabled);
   const [saved, setSaved] = useState(false);
 
-  const modeMeta = AUTOMATION_MODES.find((m) => m.value === mode);
+  const modeMeta = getAutomationModeOption(mode);
+  const hasHistoricalLlmMode =
+    !llmEnabled && automationModeRequiresLlm(automationMode);
+  const modeOptions = hasHistoricalLlmMode
+    ? AUTOMATION_MODES.filter(
+        ({ value, requiresLlm }) =>
+          !requiresLlm || value === automationMode,
+      )
+    : getAvailableAutomationModes(llmEnabled);
+
+  function handleModeChange(value: string) {
+    if (!isAutomationMode(value)) return;
+    if (!isAutomationModeAvailable(value, llmEnabled)) return;
+    setMode(value);
+    if (!llmEnabled) setIncludesLlm(false);
+  }
 
   function handleSave() {
     startTransition(async () => {
       try {
-        const r = await updateProject(projectId, {
+        const data: Parameters<typeof updateProject>[1] = {
           resolution_rule: rule,
           min_responses_for_comparison: min,
           allow_researcher_review: allowReview,
-          automation_mode: mode,
-          comparison_includes_llm: includesLlm,
           out_of_scope_enabled: outOfScope,
-        });
+        };
+        // Um valor LLM já salvo continua visível como histórico, mas não volta
+        // no payload enquanto a flag está desligada. Assim outras regras podem
+        // ser editadas sem regravar nem apagar a configuração existente.
+        if (llmEnabled || !automationModeRequiresLlm(mode)) {
+          data.automation_mode = mode;
+        }
+        if (llmEnabled || !includesLlm) {
+          data.comparison_includes_llm = includesLlm;
+        }
+
+        const r = await updateProject(projectId, data);
         if (r?.error) {
           toast.error(r.error);
           return;
@@ -93,7 +127,7 @@ function useRulesFormState({
     allowReview,
     setAllowReview,
     mode,
-    setMode,
+    handleModeChange,
     includesLlm,
     setIncludesLlm,
     outOfScope,
@@ -101,11 +135,14 @@ function useRulesFormState({
     saved,
     isPending,
     modeMeta,
+    modeOptions,
+    hasHistoricalLlmMode,
     handleSave,
   };
 }
 
 export function RulesForm(props: RulesFormProps) {
+  const llmEnabled = isLlmEnabled();
   const {
     rule,
     setRule,
@@ -114,7 +151,7 @@ export function RulesForm(props: RulesFormProps) {
     allowReview,
     setAllowReview,
     mode,
-    setMode,
+    handleModeChange,
     includesLlm,
     setIncludesLlm,
     outOfScope,
@@ -122,8 +159,10 @@ export function RulesForm(props: RulesFormProps) {
     saved,
     isPending,
     modeMeta,
+    modeOptions,
+    hasHistoricalLlmMode,
     handleSave,
-  } = useRulesFormState(props);
+  } = useRulesFormState({ ...props, llmEnabled });
 
   return (
     <Card>
@@ -133,14 +172,19 @@ export function RulesForm(props: RulesFormProps) {
       <CardContent className="space-y-5">
         <div className="space-y-2">
           <Label className="text-sm">Modo de automação</Label>
-          <Select value={mode} onValueChange={(v) => setMode(v as AutomationMode)}>
+          <Select value={mode} onValueChange={handleModeChange}>
             <SelectTrigger className="w-full">
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {AUTOMATION_MODES.map((m) => (
-                <SelectItem key={m.value} value={m.value}>
+              {modeOptions.map((m) => (
+                <SelectItem
+                  key={m.value}
+                  value={m.value}
+                  disabled={!isAutomationModeAvailable(m.value, llmEnabled)}
+                >
                   {m.label}
+                  {!llmEnabled && m.requiresLlm ? " (histórico)" : ""}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -153,14 +197,29 @@ export function RulesForm(props: RulesFormProps) {
             preenchido conforme as pessoas codificam (ou via sorteio manual).
             Determina também quais abas de revisão aparecem no projeto.
           </p>
+          {hasHistoricalLlmMode && (
+            <p
+              role="alert"
+              className="rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900"
+            >
+              Este projeto mantém o modo LLM já salvo apenas como histórico.
+              Ele não pode ser escolhido novamente enquanto o LLM estiver
+              desabilitado. Selecione Nenhuma automação ou Comparação
+              humano-vs-humano para substituí-lo; respostas e filas existentes
+              continuarão disponíveis.
+            </p>
+          )}
         </div>
 
-        {mode === "compare_humans" && (
+        {mode === "compare_humans" && (llmEnabled || includesLlm) && (
           <div className="flex items-start gap-3">
             <Switch
               id="includesLlm"
               checked={includesLlm}
-              onCheckedChange={setIncludesLlm}
+              onCheckedChange={(checked) => {
+                if (llmEnabled || !checked) setIncludesLlm(checked);
+              }}
+              disabled={!llmEnabled && !includesLlm}
               aria-label="Incluir o LLM no disparo da comparação"
             />
             <div className="space-y-1">
@@ -172,6 +231,13 @@ export function RulesForm(props: RulesFormProps) {
                 concordam mas o LLM diverge. Desligado, só dispara quando os
                 humanos divergem entre si (o LLM ainda aparece na comparação).
               </p>
+              {!llmEnabled && includesLlm && (
+                <p role="alert" className="text-xs text-amber-700">
+                  Esta opção está preservada como configuração histórica. Você
+                  pode desligá-la, mas não reativá-la enquanto o LLM estiver
+                  desabilitado.
+                </p>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/app/(app)/projects/[id]/config/rules/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rules/page.tsx
@@ -1,5 +1,47 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
+import {
+  getDefaultAutomationMode,
+  type AutomationMode,
+} from "@/lib/automation-modes";
+import { isLlmEnabled } from "@/lib/feature-flags";
 import { RulesForm } from "./RulesForm";
+
+interface ProjectRulesRow {
+  resolution_rule?: string | null;
+  min_responses_for_comparison?: number | null;
+  allow_researcher_review?: boolean | null;
+  automation_mode?: AutomationMode | null;
+  comparison_includes_llm?: boolean | null;
+  out_of_scope_enabled?: boolean | null;
+}
+
+function valueOrDefault<T>(value: T | null | undefined, fallback: T): T {
+  return value ?? fallback;
+}
+
+function normalizeRules(
+  project: ProjectRulesRow | null,
+  llmEnabled: boolean,
+) {
+  const row: ProjectRulesRow = project ?? {};
+  return {
+    resolutionRule: valueOrDefault(row.resolution_rule, "majority"),
+    minResponses: valueOrDefault(row.min_responses_for_comparison, 2),
+    allowResearcherReview: valueOrDefault(
+      row.allow_researcher_review,
+      false,
+    ),
+    automationMode: valueOrDefault(
+      row.automation_mode,
+      getDefaultAutomationMode(llmEnabled),
+    ),
+    comparisonIncludesLlm: valueOrDefault(
+      row.comparison_includes_llm,
+      llmEnabled,
+    ),
+    outOfScopeEnabled: valueOrDefault(row.out_of_scope_enabled, true),
+  };
+}
 
 export default async function RulesPage({
   params,
@@ -7,24 +49,18 @@ export default async function RulesPage({
   params: Promise<{ id: string }>;
 }) {
   const [{ id }, supabase] = await Promise.all([params, createSupabaseServer()]);
+  const llmEnabled = isLlmEnabled();
 
   const { data: project } = await supabase
     .from("projects")
     .select("resolution_rule, min_responses_for_comparison, allow_researcher_review, automation_mode, comparison_includes_llm, out_of_scope_enabled")
     .eq("id", id)
     .single();
+  const formProps = normalizeRules(project, llmEnabled);
 
   return (
     <div className="mx-auto max-w-2xl p-6">
-      <RulesForm
-        projectId={id}
-        resolutionRule={project?.resolution_rule || "majority"}
-        minResponses={project?.min_responses_for_comparison || 2}
-        allowResearcherReview={project?.allow_researcher_review ?? false}
-        automationMode={project?.automation_mode ?? "auto_review_llm"}
-        comparisonIncludesLlm={project?.comparison_includes_llm ?? true}
-        outOfScopeEnabled={project?.out_of_scope_enabled ?? true}
-      />
+      <RulesForm projectId={id} {...formProps} />
     </div>
   );
 }

--- a/frontend/src/app/(app)/projects/[id]/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/layout.tsx
@@ -4,6 +4,7 @@ import { createSupabaseServer } from "@/lib/supabase/server";
 import { getProjectAccessContext, resolveAuth } from "@/lib/auth";
 import { completionRedirectPath } from "@/lib/safe-next-path";
 import { getRunningLlmCount } from "@/actions/llm";
+import { isLlmEnabled } from "@/lib/feature-flags";
 import { Header } from "@/components/shell/Header";
 import { ProjectTabs } from "@/components/shell/ProjectTabs";
 import { notFound, redirect } from "next/navigation";
@@ -30,6 +31,7 @@ export default async function ProjectLayout({
     redirect(completionRedirectPath(pathname));
   }
   const user = resolution.user;
+  const llmEnabled = isLlmEnabled();
 
   // project + membership vem de getProjectAccessContext (request-scoped via
   // cache()) — mesma leitura reaproveitada pelos layouts filhos config/llm.
@@ -43,7 +45,7 @@ export default async function ProjectLayout({
         .single(),
       // Best-effort: o badge "LLM rodando" e cosmetico. Uma falha aqui (RLS,
       // rede) nao deve derrubar o layout inteiro do projeto — degrada para 0.
-      getRunningLlmCount(id).catch(() => 0),
+      llmEnabled ? getRunningLlmCount(id).catch(() => 0) : Promise.resolve(0),
     ]);
 
   if (!project) notFound();

--- a/frontend/src/app/(app)/projects/[id]/llm/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/layout.tsx
@@ -1,6 +1,7 @@
 import { getAuthUser, getProjectAccessContext } from "@/lib/auth";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import LlmNav from "@/components/llm/LlmNav";
+import { isLlmEnabled } from "@/lib/feature-flags";
 
 export default async function LlmLayout({
   children,
@@ -9,7 +10,10 @@ export default async function LlmLayout({
   children: React.ReactNode;
   params: Promise<{ id: string }>;
 }) {
-  const [{ id }, user] = await Promise.all([params, getAuthUser()]);
+  const { id } = await params;
+  if (!isLlmEnabled()) redirect(`/projects/${id}/analyze/code`);
+
+  const user = await getAuthUser();
   if (!user) notFound();
 
   const { isCoordinator, queryFailed } = await getProjectAccessContext(

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/layout.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/layout.tsx
@@ -1,0 +1,14 @@
+import { isLlmEnabled } from "@/lib/feature-flags";
+import { redirect } from "next/navigation";
+
+export default async function LlmInsightsLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  if (!isLlmEnabled()) redirect(`/projects/${id}/analyze/code`);
+  return children;
+}

--- a/frontend/src/app/(app)/projects/new/page.tsx
+++ b/frontend/src/app/(app)/projects/new/page.tsx
@@ -13,12 +13,23 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { AUTOMATION_MODES, type AutomationMode } from "@/lib/types";
+import { isLlmEnabled } from "@/lib/feature-flags";
+import {
+  getAutomationModeOption,
+  getAvailableAutomationModes,
+  getDefaultAutomationMode,
+  isAutomationMode,
+  type AutomationMode,
+} from "@/lib/automation-modes";
 
 export default function NewProjectPage() {
   const [state, formAction, pending] = useActionState(createProject, null);
-  const [mode, setMode] = useState<AutomationMode>("auto_review_llm");
-  const modeMeta = AUTOMATION_MODES.find((m) => m.value === mode);
+  const llmEnabled = isLlmEnabled();
+  const availableModes = getAvailableAutomationModes(llmEnabled);
+  const [mode, setMode] = useState<AutomationMode>(() =>
+    getDefaultAutomationMode(llmEnabled),
+  );
+  const modeMeta = getAutomationModeOption(mode);
 
   return (
     <main className="mx-auto max-w-lg p-6">
@@ -62,13 +73,15 @@ export default function NewProjectPage() {
               <input type="hidden" name="automation_mode" value={mode} />
               <Select
                 value={mode}
-                onValueChange={(v) => setMode(v as AutomationMode)}
+                onValueChange={(value) => {
+                  if (isAutomationMode(value)) setMode(value);
+                }}
               >
                 <SelectTrigger id="automation_mode_trigger" className="w-full">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {AUTOMATION_MODES.map((m) => (
+                  {availableModes.map((m) => (
                     <SelectItem key={m.value} value={m.value}>
                       {m.label}
                     </SelectItem>

--- a/frontend/src/components/__tests__/llm-automation-settings.test.tsx
+++ b/frontend/src/components/__tests__/llm-automation-settings.test.tsx
@@ -1,0 +1,197 @@
+// @vitest-environment jsdom
+import type { ChangeEvent, ReactNode } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("@/actions/projects", () => ({
+  createProject: mocks.createProject,
+  updateProject: mocks.updateProject,
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mocks.refresh }),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// O Radix Select depende de geometria/portals ausentes no jsdom. Este mock
+// preserva value, onValueChange, opções e disabled — exatamente o contrato de
+// UI exercitado nestes testes — por meio de um <select> nativo.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    children: ReactNode;
+  }) => (
+    <select
+      value={value}
+      onChange={(event: ChangeEvent<HTMLSelectElement>) =>
+        onValueChange(event.target.value)
+      }
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectItem: ({
+    value,
+    disabled,
+    children,
+  }: {
+    value: string;
+    disabled?: boolean;
+    children: ReactNode;
+  }) => (
+    <option value={value} disabled={disabled}>
+      {children}
+    </option>
+  ),
+}));
+
+import NewProjectPage from "@/app/(app)/projects/new/page";
+import { RulesForm } from "@/app/(app)/projects/[id]/config/rules/RulesForm";
+
+const originalFlag = process.env.NEXT_PUBLIC_LLM_ENABLED;
+const rulesProps = {
+  projectId: "p1",
+  resolutionRule: "majority",
+  minResponses: 2,
+  allowResearcherReview: false,
+  comparisonIncludesLlm: false,
+  outOfScopeEnabled: true,
+} as const;
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_LLM_ENABLED = "false";
+  mocks.createProject.mockReset();
+  mocks.updateProject.mockReset();
+  mocks.updateProject.mockResolvedValue({});
+  mocks.refresh.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  if (originalFlag === undefined) {
+    delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+  } else {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = originalFlag;
+  }
+});
+
+async function saveRules(): Promise<Record<string, unknown>> {
+  fireEvent.click(screen.getByRole("button", { name: "Salvar Regras" }));
+  await waitFor(() => expect(mocks.updateProject).toHaveBeenCalledOnce());
+  return mocks.updateProject.mock.calls[0][1] as Record<string, unknown>;
+}
+
+describe("criação de projeto sem LLM", () => {
+  it("semeia none e oferece somente none/compare_humans", () => {
+    const { container } = render(<NewProjectPage />);
+
+    const hidden = container.querySelector<HTMLInputElement>(
+      'input[name="automation_mode"]',
+    );
+    expect(hidden?.value).toBe("none");
+    expect(
+      screen.getAllByRole("option").map((option) => option.textContent),
+    ).toEqual(["Nenhuma automação", "Comparação humano-vs-humano"]);
+  });
+});
+
+describe("Configurações › Regras sem LLM", () => {
+  it("oferece somente os dois modos sem LLM para um projeto normal", () => {
+    render(<RulesForm {...rulesProps} automationMode="compare_humans" />);
+
+    const modeSelect = screen.getAllByRole("combobox")[0];
+    expect(
+      Array.from(modeSelect.querySelectorAll("option"), (option) =>
+        option.textContent,
+      ),
+    ).toEqual(["Nenhuma automação", "Comparação humano-vs-humano"]);
+    expect(
+      screen.queryByRole("switch", {
+        name: "Incluir o LLM no disparo da comparação",
+      }),
+    ).toBeNull();
+  });
+
+  it("exibe modo LLM existente como histórico desabilitado e não o regrava", async () => {
+    render(
+      <RulesForm
+        {...rulesProps}
+        automationMode="auto_review_llm"
+        comparisonIncludesLlm
+      />,
+    );
+
+    const historical = screen.getByRole("option", {
+      name: "Auto-revisão vs LLM (histórico)",
+    }) as HTMLOptionElement;
+    expect(historical.disabled).toBe(true);
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /respostas e filas existentes continuarão disponíveis/i,
+    );
+
+    const payload = await saveRules();
+    expect(payload).not.toHaveProperty("automation_mode");
+    expect(payload).not.toHaveProperty("comparison_includes_llm");
+  });
+
+  it("permite substituir o modo histórico apenas por uma opção sem LLM", async () => {
+    render(
+      <RulesForm
+        {...rulesProps}
+        automationMode="compare_llm"
+        comparisonIncludesLlm
+      />,
+    );
+
+    fireEvent.change(screen.getAllByRole("combobox")[0], {
+      target: { value: "none" },
+    });
+    const payload = await saveRules();
+    expect(payload).toMatchObject({
+      automation_mode: "none",
+      comparison_includes_llm: false,
+    });
+  });
+
+  it("mostra comparison_includes_llm=true apenas como histórico removível", async () => {
+    render(
+      <RulesForm
+        {...rulesProps}
+        automationMode="compare_humans"
+        comparisonIncludesLlm
+      />,
+    );
+
+    const historicalSwitch = screen.getByRole("switch", {
+      name: "Incluir o LLM no disparo da comparação",
+    });
+    expect(historicalSwitch.getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByRole("alert").textContent).toMatch(/pode desligá-la/i);
+
+    fireEvent.click(historicalSwitch);
+    const payload = await saveRules();
+    expect(payload).toMatchObject({ comparison_includes_llm: false });
+  });
+});

--- a/frontend/src/components/__tests__/llm-feature-visibility.test.tsx
+++ b/frontend/src/components/__tests__/llm-feature-visibility.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  useAuth: vi.fn(() => ({ getToken: vi.fn() })),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/projects/p1/analyze/code",
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@clerk/nextjs", () => ({ useAuth: mocks.useAuth }));
+vi.mock("@/lib/api", () => ({
+  fetchFastAPI: vi.fn(),
+  requireSupabaseToken: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { ProjectTabs } from "@/components/shell/ProjectTabs";
+import { ReviewsNav } from "@/components/reviews/ReviewsNav";
+import { RunLlmButton } from "@/components/shared/RunLlmButton";
+
+const originalValue = process.env.NEXT_PUBLIC_LLM_ENABLED;
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_LLM_ENABLED = "false";
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  if (originalValue === undefined) {
+    delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+  } else {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = originalValue;
+  }
+});
+
+describe("superfícies LLM com a feature desligada", () => {
+  it("remove a aba principal sem afetar as demais áreas do projeto", () => {
+    render(<ProjectTabs projectId="p1" isCoordinator isLlmRunning />);
+
+    expect(screen.queryByRole("link", { name: /LLM/ })).toBeNull();
+    expect(screen.getByRole("link", { name: "Analisar" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Configurações" })).toBeTruthy();
+  });
+
+  it("remove Erros LLM da navegação de revisão", () => {
+    render(<ReviewsNav projectId="p1" />);
+
+    expect(screen.queryByRole("link", { name: "Erros LLM" })).toBeNull();
+    expect(screen.getByRole("link", { name: "Gabarito" })).toBeTruthy();
+  });
+
+  it("remove o botão compartilhado antes de inicializar a sessão Clerk", () => {
+    const { container } = render(
+      <RunLlmButton projectId="p1" documentId="d1" canRunLlm />,
+    );
+
+    expect(container.firstChild).toBeNull();
+    expect(mocks.useAuth).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/reviews/ReviewsNav.tsx
+++ b/frontend/src/components/reviews/ReviewsNav.tsx
@@ -3,14 +3,16 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { isLlmEnabled } from "@/lib/feature-flags";
 
 const reviewsTabs: Array<{
   label: string;
   href: string;
+  llmOnly?: boolean;
 }> = [
   { label: "Gabarito", href: "gabarito" },
   { label: "Meu Gabarito", href: "my-verdicts" },
-  { label: "Erros LLM", href: "llm-insights" },
+  { label: "Erros LLM", href: "llm-insights", llmOnly: true },
   { label: "Comentários", href: "comments" },
 ];
 
@@ -23,7 +25,7 @@ export function ReviewsNav({ projectId }: ReviewsNavProps) {
 
   return (
     <nav className="flex items-center gap-1 border-b px-4 py-1">
-      {reviewsTabs.map((tab) => {
+      {reviewsTabs.filter((tab) => !tab.llmOnly || isLlmEnabled()).map((tab) => {
         const href = `/projects/${projectId}/reviews/${tab.href}`;
         const isActive = pathname.startsWith(href);
         return (

--- a/frontend/src/components/shared/RunLlmButton.tsx
+++ b/frontend/src/components/shared/RunLlmButton.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { fetchFastAPI, requireSupabaseToken } from "@/lib/api";
 import { toast } from "sonner";
 import { Bot, Loader2 } from "lucide-react";
+import { isLlmEnabled } from "@/lib/feature-flags";
 
 // Tolera N falhas consecutivas de poll (token transitório, blip de rede) antes
 // de declarar a execução terminal: o job segue rodando no backend e um erro
@@ -25,7 +26,12 @@ interface RunLlmButtonProps {
   canRunLlm?: boolean;
 }
 
-export function RunLlmButton({
+export function RunLlmButton(props: RunLlmButtonProps) {
+  if (!isLlmEnabled()) return null;
+  return <EnabledRunLlmButton {...props} />;
+}
+
+function EnabledRunLlmButton({
   projectId,
   documentId,
   onComplete,

--- a/frontend/src/components/shell/ProjectTabs.tsx
+++ b/frontend/src/components/shell/ProjectTabs.tsx
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { isLlmEnabled } from "@/lib/feature-flags";
 import { Eye, EyeOff, Users } from "lucide-react";
 import { LlmRunningBadge } from "@/components/llm/LlmRunningBadge";
 
@@ -27,7 +28,7 @@ const EMPTY_MEMBERS: ProjectMember[] = [];
 const tabs = [
   { label: "Analisar", href: "analyze" },
   { label: "Revisar", href: "reviews" },
-  { label: "LLM", href: "llm", coordinatorOnly: true },
+  { label: "LLM", href: "llm", coordinatorOnly: true, llmOnly: true },
   { label: "Configurações", href: "config", coordinatorOnly: true },
 ];
 
@@ -71,7 +72,9 @@ function ProjectTabsInner({
     : null;
 
   const visibleTabs = tabs.filter(
-    (tab) => !tab.coordinatorOnly || effectiveIsCoordinator
+    (tab) =>
+      (!tab.llmOnly || isLlmEnabled()) &&
+      (!tab.coordinatorOnly || effectiveIsCoordinator),
   );
 
   const toggleViewAs = () => {

--- a/frontend/src/lib/__tests__/automation-modes.test.ts
+++ b/frontend/src/lib/__tests__/automation-modes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  automationModeRequiresLlm,
+  getAvailableAutomationModes,
+  getDefaultAutomationMode,
+  isAutomationMode,
+  isAutomationModeAvailable,
+} from "@/lib/automation-modes";
+
+describe("contrato dos modos de automação", () => {
+  it("mantém o default histórico quando LLM está ligado", () => {
+    expect(getDefaultAutomationMode(true)).toBe("auto_review_llm");
+    expect(getAvailableAutomationModes(true).map(({ value }) => value)).toEqual([
+      "none",
+      "auto_review_llm",
+      "compare_humans",
+      "compare_llm",
+    ]);
+  });
+
+  it("usa none como default e oferece só modos sem LLM quando desligado", () => {
+    expect(getDefaultAutomationMode(false)).toBe("none");
+    expect(getAvailableAutomationModes(false).map(({ value }) => value)).toEqual([
+      "none",
+      "compare_humans",
+    ]);
+  });
+
+  it("deriva validação e requisito de LLM do mesmo contrato", () => {
+    expect(isAutomationMode("compare_llm")).toBe(true);
+    expect(isAutomationMode("inventado")).toBe(false);
+    expect(automationModeRequiresLlm("auto_review_llm")).toBe(true);
+    expect(automationModeRequiresLlm("compare_humans")).toBe(false);
+    expect(isAutomationModeAvailable("compare_llm", false)).toBe(false);
+    expect(isAutomationModeAvailable("compare_humans", false)).toBe(true);
+  });
+});

--- a/frontend/src/lib/__tests__/feature-flags.test.ts
+++ b/frontend/src/lib/__tests__/feature-flags.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { isLlmEnabled } from "@/lib/feature-flags";
+
+const originalValue = process.env.NEXT_PUBLIC_LLM_ENABLED;
+
+afterEach(() => {
+  if (originalValue === undefined) {
+    delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+  } else {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = originalValue;
+  }
+});
+
+describe("isLlmEnabled", () => {
+  it("mantém LLM ligado quando a variável não está definida", () => {
+    delete process.env.NEXT_PUBLIC_LLM_ENABLED;
+    expect(isLlmEnabled()).toBe(true);
+  });
+
+  it("desliga LLM somente com o valor explícito false", () => {
+    process.env.NEXT_PUBLIC_LLM_ENABLED = "false";
+    expect(isLlmEnabled()).toBe(false);
+  });
+});

--- a/frontend/src/lib/automation-modes.ts
+++ b/frontend/src/lib/automation-modes.ts
@@ -1,0 +1,79 @@
+// Contrato único dos modos de automação: tipo, metadados, disponibilidade e
+// defaults precisam mudar juntos para que UI e Server Actions não divirjam.
+export const AUTOMATION_MODES = [
+  {
+    value: "none",
+    label: "Nenhuma automação",
+    description:
+      "Sem revisão automática. Qualquer comparação ou revisão é criada manualmente pelo coordenador.",
+    requiresLlm: false,
+  },
+  {
+    value: "auto_review_llm",
+    label: "Auto-revisão vs LLM",
+    description:
+      "Quando uma pessoa termina de codificar e diverge do LLM, ela mesma revisa os campos divergentes; contestados vão para arbitragem.",
+    requiresLlm: true,
+  },
+  {
+    value: "compare_humans",
+    label: "Comparação humano-vs-humano",
+    description:
+      "Quando duas pessoas codificam o mesmo documento e divergem, um revisor é sorteado para comparar as codificações.",
+    requiresLlm: false,
+  },
+  {
+    value: "compare_llm",
+    label: "Comparação pessoa-vs-LLM",
+    description:
+      "Quando uma pessoa codifica e diverge do LLM, um revisor é sorteado para comparar a codificação humana contra a do LLM.",
+    requiresLlm: true,
+  },
+] as const;
+
+export type AutomationMode = (typeof AUTOMATION_MODES)[number]["value"];
+export type AutomationModeOption = (typeof AUTOMATION_MODES)[number];
+
+const AUTOMATION_MODE_VALUES = new Set<AutomationMode>(
+  AUTOMATION_MODES.map(({ value }) => value),
+);
+
+export function isAutomationMode(value: unknown): value is AutomationMode {
+  return (
+    typeof value === "string" &&
+    AUTOMATION_MODE_VALUES.has(value as AutomationMode)
+  );
+}
+
+export function getAutomationModeOption(
+  mode: AutomationMode,
+): AutomationModeOption {
+  return AUTOMATION_MODES.find(({ value }) => value === mode)!;
+}
+
+export function automationModeRequiresLlm(mode: AutomationMode): boolean {
+  return getAutomationModeOption(mode).requiresLlm;
+}
+
+export function isAutomationModeAvailable(
+  mode: AutomationMode,
+  llmEnabled: boolean,
+): boolean {
+  return llmEnabled || !automationModeRequiresLlm(mode);
+}
+
+export function getAvailableAutomationModes(
+  llmEnabled: boolean,
+): ReadonlyArray<AutomationModeOption> {
+  return llmEnabled
+    ? AUTOMATION_MODES
+    : AUTOMATION_MODES.filter(({ value }) =>
+        isAutomationModeAvailable(value, llmEnabled),
+      );
+}
+
+export function getDefaultAutomationMode(
+  llmEnabled: boolean,
+): AutomationMode {
+  return llmEnabled ? "auto_review_llm" : "none";
+}

--- a/frontend/src/lib/feature-flags.ts
+++ b/frontend/src/lib/feature-flags.ts
@@ -1,0 +1,6 @@
+// NEXT_PUBLIC_* é embutida no bundle pelo Next durante o build. Só o valor
+// explícito "false" desliga a feature; ausência preserva o comportamento
+// histórico e mantém desenvolvimento/self-hosting compatíveis por default.
+export function isLlmEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_LLM_ENABLED !== "false";
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,3 +1,7 @@
+import type { AutomationMode } from "@/lib/automation-modes";
+
+export type { AutomationMode } from "@/lib/automation-modes";
+
 export interface Profile {
   id: string;
   email: string;
@@ -14,45 +18,6 @@ export type RoundStrategy = "schema_version" | "manual";
 // "mínimo necessário para liberar a revisão" + quem revê, e governa quais abas
 // de revisão aparecem. Mutuamente exclusivo. Ver lib/auto-review.ts (auto_review_llm)
 // e lib/auto-comparison.ts (compare_*).
-export type AutomationMode =
-  | "none"
-  | "auto_review_llm"
-  | "compare_humans"
-  | "compare_llm";
-
-// Fonte única dos rótulos/descrições dos modos — reaproveitada pelos seletores
-// de criação (projects/new) e de Config › Regras (RulesForm), evitando drift.
-export const AUTOMATION_MODES: ReadonlyArray<{
-  value: AutomationMode;
-  label: string;
-  description: string;
-}> = [
-  {
-    value: "none",
-    label: "Nenhuma automação",
-    description:
-      "Sem revisão automática. Qualquer comparação ou revisão é criada manualmente pelo coordenador.",
-  },
-  {
-    value: "auto_review_llm",
-    label: "Auto-revisão vs LLM",
-    description:
-      "Quando uma pessoa termina de codificar e diverge do LLM, ela mesma revisa os campos divergentes; contestados vão para arbitragem.",
-  },
-  {
-    value: "compare_humans",
-    label: "Comparação humano-vs-humano",
-    description:
-      "Quando duas pessoas codificam o mesmo documento e divergem, um revisor é sorteado para comparar as codificações.",
-  },
-  {
-    value: "compare_llm",
-    label: "Comparação pessoa-vs-LLM",
-    description:
-      "Quando uma pessoa codifica e diverge do LLM, um revisor é sorteado para comparar a codificação humana contra a do LLM.",
-  },
-];
-
 export interface Round {
   id: string;
   project_id: string;


### PR DESCRIPTION
## Resumo

- adiciona `LLM_ENABLED` como dependência estrutural de todo `/api/llm/*`, retornando `403` antes de autenticação, banco ou execução paga;
- adiciona `NEXT_PUBLIC_LLM_ENABLED` para ocultar abas, botões e páginas dedicadas, sem afetar `/api/pydantic/*` nem apagar respostas históricas;
- configura as duas flags como `false` nos manifests Fly do alfa, mantendo default `true` para desenvolvimento e instalações existentes;
- centraliza os modos de automação e impede, na UI e nas Server Actions, criar ou salvar estados que dependam de LLM enquanto a flag estiver desligada;
- preserva configurações históricas como somente leitura até substituição explícita por `none` ou `compare_humans`;
- mantém campos `llm_only` editáveis para preparação futura: persistir schema não executa modelo nem gera custo.

Nenhum deploy, secret ou dado remoto foi alterado. As flags versionadas só passam a valer depois de eventual merge e deploy.

## Verificação

- 216 testes backend;
- 1.249 testes frontend;
- 43 testes focados da feature;
- Ruff, mypy, typecheck e lint tipado;
- React Doctor e Fallow sem achados novos;
- pre-push completo, com E2E omitido explicitamente por depender do ambiente autenticado rastreado em #426;
- duas rodadas de revisão adversarial independente; os dois bloqueantes da primeira rodada foram corrigidos.

Closes #186
