### PR TITLE
chore(deps): trava TypeScript major em 6 ate o typescript-eslint suportar TS 7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,14 @@ updates:
       # quebrou `npm run lint` e `lint:types`. Remover quando o Next suportar v10.
       - dependency-name: "eslint"
         update-types: ["version-update:semver-major"]
+      # TypeScript major fica travado em 6 ate o typescript-eslint suportar TS 7.
+      # O typescript-eslint 8.63.0 declara peer `typescript: >=4.8.4 <6.1.0`; no
+      # bump 6->7 (#471) o npm aninhou a arvore do typescript-eslint SEM aninhar
+      # um TS 6 junto, entao o parser resolvia o TS 7 da raiz com o peer violado
+      # — `lint:types` rodaria sobre versao que a upstream declara nao suportar.
+      # Remover quando sair o typescript-eslint 9 com suporte a TS 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
       - "frontend"


### PR DESCRIPTION
Adiciona `typescript` major ao `ignore` do `.github/dependabot.yml`, no mesmo padrão do `eslint` (travado em 9 até o Next suportar o 10).

## Por quê

O `typescript-eslint` 8.63.0 — o mais recente da série 8 — declara `peerDependencies.typescript: ">=4.8.4 <6.1.0"`. O TS 7.0.2 proposto no #471 fica fora da faixa.

O lockfile do #471 mostra o estrago com precisão: para lidar com o conflito, o npm empurrou toda a árvore do `typescript-eslint` para `node_modules/typescript-eslint/node_modules/` — mas **não aninhou uma cópia do TS 6 junto**. O resultado é que o parser continuava resolvendo o `typescript` da raiz, agora 7.0.2, com o peer violado. Na prática, `npm run lint:types` e o hook `lint-types` de pre-push passariam a rodar sobre uma versão de TS que a própria upstream declara não suportar.

Dois efeitos colaterais que o diff daquele PR também expunha: o TS 7 removeu o bin `tsserver` (só sobrou `tsc`, porque é o port nativo em Go, com deps de plataforma `@typescript/typescript-linux-x64` e afins), e `react-doctor` e `deslop-js` passavam a aninhar cada um sua própria cópia do TS 6.0.3.

## Quando remover

Quando sair o `typescript-eslint` 9 com suporte a TS 7. A `docs/CODE_QUALITY_TOOLING.md` já registra o contexto na seção de trabalho diferido: a API programática do compilador nativo só entra na 7.1, que é o que destrava `typescript-eslint`/`ts-morph` sobre o `tsgo`.

Ref #471 (fechado com a análise completa).