### PR TITLE
fix(types): elimina colisao de nome em AssignmentRow e CompareResponse

### DIFF
--- a/frontend/src/components/compare/compare-types.ts
+++ b/frontend/src/components/compare/compare-types.ts
@@ -2,6 +2,8 @@
 // `CompareWorkspace`. Extraídos de `ComparePage` para evitar import circular de
 // tipos quando os hooks foram destacados do container.
 
+import type { AnswerFieldHashes } from "@/lib/types";
+
 export interface EquivalencePairWire {
   id: string;
   response_a_id: string;
@@ -18,7 +20,7 @@ export interface CompareResponse {
   justifications: Record<string, string> | null;
   is_latest: boolean;
   pydantic_hash: string | null;
-  answer_field_hashes: Record<string, string> | null;
+  answer_field_hashes: AnswerFieldHashes;
   schema_version_major: number | null;
   schema_version_minor: number | null;
   schema_version_patch: number | null;

--- a/frontend/src/lib/__tests__/compare-queue.test.ts
+++ b/frontend/src/lib/__tests__/compare-queue.test.ts
@@ -12,7 +12,7 @@ import {
   buildCountsByKey,
   sortDocumentsByPendingDivergence,
   serializeEquivalencesForClient,
-  type CompareResponse,
+  type CompareQueueResponse,
   type DocCoverage,
   type QualifyDocumentsContext,
 } from "@/lib/compare-queue";
@@ -31,7 +31,7 @@ function field(overrides: Partial<PydanticField>): PydanticField {
   };
 }
 
-function response(overrides: Partial<CompareResponse> = {}): CompareResponse {
+function response(overrides: Partial<CompareQueueResponse> = {}): CompareQueueResponse {
   return {
     id: "r1",
     document_id: "doc1",
@@ -182,7 +182,7 @@ describe("buildCodingAssignedByDoc / buildCompareAssignmentStatusByDoc", () => {
 
 // Fixtures do único doc "doc1" usado pela maioria dos casos abaixo — reduz a
 // repetição do par (responsesByDoc, docsMetaMap) presente em quase todo teste.
-function doc1Responses(...responses: CompareResponse[]): Map<string, CompareResponse[]> {
+function doc1Responses(...responses: CompareQueueResponse[]): Map<string, CompareQueueResponse[]> {
   return new Map([["doc1", responses]]);
 }
 

--- a/frontend/src/lib/auto-review-backlog.ts
+++ b/frontend/src/lib/auto-review-backlog.ts
@@ -30,11 +30,11 @@ export interface ExistingFieldReviewRow {
   self_verdict: string | null;
 }
 
-// Local de proposito: e o payload de INSERT desta rodada de backlog (literais
-// estreitos), nao um tipo de dominio. Nenhum modulo importa o nome — o shape
-// chega em `field-reviews.ts` por inferencia, via o retorno de
-// `computeBacklogRows`. Exporta-lo colidia com o `AssignmentRow` homonimo de
-// `compare-queue.ts`, que e uma row de SELECT com outro shape.
+// Local de propósito: é o payload de INSERT desta rodada de backlog (literais
+// estreitos), não um tipo de domínio. Nenhum módulo importa o nome — o shape
+// chega em `field-reviews.ts` por inferência, via o retorno de
+// `computeBacklogRows`. Exportá-lo colidia com o `AssignmentRow` homônimo de
+// `compare-queue.ts`, que é uma row de SELECT com outro shape.
 interface AssignmentRow {
   project_id: string;
   document_id: string;

--- a/frontend/src/lib/auto-review-backlog.ts
+++ b/frontend/src/lib/auto-review-backlog.ts
@@ -30,7 +30,12 @@ export interface ExistingFieldReviewRow {
   self_verdict: string | null;
 }
 
-export interface AssignmentRow {
+// Local de proposito: e o payload de INSERT desta rodada de backlog (literais
+// estreitos), nao um tipo de dominio. Nenhum modulo importa o nome — o shape
+// chega em `field-reviews.ts` por inferencia, via o retorno de
+// `computeBacklogRows`. Exporta-lo colidia com o `AssignmentRow` homonimo de
+// `compare-queue.ts`, que e uma row de SELECT com outro shape.
+interface AssignmentRow {
   project_id: string;
   document_id: string;
   user_id: string;

--- a/frontend/src/lib/compare-queue.ts
+++ b/frontend/src/lib/compare-queue.ts
@@ -31,14 +31,14 @@ export interface CompareDoc {
   text: string;
 }
 
-// A row da fila e o tipo wire (`CompareResponse`, o mesmo que <ComparePage>
+// A row da fila é o tipo wire (`CompareResponse`, o mesmo que <ComparePage>
 // recebe na prop `responses`) mais o `document_id`, que a query traz e o
-// agrupamento por documento usa. O `extends` e o que impede o drift: antes os
-// dois shapes eram declarados campo a campo em modulos diferentes sob o mesmo
-// nome, e ja tinham divergido — o wire ficou sem `document_id` enquanto o mesmo
+// agrupamento por documento usa. O `extends` é o que impede o drift: antes os
+// dois shapes eram declarados campo a campo em módulos diferentes sob o mesmo
+// nome, e já tinham divergido — o wire ficou sem `document_id` enquanto o mesmo
 // objeto atravessava a fronteira RSC -> client em `compare/page.tsx`
 // (`responsesMap` sai daqui e entra na prop tipada com o wire), compilando em
-// silencio porque no call site nao e object literal e nao ha excess property
+// silêncio porque no call site não é object literal e não há excess property
 // check.
 export interface CompareQueueResponse extends CompareResponse {
   document_id: string;
@@ -91,11 +91,11 @@ export interface VersionLogRow {
   version_patch: number | null;
 }
 
-// Local de proposito: e a row de SELECT que `compare/page.tsx` passa
-// posicionalmente (checagem estrutural, sem importar o nome), nao um tipo de
-// dominio. Exporta-lo colidia com o `AssignmentRow` homonimo de
-// `auto-review-backlog.ts`, que e um payload de INSERT com outro shape
-// (tem project_id; type/status sao literais la, string solto aqui).
+// Local de propósito: é a row de SELECT que `compare/page.tsx` passa
+// posicionalmente (checagem estrutural, sem importar o nome), não um tipo de
+// domínio. Exportá-lo colidia com o `AssignmentRow` homônimo de
+// `auto-review-backlog.ts`, que é um payload de INSERT com outro shape
+// (tem project_id; type/status são literais lá, string solto aqui).
 interface AssignmentRow {
   document_id: string;
   user_id: string;

--- a/frontend/src/lib/compare-queue.ts
+++ b/frontend/src/lib/compare-queue.ts
@@ -18,8 +18,11 @@ import {
 } from "@/lib/compare-version";
 import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { EquivalencePair } from "@/lib/equivalence";
-import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
-import { respondentKey } from "@/components/compare/compare-types";
+import type { PydanticField } from "@/lib/types";
+import {
+  respondentKey,
+  type CompareResponse,
+} from "@/components/compare/compare-types";
 
 export interface CompareDoc {
   id: string;
@@ -28,21 +31,17 @@ export interface CompareDoc {
   text: string;
 }
 
-export interface CompareResponse {
-  id: string;
+// A row da fila e o tipo wire (`CompareResponse`, o mesmo que <ComparePage>
+// recebe na prop `responses`) mais o `document_id`, que a query traz e o
+// agrupamento por documento usa. O `extends` e o que impede o drift: antes os
+// dois shapes eram declarados campo a campo em modulos diferentes sob o mesmo
+// nome, e ja tinham divergido — o wire ficou sem `document_id` enquanto o mesmo
+// objeto atravessava a fronteira RSC -> client em `compare/page.tsx`
+// (`responsesMap` sai daqui e entra na prop tipada com o wire), compilando em
+// silencio porque no call site nao e object literal e nao ha excess property
+// check.
+export interface CompareQueueResponse extends CompareResponse {
   document_id: string;
-  respondent_type: "humano" | "llm";
-  respondent_name: string;
-  respondent_id: string | null;
-  answers: Record<string, unknown>;
-  justifications: Record<string, string> | null;
-  is_latest: boolean;
-  pydantic_hash: string | null;
-  answer_field_hashes: AnswerFieldHashes;
-  schema_version_major: number | null;
-  schema_version_minor: number | null;
-  schema_version_patch: number | null;
-  created_at: string;
 }
 
 export interface DocCoverage {
@@ -72,11 +71,11 @@ export interface EquivalenceRow {
 // Row solta o suficiente para aceitar o resultado do select do Supabase (que
 // também traz o join `documents`, cujo tipo inferido não bate 1:1 com
 // Omit<CompareDoc, "text">) sem replicar seu tipo inferido — mesma pragmática
-// de `as unknown as CompareResponse` que o page.tsx já usava. Sem index
+// de `as unknown as CompareQueueResponse` que o page.tsx já usava. Sem index
 // signature de propósito: bastam os campos abaixo (structural typing ignora
 // os demais campos da row real/de teste), e um index signature exigiria o
 // mesmo em qualquer valor passado (inclusive em fixtures de teste tipadas
-// como CompareResponse).
+// como CompareQueueResponse).
 interface RawResponseRow {
   document_id: string;
   respondent_name: string | null;
@@ -92,7 +91,12 @@ export interface VersionLogRow {
   version_patch: number | null;
 }
 
-export interface AssignmentRow {
+// Local de proposito: e a row de SELECT que `compare/page.tsx` passa
+// posicionalmente (checagem estrutural, sem importar o nome), nao um tipo de
+// dominio. Exporta-lo colidia com o `AssignmentRow` homonimo de
+// `auto-review-backlog.ts`, que e um payload de INSERT com outro shape
+// (tem project_id; type/status sao literais la, string solto aqui).
+interface AssignmentRow {
   document_id: string;
   user_id: string;
   type: string;
@@ -140,16 +144,16 @@ export function buildEquivalenceMap(
 }
 
 export function indexResponsesByDoc(allResponses: readonly RawResponseRow[] | null): {
-  responsesByDoc: Map<string, CompareResponse[]>;
+  responsesByDoc: Map<string, CompareQueueResponse[]>;
   docsMetaMap: Map<string, Omit<CompareDoc, "text">>;
 } {
-  const responsesByDoc = new Map<string, CompareResponse[]>();
+  const responsesByDoc = new Map<string, CompareQueueResponse[]>();
   const docsMetaMap = new Map<string, Omit<CompareDoc, "text">>();
 
   allResponses?.forEach((r) => {
     const docId = r.document_id;
     if (!responsesByDoc.has(docId)) responsesByDoc.set(docId, []);
-    responsesByDoc.get(docId)!.push(r as unknown as CompareResponse);
+    responsesByDoc.get(docId)!.push(r as unknown as CompareQueueResponse);
     // `documents` é 1:1 por doc (join pela FK document_id) — grava só na
     // primeira ocorrência em vez de sobrescrever a cada resposta do mesmo doc.
     if (r.documents && !docsMetaMap.has(docId)) {
@@ -256,7 +260,7 @@ export interface QualifyDocumentsContext {
 export interface QualifiedDocumentsResult {
   qualifiedDocIds: string[];
   divergentFields: Record<string, string[]>;
-  responsesMap: Record<string, CompareResponse[]>;
+  responsesMap: Record<string, CompareQueueResponse[]>;
   coverageByDoc: Record<string, DocCoverage>;
 }
 
@@ -272,9 +276,9 @@ interface ResponseFilterParams {
 }
 
 function filterQualifiedResponses(
-  docResponses: CompareResponse[],
+  docResponses: CompareQueueResponse[],
   params: ResponseFilterParams,
-): CompareResponse[] {
+): CompareQueueResponse[] {
   return docResponses.filter((r) => {
     if (!responseQualifiesForVersion(r, params.minVersion, params.projectVersionCtx)) return false;
     if (params.sinceMs !== null && new Date(r.created_at).getTime() < params.sinceMs) return false;
@@ -294,7 +298,7 @@ interface CoverageMetrics {
 }
 
 function computeCoverageMetrics(
-  qualifiedResponses: CompareResponse[],
+  qualifiedResponses: CompareQueueResponse[],
   assignedUsers: Set<string>,
 ): CoverageMetrics {
   // Conta respondentes humanos DISTINTOS (não linhas) — `respondentKey`
@@ -335,14 +339,14 @@ function meetsCoverageThresholds(metrics: CoverageMetrics, filters: CompareFilte
 }
 
 interface QualifiedDocument {
-  qualifiedResponses: CompareResponse[];
+  qualifiedResponses: CompareQueueResponse[];
   divergent: string[];
   coverage: DocCoverage;
 }
 
 function qualifyDocument(
   docId: string,
-  docResponses: CompareResponse[],
+  docResponses: CompareQueueResponse[],
   ctx: QualifyDocumentsContext,
 ): QualifiedDocument | null {
   const qualifiedResponses = filterQualifiedResponses(docResponses, {
@@ -388,13 +392,13 @@ function qualifyDocument(
 }
 
 export function qualifyDocumentsForCompare(
-  responsesByDoc: Map<string, CompareResponse[]>,
+  responsesByDoc: Map<string, CompareQueueResponse[]>,
   docsMetaMap: Map<string, Omit<CompareDoc, "text">>,
   ctx: QualifyDocumentsContext,
 ): QualifiedDocumentsResult {
   const qualifiedDocIds: string[] = [];
   const divergentFields: Record<string, string[]> = {};
-  const responsesMap: Record<string, CompareResponse[]> = {};
+  const responsesMap: Record<string, CompareQueueResponse[]> = {};
   const coverageByDoc: Record<string, DocCoverage> = {};
 
   for (const [docId, docResponses] of responsesByDoc) {


### PR DESCRIPTION
O `fallow` reporta 3 `duplicate-exports`, regra de severidade `error`. Eles não barram o push hoje só porque esses arquivos não entraram no escopo do `audit` — vão barrar assim que alguém tocar neles. Avaliei os três; são coisas diferentes, e só dois são deste PR.

## 1. `AssignmentRow` — os dois eram dead exports

`src/lib/auto-review-backlog.ts:33` e `src/lib/compare-queue.ts:95`.

**Nenhum módulo importa nenhum dos dois nomes.** O shape chega aos consumidores por inferência estrutural — em `field-reviews.ts` via o retorno de `computeBacklogRows`, e em `compare/page.tsx` via `allAssignments` passado posicionalmente. Não há barrel nem `export *` em `frontend/src`, então isso é exaustivo.

E os shapes são **incompatíveis de propósito**: o de `auto-review-backlog` é payload de INSERT (tem `project_id`, literais estreitos `"auto_revisao"`/`"pendente"`), o de `compare-queue` é row de SELECT (sem `project_id`, `type`/`status` como `string` solto). Dois conceitos que coincidiram no nome.

Remover o `export` mata a colisão **e** o dead export de uma vez, sem tocar em consumidor algum.

## 2. `CompareResponse` — o mesmo dado com dois nomes

`src/components/compare/compare-types.ts:12` (o tipo wire) e `src/lib/compare-queue.ts:31`.

Este é o caso que merecia atenção. O de `compare-queue` é um **superset estrito** do wire: os 12 outros campos são idênticos campo a campo (inclusive `answer_field_hashes`, já que `AnswerFieldHashes` é literalmente `Record<string, string> | null` em `types.ts:218`), e a única diferença é o `document_id`.

E o crossover **acontece de verdade**: em `compare/page.tsx`, o `responsesMap` é produzido por `qualifyDocumentsForCompare` — tipado com o `CompareResponse` de `compare-queue` — e passado direto para a prop `responses` de `<ComparePage>`, tipada com o `CompareResponse` de `compare-types`. Compila em silêncio: não é object literal no call site, então não há excess property check. Ou seja, os dois nomes carregavam o mesmo objeto atravessando a fronteira RSC → client, e os shapes **já tinham divergido**.

A correção declara o que o código já significava: renomeia o da fila para `CompareQueueResponse` e o define como `extends CompareResponse` do wire, com o `document_id` a mais. Os 12 campos deixam de ser redeclarados, e o drift fica impossível por construção em vez de depender de alguém lembrar de editar os dois lugares. `compare-queue.ts` já importava `respondentKey` de `compare-types`, então a direção de dependência não é nova.

## 3. `resolveEffectiveUserId` — fora deste PR, de propósito

`src/lib/auth.ts:217` e `src/lib/reviews/queries.ts:129` **não são duplicata**: são duas funções genuinamente diferentes, com regras de autorização diferentes. A de `auth.ts` é async e só o **master** impersona (`user.isMaster && viewAsUser`), com resolução de conta-alias via `getEffectiveMemberId`; a de `queries.ts` é síncrona e permite **master OU coordenador** (`(isMaster || isCoordinator) && viewAsUser`), que é o gate de leitura da aba "Meu Gabarito". Não são intercambiáveis nem por assinatura — uma troca acidental não compilaria.

Mais importante: **o #440 (draft) já a renomeia** para `resolveViewedRespondentId` e ainda corrige, de quebra, a assimetria de conta-alias que essa versão tem (passa a usar `ownMemberUserId`, ver #427). Mexer aqui só colidiria com trabalho melhor já em curso. Depois do #440, os `duplicate-exports` do projeto chegam a zero.

## Verificação

- `tsc --noEmit` limpo
- `vitest` 1274/1274 em 133 arquivos
- `npm run fallow`: 3 → 1 `duplicate-exports` (o remanescente é o do #440)
- pre-push completo rodou sem `SKIP`: typecheck, vitest, e2e-smoke, lint:types, fallow audit e semgrep todos **Passed**