### PR TITLE
fix(security): veda resposta atribuída ao LLM com autoria humana

### DIFF
--- a/.github/workflows/database-tests.yml
+++ b/.github/workflows/database-tests.yml
@@ -1,0 +1,38 @@
+name: Database contract tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/database-tests.yml"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+      - "frontend/supabase/migrations/**"
+      - "frontend/supabase/tests/responses_llm_actor_integrity.test.sql"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: database-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  responses-llm-actor-integrity:
+    name: Responses LLM actor integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: 24.10.0
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+      - run: npx supabase start
+      - run: npx supabase db reset --local --no-seed
+      - run: npm run test:db:responses-actor

--- a/backend/tests/test_llm_runner_response_row.py
+++ b/backend/tests/test_llm_runner_response_row.py
@@ -64,6 +64,7 @@ def test_is_latest_segue_is_partial():
 def test_campos_basicos_preservados():
     row = _build_llm_response_row(**_kwargs())
     assert row["respondent_type"] == "llm"
+    assert "respondent_id" not in row
     assert row["respondent_name"] == "google_genai/gemini-3-flash-preview"
     assert row["pydantic_hash"] == "3c5e901f76547135"
     assert row["llm_job_id"] == "job-1"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
-      "engines": {
-        "node": ">=24.10.0"
-      },
       "dependencies": {
         "@clerk/localizations": "^4.13.1",
         "@clerk/nextjs": "^7.5.15",
@@ -55,6 +52,7 @@
         "react-doctor": "0.7.3",
         "react-scan": "0.5.7",
         "shadcn": "^4.13.0",
+        "supabase": "2.109.1",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
         "typescript": "~6.0",
@@ -62,7 +60,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.10.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1107,14 +1105,14 @@
       }
     },
     "node_modules/@ecies/ciphers": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
-      "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
+      "integrity": "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "bun": ">=1",
-        "deno": ">=2",
+        "deno": ">=2.7.10",
         "node": ">=16"
       },
       "peerDependencies": {
@@ -5801,6 +5799,130 @@
       "engines": {
         "node": ">=22.0.0"
       }
+    },
+    "node_modules/@supabase/cli-darwin-arm64": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.109.1.tgz",
+      "integrity": "sha512-tkn8tfunyqIL7RE+7DVjg6Ql2cJLPkGgh9cPafp2LbXI0qDgds0TaS+UOTHQEjci8JQXXe2wS00+122ko2QI8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@supabase/cli-darwin-x64": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.109.1.tgz",
+      "integrity": "sha512-0Q5ZAoWhOyIv4ZzQOU8QbjjdB2JmznnDNyJ3VrIeuLMWoifVfUWaLZhHBNYzr4xXoxBpKrggomuAT8BaEhY3lg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-arm64": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.109.1.tgz",
+      "integrity": "sha512-MS1djJjq5laD99+jYJUoARfSZhzRX9aXmo5piZ1yl2JXb9IXTuhiTD5olkFKQcgNckRcAZqMf4fucQGTYC767A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-arm64-musl": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.109.1.tgz",
+      "integrity": "sha512-cXNOsSU7MS+jmslGQATTD4DfWBEIHiFi7LaBWyBxHmR7tzIiZXimUXgN26ZiQjfAxU+RZq52C3k0qhi7vmqXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-x64": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.109.1.tgz",
+      "integrity": "sha512-svFmamF/vIq4/oinwY50jDi869itC9/GWrPaGtsHFkK4NUBcQtl1T37WWIivGsXwbBKNC4FjZD3dGqjL7bfW1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-x64-musl": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.109.1.tgz",
+      "integrity": "sha512-zeD9MrZpEKJrjkSPcYp4nZeGJ9FQt0i/kiRij4ZprPP6R5l+SLi6Pk20ln+Vj/GZuWTVxX7IHJ11pgViaReAWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-windows-arm64": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.109.1.tgz",
+      "integrity": "sha512-NeKzgWAOpglnLwMTggTp5t44fbkfxACLkQNlCRx0q332HMM3WqsKQUsHv1MHc6ZbEc5bcMwaYjqPNI/aOWnP5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@supabase/cli-windows-x64": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.109.1.tgz",
+      "integrity": "sha512-L9/pDLM+4IR8646aT69ZDVcnJeg1lZZsB26ZgI775S3f8jOHP41+1UH9Oq1g9CvKiAQviuaLgtwkuvi0I/cc/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@supabase/functions-js": {
       "version": "2.110.2",
@@ -11857,9 +11979,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -16704,6 +16826,48 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/supabase": {
+      "version": "2.109.1",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.109.1.tgz",
+      "integrity": "sha512-N2yP2MHTxOxXBWhfn3poudpJn4pkPosAUo7J/46FTou/l7wOwFi9tox8NSN6HljWkfM0zhwPRimNNGC9XBMoxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eciesjs": "^0.5.0",
+        "jose": "^6.2.3"
+      },
+      "bin": {
+        "supabase": "dist/supabase.js"
+      },
+      "optionalDependencies": {
+        "@supabase/cli-darwin-arm64": "2.109.1",
+        "@supabase/cli-darwin-x64": "2.109.1",
+        "@supabase/cli-linux-arm64": "2.109.1",
+        "@supabase/cli-linux-arm64-musl": "2.109.1",
+        "@supabase/cli-linux-x64": "2.109.1",
+        "@supabase/cli-linux-x64-musl": "2.109.1",
+        "@supabase/cli-windows-arm64": "2.109.1",
+        "@supabase/cli-windows-x64": "2.109.1"
+      }
+    },
+    "node_modules/supabase/node_modules/eciesjs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.5.0.tgz",
+      "integrity": "sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ecies/ciphers": "^0.2.6",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0"
+      },
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2.7.10",
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "fallow:audit": "fallow audit",
     "scan": "react-scan http://localhost:3000",
     "test": "vitest run",
+    "test:db:responses-actor": "supabase test db supabase/tests/responses_llm_actor_integrity.test.sql --local",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
@@ -77,6 +78,7 @@
     "react-doctor": "0.7.3",
     "react-scan": "0.5.7",
     "shadcn": "^4.13.0",
+    "supabase": "2.109.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
     "typescript": "~6.0",

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -119,7 +119,7 @@ export default async function CodePage({
     );
 
   // Responses incluem agora round_id e schema_version para classificacao por rodada.
-  // Filtra respondent_type=humano: respostas LLM têm respondent_id distinto, mas o
+  // Filtra respondent_type=humano: respostas LLM usam respondent_id NULL, mas o
   // filtro explícito alinha com saveResponse e protege contra colisões futuras.
   const docIds = allDocuments.map((d) => d.id);
   const { data: responses } = await supabase

--- a/frontend/supabase/migrations/20260716120000_responses_llm_actor_integrity.sql
+++ b/frontend/supabase/migrations/20260716120000_responses_llm_actor_integrity.sql
@@ -1,0 +1,49 @@
+-- Impede que um membro plante uma resposta "do LLM" com a própria autoria.
+--
+-- A policy "Users manage own responses" (20260611130000_member_email_links.sql)
+-- é FOR ALL com USING mas sem WITH CHECK, e o Postgres reusa o USING no
+-- INSERT/UPDATE. O predicado autoriza pelo respondent_id e nunca olha o
+-- respondent_type, então um pesquisador do projeto podia gravar
+-- {respondent_type:'llm', respondent_id:<próprio>} direto pelo PostgREST: o
+-- braço `respondent_id IN auth_user_member_identity_ids(project_id)` aceita.
+-- Efeito do ataque: final_answers e a detecção de divergência escolhem o braço
+-- LLM por respondent_type; uma "resposta do LLM" idêntica à codificação humana
+-- não gera field_review, e o campo entra no dataset como consenso, sem revisão.
+--
+-- A correção é uma invariante de schema, não outra policy: o LLM não é uma
+-- pessoa e nunca tem respondent_id. Isso fecha o vetor pelos dois lados sem
+-- tocar no fluxo legítimo — o backend insere respostas LLM sem respondent_id
+-- (backend/services/llm_runner.py) e saveResponse grava sempre 'humano'. Com o
+-- CHECK, 'llm' + respondent_id próprio viola a constraint, e 'llm' +
+-- respondent_id NULL não satisfaz o braço de identidade da policy.
+BEGIN;
+
+-- ADD CONSTRAINT valida as linhas existentes e abortaria a migration com um
+-- erro genérico. O preflight nomeia o problema em vez de deixar o deploy
+-- falhar sem contexto; nenhum dado é corrigido automaticamente porque uma
+-- resposta LLM com autor humano é ambígua — só quem conhece o projeto decide
+-- se aquilo é resposta do LLM ou codificação de alguém.
+DO $$
+DECLARE
+  v_offenders INTEGER;
+BEGIN
+  SELECT pg_catalog.count(*)
+  INTO v_offenders
+  FROM public.responses
+  WHERE respondent_type = 'llm'
+    AND respondent_id IS NOT NULL;
+
+  IF v_offenders > 0 THEN
+    RAISE EXCEPTION
+      'responses contém % resposta(s) llm com respondent_id — revise a autoria antes de aplicar',
+      v_offenders
+      USING ERRCODE = '23514';
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.responses
+  ADD CONSTRAINT responses_llm_has_no_human_actor_check
+  CHECK (respondent_type <> 'llm' OR respondent_id IS NULL);
+
+COMMIT;

--- a/frontend/supabase/migrations/20260716154500_responses_llm_actor_integrity.sql
+++ b/frontend/supabase/migrations/20260716154500_responses_llm_actor_integrity.sql
@@ -1,4 +1,4 @@
--- Impede que um membro plante uma resposta "do LLM" com a própria autoria.
+-- Impede que uma sessão de usuário grave uma resposta atribuída ao LLM.
 --
 -- A policy "Users manage own responses" (20260611130000_member_email_links.sql)
 -- é FOR ALL com USING mas sem WITH CHECK, e o Postgres reusa o USING no
@@ -10,13 +10,31 @@
 -- LLM por respondent_type; uma "resposta do LLM" idêntica à codificação humana
 -- não gera field_review, e o campo entra no dataset como consenso, sem revisão.
 --
--- A correção é uma invariante de schema, não outra policy: o LLM não é uma
--- pessoa e nunca tem respondent_id. Isso fecha o vetor pelos dois lados sem
--- tocar no fluxo legítimo — o backend insere respostas LLM sem respondent_id
--- (backend/services/llm_runner.py) e saveResponse grava sempre 'humano'. Com o
--- CHECK, 'llm' + respondent_id próprio viola a constraint, e 'llm' +
--- respondent_id NULL não satisfaz o braço de identidade da policy.
+-- A correção explicita dois contratos complementares. Pela RLS, toda sessão
+-- JWT de usuário só pode escrever resposta humana em nome da própria identidade
+-- (direta ou canônica via alias) num projeto acessível; master segue limitado a
+-- resposta humana própria. Respostas LLM ficam no backend sem sessão de usuário,
+-- via service role. No schema, o LLM não é uma pessoa e nunca tem respondent_id,
+-- inclusive quando a escrita privilegiada ignora RLS.
 BEGIN;
+
+-- Estabiliza o conjunto validado pelo preflight até a criação da constraint.
+-- SHARE ROW EXCLUSIVE bloqueia escritas concorrentes sem impedir leituras.
+LOCK TABLE public.responses IN SHARE ROW EXCLUSIVE MODE;
+
+-- Preserva integralmente o USING vigente. O WITH CHECK restringe apenas o
+-- estado novo produzido por INSERT/UPDATE em sessões sujeitas a RLS.
+ALTER POLICY "Users manage own responses" ON public.responses
+  WITH CHECK (
+    respondent_type = 'humano'
+    AND respondent_id IN (
+      SELECT public.auth_user_member_identity_ids(project_id)
+    )
+    AND (
+      project_id IN (SELECT public.auth_user_accessible_project_ids())
+      OR public.is_master()
+    )
+  );
 
 -- ADD CONSTRAINT valida as linhas existentes e abortaria a migration com um
 -- erro genérico. O preflight nomeia o problema em vez de deixar o deploy
@@ -25,7 +43,7 @@ BEGIN;
 -- se aquilo é resposta do LLM ou codificação de alguém.
 DO $$
 DECLARE
-  v_offenders INTEGER;
+  v_offenders BIGINT;
 BEGIN
   SELECT pg_catalog.count(*)
   INTO v_offenders

--- a/frontend/supabase/tests/responses_llm_actor_integrity.test.sql
+++ b/frontend/supabase/tests/responses_llm_actor_integrity.test.sql
@@ -1,145 +1,305 @@
--- Regressão: membro não pode plantar resposta "do LLM" com a própria autoria.
---
--- Como rodar após `npx supabase db reset`:
---   docker exec -i supabase_db_frontend psql -U postgres -d postgres \
---     -X -v ON_ERROR_STOP=1 < supabase/tests/responses_llm_actor_integrity.test.sql
--- Sucesso = nenhuma exceção e os NOTICE "OK ..." no final. Qualquer FALHOU aborta.
---
--- IMPORTANTE — por que este arquivo concede DML explicitamente: o Supabase
--- remoto concede INSERT/UPDATE/DELETE a `authenticated` no schema public por
--- default privileges, mas o ambiente local não. Um teste que apenas tentasse o
--- INSERT malicioso passaria aqui por falta de privilégio (42501) e continuaria
--- cego ao que produção permite. Os GRANTs abaixo replicam a superfície do
--- remoto para que a RLS e as constraints sejam de fato exercidas.
+-- Contrato de autoria das responses: toda sessão JWT grava somente sua
+-- resposta humana; o backend privilegiado grava o braço LLM sem respondent_id.
 
 BEGIN;
 
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SELECT plan(10);
+
+CREATE OR REPLACE FUNCTION pg_temp.rejected_sqlstate(statement TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  actual_sqlstate TEXT;
+BEGIN
+  EXECUTE statement;
+  RETURN NULL;
+EXCEPTION WHEN OTHERS THEN
+  GET STACKED DIAGNOSTICS actual_sqlstate = RETURNED_SQLSTATE;
+  RETURN actual_sqlstate;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.rejected_constraint(statement TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  actual_constraint TEXT;
+BEGIN
+  EXECUTE statement;
+  RETURN NULL;
+EXCEPTION WHEN OTHERS THEN
+  GET STACKED DIAGNOSTICS actual_constraint = CONSTRAINT_NAME;
+  RETURN actual_constraint;
+END;
+$$;
+
+-- O trigger de auth cria automaticamente os profiles correspondentes.
 INSERT INTO auth.users (id, email) VALUES
-  ('11100000-0000-0000-0000-000000000001', 'coord@example.test'),
-  ('11100000-0000-0000-0000-000000000002', 'pesquisador@example.test');
+  ('48310000-0000-0000-0000-000000000001', 'coordinator-483@example.test'),
+  ('48310000-0000-0000-0000-000000000002', 'researcher-483@example.test'),
+  ('48310000-0000-0000-0000-000000000003', 'creator-483@example.test'),
+  ('48310000-0000-0000-0000-000000000004', 'master-483@example.test'),
+  ('48310000-0000-0000-0000-000000000005', 'outsider-483@example.test'),
+  ('48310000-0000-0000-0000-000000000006', 'alias-483@example.test');
 
-INSERT INTO public.clerk_user_mapping (clerk_user_id, supabase_user_id)
-SELECT id::text, id
-FROM auth.users
-WHERE id::text LIKE '11100000-0000-0000-0000-%';
-
-INSERT INTO public.projects (id, name, created_by) VALUES
-  ('22200000-0000-0000-0000-000000000001', 'llm actor integrity',
-   '11100000-0000-0000-0000-000000000001');
-
-INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
-  ('33300000-0000-0000-0000-000000000001', '22200000-0000-0000-0000-000000000001',
-   'doc', 'texto', 'h-doc');
+INSERT INTO public.projects (id, name, created_by) VALUES (
+  '48320000-0000-0000-0000-000000000001',
+  'responses actor integrity',
+  '48310000-0000-0000-0000-000000000003'
+);
 
 INSERT INTO public.project_members (project_id, user_id, role) VALUES
-  ('22200000-0000-0000-0000-000000000001',
-   '11100000-0000-0000-0000-000000000002', 'pesquisador');
+  (
+    '48320000-0000-0000-0000-000000000001',
+    '48310000-0000-0000-0000-000000000001',
+    'coordenador'
+  ),
+  (
+    '48320000-0000-0000-0000-000000000001',
+    '48310000-0000-0000-0000-000000000002',
+    'pesquisador'
+  );
+
+INSERT INTO public.master_users (user_id) VALUES
+  ('48310000-0000-0000-0000-000000000004');
+
+INSERT INTO public.member_email_links (
+  project_id,
+  member_user_id,
+  email,
+  linked_user_id,
+  created_by
+) VALUES (
+  '48320000-0000-0000-0000-000000000001',
+  '48310000-0000-0000-0000-000000000002',
+  'alias-483@example.test',
+  '48310000-0000-0000-0000-000000000006',
+  '48310000-0000-0000-0000-000000000003'
+);
+
+INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
+  (
+    '48330000-0000-0000-0000-000000000001',
+    '48320000-0000-0000-0000-000000000001',
+    'backend llm', 'texto', 'hash-483-1'
+  ),
+  (
+    '48330000-0000-0000-0000-000000000002',
+    '48320000-0000-0000-0000-000000000001',
+    'human response', 'texto', 'hash-483-2'
+  ),
+  (
+    '48330000-0000-0000-0000-000000000003',
+    '48320000-0000-0000-0000-000000000001',
+    'alias response', 'texto', 'hash-483-3'
+  );
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.responses TO authenticated;
 
+SELECT lives_ok(
+  $sql$
+    INSERT INTO public.responses (
+      project_id, document_id, respondent_type, respondent_name, answers
+    ) VALUES (
+      '48320000-0000-0000-0000-000000000001',
+      '48330000-0000-0000-0000-000000000001',
+      'llm', 'openai/gpt-5', '{"q1":"backend"}'
+    )
+  $sql$,
+  'backend privilegiado grava LLM sem respondent_id'
+);
+
+SELECT is(
+  pg_temp.rejected_constraint(
+    $sql$
+      INSERT INTO public.responses (
+        project_id, document_id, respondent_id, respondent_type, answers
+      ) VALUES (
+        '48320000-0000-0000-0000-000000000001',
+        '48330000-0000-0000-0000-000000000001',
+        '48310000-0000-0000-0000-000000000002',
+        'llm', '{"q1":"forjado"}'
+      )
+    $sql$
+  ),
+  'responses_llm_has_no_human_actor_check',
+  'constraint nomeada rejeita LLM com ator humano até em escrita privilegiada'
+);
+
 SELECT set_config(
   'request.jwt.claims',
-  '{"sub":"11100000-0000-0000-0000-000000000002",'
-    || '"supabase_uid":"11100000-0000-0000-0000-000000000002"}',
+  '{"supabase_uid":"48310000-0000-0000-0000-000000000002"}',
   true
 );
 SET LOCAL ROLE authenticated;
-
--- ========== O braço LLM não aceita autor humano ==========
-DO $$
-BEGIN
-  -- A policy autoriza pelo respondent_id, então este INSERT passa pela RLS: o
-  -- pesquisador é dono da linha. Quem recusa é a constraint de schema — sem
-  -- ela, esta resposta entraria como "a do LLM", idêntica à codificação
-  -- humana, e o campo sairia como consenso sem nunca gerar field_review.
-  BEGIN
-    INSERT INTO public.responses
-      (project_id, document_id, respondent_id, respondent_type, answers, is_latest)
-    VALUES
-      ('22200000-0000-0000-0000-000000000001',
-       '33300000-0000-0000-0000-000000000001',
-       '11100000-0000-0000-0000-000000000002',
-       'llm', '{"q1":"forjado"}', true);
-    RAISE EXCEPTION
-      'FALHOU integridade: membro plantou resposta llm com a própria autoria';
-  EXCEPTION
-    WHEN check_violation THEN
-      RAISE NOTICE 'OK: resposta llm com autor humano recusada';
-  END;
-END;
-$$;
-
--- ========== Sem autor, a policy é quem recusa ==========
-DO $$
-BEGIN
-  -- Contornar a constraint zerando o respondent_id não ajuda: nenhum braço da
-  -- policy cobre a linha (não é dele, e ele não é coordenador nem master).
-  BEGIN
-    INSERT INTO public.responses
-      (project_id, document_id, respondent_id, respondent_type, answers, is_latest)
-    VALUES
-      ('22200000-0000-0000-0000-000000000001',
-       '33300000-0000-0000-0000-000000000001',
-       NULL, 'llm', '{"q1":"forjado"}', true);
-    RAISE EXCEPTION
-      'FALHOU integridade: membro plantou resposta llm anônima';
-  EXCEPTION
-    WHEN insufficient_privilege THEN
-      RAISE NOTICE 'OK: resposta llm sem autor recusada pela RLS';
-  END;
-END;
-$$;
-
--- ========== A codificação humana legítima continua passando ==========
-DO $$
-DECLARE
-  n INTEGER;
-BEGIN
-  INSERT INTO public.responses
-    (project_id, document_id, respondent_id, respondent_type, answers, is_latest)
-  VALUES
-    ('22200000-0000-0000-0000-000000000001',
-     '33300000-0000-0000-0000-000000000001',
-     '11100000-0000-0000-0000-000000000002',
-     'humano', '{"q1":"a"}', true);
-
-  SELECT count(*) INTO n FROM public.responses
-  WHERE project_id = '22200000-0000-0000-0000-000000000001'
-    AND respondent_type = 'humano';
-  IF n <> 1 THEN
-    RAISE EXCEPTION 'FALHOU: codificação humana legítima foi bloqueada';
-  END IF;
-
-  RAISE NOTICE 'OK: codificação humana do próprio membro segue permitida';
-END;
-$$;
-
--- ========== O backend continua podendo gravar o braço LLM ==========
+SELECT lives_ok(
+  $sql$
+    INSERT INTO public.responses (
+      id, project_id, document_id, respondent_id, respondent_type, answers
+    ) VALUES (
+      '48340000-0000-0000-0000-000000000001',
+      '48320000-0000-0000-0000-000000000001',
+      '48330000-0000-0000-0000-000000000002',
+      '48310000-0000-0000-0000-000000000002',
+      'humano', '{"q1":"legitimo"}'
+    )
+  $sql$,
+  'pesquisador grava a própria resposta humana'
+);
+SELECT is(
+  pg_temp.rejected_sqlstate(
+    $sql$
+      INSERT INTO public.responses (
+        project_id, document_id, respondent_type, answers
+      ) VALUES (
+        '48320000-0000-0000-0000-000000000001',
+        '48330000-0000-0000-0000-000000000001',
+        'llm', '{"q1":"forjado"}'
+      )
+    $sql$
+  ),
+  '42501',
+  'pesquisador não grava resposta LLM anônima'
+);
 RESET ROLE;
-SELECT set_config('request.jwt.claims', '', true);
 
-DO $$
-DECLARE
-  n INTEGER;
-BEGIN
-  -- llm_runner grava sem respondent_id: é assim que a constraint distingue o
-  -- LLM de uma pessoa.
-  INSERT INTO public.responses
-    (project_id, document_id, respondent_type, respondent_name, answers, is_latest)
-  VALUES
-    ('22200000-0000-0000-0000-000000000001',
-     '33300000-0000-0000-0000-000000000001',
-     'llm', 'openai/gpt-5', '{"q1":"b"}', true);
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"48310000-0000-0000-0000-000000000001"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+SELECT is(
+  pg_temp.rejected_sqlstate(
+    $sql$
+      INSERT INTO public.responses (
+        project_id, document_id, respondent_type, answers
+      ) VALUES (
+        '48320000-0000-0000-0000-000000000001',
+        '48330000-0000-0000-0000-000000000001',
+        'llm', '{"q1":"coordenador"}'
+      )
+    $sql$
+  ),
+  '42501',
+  'coordenador não grava resposta LLM'
+);
+RESET ROLE;
 
-  SELECT count(*) INTO n FROM public.responses
-  WHERE project_id = '22200000-0000-0000-0000-000000000001'
-    AND respondent_type = 'llm';
-  IF n <> 1 THEN
-    RAISE EXCEPTION 'FALHOU: backend não conseguiu gravar a resposta do LLM';
-  END IF;
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"48310000-0000-0000-0000-000000000003"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+SELECT is(
+  pg_temp.rejected_sqlstate(
+    $sql$
+      INSERT INTO public.responses (
+        project_id, document_id, respondent_type, answers
+      ) VALUES (
+        '48320000-0000-0000-0000-000000000001',
+        '48330000-0000-0000-0000-000000000001',
+        'llm', '{"q1":"criador"}'
+      )
+    $sql$
+  ),
+  '42501',
+  'criador não grava resposta LLM'
+);
+RESET ROLE;
 
-  RAISE NOTICE 'OK: backend grava o braço llm sem respondent_id';
-END;
-$$;
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"48310000-0000-0000-0000-000000000004"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+SELECT is(
+  pg_temp.rejected_sqlstate(
+    $sql$
+      INSERT INTO public.responses (
+        project_id, document_id, respondent_type, answers
+      ) VALUES (
+        '48320000-0000-0000-0000-000000000001',
+        '48330000-0000-0000-0000-000000000001',
+        'llm', '{"q1":"master"}'
+      )
+    $sql$
+  ),
+  '42501',
+  'master não grava resposta LLM'
+);
+RESET ROLE;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"48310000-0000-0000-0000-000000000005"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+SELECT is(
+  pg_temp.rejected_sqlstate(
+    $sql$
+      INSERT INTO public.responses (
+        project_id, document_id, respondent_id, respondent_type, answers
+      ) VALUES (
+        '48320000-0000-0000-0000-000000000001',
+        '48330000-0000-0000-0000-000000000002',
+        '48310000-0000-0000-0000-000000000005',
+        'humano', '{"q1":"outsider"}'
+      )
+    $sql$
+  ),
+  '42501',
+  'outsider não grava resposta humana em projeto alheio'
+);
+RESET ROLE;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"48310000-0000-0000-0000-000000000006"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+SELECT lives_ok(
+  $sql$
+    INSERT INTO public.responses (
+      project_id, document_id, respondent_id, respondent_type, answers
+    ) VALUES (
+      '48320000-0000-0000-0000-000000000001',
+      '48330000-0000-0000-0000-000000000003',
+      '48310000-0000-0000-0000-000000000002',
+      'humano', '{"q1":"alias"}'
+    )
+  $sql$,
+  'conta-alias grava com a identidade canônica do projeto'
+);
+RESET ROLE;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"supabase_uid":"48310000-0000-0000-0000-000000000002"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+SELECT is(
+  pg_temp.rejected_sqlstate(
+    $sql$
+      UPDATE public.responses
+      SET respondent_type = 'llm', respondent_id = NULL
+      WHERE id = '48340000-0000-0000-0000-000000000001'
+    $sql$
+  ),
+  '42501',
+  'pesquisador não converte sua resposta humana em LLM anônima'
+);
+RESET ROLE;
+
+SELECT * FROM finish();
 
 ROLLBACK;

--- a/frontend/supabase/tests/responses_llm_actor_integrity.test.sql
+++ b/frontend/supabase/tests/responses_llm_actor_integrity.test.sql
@@ -1,0 +1,145 @@
+-- Regressão: membro não pode plantar resposta "do LLM" com a própria autoria.
+--
+-- Como rodar após `npx supabase db reset`:
+--   docker exec -i supabase_db_frontend psql -U postgres -d postgres \
+--     -X -v ON_ERROR_STOP=1 < supabase/tests/responses_llm_actor_integrity.test.sql
+-- Sucesso = nenhuma exceção e os NOTICE "OK ..." no final. Qualquer FALHOU aborta.
+--
+-- IMPORTANTE — por que este arquivo concede DML explicitamente: o Supabase
+-- remoto concede INSERT/UPDATE/DELETE a `authenticated` no schema public por
+-- default privileges, mas o ambiente local não. Um teste que apenas tentasse o
+-- INSERT malicioso passaria aqui por falta de privilégio (42501) e continuaria
+-- cego ao que produção permite. Os GRANTs abaixo replicam a superfície do
+-- remoto para que a RLS e as constraints sejam de fato exercidas.
+
+BEGIN;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('11100000-0000-0000-0000-000000000001', 'coord@example.test'),
+  ('11100000-0000-0000-0000-000000000002', 'pesquisador@example.test');
+
+INSERT INTO public.clerk_user_mapping (clerk_user_id, supabase_user_id)
+SELECT id::text, id
+FROM auth.users
+WHERE id::text LIKE '11100000-0000-0000-0000-%';
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('22200000-0000-0000-0000-000000000001', 'llm actor integrity',
+   '11100000-0000-0000-0000-000000000001');
+
+INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
+  ('33300000-0000-0000-0000-000000000001', '22200000-0000-0000-0000-000000000001',
+   'doc', 'texto', 'h-doc');
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('22200000-0000-0000-0000-000000000001',
+   '11100000-0000-0000-0000-000000000002', 'pesquisador');
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.responses TO authenticated;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"11100000-0000-0000-0000-000000000002",'
+    || '"supabase_uid":"11100000-0000-0000-0000-000000000002"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+
+-- ========== O braço LLM não aceita autor humano ==========
+DO $$
+BEGIN
+  -- A policy autoriza pelo respondent_id, então este INSERT passa pela RLS: o
+  -- pesquisador é dono da linha. Quem recusa é a constraint de schema — sem
+  -- ela, esta resposta entraria como "a do LLM", idêntica à codificação
+  -- humana, e o campo sairia como consenso sem nunca gerar field_review.
+  BEGIN
+    INSERT INTO public.responses
+      (project_id, document_id, respondent_id, respondent_type, answers, is_latest)
+    VALUES
+      ('22200000-0000-0000-0000-000000000001',
+       '33300000-0000-0000-0000-000000000001',
+       '11100000-0000-0000-0000-000000000002',
+       'llm', '{"q1":"forjado"}', true);
+    RAISE EXCEPTION
+      'FALHOU integridade: membro plantou resposta llm com a própria autoria';
+  EXCEPTION
+    WHEN check_violation THEN
+      RAISE NOTICE 'OK: resposta llm com autor humano recusada';
+  END;
+END;
+$$;
+
+-- ========== Sem autor, a policy é quem recusa ==========
+DO $$
+BEGIN
+  -- Contornar a constraint zerando o respondent_id não ajuda: nenhum braço da
+  -- policy cobre a linha (não é dele, e ele não é coordenador nem master).
+  BEGIN
+    INSERT INTO public.responses
+      (project_id, document_id, respondent_id, respondent_type, answers, is_latest)
+    VALUES
+      ('22200000-0000-0000-0000-000000000001',
+       '33300000-0000-0000-0000-000000000001',
+       NULL, 'llm', '{"q1":"forjado"}', true);
+    RAISE EXCEPTION
+      'FALHOU integridade: membro plantou resposta llm anônima';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      RAISE NOTICE 'OK: resposta llm sem autor recusada pela RLS';
+  END;
+END;
+$$;
+
+-- ========== A codificação humana legítima continua passando ==========
+DO $$
+DECLARE
+  n INTEGER;
+BEGIN
+  INSERT INTO public.responses
+    (project_id, document_id, respondent_id, respondent_type, answers, is_latest)
+  VALUES
+    ('22200000-0000-0000-0000-000000000001',
+     '33300000-0000-0000-0000-000000000001',
+     '11100000-0000-0000-0000-000000000002',
+     'humano', '{"q1":"a"}', true);
+
+  SELECT count(*) INTO n FROM public.responses
+  WHERE project_id = '22200000-0000-0000-0000-000000000001'
+    AND respondent_type = 'humano';
+  IF n <> 1 THEN
+    RAISE EXCEPTION 'FALHOU: codificação humana legítima foi bloqueada';
+  END IF;
+
+  RAISE NOTICE 'OK: codificação humana do próprio membro segue permitida';
+END;
+$$;
+
+-- ========== O backend continua podendo gravar o braço LLM ==========
+RESET ROLE;
+SELECT set_config('request.jwt.claims', '', true);
+
+DO $$
+DECLARE
+  n INTEGER;
+BEGIN
+  -- llm_runner grava sem respondent_id: é assim que a constraint distingue o
+  -- LLM de uma pessoa.
+  INSERT INTO public.responses
+    (project_id, document_id, respondent_type, respondent_name, answers, is_latest)
+  VALUES
+    ('22200000-0000-0000-0000-000000000001',
+     '33300000-0000-0000-0000-000000000001',
+     'llm', 'openai/gpt-5', '{"q1":"b"}', true);
+
+  SELECT count(*) INTO n FROM public.responses
+  WHERE project_id = '22200000-0000-0000-0000-000000000001'
+    AND respondent_type = 'llm';
+  IF n <> 1 THEN
+    RAISE EXCEPTION 'FALHOU: backend não conseguiu gravar a resposta do LLM';
+  END IF;
+
+  RAISE NOTICE 'OK: backend grava o braço llm sem respondent_id';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
> [!NOTE]
> **`20260716154500_responses_llm_actor_integrity.sql` foi aplicada no remoto antes do merge.**
>
> O preflight encontrou 0 respostas LLM com autoria humana, e a migration consta no histórico remoto.

## Problema

A policy `Users manage own responses` era `FOR ALL` com `USING` e sem `WITH CHECK`. O Postgres reutilizava o `USING` para INSERT/UPDATE: um pesquisador podia marcar como `llm` uma resposta com o próprio `respondent_id`, enquanto coordenador, criador e master podiam gravar uma resposta `llm` anônima pelos braços administrativos da policy.

Como `final_answers` e a detecção de divergência escolhem o braço LLM por `respondent_type`, uma resposta forjada e idêntica à codificação humana podia entrar como consenso sem gerar `field_review`.

## Correção

A migration fecha dois contratos complementares. Primeiro, o `WITH CHECK` explícito permite que sessões JWT gravem somente respostas `humano`, com identidade própria ou canônica via alias e dentro de projeto acessível; o backend continua gravando respostas LLM pelo service role. Segundo, a constraint `responses_llm_has_no_human_actor_check` torna impossível persistir `respondent_type = 'llm'` com `respondent_id`, inclusive em escritas privilegiadas que ignoram RLS.

O preflight usa conjunto estável: a migration adquire `SHARE ROW EXCLUSIVE`, conta eventuais linhas incompatíveis e só então instala a constraint. Nenhum dado ambíguo é corrigido automaticamente.

## Testes

O teste foi convertido para pgTAP e cobre 10 cenários: backend privilegiado, pesquisador, coordenador, criador, master, outsider, conta-alias e conversão por UPDATE. Um workflow novo sobe um Supabase limpo em todo PR que altera migrations ou esse contrato e executa o arquivo com `supabase test db`.

Verificação local desta revisão:

- schema completo aplicado do zero;
- pgTAP: 10/10;
- payload Python: 6/6;
- Vitest: 1.333/1.333;
- TypeScript: `tsc --noEmit` sem erros;
- `actionlint` e hooks de pre-commit verdes.

## Rollout

Produção possuía 1.154 respostas e, antes da aplicação, 0 linhas `llm` com `respondent_id`. A migration foi aplicada no remoto em 16 de julho de 2026 e confirmada no histórico antes do squash merge.
