### PR TITLE
chore(deps): trava TypeScript na 6.0.x (o teto do peer e 6.1, nao 7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,9 @@ updates:
       # bump 6->7 (#471) o npm aninhou a arvore do typescript-eslint SEM aninhar
       # um TS 6 junto, entao o parser resolvia o TS 7 da raiz com o peer violado
       # — `lint:types` rodaria sobre versao que a upstream declara nao suportar.
-      # Remover quando sair o typescript-eslint 9 com suporte a TS 7.
+      # O teto do peer e 6.1, nao 7: por isso o `package.json` declara `~6.0`, que
+      # e quem de fato barra o 6.1 (esta regra so cobre o major). Ao destravar,
+      # mexer nos dois. Remover quando sair o typescript-eslint 9 com suporte a TS 7.
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,11 +33,15 @@ updates:
       # bump 6->7 (#471) o npm aninhou a arvore do typescript-eslint SEM aninhar
       # um TS 6 junto, entao o parser resolvia o TS 7 da raiz com o peer violado
       # — `lint:types` rodaria sobre versao que a upstream declara nao suportar.
-      # O teto do peer e 6.1, nao 7: por isso o `package.json` declara `~6.0`, que
-      # e quem de fato barra o 6.1 (esta regra so cobre o major). Ao destravar,
-      # mexer nos dois. Remover quando sair o typescript-eslint 9 com suporte a TS 7.
+      # O teto do peer e 6.1, nao 7 — fronteira minor. Por isso a trava e dupla e
+      # simetrica: o `package.json` declara `~6.0` (barra o `npm install`) e este
+      # ignore cobre minor+major (barra o Dependabot, que sob o `versioning-strategy`
+      # default `auto` elevaria a faixa para `~6.1` num PR do grupo minor-patch —
+      # 6.0.3->6.1.0 e semver-minor, entao um ignore so de major nao pegaria).
+      # A 6.0.x segue livre. Ao destravar, mexer nos dois: faixa e ignore.
+      # Remover quando sair o typescript-eslint 9 com suporte a TS 7.
       - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-minor", "version-update:semver-major"]
     labels:
       - "dependencies"
       - "frontend"

--- a/docs/CODE_QUALITY_TOOLING.md
+++ b/docs/CODE_QUALITY_TOOLING.md
@@ -35,7 +35,7 @@ Baseline (full scan, 3388 símbolos analisados, manutenibilidade global 90,7): *
 
 ### typescript-eslint type-checked — os tipos
 
-`typescript-eslint` 8.62.0 (devDependency pinada), via a config dedicada `frontend/eslint.config.typed.mjs` e o script `npm run lint:types`. É separada da config base (`eslint.config.mjs`) e do `npm run lint` rápido porque regras type-checked precisam do `projectService` (carregam o programa de tipos inteiro) e são lentas demais para o lint do dia a dia. O subset é curado de propósito — `no-floating-promises` e `no-misused-promises`, não o `recommendedTypeChecked` inteiro — para mirar o footgun que mais aparece nesta base: promessa async não-tratada em Server Action, hook ou handler de evento.
+`typescript-eslint` 8.63.0 (devDependency pinada), via a config dedicada `frontend/eslint.config.typed.mjs` e o script `npm run lint:types`. É separada da config base (`eslint.config.mjs`) e do `npm run lint` rápido porque regras type-checked precisam do `projectService` (carregam o programa de tipos inteiro) e são lentas demais para o lint do dia a dia. O subset é curado de propósito — `no-floating-promises` e `no-misused-promises`, não o `recommendedTypeChecked` inteiro — para mirar o footgun que mais aparece nesta base: promessa async não-tratada em Server Action, hook ou handler de evento.
 
 A escolha se justificou empiricamente: o primeiro scan encontrou 59 errors em cerca de 11 arquivos — promessas não-aguardadas em hooks como `useLlmRunProgress`, `useFieldOrder`, `usePromptPreview`, em componentes como `UserMenu`, `RunLlmButton`, `CopyLinkButton`, `ExportPanel`, e em Server Actions. Eram bugs latentes que o lint sintático não via (ex.: falha de rede silenciosa ao salvar, sem toast nem log). A issue [#378](https://github.com/bdcdo/dataframeitGUI/issues/378) (onda `lint:types` da epic [#376](https://github.com/bdcdo/dataframeitGUI/issues/376)) zerou o débito real (46 errors, 25 arquivos no scan atual): hoje `npm run lint:types` passa com **0 errors** de `no-floating-promises`/`no-misused-promises` no projeto inteiro — o gate de pre-push segue file-scoped por velocidade, mas não há mais débito legado escondido atrás dele.
 
@@ -129,6 +129,8 @@ uv run mypy .            # type-check (llm_runner.py isento; ver seção mypy ac
 ## Monitorar
 
 - **tsgo / TypeScript 7 (Project Corsa)** — compilador nativo em Go, ~10× mais rápido, em RC desde 18/06/2026, GA estimado ~1 mês depois. Não adotado agora: a API programática só entra na 7.1, então `typescript-eslint`/`ts-morph` ainda não rodam sobre o nativo. Quando o GA sair, trocar `tsc` por `tsgo` no script `typecheck` é um drop-in. O agente também pode chamar o MCP/skill do fallow e os findings do semgrep guardian sob demanda.
+
+  Enquanto isso o TypeScript fica pinado em `~6.0` no `frontend/package.json`, porque o `typescript-eslint` 8.63.0 declara peer `typescript: >=4.8.4 <6.1.0` — o teto é 6.1, não 7, então uma faixa `^6` já bastaria para violá-lo assim que a 6.1 for publicada (hoje a última 6.x é a 6.0.3). O `.github/dependabot.yml` complementa ignorando o major, mas quem barra o 6.1 é o `~6.0`. A condição de destrave é o `typescript-eslint` 9 com suporte a TS 7 — aí os dois saem juntos.
 
 ## Avaliadas e diferidas
 

--- a/docs/CODE_QUALITY_TOOLING.md
+++ b/docs/CODE_QUALITY_TOOLING.md
@@ -41,7 +41,7 @@ A escolha se justificou empiricamente: o primeiro scan encontrou 59 errors em ce
 
 ### typecheck (tsc) — o prerequisito que faltava
 
-O projeto não tinha sequer um script `tsc --noEmit`. O `npm run typecheck` preenche isso e roda no pre-push (projeto inteiro, sem grandfathering — hoje passa com **0 erros**, então qualquer erro de tipo novo barra o push). O compilador nativo em Go (tsgo / TypeScript 7) está em RC mas ainda não foi adotado (ver "Monitorar"); quando o GA sair, basta trocar `tsc` por `tsgo` nesse script.
+O projeto não tinha sequer um script `tsc --noEmit`. O `npm run typecheck` preenche isso e roda no pre-push (projeto inteiro, sem grandfathering — hoje passa com **0 erros**, então qualquer erro de tipo novo barra o push). O compilador nativo em Go (tsgo / TypeScript 7) já está em GA mas ainda não foi adotado, porque o peer do `typescript-eslint` 8 exclui o TS 7 (ver "Monitorar"); ao destravar, basta trocar `tsc` por `tsgo` nesse script.
 
 ### Exports de Server Actions — contrato do projeto
 
@@ -128,9 +128,9 @@ uv run mypy .            # type-check (llm_runner.py isento; ver seção mypy ac
 
 ## Monitorar
 
-- **tsgo / TypeScript 7 (Project Corsa)** — compilador nativo em Go, ~10× mais rápido, em RC desde 18/06/2026, GA estimado ~1 mês depois. Não adotado agora: a API programática só entra na 7.1, então `typescript-eslint`/`ts-morph` ainda não rodam sobre o nativo. Quando o GA sair, trocar `tsc` por `tsgo` no script `typecheck` é um drop-in. O agente também pode chamar o MCP/skill do fallow e os findings do semgrep guardian sob demanda.
+- **tsgo / TypeScript 7 (Project Corsa)** — compilador nativo em Go, ~10× mais rápido, **já em GA** (a `latest` no npm é a 7.0.2). Ainda assim não adotado, por dois motivos que se somam: a API programática só entra na 7.1, que ainda não saiu como estável (só builds `dev`), então `typescript-eslint`/`ts-morph` não rodam sobre o nativo; e o `typescript-eslint` 8 declara peer que exclui o TS 7, de modo que instalar a 7 é exatamente o que o pin abaixo impede. Trocar `tsc` por `tsgo` no script `typecheck` segue sendo um drop-in em si, mas está **bloqueado pela mesma condição de destrave do pin** — não pelo calendário do GA, que já passou. O agente também pode chamar o MCP/skill do fallow e os findings do semgrep guardian sob demanda.
 
-  Enquanto isso o TypeScript fica pinado em `~6.0` no `frontend/package.json`, porque o `typescript-eslint` 8.63.0 declara peer `typescript: >=4.8.4 <6.1.0` — o teto é 6.1, não 7, então uma faixa `^6` já bastaria para violá-lo assim que a 6.1 for publicada (hoje a última 6.x é a 6.0.3). O `.github/dependabot.yml` complementa ignorando o major, mas quem barra o 6.1 é o `~6.0`. A condição de destrave é o `typescript-eslint` 9 com suporte a TS 7 — aí os dois saem juntos.
+  Por isso o TypeScript fica pinado em `~6.0` no `frontend/package.json`: o `typescript-eslint` 8.63.0 declara peer `typescript: >=4.8.4 <6.1.0` — o teto é **6.1, não 7**, fronteira minor (hoje a última 6.x publicada é a 6.0.3). A trava é dupla e simétrica, porque os caminhos de violação são dois e independentes. Primeiro, o `~6.0` barra o `npm install`: uma faixa `^6` deixaria a 6.1 entrar sozinha em qualquer refresh de lockfile, sem diff no `package.json`. Segundo, o `ignore` de **minor+major** no `.github/dependabot.yml` barra o Dependabot, que sob o `versioning-strategy` default `auto` elevaria a faixa para `~6.1` num PR do grupo `frontend-minor-patch` — 6.0.3→6.1.0 é `semver-minor`, então um ignore só de major não pegaria. A 6.0.x segue fluindo normalmente. A condição de destrave é o `typescript-eslint` 9 com suporte a TS 7 — aí saem juntos a faixa, o ignore e o bloqueio do tsgo.
 
 ## Avaliadas e diferidas
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -56,7 +56,7 @@
         "shadcn": "^4.13.0",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^6",
+        "typescript": "~6.0",
         "typescript-eslint": "8.63.0",
         "vitest": "^4.1.10"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,7 +81,7 @@
     "shadcn": "^4.13.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6",
+    "typescript": "~6.0",
     "typescript-eslint": "8.63.0",
     "vitest": "^4.1.10"
   }


### PR DESCRIPTION
Follow-up do #478, que veio da revisão dele.

## O problema que o #478 não alcança

O #478 ignora bumps **major** de `typescript` no Dependabot. Mas o peer do `typescript-eslint` 8.63.0 é `typescript: ">=4.8.4 <6.1.0"` — o teto é **6.1**, fronteira minor, não 7.

Como o `frontend/package.json` declarava `"typescript": "^6"`, a faixa já autorizava a violação por **dois caminhos independentes** que o `ignore` de major não cobre:

1. **`npm install`** — qualquer refresh de lockfile puxaria a 6.1 sozinha, sem diff no `package.json`.
2. **Dependabot** — 6.0.3→6.1.0 é `semver-minor` (o update-type vem da versão, não do range), então a proposta cai no grupo `frontend-minor-patch`, justamente o PR de menor escrutínio.

Seria o mesmo estrago do #471, um degrau abaixo. A 6.1 ainda não existe (a última 6.x publicada é a 6.0.3), então esta é a hora barata de fechar a porta.

## O que muda

A trava vira **dupla e simétrica** — um ponto de aplicação para cada caminho, ambos dizendo a mesma coisa (patch-only na 6.0.x):

- **`frontend/package.json`**: `"typescript": "^6"` → `"typescript": "~6.0"`. Fecha o caminho (1), declarando a restrição onde o npm de fato a lê. Alinha ao pin exato que o projeto já usa nas ferramentas do mesmo eixo (`typescript-eslint`, `react-doctor`) — `typescript` era o outlier.
- **`.github/dependabot.yml`**: o `ignore` do `typescript` passa a cobrir **minor+major**. Fecha o caminho (2). O `~6.0` sozinho não bastaria: sob o `versioning-strategy` default `auto`, a 6.1.0 cai fora da faixa e o Dependabot **eleva o range para `~6.1`** em vez de desistir. E o conflito de peer não salva — o #471 mostrou que o npm aninha a árvore em vez de falhar, então o install passa e o PR é aberto.
- **`docs/CODE_QUALITY_TOOLING.md`**: registra a trava dupla na seção "Monitorar". Corrige três drifts encontrados no caminho: a doc citava `typescript-eslint` 8.62.0 (a main está em 8.63.0); dizia que o TS 7 estava "em RC, GA estimado ~1 mês depois" quando a `latest` no npm **já é a 7.0.2**; e atribuía o bloqueio do tsgo ao calendário do GA, quando na verdade é o peer do `typescript-eslint` 8 — a mesma condição de destrave do pin.

A 6.0.x segue fluindo normalmente (patches de segurança do TS entram).

## Verificação

- `npm install` → lockfile mexe **uma linha** (o espelho da faixa); `typescript` segue em 6.0.3, nenhuma outra árvore alterada.
- `npm run typecheck` → 0 erros. `npm run lint:types` → 0 errors.
- `dependabot.yml` valida como YAML e as duas regras de `ignore` parseiam como esperado.
- Pre-push completo verde, incluindo `playwright e2e smoke` — nenhum gate pulado.

Condição de remoção (das travas juntas): `typescript-eslint` 9 com suporte a TS 7. Nesse momento saem a faixa, o `ignore` e o bloqueio do tsgo.

Ref #478, #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)