### PR TITLE
fix(auto-revisao): reabre a fila quando surge trabalho novo no documento

### DIFF
--- a/frontend/src/actions/__tests__/auto-review-backlog-wiring.test.ts
+++ b/frontend/src/actions/__tests__/auto-review-backlog-wiring.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  makeSupabaseAdminModuleMock,
+  makeSupabaseServerModuleMock,
+  makeFilterAwareSupabaseMock,
+  type RpcCall,
+  type WriteCall,
+} from "@/test-utils/supabase-mock";
+import { authModuleMock } from "@/test-utils/auth-mock";
+
+// Fiação de regenerateAutoReviewBacklog com o reconcile da fila. Arquivo
+// separado de arbitration-retry.test.ts porque este caminho lê `responses` duas
+// vezes na mesma tabela (humano vs LLM, discriminados por respondent_type), o
+// que exige o mock filter-aware — o simples devolveria a mesma linha para os
+// dois e nunca produziria divergência.
+
+// Uma lista só para escritas e RPCs: o que este teste fixa é a ORDEM entre elas
+// (o reconcile só reabre o que o upsert de field_reviews já devolveu ao
+// backlog), e arrays separados não a capturariam.
+type Step = WriteCall | RpcCall;
+let timeline: Step[];
+let tableData: Record<string, unknown[]>;
+
+const hoisted = vi.hoisted(() => ({
+  isCoord: vi.fn<() => Promise<boolean>>(async () => true),
+  adminFactory: vi.fn(),
+}));
+
+function makeClient() {
+  return makeFilterAwareSupabaseMock({
+    tableData,
+    writeCalls: timeline as WriteCall[],
+    rpcCalls: timeline as RpcCall[],
+  });
+}
+
+vi.mock("next/cache", () => ({ revalidatePath: () => {} }));
+vi.mock("@/lib/auth", () => authModuleMock(hoisted.isCoord));
+vi.mock("@/lib/supabase/server", () => makeSupabaseServerModuleMock(makeClient));
+vi.mock("@/lib/supabase/admin", () =>
+  makeSupabaseAdminModuleMock(makeClient, hoisted.adminFactory),
+);
+
+beforeEach(() => {
+  timeline = [];
+  hoisted.isCoord.mockResolvedValue(true);
+  hoisted.adminFactory.mockClear();
+  tableData = {
+    projects: [
+      {
+        id: "p1",
+        pydantic_fields: [
+          { name: "q1", type: "single", options: ["a", "b"], target: "all" },
+        ],
+      },
+    ],
+    // Humano diverge do LLM em q1 → o backlog tem uma linha para materializar.
+    responses: [
+      {
+        id: "h1",
+        project_id: "p1",
+        document_id: "d1",
+        respondent_id: "u1",
+        respondent_type: "humano",
+        is_partial: false,
+        answers: { q1: "a" },
+        answer_field_hashes: null,
+      },
+      {
+        id: "l1",
+        project_id: "p1",
+        document_id: "d1",
+        respondent_type: "llm",
+        is_latest: true,
+        answers: { q1: "b" },
+        answer_field_hashes: null,
+      },
+    ],
+    response_equivalences: [],
+    field_reviews: [],
+    assignments: [],
+  };
+});
+
+async function loadRegenerate() {
+  return (await import("@/actions/field-reviews")).regenerateAutoReviewBacklog;
+}
+
+describe("regenerateAutoReviewBacklog — reconcile da fila", () => {
+  it("reabre a fila depois de devolver field_reviews ao backlog", async () => {
+    const regenerate = await loadRegenerate();
+
+    const r = await regenerate("p1");
+
+    expect(r.success).toBe(true);
+
+    const reopenAt = timeline.findIndex(
+      (s) => (s as RpcCall).fn === "reopen_auto_review_assignments_with_pending",
+    );
+    const upsertAt = timeline.findIndex(
+      (s) =>
+        (s as WriteCall).table === "field_reviews" &&
+        (s as WriteCall).op === "upsert",
+    );
+
+    // Sem o reconcile, um campo devolvido ao backlog fica pendente num
+    // documento que o upsert de assignments — que usa ignoreDuplicates — deixou
+    // 'concluido'; o documento some da fila com veredito por fazer.
+    expect(reopenAt).toBeGreaterThan(-1);
+    expect(timeline[reopenAt]).toEqual({
+      fn: "reopen_auto_review_assignments_with_pending",
+      args: { p_project_id: "p1" },
+    });
+    // Antes do upsert, o reconcile não teria o que enxergar.
+    expect(upsertAt).toBeGreaterThan(-1);
+    expect(reopenAt).toBeGreaterThan(upsertAt);
+  });
+});

--- a/frontend/src/actions/__tests__/field-reviews.test.ts
+++ b/frontend/src/actions/__tests__/field-reviews.test.ts
@@ -5,7 +5,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Builder chainable e thenable — `await builder` (ou apos .select()) resolve
 // { data, error }.
 type WriteCall = { table: string; op: string; payload: unknown };
+type RpcCall = { fn: string; args: unknown };
 let writeCalls: WriteCall[];
+let rpcCalls: RpcCall[];
 let tableData: Record<string, unknown>;
 let projectAccessible: boolean;
 let adminFactoryCalls: number;
@@ -15,6 +17,10 @@ const updateCallsOf = (table?: string) =>
 
 function makeClient() {
   return {
+    rpc: async (fn: string, args: unknown) => {
+      rpcCalls.push({ fn, args });
+      return { data: tableData[`rpc:${fn}`] ?? null, error: null };
+    },
     from: (table: string) => {
       // `limited` distingue a query de "ainda há campo pendente?" (usa .limit)
       // do UPDATE de field_reviews (usa .select) — ambos batem na mesma tabela.
@@ -88,6 +94,7 @@ vi.mock("@/lib/supabase/admin", () => ({
 
 beforeEach(() => {
   writeCalls = [];
+  rpcCalls = [];
   projectAccessible = true;
   adminFactoryCalls = 0;
   tableData = {
@@ -319,30 +326,29 @@ describe("submitAutoReview — vereditos equivalente e ambiguo", () => {
   });
 });
 
-describe("submitAutoReview — envio parcial e conclusão do assignment", () => {
-  const assignmentConcluido = () =>
-    updateCallsOf("assignments").find(
-      (u) => (u.payload as Record<string, unknown>).status === "concluido",
-    );
-
-  it("ainda há campo pendente → assignment NÃO é concluído", async () => {
-    tableData.field_reviews_pending = [{ id: "fr2" }];
+describe("submitAutoReview — conclusão do assignment", () => {
+  // "Sobrou campo pendente?" é decidido dentro de sync_auto_review_assignment_status,
+  // sob a mesma trava que assign_auto_review_if_eligible pega — ler as pendências
+  // aqui e gravar 'concluido' em seguida deixaria um stub criado no intervalo
+  // invisível, e o documento sairia da fila com veredito por fazer. Ao TypeScript
+  // resta delegar: o comportamento parcial-vs-completo é coberto em
+  // supabase/tests/auto_review_assignment_reopen.test.sql, contra o Postgres real.
+  it("delega o fechamento à RPC, sem escrever em assignments", async () => {
     const submitAutoReview = await loadSubmit();
     const r = await submitAutoReview("p1", "doc1", [
       { fieldName: "q1", verdict: "admite_erro" },
     ]);
     expect(r.success).toBe(true);
-    expect(assignmentConcluido()).toBeUndefined();
-  });
 
-  it("nenhum campo pendente restante → assignment é concluído", async () => {
-    tableData.field_reviews_pending = [];
-    const submitAutoReview = await loadSubmit();
-    const r = await submitAutoReview("p1", "doc1", [
-      { fieldName: "q1", verdict: "admite_erro" },
-    ]);
-    expect(r.success).toBe(true);
-    expect(assignmentConcluido()).toBeDefined();
+    expect(rpcCalls).toContainEqual({
+      fn: "sync_auto_review_assignment_status",
+      args: {
+        p_project_id: "p1",
+        p_document_id: "doc1",
+        p_user_id: "user1",
+      },
+    });
+    expect(updateCallsOf("assignments")).toHaveLength(0);
   });
 });
 

--- a/frontend/src/actions/__tests__/field-reviews.test.ts
+++ b/frontend/src/actions/__tests__/field-reviews.test.ts
@@ -8,6 +8,9 @@ type WriteCall = { table: string; op: string; payload: unknown };
 type RpcCall = { fn: string; args: unknown };
 let writeCalls: WriteCall[];
 let rpcCalls: RpcCall[];
+// Faz uma RPC especifica falhar, por nome — usado para fixar o que sobrevive
+// quando o fechamento da fila cai.
+let rpcErrors: Record<string, string>;
 let tableData: Record<string, unknown>;
 let projectAccessible: boolean;
 let adminFactoryCalls: number;
@@ -19,7 +22,8 @@ function makeClient() {
   return {
     rpc: async (fn: string, args: unknown) => {
       rpcCalls.push({ fn, args });
-      return { data: tableData[`rpc:${fn}`] ?? null, error: null };
+      const message = rpcErrors[fn];
+      return { data: null, error: message ? { message } : null };
     },
     from: (table: string) => {
       // `limited` distingue a query de "ainda há campo pendente?" (usa .limit)
@@ -95,6 +99,7 @@ vi.mock("@/lib/supabase/admin", () => ({
 beforeEach(() => {
   writeCalls = [];
   rpcCalls = [];
+  rpcErrors = {};
   projectAccessible = true;
   adminFactoryCalls = 0;
   tableData = {
@@ -108,7 +113,9 @@ beforeEach(() => {
         llm_response_id: "lr1",
       },
     ],
-    // por padrão não sobra campo pendente → assignment é concluído
+    // Consumida pelo `.limit(1)` de syncArbitragemAssignmentStatus, que ainda
+    // decide o fechamento da ARBITRAGEM no TypeScript (a auto-revisão decide na
+    // RPC). Vazia = nada pendente, o caminho que não explode.
     field_reviews_pending: [],
     // respostas para o contexto do comentario de "ambiguo"
     responses: [
@@ -349,6 +356,28 @@ describe("submitAutoReview — conclusão do assignment", () => {
       },
     });
     expect(updateCallsOf("assignments")).toHaveLength(0);
+  });
+
+  // O fechamento é o ÚLTIMO passo porque a RPC lança e falhar antes da
+  // arbitragem seria definitivo: o veredito já está gravado, então o re-submit
+  // casa 0 linhas no UPDATE (`.is("self_verdict", null)`), `updatedFieldNames`
+  // sai vazio e o árbitro nunca mais é sorteado. Perder o fechamento, não: a
+  // próxima submissão ou o reconcile do backlog o recuperam.
+  it("fechamento falha → arbitragem de contesta_llm já foi criada", async () => {
+    rpcErrors.sync_auto_review_assignment_status = "lock timeout";
+    tableData.project_members = [{ user_id: "arb1", role: "pesquisador" }];
+    const submitAutoReview = await loadSubmit();
+
+    const r = await submitAutoReview("p1", "doc1", [
+      { fieldName: "q1", verdict: "contesta_llm", justification: "discordo" },
+    ]);
+
+    expect(r.success).toBe(false);
+    const order = rpcCalls.map((c) => c.fn);
+    expect(order).toEqual([
+      "assign_arbitration_if_eligible",
+      "sync_auto_review_assignment_status",
+    ]);
   });
 });
 

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -132,7 +132,7 @@ export async function submitAutoReview(
     }
 
     // Sync do assignment auto_revisao — ver lib/auto-revisao-sync.ts.
-    await syncAutoRevisaoAssignmentStatus(admin, projectId, documentId, effectiveId, now);
+    await syncAutoRevisaoAssignmentStatus(admin, projectId, documentId, effectiveId);
 
     // Efeitos colaterais de equivalente/ambiguo precisam rodar tanto para
     // campos recem-atualizados quanto para os que JA estavam com o verdict

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -1008,6 +1008,19 @@ export async function regenerateAutoReviewBacklog(
       if (error) return { success: false, error: error.message };
     }
 
+    if (admin) {
+      // Precisa vir depois dos field_reviews: o upsert de assignments acima usa
+      // ignoreDuplicates e não reabre linha concluída, então um campo devolvido
+      // ao backlog ficaria pendente num documento fora da fila. Reconcilia o
+      // projeto inteiro, não só as linhas deste lote — filas fechadas cedo por
+      // execuções anteriores também voltam.
+      const { error } = await admin.rpc(
+        "reopen_auto_review_assignments_with_pending",
+        { p_project_id: projectId },
+      );
+      if (error) return { success: false, error: error.message };
+    }
+
     await removeOrphanAssignments(supabase, projectId);
 
     revalidatePath(`/projects/${projectId}/analyze/auto-revisao`);

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -131,9 +131,6 @@ export async function submitAutoReview(
       }
     }
 
-    // Sync do assignment auto_revisao — ver lib/auto-revisao-sync.ts.
-    await syncAutoRevisaoAssignmentStatus(admin, projectId, documentId, effectiveId);
-
     // Efeitos colaterais de equivalente/ambiguo precisam rodar tanto para
     // campos recem-atualizados quanto para os que JA estavam com o verdict
     // gravado — retry apos falha parcial (o UPDATE acima casa 0 linhas porque
@@ -312,6 +309,14 @@ export async function submitAutoReview(
         warning = `Não há árbitros elegíveis para ${contested.length} campo(s) contestado(s). Peça ao coordenador para marcar membros como elegíveis em Configuração → Equipe.`;
       }
     }
+
+    // Último passo de propósito: o sync lança se a RPC falhar, e falhar aqui
+    // custa só o fechamento do assignment — que a próxima submissão ou
+    // reopen_auto_review_assignments_with_pending reconciliam. Antes da
+    // arbitragem, a mesma falha seria definitiva: o veredito já está gravado,
+    // então o re-submit casa 0 linhas no UPDATE acima, `updatedFieldNames` sai
+    // vazio e o árbitro de contesta_llm nunca mais seria sorteado.
+    await syncAutoRevisaoAssignmentStatus(admin, projectId, documentId, effectiveId);
 
     revalidatePath(`/projects/${projectId}/analyze/auto-revisao`);
     revalidatePath(`/projects/${projectId}/analyze/arbitragem`);
@@ -1009,11 +1014,17 @@ export async function regenerateAutoReviewBacklog(
     }
 
     if (admin) {
-      // Precisa vir depois dos field_reviews: o upsert de assignments acima usa
-      // ignoreDuplicates e não reabre linha concluída, então um campo devolvido
-      // ao backlog ficaria pendente num documento fora da fila. Reconcilia o
-      // projeto inteiro, não só as linhas deste lote — filas fechadas cedo por
-      // execuções anteriores também voltam.
+      // Depois dos field_reviews: o upsert de assignments acima usa
+      // ignoreDuplicates e não reabre linha concluída. Reconcilia o projeto
+      // inteiro, não só este lote — filas fechadas cedo por execuções
+      // anteriores também voltam.
+      //
+      // Pular quando `admin` é null (lote sem field_reviews) é seguro por um
+      // invariante que não é local: diffReviewsToRemove manda para idsToDelete
+      // TODA linha existente fora do conjunto novo com self_verdict null, e o
+      // DELETE acima as apaga. Lote vazio ⇒ nenhuma pendência sobrevive ⇒ não há
+      // o que reabrir. Se aquele diff um dia passar a preservar pendência, este
+      // gate precisa deixar de depender do tamanho do lote.
       const { error } = await admin.rpc(
         "reopen_auto_review_assignments_with_pending",
         { p_project_id: projectId },

--- a/frontend/src/lib/__tests__/auto-review.test.ts
+++ b/frontend/src/lib/__tests__/auto-review.test.ts
@@ -8,6 +8,11 @@ type UpsertCall = {
   options: unknown;
 };
 
+type RpcCall = {
+  fn: string;
+  args: Record<string, unknown>;
+};
+
 interface MockState {
   project: { pydantic_fields: unknown } | null;
   humanResponse: { id: string; answers: Record<string, unknown> } | null;
@@ -18,6 +23,7 @@ interface MockState {
     response_b_id: string;
   }>;
   upserts: UpsertCall[];
+  rpcs: RpcCall[];
 }
 
 let state: MockState;
@@ -29,6 +35,7 @@ beforeEach(() => {
     llmResponse: null,
     equivalences: [],
     upserts: [],
+    rpcs: [],
   };
 });
 
@@ -80,6 +87,10 @@ vi.mock("@/lib/supabase/admin", () => {
         }
         throw new Error(`Unexpected table: ${table}`);
       },
+      rpc: async (fn: string, args: Record<string, unknown>) => {
+        state.rpcs.push({ fn, args });
+        return { data: null, error: null };
+      },
     };
   };
   return { createSupabaseAdmin: adminFactory };
@@ -124,31 +135,19 @@ describe("createAutoReviewIfDiverges", () => {
     // Apenas q1 diverge
     expect(r.divergentCount).toBe(1);
 
-    const assignmentUpsert = state.upserts.find(
-      (u) => u.table === "assignments",
-    );
-    expect(assignmentUpsert).toBeDefined();
-    expect(assignmentUpsert?.rows).toMatchObject({
-      project_id: "p1",
-      document_id: "doc1",
-      user_id: "user1",
-      type: "auto_revisao",
-      status: "pendente",
-    });
-
-    const frUpsert = state.upserts.find((u) => u.table === "field_reviews");
-    expect(frUpsert).toBeDefined();
-    expect(Array.isArray(frUpsert?.rows)).toBe(true);
-    const rows = frUpsert?.rows as Array<Record<string, unknown>>;
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({
-      project_id: "p1",
-      document_id: "doc1",
-      field_name: "q1",
-      human_response_id: "h1",
-      llm_response_id: "l1",
-      self_reviewer_id: "user1",
-    });
+    expect(state.rpcs).toEqual([
+      {
+        fn: "assign_auto_review_if_eligible",
+        args: {
+          p_project_id: "p1",
+          p_document_id: "doc1",
+          p_self_reviewer_id: "user1",
+          p_field_names: ["q1"],
+          p_human_response_id: "h1",
+          p_llm_response_id: "l1",
+        },
+      },
+    ]);
   });
 
   it("codificacao humana incompleta → divergentCount=0 e nenhum upsert (#174)", async () => {
@@ -186,7 +185,11 @@ describe("createAutoReviewIfDiverges", () => {
     expect(state.upserts).toHaveLength(0);
   });
 
-  it("upserts usam ignoreDuplicates (idempotencia)", async () => {
+  // Antes, os stubs e o assignment eram dois upserts com ignoreDuplicates: um
+  // campo divergente novo nascia pendente sem reabrir o assignment concluído, e
+  // o documento sumia da fila. A reabertura condicional só existe dentro da
+  // RPC, então escrever nessas tabelas por fora traz o bug de volta.
+  it("não escreve em assignments/field_reviews fora da RPC", async () => {
     const { createAutoReviewIfDiverges } = await import("@/lib/auto-review");
     state.project = {
       pydantic_fields: [
@@ -198,8 +201,9 @@ describe("createAutoReviewIfDiverges", () => {
 
     await createAutoReviewIfDiverges("p1", "doc1", "user1");
 
-    for (const u of state.upserts) {
-      expect(u.options).toMatchObject({ ignoreDuplicates: true });
-    }
+    expect(state.upserts).toEqual([]);
+    expect(state.rpcs.map((c) => c.fn)).toEqual([
+      "assign_auto_review_if_eligible",
+    ]);
   });
 });

--- a/frontend/src/lib/__tests__/auto-review.test.ts
+++ b/frontend/src/lib/__tests__/auto-review.test.ts
@@ -97,15 +97,15 @@ vi.mock("@/lib/supabase/admin", () => {
 });
 
 describe("createAutoReviewIfDiverges", () => {
-  it("sem projeto/respostas → divergentCount=0 e nenhum upsert", async () => {
+  it("sem projeto/respostas → divergentCount=0 e nenhuma RPC", async () => {
     const { createAutoReviewIfDiverges } = await import("@/lib/auto-review");
     state.project = null;
     const r = await createAutoReviewIfDiverges("p1", "doc1", "user1");
     expect(r.divergentCount).toBe(0);
-    expect(state.upserts).toHaveLength(0);
+    expect(state.rpcs).toEqual([]);
   });
 
-  it("respostas iguais → divergentCount=0 e nenhum upsert", async () => {
+  it("respostas iguais → divergentCount=0 e nenhuma RPC", async () => {
     const { createAutoReviewIfDiverges } = await import("@/lib/auto-review");
     state.project = {
       pydantic_fields: [
@@ -116,7 +116,7 @@ describe("createAutoReviewIfDiverges", () => {
     state.llmResponse = { id: "l1", answers: { q1: "a" } };
     const r = await createAutoReviewIfDiverges("p1", "doc1", "user1");
     expect(r.divergentCount).toBe(0);
-    expect(state.upserts).toHaveLength(0);
+    expect(state.rpcs).toEqual([]);
   });
 
   it("respostas divergentes → cria 1 assignment + N field_reviews", async () => {
@@ -135,6 +135,11 @@ describe("createAutoReviewIfDiverges", () => {
     // Apenas q1 diverge
     expect(r.divergentCount).toBe(1);
 
+    // Antes, os stubs e o assignment eram dois upserts com ignoreDuplicates: um
+    // campo divergente novo nascia pendente sem reabrir o assignment concluído,
+    // e o documento sumia da fila. A reabertura condicional só existe dentro da
+    // RPC, então escrever nessas tabelas por fora traz o bug de volta.
+    expect(state.upserts).toEqual([]);
     expect(state.rpcs).toEqual([
       {
         fn: "assign_auto_review_if_eligible",
@@ -150,7 +155,7 @@ describe("createAutoReviewIfDiverges", () => {
     ]);
   });
 
-  it("codificacao humana incompleta → divergentCount=0 e nenhum upsert (#174)", async () => {
+  it("codificacao humana incompleta → divergentCount=0 e nenhuma RPC (#174)", async () => {
     const { createAutoReviewIfDiverges } = await import("@/lib/auto-review");
     state.project = {
       pydantic_fields: [
@@ -165,7 +170,9 @@ describe("createAutoReviewIfDiverges", () => {
 
     const r = await createAutoReviewIfDiverges("p1", "doc1", "user1");
     expect(r.divergentCount).toBe(0);
-    expect(state.upserts).toHaveLength(0);
+    // A RPC reabre por pendência viva do revisor, sem filtrar por p_field_names:
+    // chamá-la com lista vazia devolveria à fila um documento já resolvido.
+    expect(state.rpcs).toEqual([]);
   });
 
   it("equivalencia marcada → campo nao conta como divergente", async () => {
@@ -182,28 +189,6 @@ describe("createAutoReviewIfDiverges", () => {
 
     const r = await createAutoReviewIfDiverges("p1", "doc1", "user1");
     expect(r.divergentCount).toBe(0);
-    expect(state.upserts).toHaveLength(0);
-  });
-
-  // Antes, os stubs e o assignment eram dois upserts com ignoreDuplicates: um
-  // campo divergente novo nascia pendente sem reabrir o assignment concluído, e
-  // o documento sumia da fila. A reabertura condicional só existe dentro da
-  // RPC, então escrever nessas tabelas por fora traz o bug de volta.
-  it("não escreve em assignments/field_reviews fora da RPC", async () => {
-    const { createAutoReviewIfDiverges } = await import("@/lib/auto-review");
-    state.project = {
-      pydantic_fields: [
-        { name: "q1", type: "single", options: ["a", "b"], target: "all" },
-      ],
-    };
-    state.humanResponse = { id: "h1", answers: { q1: "a" } };
-    state.llmResponse = { id: "l1", answers: { q1: "b" } };
-
-    await createAutoReviewIfDiverges("p1", "doc1", "user1");
-
-    expect(state.upserts).toEqual([]);
-    expect(state.rpcs.map((c) => c.fn)).toEqual([
-      "assign_auto_review_if_eligible",
-    ]);
+    expect(state.rpcs).toEqual([]);
   });
 });

--- a/frontend/src/lib/auto-review.ts
+++ b/frontend/src/lib/auto-review.ts
@@ -146,9 +146,8 @@ export async function createAutoReviewIfDiverges(
     return { divergentCount: 0 };
   }
 
-  // Stubs e assignment numa transação só, sob a mesma chave que o fechamento
-  // usa: escritos daqui em requests separadas, um campo divergente novo podia
-  // nascer depois do assignment ter sido concluído e nunca mais voltar à fila.
+  // RPC porque stubs e assignment precisam da mesma transação e da mesma trava
+  // que o fechamento pega — ver migration 20260716130000.
   const { error: assignErr } = await admin.rpc("assign_auto_review_if_eligible", {
     p_project_id: projectId,
     p_document_id: documentId,

--- a/frontend/src/lib/auto-review.ts
+++ b/frontend/src/lib/auto-review.ts
@@ -146,53 +146,30 @@ export async function createAutoReviewIfDiverges(
     return { divergentCount: 0 };
   }
 
-  // Upsert assignment auto_revisao para o humano (idempotente via UNIQUE doc+user+type)
-  const { error: asgErr } = await admin.from("assignments").upsert(
-    {
-      project_id: projectId,
-      document_id: documentId,
-      user_id: humanUserId,
-      type: "auto_revisao",
-      status: "pendente",
-    },
-    { onConflict: "document_id,user_id,type", ignoreDuplicates: true },
-  );
-  if (asgErr) {
-    log(
-      "assignment_upsert_failed",
-      { projectId, documentId, userId: humanUserId, error: asgErr.message },
-      "error",
-    );
-    throw new Error(asgErr.message);
-  }
-
-  // Upsert field_reviews stubs (1 por campo divergente)
-  const rows = divergent.map((fieldName) => ({
-    project_id: projectId,
-    document_id: documentId,
-    field_name: fieldName,
-    human_response_id: humanResponse.id,
-    llm_response_id: llmResponse.id,
-    self_reviewer_id: humanUserId,
-  }));
-
-  const { error: frErr } = await admin.from("field_reviews").upsert(rows, {
-    onConflict: "document_id,field_name",
-    ignoreDuplicates: true,
+  // Stubs e assignment numa transação só, sob a mesma chave que o fechamento
+  // usa: escritos daqui em requests separadas, um campo divergente novo podia
+  // nascer depois do assignment ter sido concluído e nunca mais voltar à fila.
+  const { error: assignErr } = await admin.rpc("assign_auto_review_if_eligible", {
+    p_project_id: projectId,
+    p_document_id: documentId,
+    p_self_reviewer_id: humanUserId,
+    p_field_names: divergent,
+    p_human_response_id: humanResponse.id,
+    p_llm_response_id: llmResponse.id,
   });
-  if (frErr) {
+  if (assignErr) {
     log(
-      "field_reviews_upsert_failed",
+      "auto_review_assign_failed",
       {
         projectId,
         documentId,
         userId: humanUserId,
         divergentCount: divergent.length,
-        error: frErr.message,
+        error: assignErr.message,
       },
       "error",
     );
-    throw new Error(frErr.message);
+    throw new Error(assignErr.message);
   }
 
   log("created", {

--- a/frontend/src/lib/auto-revisao-sync.ts
+++ b/frontend/src/lib/auto-revisao-sync.ts
@@ -5,29 +5,21 @@ import type { createSupabaseAdmin } from "@/lib/supabase/admin";
 // Marca o assignment auto_revisao como concluido APENAS quando nao sobra
 // nenhum field_review pendente do doc — o envio e parcial, entao um submit
 // de subconjunto nao pode tirar o doc da fila.
+//
+// A decisao vive na RPC porque ler as pendencias aqui e gravar 'concluido' em
+// seguida sao duas requests: um stub liberado no intervalo por
+// assign_auto_review_if_eligible ficaria invisivel, e o documento sairia da fila
+// com veredito por fazer. A RPC serializa os dois lados pela mesma chave.
 export async function syncAutoRevisaoAssignmentStatus(
   admin: ReturnType<typeof createSupabaseAdmin>,
   projectId: string,
   documentId: string,
   userId: string,
-  now: string,
 ): Promise<void> {
-  const { data: stillPending } = await admin
-    .from("field_reviews")
-    .select("id")
-    .eq("project_id", projectId)
-    .eq("document_id", documentId)
-    .eq("self_reviewer_id", userId)
-    .is("self_verdict", null)
-    .limit(1);
-
-  if (!stillPending || stillPending.length === 0) {
-    await admin
-      .from("assignments")
-      .update({ status: "concluido", completed_at: now })
-      .eq("project_id", projectId)
-      .eq("document_id", documentId)
-      .eq("user_id", userId)
-      .eq("type", "auto_revisao");
-  }
+  const { error } = await admin.rpc("sync_auto_review_assignment_status", {
+    p_project_id: projectId,
+    p_document_id: documentId,
+    p_user_id: userId,
+  });
+  if (error) throw new Error(error.message);
 }

--- a/frontend/src/lib/auto-revisao-sync.ts
+++ b/frontend/src/lib/auto-revisao-sync.ts
@@ -6,10 +6,8 @@ import type { createSupabaseAdmin } from "@/lib/supabase/admin";
 // nenhum field_review pendente do doc — o envio e parcial, entao um submit
 // de subconjunto nao pode tirar o doc da fila.
 //
-// A decisao vive na RPC porque ler as pendencias aqui e gravar 'concluido' em
-// seguida sao duas requests: um stub liberado no intervalo por
-// assign_auto_review_if_eligible ficaria invisivel, e o documento sairia da fila
-// com veredito por fazer. A RPC serializa os dois lados pela mesma chave.
+// A decisao vive na RPC, sob a trava que o produtor tambem pega — ver migration
+// 20260716130000.
 export async function syncAutoRevisaoAssignmentStatus(
   admin: ReturnType<typeof createSupabaseAdmin>,
   projectId: string,

--- a/frontend/supabase/migrations/20260716130000_auto_review_assignment_reopen.sql
+++ b/frontend/supabase/migrations/20260716130000_auto_review_assignment_reopen.sql
@@ -1,0 +1,184 @@
+-- A fila da auto-revisão não voltava quando surgia trabalho novo.
+--
+-- createAutoReviewIfDiverges grava o assignment e os stubs de field_reviews com
+-- upsert + ignoreDuplicates, que ignora a linha existente em vez de devolvê-la
+-- para 'pendente'. Então, depois que o pesquisador conclui a auto-revisão de um
+-- documento, qualquer campo que passe a divergir do LLM — ao editar a
+-- codificação, por exemplo — nasce com self_verdict NULL enquanto o assignment
+-- continua 'concluido'. O documento fica fora da fila com veredito por fazer, e
+-- só volta por intervenção manual.
+--
+-- Os dois upserts também rodam em requests separadas, sem trava: um stub criado
+-- entre a leitura de pendências e o fechamento não é enxergado, porque sob READ
+-- COMMITTED cada statement lê um snapshot novo.
+--
+-- A arbitragem já resolve isso: assign_arbitration_if_eligible pega
+-- lock_arbitration_assignment e reabre com DO UPDATE ... WHERE
+-- status = 'concluido'. Esta migration dá o par equivalente à auto-revisão.
+BEGIN;
+
+-- Atribuição e fechamento da mesma fila compartilham uma única chave, então em
+-- qualquer ordem concorrente ou o fechamento enxerga o campo pendente novo, ou
+-- a atribuição posterior reabre o assignment depois do fechamento.
+CREATE OR REPLACE FUNCTION public.lock_auto_review_assignment(
+  p_project_id UUID,
+  p_document_id UUID,
+  p_user_id UUID
+) RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(
+      'auto-review-assignment:'
+        || p_project_id::text || ':'
+        || p_document_id::text || ':'
+        || p_user_id::text,
+      0
+    )
+  )
+$$;
+
+-- Ambos os chamadores (sync_auto_review_assignment_status e
+-- assign_auto_review_if_eligible) são SECURITY DEFINER e rodam como owner, então
+-- nenhum role precisa deste EXECUTE — concedê-lo só abriria a trava da fila
+-- alheia a qualquer sessão.
+REVOKE ALL ON FUNCTION public.lock_auto_review_assignment(UUID, UUID, UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.lock_auto_review_assignment(UUID, UUID, UUID)
+  TO service_role;
+
+-- Chamada pelo backend (service_role) no fluxo de saveResponse, onde
+-- clerk_uid() é NULL — por isso não há gate de identidade como no sync, e o
+-- REVOKE abaixo é o que mantém a função fora do alcance de authenticated.
+CREATE OR REPLACE FUNCTION public.assign_auto_review_if_eligible(
+  p_project_id UUID,
+  p_document_id UUID,
+  p_self_reviewer_id UUID,
+  p_field_names TEXT[],
+  p_human_response_id UUID,
+  p_llm_response_id UUID
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_created INTEGER;
+BEGIN
+  IF p_field_names IS NULL OR pg_catalog.array_length(p_field_names, 1) IS NULL
+  THEN
+    RETURN 0;
+  END IF;
+
+  -- Mesma chave do fechamento: a partir daqui, sync_auto_review_assignment_status
+  -- para este (projeto, documento, revisor) espera esta transação terminar.
+  PERFORM public.lock_auto_review_assignment(
+    p_project_id,
+    p_document_id,
+    p_self_reviewer_id
+  );
+
+  INSERT INTO public.field_reviews (
+    project_id,
+    document_id,
+    field_name,
+    human_response_id,
+    llm_response_id,
+    self_reviewer_id
+  )
+  SELECT
+    p_project_id,
+    p_document_id,
+    field_name,
+    p_human_response_id,
+    p_llm_response_id,
+    p_self_reviewer_id
+  FROM pg_catalog.unnest(p_field_names) AS field_name
+  ON CONFLICT (document_id, field_name) DO NOTHING;
+
+  GET DIAGNOSTICS v_created = ROW_COUNT;
+
+  -- A reabertura é condicionada ao trabalho pendente real, não a v_created: um
+  -- retry que não cria stub nenhum ainda precisa reabrir um assignment fechado
+  -- cedo demais por uma execução anterior.
+  INSERT INTO public.assignments (
+    project_id,
+    document_id,
+    user_id,
+    type,
+    status
+  ) VALUES (
+    p_project_id,
+    p_document_id,
+    p_self_reviewer_id,
+    'auto_revisao',
+    'pendente'
+  )
+  ON CONFLICT (document_id, user_id, type) DO UPDATE
+  SET status = 'pendente',
+      completed_at = NULL
+  WHERE assignments.status = 'concluido'
+    AND EXISTS (
+      SELECT 1
+      FROM public.field_reviews AS review
+      WHERE review.project_id = p_project_id
+        AND review.document_id = p_document_id
+        AND review.self_reviewer_id = p_self_reviewer_id
+        AND review.self_verdict IS NULL
+    );
+
+  RETURN v_created;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.assign_auto_review_if_eligible(
+  UUID, UUID, UUID, TEXT[], UUID, UUID
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.assign_auto_review_if_eligible(
+  UUID, UUID, UUID, TEXT[], UUID, UUID
+) TO service_role;
+
+-- Reconciliação em lote para a regeneração manual do backlog, que insere
+-- assignments e field_reviews em passos separados e pela mesma razão não
+-- reabria nada. Aqui não há trava por documento: é uma varredura idempotente
+-- de coordenador, e o pior caso de uma corrida é outra rodada reabrir depois.
+CREATE OR REPLACE FUNCTION public.reopen_auto_review_assignments_with_pending(
+  p_project_id UUID
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_reopened INTEGER;
+BEGIN
+  UPDATE public.assignments AS assignment
+  SET status = 'pendente',
+      completed_at = NULL
+  WHERE assignment.project_id = p_project_id
+    AND assignment.type = 'auto_revisao'
+    AND assignment.status = 'concluido'
+    AND EXISTS (
+      SELECT 1
+      FROM public.field_reviews AS review
+      WHERE review.project_id = assignment.project_id
+        AND review.document_id = assignment.document_id
+        AND review.self_reviewer_id = assignment.user_id
+        AND review.self_verdict IS NULL
+    );
+
+  GET DIAGNOSTICS v_reopened = ROW_COUNT;
+  RETURN v_reopened;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION
+  public.reopen_auto_review_assignments_with_pending(UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION
+  public.reopen_auto_review_assignments_with_pending(UUID)
+  TO service_role;
+
+COMMIT;

--- a/frontend/supabase/migrations/20260716130000_auto_review_assignment_reopen.sql
+++ b/frontend/supabase/migrations/20260716130000_auto_review_assignment_reopen.sql
@@ -33,7 +33,6 @@ CREATE OR REPLACE FUNCTION public.lock_auto_review_assignment(
   p_user_id UUID
 ) RETURNS void
 LANGUAGE sql
-SECURITY DEFINER
 SET search_path = ''
 AS $$
   SELECT pg_catalog.pg_advisory_xact_lock(
@@ -47,12 +46,10 @@ AS $$
   )
 $$;
 
--- Ambos os chamadores (assign_auto_review_if_eligible e
--- sync_auto_review_assignment_status) são SECURITY DEFINER e rodam como owner,
--- que mantém o EXECUTE independentemente destes REVOKE. Nenhum role de runtime
--- precisa da trava avulsa, e concedê-la deixaria qualquer sessão segurar a fila
--- alheia até o fim da transação — daí service_role entrar no REVOKE também: as
--- default privileges do schema public dariam EXECUTE a ele por omissão.
+-- service_role entra no REVOKE junto com os roles de cliente: as default
+-- privileges do schema public dariam EXECUTE a ele por omissão, e a trava avulsa
+-- na mão de uma sessão qualquer segura a fila alheia até o fim da transação. Os
+-- dois chamadores continuam alcançando-a por rodarem como owner.
 REVOKE ALL ON FUNCTION public.lock_auto_review_assignment(UUID, UUID, UUID)
   FROM PUBLIC, anon, authenticated, service_role;
 
@@ -74,11 +71,6 @@ AS $$
 DECLARE
   v_created INTEGER;
 BEGIN
-  IF p_field_names IS NULL OR pg_catalog.array_length(p_field_names, 1) IS NULL
-  THEN
-    RETURN 0;
-  END IF;
-
   -- Mesma chave do fechamento: a partir daqui, sync_auto_review_assignment_status
   -- para este (projeto, documento, revisor) espera esta transação terminar.
   PERFORM public.lock_auto_review_assignment(
@@ -107,34 +99,42 @@ BEGIN
 
   GET DIAGNOSTICS v_created = ROW_COUNT;
 
-  -- A reabertura é condicionada ao trabalho pendente real, não a v_created: um
-  -- retry que não cria stub nenhum ainda precisa reabrir um assignment fechado
-  -- cedo demais por uma execução anterior.
+  -- O trabalho pendente real — não v_created — governa criar E reabrir.
+  --
+  -- Reabrir por pendência, e não por ter criado stub agora, é o que faz um retry
+  -- sem stub novo ainda resgatar uma fila fechada cedo demais por uma execução
+  -- anterior. Criar sob a mesma condição fecha o outro lado: a UNIQUE de
+  -- field_reviews é (document_id, field_name) — global, não por humano —, então
+  -- o stub do segundo humano a codificar o documento colide e o DO NOTHING acima
+  -- o descarta. Sem o EXISTS governando o INSERT, ele ganharia uma fila
+  -- 'pendente' sem nenhum field_review seu para revisar, contrariando o contrato
+  -- da constraint (ver 20260513000001/20260513040000: só o primeiro humano entra
+  -- na auto-revisão do par (doc, campo)).
   INSERT INTO public.assignments (
     project_id,
     document_id,
     user_id,
     type,
     status
-  ) VALUES (
+  )
+  SELECT
     p_project_id,
     p_document_id,
     p_self_reviewer_id,
     'auto_revisao',
     'pendente'
+  WHERE EXISTS (
+    SELECT 1
+    FROM public.field_reviews AS review
+    WHERE review.project_id = p_project_id
+      AND review.document_id = p_document_id
+      AND review.self_reviewer_id = p_self_reviewer_id
+      AND review.self_verdict IS NULL
   )
   ON CONFLICT (document_id, user_id, type) DO UPDATE
   SET status = 'pendente',
       completed_at = NULL
-  WHERE assignments.status = 'concluido'
-    AND EXISTS (
-      SELECT 1
-      FROM public.field_reviews AS review
-      WHERE review.project_id = p_project_id
-        AND review.document_id = p_document_id
-        AND review.self_reviewer_id = p_self_reviewer_id
-        AND review.self_verdict IS NULL
-    );
+  WHERE assignments.status = 'concluido';
 
   RETURN v_created;
 END;
@@ -147,18 +147,10 @@ GRANT EXECUTE ON FUNCTION public.assign_auto_review_if_eligible(
   UUID, UUID, UUID, TEXT[], UUID, UUID
 ) TO service_role;
 
--- O outro tomador da trava. Antes o fechamento era SELECT de pendências seguido
--- de UPDATE, em duas requests do cliente admin: entre as duas, um stub recém
--- liberado para o mesmo (documento, auto-revisor) ficava invisível e o
--- assignment ia para 'concluido' com self_verdict IS NULL vivo. Trazido para o
--- banco, o EXISTS e o UPDATE passam a ler o mesmo snapshot sob a trava que
--- assign_auto_review_if_eligible também pega, então em qualquer ordem
--- concorrente ou o fechamento enxerga o campo novo, ou a atribuição reabre o
--- assignment depois do fechamento.
---
--- Chamada pelo backend (service_role) no submit da auto-revisão, onde clerk_uid()
--- é NULL: como no produtor, não há gate de identidade e o REVOKE é o que mantém
--- a função fora do alcance de authenticated.
+-- O outro tomador da trava, e a razão de o fechamento ter saído do TypeScript:
+-- aqui o EXISTS e o UPDATE leem o mesmo snapshot, sob a chave que o produtor
+-- também pega. Mesma superfície do produtor (service_role, sem gate de
+-- identidade).
 CREATE OR REPLACE FUNCTION public.sync_auto_review_assignment_status(
   p_project_id UUID,
   p_document_id UUID,
@@ -190,7 +182,7 @@ BEGIN
 
   UPDATE public.assignments AS assignment
   SET status = 'concluido',
-      completed_at = pg_catalog.statement_timestamp()
+      completed_at = pg_catalog.now()
   WHERE assignment.project_id = p_project_id
     AND assignment.document_id = p_document_id
     AND assignment.user_id = p_user_id

--- a/frontend/supabase/migrations/20260716130000_auto_review_assignment_reopen.sql
+++ b/frontend/supabase/migrations/20260716130000_auto_review_assignment_reopen.sql
@@ -8,13 +8,20 @@
 -- continua 'concluido'. O documento fica fora da fila com veredito por fazer, e
 -- só volta por intervenção manual.
 --
--- Os dois upserts também rodam em requests separadas, sem trava: um stub criado
--- entre a leitura de pendências e o fechamento não é enxergado, porque sob READ
--- COMMITTED cada statement lê um snapshot novo.
+-- Os dois upserts também rodam em requests separadas, sem trava, e o fechamento
+-- (syncAutoRevisaoAssignmentStatus, em TypeScript) lê as pendências e grava
+-- 'concluido' em duas requests próprias: um stub criado entre a leitura e o
+-- UPDATE não é enxergado, porque sob READ COMMITTED cada statement lê um
+-- snapshot novo. Corrigir só o produtor não fecharia essa janela — uma trava com
+-- um único tomador não serializa nada —, então esta migration move o fechamento
+-- para o banco e faz os dois lados compartilharem a mesma chave.
 --
--- A arbitragem já resolve isso: assign_arbitration_if_eligible pega
--- lock_arbitration_assignment e reabre com DO UPDATE ... WHERE
--- status = 'concluido'. Esta migration dá o par equivalente à auto-revisão.
+-- A arbitragem resolve o problema irmão por outro desenho:
+-- assign_arbitration_if_eligible (migration 20260715160000) é SECURITY INVOKER e
+-- serializa por FOR UPDATE em project_members. Aqui a serialização não pode
+-- pendurar-se na linha de membership: quem produz é o backend no fluxo de
+-- saveResponse e quem fecha é o submit da própria fila, então a chave precisa
+-- ser o par (documento, auto-revisor) — daí a trava consultiva abaixo.
 BEGIN;
 
 -- Atribuição e fechamento da mesma fila compartilham uma única chave, então em
@@ -40,18 +47,18 @@ AS $$
   )
 $$;
 
--- Ambos os chamadores (sync_auto_review_assignment_status e
--- assign_auto_review_if_eligible) são SECURITY DEFINER e rodam como owner, então
--- nenhum role precisa deste EXECUTE — concedê-lo só abriria a trava da fila
--- alheia a qualquer sessão.
+-- Ambos os chamadores (assign_auto_review_if_eligible e
+-- sync_auto_review_assignment_status) são SECURITY DEFINER e rodam como owner,
+-- que mantém o EXECUTE independentemente destes REVOKE. Nenhum role de runtime
+-- precisa da trava avulsa, e concedê-la deixaria qualquer sessão segurar a fila
+-- alheia até o fim da transação — daí service_role entrar no REVOKE também: as
+-- default privileges do schema public dariam EXECUTE a ele por omissão.
 REVOKE ALL ON FUNCTION public.lock_auto_review_assignment(UUID, UUID, UUID)
-  FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.lock_auto_review_assignment(UUID, UUID, UUID)
-  TO service_role;
+  FROM PUBLIC, anon, authenticated, service_role;
 
 -- Chamada pelo backend (service_role) no fluxo de saveResponse, onde
--- clerk_uid() é NULL — por isso não há gate de identidade como no sync, e o
--- REVOKE abaixo é o que mantém a função fora do alcance de authenticated.
+-- clerk_uid() é NULL — por isso não há gate de identidade, e o REVOKE abaixo é o
+-- que mantém a função fora do alcance de authenticated.
 CREATE OR REPLACE FUNCTION public.assign_auto_review_if_eligible(
   p_project_id UUID,
   p_document_id UUID,
@@ -139,6 +146,67 @@ REVOKE ALL ON FUNCTION public.assign_auto_review_if_eligible(
 GRANT EXECUTE ON FUNCTION public.assign_auto_review_if_eligible(
   UUID, UUID, UUID, TEXT[], UUID, UUID
 ) TO service_role;
+
+-- O outro tomador da trava. Antes o fechamento era SELECT de pendências seguido
+-- de UPDATE, em duas requests do cliente admin: entre as duas, um stub recém
+-- liberado para o mesmo (documento, auto-revisor) ficava invisível e o
+-- assignment ia para 'concluido' com self_verdict IS NULL vivo. Trazido para o
+-- banco, o EXISTS e o UPDATE passam a ler o mesmo snapshot sob a trava que
+-- assign_auto_review_if_eligible também pega, então em qualquer ordem
+-- concorrente ou o fechamento enxerga o campo novo, ou a atribuição reabre o
+-- assignment depois do fechamento.
+--
+-- Chamada pelo backend (service_role) no submit da auto-revisão, onde clerk_uid()
+-- é NULL: como no produtor, não há gate de identidade e o REVOKE é o que mantém
+-- a função fora do alcance de authenticated.
+CREATE OR REPLACE FUNCTION public.sync_auto_review_assignment_status(
+  p_project_id UUID,
+  p_document_id UUID,
+  p_user_id UUID
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM public.lock_auto_review_assignment(
+    p_project_id,
+    p_document_id,
+    p_user_id
+  );
+
+  -- O envio é parcial: enquanto sobrar um campo sem veredito, o documento
+  -- continua na fila.
+  IF EXISTS (
+    SELECT 1
+    FROM public.field_reviews AS review
+    WHERE review.project_id = p_project_id
+      AND review.document_id = p_document_id
+      AND review.self_reviewer_id = p_user_id
+      AND review.self_verdict IS NULL
+  ) THEN
+    RETURN false;
+  END IF;
+
+  UPDATE public.assignments AS assignment
+  SET status = 'concluido',
+      completed_at = pg_catalog.statement_timestamp()
+  WHERE assignment.project_id = p_project_id
+    AND assignment.document_id = p_document_id
+    AND assignment.user_id = p_user_id
+    AND assignment.type = 'auto_revisao'
+    AND assignment.status IS DISTINCT FROM 'concluido';
+
+  RETURN FOUND;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION
+  public.sync_auto_review_assignment_status(UUID, UUID, UUID)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION
+  public.sync_auto_review_assignment_status(UUID, UUID, UUID)
+  TO service_role;
 
 -- Reconciliação em lote para a regeneração manual do backlog, que insere
 -- assignments e field_reviews em passos separados e pela mesma razão não

--- a/frontend/supabase/tests/auto_review_assignment_reopen.test.sql
+++ b/frontend/supabase/tests/auto_review_assignment_reopen.test.sql
@@ -201,4 +201,97 @@ BEGIN
 END;
 $$;
 
+-- ========== Fechamento: o outro lado do par ==========
+-- Estado herdado do bloco anterior: q1 pendente de novo, q2 já resolvido,
+-- assignment reaberto. O envio é parcial, então enquanto q1 não tiver veredito o
+-- documento continua na fila.
+DO $$
+DECLARE
+  v_closed BOOLEAN;
+  current_status TEXT;
+BEGIN
+  v_closed := public.sync_auto_review_assignment_status(
+    'b0000000-0000-0000-0000-000000000001',
+    'c0000000-0000-0000-0000-000000000001',
+    'a0000000-0000-0000-0000-000000000001'
+  );
+
+  IF v_closed THEN
+    RAISE EXCEPTION 'FALHOU: fechou a fila com campo pendente vivo';
+  END IF;
+
+  SELECT status INTO current_status FROM public.assignments
+  WHERE id = 'e0000000-0000-0000-0000-000000000001';
+  IF current_status <> 'pendente' THEN
+    RAISE EXCEPTION 'FALHOU: envio parcial tirou o doc da fila (status=%)',
+      current_status;
+  END IF;
+
+  -- O pesquisador resolve o que faltava: agora sim a fila fecha.
+  UPDATE public.field_reviews
+    SET self_verdict = 'admite_erro', self_reviewed_at = now()
+    WHERE id = 'f0000000-0000-0000-0000-000000000001';
+
+  v_closed := public.sync_auto_review_assignment_status(
+    'b0000000-0000-0000-0000-000000000001',
+    'c0000000-0000-0000-0000-000000000001',
+    'a0000000-0000-0000-0000-000000000001'
+  );
+
+  IF NOT v_closed THEN
+    RAISE EXCEPTION 'FALHOU: fila sem pendência não fechou';
+  END IF;
+
+  SELECT status INTO current_status FROM public.assignments
+  WHERE id = 'e0000000-0000-0000-0000-000000000001';
+  IF current_status <> 'concluido' THEN
+    RAISE EXCEPTION 'FALHOU: assignment ficou em % após resolver tudo',
+      current_status;
+  END IF;
+
+  RAISE NOTICE 'OK: envio parcial mantém o doc na fila; completo fecha';
+END;
+$$;
+
+-- ========== Grants ==========
+-- Quem cria e quem fecha a auto-revisão é o backend, e a trava não é chamável
+-- por role de runtime nenhum: os dois entrypoints são SECURITY DEFINER e rodam
+-- como owner. Sem estas asserções o REVOKE quebraria em silêncio — as default
+-- privileges do schema public dão EXECUTE a anon/authenticated/service_role por
+-- omissão em toda função nova.
+DO $$
+DECLARE
+  v_fn TEXT;
+  v_entrypoints TEXT[] := ARRAY[
+    'public.assign_auto_review_if_eligible(uuid,uuid,uuid,text[],uuid,uuid)',
+    'public.sync_auto_review_assignment_status(uuid,uuid,uuid)',
+    'public.reopen_auto_review_assignments_with_pending(uuid)'
+  ];
+BEGIN
+  FOREACH v_fn IN ARRAY v_entrypoints LOOP
+    IF has_function_privilege('anon', v_fn, 'EXECUTE')
+       OR has_function_privilege('authenticated', v_fn, 'EXECUTE') THEN
+      RAISE EXCEPTION 'FALHOU: % alcançável por role de cliente', v_fn;
+    END IF;
+    IF NOT has_function_privilege('service_role', v_fn, 'EXECUTE') THEN
+      RAISE EXCEPTION 'FALHOU: % inalcançável pelo backend', v_fn;
+    END IF;
+  END LOOP;
+
+  FOREACH v_fn IN ARRAY ARRAY[
+    'public.lock_auto_review_assignment(uuid,uuid,uuid)'
+  ] LOOP
+    IF has_function_privilege('anon', v_fn, 'EXECUTE')
+       OR has_function_privilege('authenticated', v_fn, 'EXECUTE')
+       OR has_function_privilege('service_role', v_fn, 'EXECUTE') THEN
+      RAISE EXCEPTION
+        'FALHOU: % chamável avulsa — uma sessão poderia segurar a fila alheia',
+        v_fn;
+    END IF;
+  END LOOP;
+
+  RAISE NOTICE 'OK: entrypoints service_role-only e trava fora de alcance';
+END;
+$$;
+
 ROLLBACK;

--- a/frontend/supabase/tests/auto_review_assignment_reopen.test.sql
+++ b/frontend/supabase/tests/auto_review_assignment_reopen.test.sql
@@ -210,6 +210,17 @@ DECLARE
   v_closed BOOLEAN;
   current_status TEXT;
 BEGIN
+  -- Único bloco que depende do estado deixado pelo anterior. Sem este guard,
+  -- reordenar os blocos faria a falha acusar a RPC em vez da ordem do arquivo.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.field_reviews
+    WHERE document_id = 'c0000000-0000-0000-0000-000000000001'
+      AND self_verdict IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'pré-condição do cenário quebrou: o bloco anterior não deixou campo pendente';
+  END IF;
+
   v_closed := public.sync_auto_review_assignment_status(
     'b0000000-0000-0000-0000-000000000001',
     'c0000000-0000-0000-0000-000000000001',
@@ -253,6 +264,141 @@ BEGIN
 END;
 $$;
 
+-- ========== Segundo humano não herda fila alheia ==========
+-- A UNIQUE de field_reviews é (document_id, field_name) — global, não por
+-- humano: só o primeiro que codifica entra na auto-revisão do par (doc, campo).
+-- O stub do segundo colide e é descartado; sem o EXISTS governando o INSERT do
+-- assignment, ele ganharia uma fila 'pendente' sem nada para revisar.
+DO $$
+DECLARE
+  v_created INTEGER;
+  n INTEGER;
+BEGIN
+  INSERT INTO auth.users (id, email) VALUES
+    ('a0000000-0000-0000-0000-000000000002', 'segundo@example.test');
+  INSERT INTO public.project_members (project_id, user_id, role) VALUES
+    ('b0000000-0000-0000-0000-000000000001',
+     'a0000000-0000-0000-0000-000000000002', 'pesquisador');
+  INSERT INTO public.responses
+    (id, project_id, document_id, respondent_id, respondent_type, answers)
+  VALUES
+    ('d0000000-0000-0000-0000-000000000003',
+     'b0000000-0000-0000-0000-000000000001',
+     'c0000000-0000-0000-0000-000000000001',
+     'a0000000-0000-0000-0000-000000000002', 'humano', '{"q1":"z","q2":"w"}');
+
+  v_created := public.assign_auto_review_if_eligible(
+    'b0000000-0000-0000-0000-000000000001',
+    'c0000000-0000-0000-0000-000000000001',
+    'a0000000-0000-0000-0000-000000000002',
+    ARRAY['q1', 'q2'],
+    'd0000000-0000-0000-0000-000000000003',
+    'd0000000-0000-0000-0000-000000000002'
+  );
+
+  IF v_created <> 0 THEN
+    RAISE EXCEPTION
+      'FALHOU: criou % stub(s) para o segundo humano (a chave é por doc+campo)',
+      v_created;
+  END IF;
+
+  SELECT count(*) INTO n FROM public.assignments
+  WHERE document_id = 'c0000000-0000-0000-0000-000000000001'
+    AND user_id = 'a0000000-0000-0000-0000-000000000002'
+    AND type = 'auto_revisao';
+  IF n <> 0 THEN
+    RAISE EXCEPTION
+      'FALHOU: segundo humano ganhou fila de auto-revisão sem field_review seu';
+  END IF;
+
+  RAISE NOTICE 'OK: segundo humano não entra na fila sem trabalho próprio';
+END;
+$$;
+
+-- ========== Produtor e fechamento não divergem de chave ==========
+-- A serialização depende de os dois lados derivarem a MESMA chave, e nenhum
+-- cenário acima enxerga isso: em sessão única a trava nunca bloqueia, então
+-- inlinar a chave num dos lados com string ou ordem de parâmetros diferente
+-- deixaria a suíte verde e a corrida reaberta. pg_locks expõe a chave tomada.
+--
+-- O que este bloco NÃO prova: que o sync chega a pegar a trava. Advisory xact
+-- lock é reentrante, então a segunda aquisição da mesma chave na mesma
+-- transação não cria linha nova em pg_locks — "mesma chave" e "nenhuma trava"
+-- são indistinguíveis daqui. O que ele prova é que o sync não pega chave
+-- DIVERGENTE (que apareceria como uma segunda linha), que é o modo de falha
+-- silencioso. A serialização de fato exige duas sessões e é verificada à mão:
+-- produtor segurando a trava em transação aberta + SET lock_timeout no
+-- fechamento → 'canceling statement due to lock timeout'.
+DO $$
+DECLARE
+  v_expected BIGINT;
+  v_matching INTEGER;
+  v_before INTEGER;
+  v_mid INTEGER;
+  v_after INTEGER;
+  -- Tripla própria, que nenhum bloco acima tocou: as travas são xact e
+  -- reentrantes, então reusar um par já exercitado esconderia a divergência —
+  -- a trava divergente já estaria tomada e o delta daria zero. Com
+  -- p_field_names vazio as duas funções só pegam a trava: unnest não produz
+  -- linha e o EXISTS não acha pendência, então nada é escrito e nenhuma FK é
+  -- tocada (por isso os UUIDs não precisam existir).
+  k_project CONSTANT UUID := '0000aaaa-0000-0000-0000-00000000000a';
+  k_document CONSTANT UUID := '0000aaaa-0000-0000-0000-00000000000b';
+  k_user CONSTANT UUID := '0000aaaa-0000-0000-0000-00000000000c';
+BEGIN
+  -- Espelha a derivação de lock_auto_review_assignment. Mudar a chave lá exige
+  -- mudar aqui — de propósito: a chave é contrato entre os dois lados.
+  v_expected := pg_catalog.hashtextextended(
+    'auto-review-assignment:'
+      || k_project::text || ':' || k_document::text || ':' || k_user::text,
+    0
+  );
+
+  SELECT count(*) INTO v_before
+  FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid();
+
+  PERFORM public.assign_auto_review_if_eligible(
+    k_project, k_document, k_user, ARRAY[]::TEXT[], NULL, NULL
+  );
+
+  -- A trava é xact: segue segurada até o ROLLBACK final, então dá para
+  -- conferi-la aqui. O lock manager parte a chave de 64 bits em classid (32
+  -- altos) e objid (32 baixos); comparamos as metades com máscara em vez de
+  -- remontar, que estouraria bigint quando o bit alto vem 1.
+  SELECT count(*) INTO v_matching
+  FROM pg_locks
+  WHERE locktype = 'advisory'
+    AND pid = pg_backend_pid()
+    AND classid::BIGINT = ((v_expected >> 32) & 4294967295)
+    AND objid::BIGINT = (v_expected & 4294967295);
+
+  IF v_matching = 0 THEN
+    RAISE EXCEPTION
+      'FALHOU: assign_auto_review_if_eligible não segura a chave derivada de lock_auto_review_assignment (mudou a derivação?)';
+  END IF;
+
+  SELECT count(*) INTO v_mid
+  FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid();
+  IF v_mid <> v_before + 1 THEN
+    RAISE EXCEPTION 'FALHOU: o produtor tomou % travas, esperava 1',
+      v_mid - v_before;
+  END IF;
+
+  PERFORM public.sync_auto_review_assignment_status(k_project, k_document, k_user);
+
+  SELECT count(*) INTO v_after
+  FROM pg_locks WHERE locktype = 'advisory' AND pid = pg_backend_pid();
+
+  IF v_after <> v_mid THEN
+    RAISE EXCEPTION
+      'FALHOU: o fechamento tomou uma trava nova (% → %) — chave divergente do produtor',
+      v_mid, v_after;
+  END IF;
+
+  RAISE NOTICE 'OK: produtor e fechamento não divergem de chave';
+END;
+$$;
+
 -- ========== Grants ==========
 -- Quem cria e quem fecha a auto-revisão é o backend, e a trava não é chamável
 -- por role de runtime nenhum: os dois entrypoints são SECURITY DEFINER e rodam
@@ -262,19 +408,36 @@ $$;
 DO $$
 DECLARE
   v_fn TEXT;
+  v_args TEXT;
   v_entrypoints TEXT[] := ARRAY[
     'public.assign_auto_review_if_eligible(uuid,uuid,uuid,text[],uuid,uuid)',
     'public.sync_auto_review_assignment_status(uuid,uuid,uuid)',
     'public.reopen_auto_review_assignments_with_pending(uuid)'
   ];
+  -- supabase.rpc() envia os argumentos por NOME: renomear um parâmetro mantém a
+  -- assinatura por tipo intacta (e a suíte verde) enquanto produção quebra com
+  -- PGRST202. Estes são os nomes que o TypeScript manda.
+  v_expected_args TEXT[] := ARRAY[
+    'p_project_id uuid, p_document_id uuid, p_self_reviewer_id uuid, p_field_names text[], p_human_response_id uuid, p_llm_response_id uuid',
+    'p_project_id uuid, p_document_id uuid, p_user_id uuid',
+    'p_project_id uuid'
+  ];
+  i INTEGER := 0;
 BEGIN
   FOREACH v_fn IN ARRAY v_entrypoints LOOP
+    i := i + 1;
     IF has_function_privilege('anon', v_fn, 'EXECUTE')
        OR has_function_privilege('authenticated', v_fn, 'EXECUTE') THEN
       RAISE EXCEPTION 'FALHOU: % alcançável por role de cliente', v_fn;
     END IF;
     IF NOT has_function_privilege('service_role', v_fn, 'EXECUTE') THEN
       RAISE EXCEPTION 'FALHOU: % inalcançável pelo backend', v_fn;
+    END IF;
+
+    SELECT pg_get_function_arguments(v_fn::regprocedure) INTO v_args;
+    IF v_args <> v_expected_args[i] THEN
+      RAISE EXCEPTION 'FALHOU: parâmetros de % mudaram: % (esperado %)',
+        v_fn, v_args, v_expected_args[i];
     END IF;
   END LOOP;
 

--- a/frontend/supabase/tests/auto_review_assignment_reopen.test.sql
+++ b/frontend/supabase/tests/auto_review_assignment_reopen.test.sql
@@ -1,0 +1,204 @@
+-- Regressão da reabertura da fila de auto-revisão.
+--
+-- Como rodar após `npx supabase db reset`:
+--   docker exec -i supabase_db_frontend psql -U postgres -d postgres \
+--     -X -v ON_ERROR_STOP=1 < supabase/tests/auto_review_assignment_reopen.test.sql
+-- Sucesso = nenhuma exceção e os NOTICE "OK ..." no final. Qualquer FALHOU aborta.
+--
+-- O upsert com ignoreDuplicates nunca devolve um assignment concluído para
+-- 'pendente': trabalho novo num documento já revisado ficava preso fora da
+-- fila. As funções exercidas aqui rodam como service_role (é o backend que
+-- cria a auto-revisão), então nenhum bloco troca de role. BEGIN ... ROLLBACK.
+
+BEGIN;
+
+-- ========== Fixtures: fila já concluída ==========
+INSERT INTO auth.users (id, email) VALUES
+  ('a0000000-0000-0000-0000-000000000001', 'pesquisador@example.test');
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('b0000000-0000-0000-0000-000000000001', 'auto review reopen',
+   'a0000000-0000-0000-0000-000000000001');
+
+INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
+  ('c0000000-0000-0000-0000-000000000001', 'b0000000-0000-0000-0000-000000000001',
+   'doc', 'texto', 'h-doc');
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('b0000000-0000-0000-0000-000000000001',
+   'a0000000-0000-0000-0000-000000000001', 'pesquisador');
+
+INSERT INTO public.responses
+  (id, project_id, document_id, respondent_id, respondent_type, answers)
+VALUES
+  ('d0000000-0000-0000-0000-000000000001', 'b0000000-0000-0000-0000-000000000001',
+   'c0000000-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000001',
+   'humano', '{"q1":"x","q2":"y"}'),
+  ('d0000000-0000-0000-0000-000000000002', 'b0000000-0000-0000-0000-000000000001',
+   'c0000000-0000-0000-0000-000000000001', NULL, 'llm', '{"q1":"a","q2":"b"}');
+
+-- O pesquisador já revisou o que divergia e a fila fechou.
+INSERT INTO public.assignments
+  (id, project_id, document_id, user_id, type, status, completed_at)
+VALUES
+  ('e0000000-0000-0000-0000-000000000001', 'b0000000-0000-0000-0000-000000000001',
+   'c0000000-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000001',
+   'auto_revisao', 'concluido', now());
+
+INSERT INTO public.field_reviews
+  (id, project_id, document_id, field_name, human_response_id, llm_response_id,
+   self_reviewer_id, self_verdict, self_reviewed_at)
+VALUES
+  ('f0000000-0000-0000-0000-000000000001', 'b0000000-0000-0000-0000-000000000001',
+   'c0000000-0000-0000-0000-000000000001', 'q1',
+   'd0000000-0000-0000-0000-000000000001', 'd0000000-0000-0000-0000-000000000002',
+   'a0000000-0000-0000-0000-000000000001', 'admite_erro', now());
+
+-- ========== Trabalho novo devolve o documento à fila ==========
+DO $$
+DECLARE
+  v_created INTEGER;
+  current_status TEXT;
+BEGIN
+  -- O pesquisador edita a codificação e q2 passa a divergir do LLM. Antes, o
+  -- stub nascia pendente e o assignment continuava 'concluido' — documento fora
+  -- da fila com veredito por fazer, sem volta.
+  v_created := public.assign_auto_review_if_eligible(
+    'b0000000-0000-0000-0000-000000000001',
+    'c0000000-0000-0000-0000-000000000001',
+    'a0000000-0000-0000-0000-000000000001',
+    ARRAY['q2'],
+    'd0000000-0000-0000-0000-000000000001',
+    'd0000000-0000-0000-0000-000000000002'
+  );
+
+  IF v_created <> 1 THEN
+    RAISE EXCEPTION 'FALHOU: esperava 1 stub novo, criou %', v_created;
+  END IF;
+
+  SELECT status INTO current_status FROM public.assignments
+  WHERE id = 'e0000000-0000-0000-0000-000000000001';
+  IF current_status <> 'pendente' THEN
+    RAISE EXCEPTION
+      'FALHOU reabertura: campo pendente novo não devolveu o doc à fila (status=%)',
+      current_status;
+  END IF;
+
+  RAISE NOTICE 'OK: trabalho novo reabre o assignment concluído';
+END;
+$$;
+
+-- ========== Reexecução não recria stub nem apaga veredito ==========
+DO $$
+DECLARE
+  v_created INTEGER;
+  n INTEGER;
+BEGIN
+  -- A auto-revisão dispara a cada submit de codificação, então reexecutar com
+  -- os mesmos campos é o caso comum, não a exceção.
+  v_created := public.assign_auto_review_if_eligible(
+    'b0000000-0000-0000-0000-000000000001',
+    'c0000000-0000-0000-0000-000000000001',
+    'a0000000-0000-0000-0000-000000000001',
+    ARRAY['q1', 'q2'],
+    'd0000000-0000-0000-0000-000000000001',
+    'd0000000-0000-0000-0000-000000000002'
+  );
+
+  IF v_created <> 0 THEN
+    RAISE EXCEPTION 'FALHOU idempotência: recriou % stub(s)', v_created;
+  END IF;
+
+  SELECT count(*) INTO n FROM public.field_reviews
+  WHERE document_id = 'c0000000-0000-0000-0000-000000000001';
+  IF n <> 2 THEN
+    RAISE EXCEPTION 'FALHOU idempotência: % field_reviews (esperava 2)', n;
+  END IF;
+
+  SELECT count(*) INTO n FROM public.field_reviews
+  WHERE id = 'f0000000-0000-0000-0000-000000000001'
+    AND self_verdict = 'admite_erro';
+  IF n <> 1 THEN
+    RAISE EXCEPTION 'FALHOU idempotência: veredito existente foi sobrescrito';
+  END IF;
+
+  RAISE NOTICE 'OK: reexecução não recria stub nem apaga veredito';
+END;
+$$;
+
+-- ========== Fila sem pendência permanece fechada ==========
+DO $$
+DECLARE
+  v_created INTEGER;
+  current_status TEXT;
+BEGIN
+  UPDATE public.field_reviews
+    SET self_verdict = 'admite_erro', self_reviewed_at = now()
+    WHERE document_id = 'c0000000-0000-0000-0000-000000000001'
+      AND self_verdict IS NULL;
+  UPDATE public.assignments SET status = 'concluido', completed_at = now()
+    WHERE id = 'e0000000-0000-0000-0000-000000000001';
+
+  v_created := public.assign_auto_review_if_eligible(
+    'b0000000-0000-0000-0000-000000000001',
+    'c0000000-0000-0000-0000-000000000001',
+    'a0000000-0000-0000-0000-000000000001',
+    ARRAY['q1', 'q2'],
+    'd0000000-0000-0000-0000-000000000001',
+    'd0000000-0000-0000-0000-000000000002'
+  );
+
+  IF v_created <> 0 THEN
+    RAISE EXCEPTION 'FALHOU: criou stub para campo já resolvido';
+  END IF;
+
+  SELECT status INTO current_status FROM public.assignments
+  WHERE id = 'e0000000-0000-0000-0000-000000000001';
+  IF current_status <> 'concluido' THEN
+    RAISE EXCEPTION
+      'FALHOU: reabriu fila sem trabalho pendente (status=%)', current_status;
+  END IF;
+
+  RAISE NOTICE 'OK: fila sem pendência permanece fechada';
+END;
+$$;
+
+-- ========== Reconciliação em lote do backlog ==========
+DO $$
+DECLARE
+  v_reopened INTEGER;
+  current_status TEXT;
+BEGIN
+  -- Simula o que a regeneração manual produzia: field_review devolvido ao
+  -- backlog enquanto o assignment seguia concluído.
+  UPDATE public.field_reviews
+    SET self_verdict = NULL, self_reviewed_at = NULL
+    WHERE id = 'f0000000-0000-0000-0000-000000000001';
+
+  v_reopened := public.reopen_auto_review_assignments_with_pending(
+    'b0000000-0000-0000-0000-000000000001'
+  );
+
+  IF v_reopened <> 1 THEN
+    RAISE EXCEPTION 'FALHOU backlog: reabriu % assignment(s)', v_reopened;
+  END IF;
+
+  SELECT status INTO current_status FROM public.assignments
+  WHERE id = 'e0000000-0000-0000-0000-000000000001';
+  IF current_status <> 'pendente' THEN
+    RAISE EXCEPTION 'FALHOU backlog: assignment ficou em %', current_status;
+  END IF;
+
+  v_reopened := public.reopen_auto_review_assignments_with_pending(
+    'b0000000-0000-0000-0000-000000000001'
+  );
+  IF v_reopened <> 0 THEN
+    RAISE EXCEPTION 'FALHOU backlog: reabriu % assignment(s) já pendentes',
+      v_reopened;
+  END IF;
+
+  RAISE NOTICE 'OK: backlog reconcilia fila fechada com campo pendente';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
> [!WARNING]
> **Aplicar `20260716130000_auto_review_assignment_reopen.sql` no remoto ANTES do merge.**
>
> Este PR não está bloqueado por outro PR — mas tem um **pré-requisito operacional**. A migration cria `assign_auto_review_if_eligible` / `lock_auto_review_assignment` / `sync_auto_review_assignment_status`, e o código passa a chamá-las via `.rpc()`. O merge dispara deploy automático e a migration é manual: **mergear antes de aplicá-la sobe código que chama RPC inexistente**. Mesmo padrão do #135/PR #455.
>
> Ordem: aplicar a migration no remoto → mergear. (Detalhe em "Rollout", abaixo.)

## Problema

`createAutoReviewIfDiverges` grava o assignment e os stubs de `field_reviews` com `upsert` + `ignoreDuplicates`, que **ignora a linha existente** em vez de devolvê-la para `'pendente'`.

Consequência, determinística: depois que o pesquisador conclui a auto-revisão de um documento, qualquer campo que passe a divergir do LLM — ao editar a codificação, por exemplo — nasce com `self_verdict NULL` enquanto o assignment continua `'concluido'`. **O documento fica fora da fila com veredito por fazer e só volta por intervenção manual.** A regeneração manual do backlog tem o mesmo efeito, porque escreve `assignments` e `field_reviews` em passos separados.

Há também uma corrida. Os dois lados da fila rodam em requests separadas e sem trava: o produtor cria o stub, e o fechamento (`syncAutoRevisaoAssignmentStatus`, em TypeScript) lê as pendências e grava `'concluido'` em duas requests próprias. Um stub criado entre a leitura e o `UPDATE` não é enxergado, porque sob READ COMMITTED cada statement lê um snapshot novo.

## Correção

Uma RPC transacional para cada lado da fila, ambas sob a mesma chave `(projeto, documento, auto-revisor)`:

- **`assign_auto_review_if_eligible`** — stubs e assignment na mesma transação. Um único `EXISTS` de trabalho pendente governa **criar e reabrir**: reabrir por pendência (e não por ter criado stub agora) é o que faz um retry sem stub novo resgatar uma fila fechada cedo demais; criar sob a mesma condição impede a fila vazia descrita abaixo.
- **`sync_auto_review_assignment_status`** — traz o fechamento para o banco, para o `EXISTS` e o `UPDATE` lerem o mesmo snapshot sob a trava que o produtor também pega. Sem este lado a trava teria um tomador só, e **uma trava com um único tomador não serializa nada**.
- **`reopen_auto_review_assignments_with_pending`** — reconcilia o backlog em lote, para a regeneração manual.

As funções são `service_role` (quem cria e quem fecha a auto-revisão é o backend). O `REVOKE` mantém `authenticated` fora — e a trava fica fora do alcance de todo role de runtime, inclusive `service_role`: os dois chamadores são `SECURITY DEFINER` e rodam como owner, e concedê-la deixaria qualquer sessão segurar a fila alheia. Como as default privileges do schema `public` dão EXECUTE por omissão, não bastava omitir o `GRANT`.

Nota sobre o desenho: a arbitragem resolve o problema irmão por outro caminho — `assign_arbitration_if_eligible` é `SECURITY INVOKER` e serializa por `FOR UPDATE` em `project_members`. Aqui a serialização não pode pendurar-se na linha de membership, porque quem produz é o backend no fluxo de `saveResponse` e quem fecha é o submit da própria fila; daí a trava consultiva na chave do par.

## Dois defeitos achados revisando o próprio PR

- **O fechamento é o último passo da action.** A RPC lança, e lançar **antes** do sorteio de árbitro era definitivo: o veredito já está gravado, então o re-submit casa 0 linhas no `UPDATE` (`.is("self_verdict", null)`), `updatedFieldNames` sai vazio e o árbitro de `contesta_llm` nunca mais seria sorteado. Perder o fechamento, não: a próxima submissão ou o reconcile o recuperam.
- **Fila só nasce com trabalho dentro.** A UNIQUE de `field_reviews` é `(document_id, field_name)` — global, não por humano —, então o stub do segundo humano a codificar colide e é descartado, mas a fila `'pendente'` dele nascia vazia. O contrato já dizia o oposto (`20260513040000`: só o primeiro humano entra na auto-revisão do par). Pré-existente na main; entra aqui por viver no statement que este PR reescreve.

## Nota sobre os testes alterados

O teste que fixava `ignoreDuplicates: true` foi substituído — **ele fixava o defeito**. As quatro asserções `state.upserts` de `auto-review.test.ts` — inclusive o guard do #174 — espiavam um canal que o código não usa mais desde a troca para RPC e **passavam a toa**; agora asserem as RPCs. Os dois testes de "envio parcial vs. completo" viraram um teste de delegação: a decisão saiu do TypeScript, e mantê-los seria testar o mock; o comportamento passou a ser coberto contra o Postgres real.

## Verificação

- Suíte SQL: 8 cenários (trabalho novo reabre; reexecução não recria stub nem apaga veredito; fila sem pendência permanece fechada; backlog reconcilia; envio parcial mantém na fila e completo fecha; segundo humano não entra sem trabalho próprio; produtor e fechamento não divergem de chave; entrypoints `service_role`-only com a trava fora de alcance).
- **Todo teste novo foi verificado nos dois sentidos** — reintroduzi cada defeito e confirmei o vermelho antes de aceitar o verde.
- Serialização provada com duas sessões: com o produtor segurando a trava em transação aberta, o fechamento bloqueia e estoura `lock_timeout` dentro de `sync_auto_review_assignment_status`, na linha do `PERFORM lock_auto_review_assignment`.
- `tsc --noEmit` limpo; vitest completo (1282) passa; pre-push inteiro verde, incluindo e2e-smoke e `fallow audit`, sem skips.

## Rollout

A migration precisa ser aplicada no remoto antes do merge.

Encontrado na revisão do #440; extraído para PR próprio por ser independente da identidade canônica.

