### PR TITLE
fix(compare): renderiza opção de multi que saiu do schema

### DIFF
--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -13,6 +13,10 @@ import { normalizeForComparison } from "@/lib/utils";
 import {
   buildResponseGroupKeys,
 } from "@/lib/equivalence";
+import {
+  comparableMultiOptions,
+  multiSelectionSets,
+} from "@/lib/compare-multi-options";
 import { ArrowRight, CheckCircle2, MessageSquare, Lightbulb } from "lucide-react";
 import { FieldHeaderLabel } from "@/components/shared/FieldHeaderLabel";
 import type { VerdictInfo } from "@/lib/compare-reviews";
@@ -145,6 +149,28 @@ export function ComparisonPanel({
   }, [docComplete, docHasNext, documentId]);
 
   const isMulti = fieldType === "multi" && !!fieldOptions?.length;
+
+  // Opções a exibir num multi: as do schema mais as que alguém marcou e que
+  // saíram do schema depois. Sem a união, uma divergência causada por opção
+  // removida — que `computeDivergentFieldNames` conta, pela MESMA primitiva —
+  // não teria linha na tela: o revisor via tudo concordando e não conseguia
+  // resolver o campo, que voltava à fila para sempre. Pior, `isAnswerCorrect`
+  // compara o conjunto do veredito com o da resposta, então a opção nunca
+  // renderizada nunca entrava no veredito e marcava a resposta como incorreta
+  // em definitivo (#484). As do schema mantêm posição — e portanto o atalho
+  // numérico. Calculado aqui, e não no MultiOptionReview, para o `optionCount`
+  // dos atalhos não recomputar a mesma união e sair dessincronizado.
+  const displayOptions = useMemo(
+    () =>
+      isMulti
+        ? comparableMultiOptions(
+            fieldOptions ?? [],
+            multiSelectionSets(responses.map((r) => r.answer)),
+          )
+        : [],
+    [isMulti, fieldOptions, responses],
+  );
+
   const groupCount = useMemo(() => {
     const present = responses.filter((r) => r.answer !== undefined);
     const groupKeys = buildResponseGroupKeys(present, equivalences, (r) =>
@@ -200,7 +226,7 @@ export function ComparisonPanel({
           <MultiOptionReview
             key={`${documentId}|${fieldName}|${readOnly}`}
             readOnly={readOnly}
-            options={fieldOptions}
+            options={displayOptions}
             responses={responses}
             existingVerdict={existingVerdict}
             isSubmitting={isSavingVerdict}
@@ -349,7 +375,7 @@ export function ComparisonPanel({
           readOnly={readOnly}
           groupCount={groupCount}
           isMulti={isMulti}
-          optionCount={isMulti ? fieldOptions.length : undefined}
+          optionCount={isMulti ? displayOptions.length : undefined}
         />
       )}
     </div>

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -152,14 +152,24 @@ export function ComparisonPanel({
 
   // Opções a exibir num multi: as do schema mais as que alguém marcou e que
   // saíram do schema depois. Sem a união, uma divergência causada por opção
-  // removida — que `computeDivergentFieldNames` conta, pela MESMA primitiva —
+  // removida — que `computeDivergentFieldNames` conta pela mesma primitiva —
   // não teria linha na tela: o revisor via tudo concordando e não conseguia
   // resolver o campo, que voltava à fila para sempre. Pior, `isAnswerCorrect`
   // compara o conjunto do veredito com o da resposta, então a opção nunca
-  // renderizada nunca entrava no veredito e marcava a resposta como incorreta
-  // em definitivo (#484). As do schema mantêm posição — e portanto o atalho
-  // numérico. Calculado aqui, e não no MultiOptionReview, para o `optionCount`
-  // dos atalhos não recomputar a mesma união e sair dessincronizado.
+  // renderizada nunca entrava no veredito e a resposta que a marcasse ficava
+  // sem como ser julgada correta (#484). As do schema mantêm posição — e
+  // portanto o atalho numérico. Calculado aqui, e não no MultiOptionReview,
+  // para o `optionCount` dos atalhos não recomputar a mesma união e sair
+  // dessincronizado.
+  //
+  // A primitiva é a mesma da divergência, mas o CONJUNTO DE ENTRADA é
+  // deliberadamente mais amplo: `computeDivergentFieldNames` filtra por
+  // staleness e visibilidade condicional antes de montar os conjuntos, e aqui
+  // entram todas as respostas — inclusive as stale, que o painel exibe. Ou
+  // seja, este conjunto contém o da divergência: nunca falta linha para uma
+  // opção que divergiu, e pode sobrar linha para uma opção que só uma resposta
+  // stale marcou. Sobrar é coerente com exibir a resposta stale; faltar é o
+  // bug que este código corrige.
   const displayOptions = useMemo(
     () =>
       isMulti

--- a/frontend/src/components/compare/MultiOptionReview.tsx
+++ b/frontend/src/components/compare/MultiOptionReview.tsx
@@ -89,7 +89,17 @@ export function MultiOptionReview({
 
   const handleSubmit = () => {
     if (readOnly || isSubmitting) return;
-    onSubmit(JSON.stringify(choices));
+    // O veredito cobre TODA opção exibida, e não só as chaves presentes no
+    // mapa de escolhas. `choices` é inicializado uma vez (o reset é por `key`
+    // no pai), então uma opção que entrou em `options` depois do mount — ou
+    // que falta num veredito salvo antes de #484 — apareceria na tela, com o
+    // valor de `?? false`, e mesmo assim sairia sem chave do veredito. Como
+    // `isAnswerCorrect` compara CONJUNTOS, chave ausente é exatamente a classe
+    // de bug que este componente corrige: o valor exibido é o valor gravado.
+    const verdict = Object.fromEntries(
+      options.map((opt) => [opt, choices[opt] ?? false]),
+    );
+    onSubmit(JSON.stringify(verdict));
   };
 
   // Keyboard shortcuts: 1-N toggle options, Enter submits.

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/components/stats/SuggestFieldDialog", () => ({
 
 import { ComparisonPanel } from "@/components/compare/ComparisonPanel";
 import type { PydanticField } from "@/lib/types";
+import { panelProps, panelResponse } from "./compare-test-helpers";
 
 afterEach(cleanup);
 
@@ -43,58 +44,38 @@ function renderPanel(
       );
     return (
       <ComparisonPanel
-        readOnly={readOnly}
-        projectId="p1"
-        documentId="d1"
-        documentTitle="Nota técnica 1"
-        fieldName="data_parecer"
-        fieldDescription="Data do parecer"
-        fieldType="date"
-        fieldOptions={null}
-        fields={[FIELD]}
-        fieldIndex={0}
-        totalFields={1}
-        responses={[
-          {
-            id: "r-llm",
-            respondent_type: "llm",
-            respondent_id: null,
-            respondent_name: "Robô",
-            answer: "2021-05-10",
-            is_latest: true,
-            isFieldStale: false,
+        {...panelProps({
+          readOnly,
+          documentTitle: "Nota técnica 1",
+          fieldName: "data_parecer",
+          fieldDescription: "Data do parecer",
+          fieldType: "date",
+          fields: [FIELD],
+          responses: [
+            panelResponse({
+              id: "r-llm",
+              respondent_type: "llm",
+              respondent_name: "Robô",
+              answer: "2021-05-10",
+            }),
+          ],
+          onVerdict,
+          // Estes três são o harness stateful deste arquivo: precisam do
+          // `pendingVerdict` local, então não vêm do builder compartilhado.
+          pendingVerdict,
+          onPrepareVerdict: setPendingVerdict,
+          onConfirmPendingVerdict: () => {
+            if (pendingVerdict) {
+              onVerdict(
+                pendingVerdict.verdict,
+                pendingVerdict.kind === "response"
+                  ? pendingVerdict.chosenResponseId
+                  : undefined,
+              );
+            }
           },
-        ]}
-        existingVerdict={null}
-        reviewed={[false]}
-        isDivergent={true}
-        docStatus={{ complete: false }}
-        onFieldNavigate={vi.fn()}
-        onVerdict={onVerdict}
-        pendingVerdict={pendingVerdict}
-        onPrepareVerdict={setPendingVerdict}
-        onConfirmPendingVerdict={() => {
-          if (pendingVerdict) {
-            onVerdict(
-              pendingVerdict.verdict,
-              pendingVerdict.kind === "response"
-                ? pendingVerdict.chosenResponseId
-                : undefined,
-            );
-          }
-        }}
-        onDiscardPendingVerdict={() => setPendingVerdict(null)}
-        isSavingVerdict={false}
-        onMarkReviewed={vi.fn()}
-        comment=""
-        onCommentChange={vi.fn()}
-        commentCount={0}
-        suggestionCount={0}
-        equivalence={{ allow: false, canManageAnyPair: false }}
-        equivalences={[]}
-        onConfirmEquivalent={vi.fn(async () => {})}
-        onUnmarkEquivalencePair={vi.fn(async () => {})}
-        currentUserId="u1"
+          onDiscardPendingVerdict: () => setPendingVerdict(null),
+        })}
         {...staticProps}
       />
     );

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.multiStaleOptions.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.multiStaleOptions.test.tsx
@@ -12,6 +12,11 @@ vi.mock("@/components/stats/SuggestFieldDialog", () => ({
 
 import { ComparisonPanel } from "@/components/compare/ComparisonPanel";
 import type { PydanticField } from "@/lib/types";
+import {
+  panelProps,
+  panelResponse as resp,
+  type PanelResponse as Resp,
+} from "./compare-test-helpers";
 
 afterEach(cleanup);
 
@@ -24,56 +29,18 @@ const FIELD: PydanticField = {
   description: "Tags",
 } as PydanticField;
 
-type Resp = Parameters<typeof ComparisonPanel>[0]["responses"][number];
-
-function resp(over: Partial<Resp> & { id: string }): Resp {
-  return {
-    respondent_type: "humano",
-    respondent_name: "Anon",
-    respondent_id: null,
-    answer: undefined,
-    is_latest: true,
-    isFieldStale: false,
-    ...over,
-  } as Resp;
-}
-
 function renderPanel(responses: Resp[], onVerdict = vi.fn()) {
   render(
     <ComparisonPanel
-      readOnly={false}
-      projectId="p1"
-      documentId="d1"
-      documentTitle="Doc 1"
-      fieldName="tags"
-      fieldDescription="Tags"
-      fieldType="multi"
-      fieldOptions={FIELD.options}
-      fields={[FIELD]}
-      fieldIndex={0}
-      totalFields={1}
-      responses={responses}
-      existingVerdict={null}
-      reviewed={[false]}
-      isDivergent={true}
-      docStatus={{ complete: false }}
-      onFieldNavigate={vi.fn()}
-      onVerdict={onVerdict}
-      pendingVerdict={null}
-      onPrepareVerdict={vi.fn()}
-      onConfirmPendingVerdict={vi.fn()}
-      onDiscardPendingVerdict={vi.fn()}
-      isSavingVerdict={false}
-      onMarkReviewed={vi.fn()}
-      comment=""
-      onCommentChange={vi.fn()}
-      commentCount={0}
-      suggestionCount={0}
-      equivalence={{ allow: false, canManageAnyPair: false }}
-      equivalences={[]}
-      onConfirmEquivalent={vi.fn(async () => {})}
-      onUnmarkEquivalencePair={vi.fn(async () => {})}
-      currentUserId="u1"
+      {...panelProps({
+        fieldName: "tags",
+        fieldDescription: "Tags",
+        fieldType: "multi",
+        fieldOptions: FIELD.options,
+        fields: [FIELD],
+        responses,
+        onVerdict,
+      })}
     />,
   );
   return onVerdict;
@@ -98,7 +65,7 @@ describe("ComparisonPanel — multi com opção fora das opções atuais (#484)"
     expect(screen.getByText("y")).toBeTruthy();
   });
 
-  it("a opção stale entra no veredito e é resolvível pelo revisor", async () => {
+  it("a opção stale entra no veredito com o pré-preenchimento de maioria", async () => {
     const user = userEvent.setup();
     const onVerdict = renderPanel([
       resp({ id: "ana", respondent_name: "Ana", answer: ["x", "z"] }),
@@ -117,12 +84,57 @@ describe("ComparisonPanel — multi com opção fora das opções atuais (#484)"
     expect(verdict.z).toBe(false);
   });
 
-  it("sem opção stale, o veredito só tem as opções do schema", () => {
+  // O núcleo da issue não é o pré-preenchimento e sim a AGÊNCIA do revisor:
+  // sem linha na tela ele não tinha como dizer que a opção fora do schema é a
+  // correta. Marcar a checkbox e ver o `true` sair no veredito é o que prova
+  // que a divergência ficou resolvível.
+  it("o revisor consegue marcar a opção stale e ela sai true no veredito", async () => {
+    const user = userEvent.setup();
+    const onVerdict = renderPanel([
+      resp({ id: "ana", respondent_name: "Ana", answer: ["x", "z"] }),
+      resp({ id: "bia", respondent_name: "Bia", answer: ["x"] }),
+    ]);
+
+    await user.click(screen.getByText("z"));
+    await user.click(screen.getByRole("button", { name: /Confirmar/i }));
+
+    const verdict = JSON.parse(onVerdict.mock.calls[0][0] as string);
+    expect(verdict.z).toBe(true);
+    expect(verdict.x).toBe(true);
+  });
+
+  it("sem opção stale, o veredito tem exatamente as opções do schema", async () => {
+    const user = userEvent.setup();
     const onVerdict = renderPanel([
       resp({ id: "ana", respondent_name: "Ana", answer: ["x"] }),
       resp({ id: "bia", respondent_name: "Bia", answer: ["x"] }),
     ]);
     expect(screen.queryByText("z")).toBeNull();
-    expect(onVerdict).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /Confirmar/i }));
+
+    const verdict = JSON.parse(onVerdict.mock.calls[0][0] as string);
+    // Toda opção EXIBIDA tem chave no veredito, inclusive a que ninguém marcou
+    // ("y"): `isAnswerCorrect` compara conjuntos, então chave faltando é a
+    // mesma classe de bug em escala menor.
+    expect(Object.keys(verdict).toSorted()).toEqual(["x", "y"]);
+    expect(verdict.x).toBe(true);
+    expect(verdict.y).toBe(false);
+  });
+
+  // Uma resposta stale (isFieldStale) segue exibida no painel, então as opções
+  // que ela marcou também precisam de linha — o conjunto de entrada da união
+  // aqui é deliberadamente mais amplo que o de `computeDivergentFieldNames`.
+  it("opção marcada só por resposta stale também ganha linha", () => {
+    renderPanel([
+      resp({
+        id: "ana",
+        respondent_name: "Ana",
+        answer: ["x", "w"],
+        isFieldStale: true,
+      }),
+      resp({ id: "bia", respondent_name: "Bia", answer: ["x"] }),
+    ]);
+    expect(screen.getByText("w")).toBeTruthy();
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.multiStaleOptions.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.multiStaleOptions.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/components/shared/AddNoteButton", () => ({
+  AddNoteButton: () => <button type="button">Anotar</button>,
+}));
+vi.mock("@/components/stats/SuggestFieldDialog", () => ({
+  SuggestFieldDialog: () => null,
+}));
+
+import { ComparisonPanel } from "@/components/compare/ComparisonPanel";
+import type { PydanticField } from "@/lib/types";
+
+afterEach(cleanup);
+
+// Campo cujas opções mudaram depois da codificação: "z" saiu do schema, mas a
+// resposta de Ana ainda a tem marcada.
+const FIELD: PydanticField = {
+  name: "tags",
+  type: "multi",
+  options: ["x", "y"],
+  description: "Tags",
+} as PydanticField;
+
+type Resp = Parameters<typeof ComparisonPanel>[0]["responses"][number];
+
+function resp(over: Partial<Resp> & { id: string }): Resp {
+  return {
+    respondent_type: "humano",
+    respondent_name: "Anon",
+    respondent_id: null,
+    answer: undefined,
+    is_latest: true,
+    isFieldStale: false,
+    ...over,
+  } as Resp;
+}
+
+function renderPanel(responses: Resp[], onVerdict = vi.fn()) {
+  render(
+    <ComparisonPanel
+      readOnly={false}
+      projectId="p1"
+      documentId="d1"
+      documentTitle="Doc 1"
+      fieldName="tags"
+      fieldDescription="Tags"
+      fieldType="multi"
+      fieldOptions={FIELD.options}
+      fields={[FIELD]}
+      fieldIndex={0}
+      totalFields={1}
+      responses={responses}
+      existingVerdict={null}
+      reviewed={[false]}
+      isDivergent={true}
+      docStatus={{ complete: false }}
+      onFieldNavigate={vi.fn()}
+      onVerdict={onVerdict}
+      pendingVerdict={null}
+      onPrepareVerdict={vi.fn()}
+      onConfirmPendingVerdict={vi.fn()}
+      onDiscardPendingVerdict={vi.fn()}
+      isSavingVerdict={false}
+      onMarkReviewed={vi.fn()}
+      comment=""
+      onCommentChange={vi.fn()}
+      commentCount={0}
+      suggestionCount={0}
+      equivalence={{ allow: false, canManageAnyPair: false }}
+      equivalences={[]}
+      onConfirmEquivalent={vi.fn(async () => {})}
+      onUnmarkEquivalencePair={vi.fn(async () => {})}
+      currentUserId="u1"
+    />,
+  );
+  return onVerdict;
+}
+
+// `computeDivergentFieldNames` conta uma opção fora do schema atual como
+// divergência (união schema + marcadas). Antes, a UI renderizava só as opções
+// atuais: o revisor via tudo concordando e não tinha como resolver o campo, que
+// voltava à fila para sempre — e `isAnswerCorrect`, que compara conjuntos,
+// marcava a resposta que tinha a opção como incorreta em definitivo.
+describe("ComparisonPanel — multi com opção fora das opções atuais (#484)", () => {
+  it("renderiza a opção que saiu do schema, depois das atuais", () => {
+    renderPanel([
+      resp({ id: "ana", respondent_name: "Ana", answer: ["x", "z"] }),
+      resp({ id: "bia", respondent_name: "Bia", answer: ["x"] }),
+    ]);
+
+    expect(screen.getByText("z")).toBeTruthy();
+    // As do schema seguem presentes e na frente — o atalho numérico delas não
+    // muda por causa de uma opção stale.
+    expect(screen.getByText("x")).toBeTruthy();
+    expect(screen.getByText("y")).toBeTruthy();
+  });
+
+  it("a opção stale entra no veredito e é resolvível pelo revisor", async () => {
+    const user = userEvent.setup();
+    const onVerdict = renderPanel([
+      resp({ id: "ana", respondent_name: "Ana", answer: ["x", "z"] }),
+      resp({ id: "bia", respondent_name: "Bia", answer: ["x"] }),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: /Confirmar/i }));
+
+    expect(onVerdict).toHaveBeenCalledTimes(1);
+    const verdict = JSON.parse(onVerdict.mock.calls[0][0] as string);
+    // "x" marcado por 2/2 vence pela maioria; "z" por 1/2 não atinge a maioria
+    // estrita. O que importa é que "z" EXISTE no veredito — antes, a chave nem
+    // era oferecida e o campo ficava travado.
+    expect(verdict).toHaveProperty("z");
+    expect(verdict.x).toBe(true);
+    expect(verdict.z).toBe(false);
+  });
+
+  it("sem opção stale, o veredito só tem as opções do schema", () => {
+    const onVerdict = renderPanel([
+      resp({ id: "ana", respondent_name: "Ana", answer: ["x"] }),
+      resp({ id: "bia", respondent_name: "Bia", answer: ["x"] }),
+    ]);
+    expect(screen.queryByText("z")).toBeNull();
+    expect(onVerdict).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
@@ -11,6 +11,11 @@ vi.mock("@/components/stats/SuggestFieldDialog", () => ({
 
 import { ComparisonPanel } from "@/components/compare/ComparisonPanel";
 import type { PydanticField } from "@/lib/types";
+import {
+  panelProps,
+  panelResponse as resp,
+  type PanelResponse as Resp,
+} from "./compare-test-helpers";
 
 afterEach(cleanup);
 
@@ -20,59 +25,20 @@ const FIELD: PydanticField = {
   description: "Data do parecer",
 } as PydanticField;
 
-type Resp = Parameters<typeof ComparisonPanel>[0]["responses"][number];
-
 function renderPanel(responses: Resp[], fieldHelpText?: string) {
   render(
     <ComparisonPanel
-      readOnly={false}
-      projectId="p1"
-      documentId="d1"
-      documentTitle="Nota técnica 1"
-      fieldName="data_parecer"
-      fieldDescription="Data do parecer"
-      fieldHelpText={fieldHelpText}
-      fieldType="date"
-      fieldOptions={null}
-      fields={[FIELD]}
-      fieldIndex={0}
-      totalFields={1}
-      responses={responses}
-      existingVerdict={null}
-      reviewed={[false]}
-      isDivergent={true}
-      docStatus={{ complete: false }}
-      onFieldNavigate={vi.fn()}
-      onVerdict={vi.fn()}
-      pendingVerdict={null}
-      onPrepareVerdict={vi.fn()}
-      onConfirmPendingVerdict={vi.fn()}
-      onDiscardPendingVerdict={vi.fn()}
-      isSavingVerdict={false}
-      onMarkReviewed={vi.fn()}
-      comment=""
-      onCommentChange={vi.fn()}
-      commentCount={0}
-      suggestionCount={0}
-      equivalence={{ allow: false, canManageAnyPair: false }}
-      equivalences={[]}
-      onConfirmEquivalent={vi.fn(async () => {})}
-      onUnmarkEquivalencePair={vi.fn(async () => {})}
-      currentUserId="u1"
+      {...panelProps({
+        documentTitle: "Nota técnica 1",
+        fieldName: "data_parecer",
+        fieldDescription: "Data do parecer",
+        fieldHelpText,
+        fieldType: "date",
+        fields: [FIELD],
+        responses,
+      })}
     />,
   );
-}
-
-function resp(over: Partial<Resp> & { id: string }): Resp {
-  return {
-    respondent_type: "humano",
-    respondent_name: "Anon",
-    respondent_id: null,
-    answer: undefined,
-    is_latest: true,
-    isFieldStale: false,
-    ...over,
-  } as Resp;
 }
 
 describe("ComparisonPanel — não preencheu este campo (issue #247, ponto 3)", () => {

--- a/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
+++ b/frontend/src/components/compare/__tests__/MultiOptionReview.test.tsx
@@ -169,3 +169,76 @@ describe("MultiOptionReview — reset via key (contrato do ComparisonPanel)", ()
     expect(boxes[1].getAttribute("aria-checked")).toBe("true"); // B vem do novo verdict
   });
 });
+
+// `choices` é inicializado UMA vez (o reset é por `key` no pai), então uma
+// opção que entra em `options` sem troca de documento/campo — a união de
+// opções do ComparisonPanel recalcula quando as respostas são refetchadas —
+// não tem chave no mapa de escolhas. Como `isAnswerCorrect` compara conjuntos,
+// gravar o mapa cru deixaria a opção exibida fora do veredito: a mesma classe
+// de bug do #484, em escala menor.
+describe("MultiOptionReview — veredito cobre toda opção exibida", () => {
+  it("opção que entra em options depois do mount sai no veredito", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const { rerender } = render(
+      <MultiOptionReview
+        key="doc1|campoA"
+        readOnly={false}
+        options={["A"]}
+        responses={[]}
+        existingVerdict={null}
+        isSubmitting={false}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    // Mesma key: sem remount, o inicializador NÃO roda de novo e "Z" nunca
+    // entra em `choices`.
+    rerender(
+      <MultiOptionReview
+        key="doc1|campoA"
+        readOnly={false}
+        options={["A", "Z"]}
+        responses={[]}
+        existingVerdict={null}
+        isSubmitting={false}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    expect(screen.getAllByRole("checkbox")).toHaveLength(2);
+    await user.click(screen.getByRole("button", { name: /Confirmar/i }));
+
+    expect(JSON.parse(onSubmit.mock.calls[0][0])).toEqual({
+      A: false,
+      Z: false,
+    });
+  });
+
+  it("veredito salvo sem a chave de uma opção exibida é completado", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(
+      <MultiOptionReview
+        readOnly={false}
+        options={["A", "Z"]}
+        responses={[]}
+        // Veredito gravado antes do #484: só tem as opções do schema da época.
+        existingVerdict={{
+          verdict: '{"A":true}',
+          chosenResponseId: null,
+          comment: null,
+        }}
+        isSubmitting={false}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Confirmar/i }));
+
+    expect(JSON.parse(onSubmit.mock.calls[0][0])).toEqual({
+      A: true,
+      Z: false,
+    });
+  });
+});

--- a/frontend/src/components/compare/__tests__/compare-test-helpers.ts
+++ b/frontend/src/components/compare/__tests__/compare-test-helpers.ts
@@ -1,4 +1,7 @@
+import { vi } from "vitest";
 import type { CompareDocument } from "@/components/compare/compare-types";
+import type { ComparisonPanel } from "@/components/compare/ComparisonPanel";
+import type { PydanticField } from "@/lib/types";
 
 /**
  * Fixture de `CompareDocument` compartilhada entre os testes de hooks de
@@ -11,5 +14,82 @@ export function doc(id: string, title?: string, text = ""): CompareDocument {
     title: title ?? `Doc ${id}`,
     external_id: null,
     text,
+  };
+}
+
+export type PanelProps = Parameters<typeof ComparisonPanel>[0];
+export type PanelResponse = PanelProps["responses"][number];
+
+/**
+ * Resposta de comparação com os campos obrigatórios preenchidos. `answer`
+ * default é `undefined` — "a resposta não tem este campo" —, que é justamente
+ * o caso que o painel trata de forma especial.
+ */
+export function panelResponse(
+  over: Partial<PanelResponse> & { id: string },
+): PanelResponse {
+  return {
+    respondent_type: "humano",
+    respondent_name: "Anon",
+    respondent_id: null,
+    answer: undefined,
+    is_latest: true,
+    isFieldStale: false,
+    ...over,
+  };
+}
+
+/**
+ * Props completas do `ComparisonPanel`, com os ~30 callbacks e flags que o
+ * componente exige preenchidos por default. Cada arquivo de teste sobrescreve
+ * só o que o caso exercita.
+ *
+ * Existe porque a interface do painel é larga: sem uma base compartilhada, cada
+ * arquivo reimplementava o objeto inteiro e um prop novo obrigava a editar
+ * todos eles. Note que `pendingVerdict` costuma ser estado do harness do
+ * chamador — passar o valor inicial aqui e deixar o componente sob teste
+ * receber o valor stateful continua sendo responsabilidade de quem renderiza.
+ */
+export function panelProps(over: Partial<PanelProps> = {}): PanelProps {
+  const field = {
+    name: "campo",
+    type: "text",
+    description: "Campo",
+  } as PydanticField;
+  return {
+    readOnly: false,
+    projectId: "p1",
+    documentId: "d1",
+    documentTitle: "Doc 1",
+    fieldName: field.name,
+    fieldDescription: field.description ?? "",
+    fieldType: "text",
+    fieldOptions: null,
+    fields: [field],
+    fieldIndex: 0,
+    totalFields: 1,
+    responses: [],
+    existingVerdict: null,
+    reviewed: [false],
+    isDivergent: true,
+    docStatus: { complete: false },
+    onFieldNavigate: vi.fn(),
+    onVerdict: vi.fn(),
+    pendingVerdict: null,
+    onPrepareVerdict: vi.fn(),
+    onConfirmPendingVerdict: vi.fn(),
+    onDiscardPendingVerdict: vi.fn(),
+    isSavingVerdict: false,
+    onMarkReviewed: vi.fn(),
+    comment: "",
+    onCommentChange: vi.fn(),
+    commentCount: 0,
+    suggestionCount: 0,
+    equivalence: { allow: false, canManageAnyPair: false },
+    equivalences: [],
+    onConfirmEquivalent: vi.fn(async () => {}),
+    onUnmarkEquivalencePair: vi.fn(async () => {}),
+    currentUserId: "u1",
+    ...over,
   };
 }

--- a/frontend/src/components/compare/useCompareFieldData.ts
+++ b/frontend/src/components/compare/useCompareFieldData.ts
@@ -49,36 +49,50 @@ export function useCompareFieldData({
   projectPydanticHash,
   equivalencesByDocField,
 }: UseCompareFieldDataParams): CompareFieldData {
-  const docResponses = currentDoc ? responses[currentDoc.id] || [] : [];
+  const docResponses = useMemo(
+    () => (currentDoc ? responses[currentDoc.id] || [] : []),
+    [currentDoc, responses],
+  );
 
   const currentFieldHashes = useMemo(() => buildFieldHashMap(fields), [fields]);
 
-  const fieldResponses: FieldResponse[] = docResponses.map((r) => {
-    const stale = isFieldStale({
-      answerFieldHashes: r.answer_field_hashes,
-      pydanticHash: r.pydantic_hash,
-      fieldName: currentFieldName,
-      currentFieldHashes,
-      projectPydanticHash,
-    });
-    const version =
-      r.schema_version_major !== null
-        ? `${r.schema_version_major}.${r.schema_version_minor ?? 0}.${r.schema_version_patch ?? 0}`
-        : null;
-    return {
-      id: r.id,
-      respondent_type: r.respondent_type,
-      respondent_name: r.respondent_name,
-      respondent_id: r.respondent_id,
-      answer: Object.prototype.hasOwnProperty.call(r.answers, currentFieldName)
-        ? r.answers[currentFieldName]
-        : undefined,
-      justification: r.justifications?.[currentFieldName],
-      is_latest: r.is_latest,
-      isFieldStale: stale,
-      schemaVersion: version,
-    };
-  });
+  // Memoizado porque a identidade deste array é dependência de memos a jusante
+  // — no `ComparisonPanel`, `displayOptions` (a união de opções de um multi) e
+  // `groupCount`. Sem memo aqui, o `.map()` devolvia um array novo a cada
+  // render e aqueles memos nunca acertavam o cache.
+  const fieldResponses: FieldResponse[] = useMemo(
+    () =>
+      docResponses.map((r) => {
+        const stale = isFieldStale({
+          answerFieldHashes: r.answer_field_hashes,
+          pydanticHash: r.pydantic_hash,
+          fieldName: currentFieldName,
+          currentFieldHashes,
+          projectPydanticHash,
+        });
+        const version =
+          r.schema_version_major !== null
+            ? `${r.schema_version_major}.${r.schema_version_minor ?? 0}.${r.schema_version_patch ?? 0}`
+            : null;
+        return {
+          id: r.id,
+          respondent_type: r.respondent_type,
+          respondent_name: r.respondent_name,
+          respondent_id: r.respondent_id,
+          answer: Object.prototype.hasOwnProperty.call(
+            r.answers,
+            currentFieldName,
+          )
+            ? r.answers[currentFieldName]
+            : undefined,
+          justification: r.justifications?.[currentFieldName],
+          is_latest: r.is_latest,
+          isFieldStale: stale,
+          schemaVersion: version,
+        };
+      }),
+    [docResponses, currentFieldName, currentFieldHashes, projectPydanticHash],
+  );
 
   const fieldEquivalences = useMemo<EquivalencePairWire[]>(() => {
     if (!currentDoc || !currentFieldName) return [];

--- a/frontend/src/lib/__tests__/compare-divergence.test.ts
+++ b/frontend/src/lib/__tests__/compare-divergence.test.ts
@@ -173,6 +173,29 @@ describe("computeDivergentFieldNames", () => {
     expect(computeDivergentFieldNames(fields, responses)).toEqual([]);
   });
 
+  // A comparação de multi considera a UNIÃO das opções do schema com as
+  // efetivamente marcadas, então uma opção removida do schema depois da
+  // codificação não some da comparação — sumi-la fabricaria uma concordância
+  // que não existe. É a mesma primitiva que a UI usa para montar as linhas
+  // (ver ComparisonPanel), para que a divergência siga resolvível (#484).
+  it("multi: opção fora das opções atuais ainda diverge", () => {
+    const fields = [field({ name: "tags", type: "multi", options: ["x"] })];
+    const responses = [
+      { id: "1", answers: { tags: ["x", "z"] } },
+      { id: "2", answers: { tags: ["x"] } },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual(["tags"]);
+  });
+
+  it("multi: opção fora das opções atuais marcada por todos não diverge", () => {
+    const fields = [field({ name: "tags", type: "multi", options: ["x"] })];
+    const responses = [
+      { id: "1", answers: { tags: ["x", "z"] } },
+      { id: "2", answers: { tags: ["z", "x"] } },
+    ];
+    expect(computeDivergentFieldNames(fields, responses)).toEqual([]);
+  });
+
   it("staleness: a field absent from a response's answerFieldHashes is excluded from comparison", () => {
     // `b` foi adicionado ao schema depois que a response 1 foi codificada:
     // o answerFieldHashes dela não tem a chave `b`. Sem a resposta 1, sobra

--- a/frontend/src/lib/__tests__/compare-multi-options.test.ts
+++ b/frontend/src/lib/__tests__/compare-multi-options.test.ts
@@ -34,6 +34,12 @@ describe("comparableMultiOptions", () => {
   it("sem respostas, são as opções do schema", () => {
     expect(comparableMultiOptions(["x", "y"], [])).toEqual(["x", "y"]);
   });
+
+  // A UI usa a opção como `key` de lista: schema com opção repetida geraria
+  // duas linhas com a mesma key.
+  it("dedupa opção repetida no próprio schema, mantendo a 1ª posição", () => {
+    expect(comparableMultiOptions(["x", "y", "x"], [])).toEqual(["x", "y"]);
+  });
 });
 
 describe("multiSelectionsAgree", () => {

--- a/frontend/src/lib/__tests__/compare-multi-options.test.ts
+++ b/frontend/src/lib/__tests__/compare-multi-options.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import {
+  comparableMultiOptions,
+  multiSelectionSets,
+  multiSelectionsAgree,
+} from "@/lib/compare-multi-options";
+
+describe("multiSelectionSets", () => {
+  it("converte arrays em conjuntos e ignora não-strings", () => {
+    const [a, b] = multiSelectionSets([["x", 1, "y"], ["x"]]);
+    expect([...a]).toEqual(["x", "y"]);
+    expect([...b]).toEqual(["x"]);
+  });
+
+  it("valor ausente ou não-array vira conjunto vazio (não marcou nada)", () => {
+    const sets = multiSelectionSets([undefined, null, "x"]);
+    expect(sets.every((s) => s.size === 0)).toBe(true);
+  });
+});
+
+describe("comparableMultiOptions", () => {
+  it("mantém a ordem do schema e acrescenta as fora do schema no fim", () => {
+    // A ordem importa: as opções do schema conservam a posição, e portanto o
+    // atalho numérico da UI não muda quando surge uma opção stale.
+    expect(
+      comparableMultiOptions(["x", "y"], multiSelectionSets([["z", "x"], ["w"]])),
+    ).toEqual(["x", "y", "z", "w"]);
+  });
+
+  it("não duplica opção já presente no schema", () => {
+    expect(comparableMultiOptions(["x"], multiSelectionSets([["x"], ["x"]]))).toEqual(["x"]);
+  });
+
+  it("sem respostas, são as opções do schema", () => {
+    expect(comparableMultiOptions(["x", "y"], [])).toEqual(["x", "y"]);
+  });
+});
+
+describe("multiSelectionsAgree", () => {
+  it("mesmo conjunto em ordem diferente concorda", () => {
+    expect(multiSelectionsAgree(["x", "y"], multiSelectionSets([["x", "y"], ["y", "x"]]))).toBe(
+      true,
+    );
+  });
+
+  it("seleções diferentes divergem", () => {
+    expect(multiSelectionsAgree(["x", "y"], multiSelectionSets([["x", "y"], ["x"]]))).toBe(false);
+  });
+
+  // O caminho que a união existe para cobrir e que não tinha teste em lugar
+  // nenhum: a opção saiu do schema mas alguém ainda a tem marcada.
+  it("opção fora do schema atual ainda diverge (#484)", () => {
+    expect(multiSelectionsAgree(["x"], multiSelectionSets([["x", "z"], ["x"]]))).toBe(false);
+  });
+
+  it("opção fora do schema marcada por TODOS concorda", () => {
+    expect(multiSelectionsAgree(["x"], multiSelectionSets([["x", "z"], ["x", "z"]]))).toBe(true);
+  });
+
+  it("sem respostas, concorda vacuamente — o mínimo é dos chamadores", () => {
+    expect(multiSelectionsAgree(["x"], [])).toBe(true);
+  });
+});

--- a/frontend/src/lib/__tests__/export-assemble.test.ts
+++ b/frontend/src/lib/__tests__/export-assemble.test.ts
@@ -193,6 +193,21 @@ describe("assembleExport — auto-fill de concordância", () => {
     });
     expect(d.verdicts.rows).toHaveLength(0);
   });
+
+  // A concordância também considera a união com as opções efetivamente
+  // marcadas: uma opção removida do schema não pode ser ignorada e produzir um
+  // auto-fill de concordância que os codificadores não têm (#484).
+  it("campo multi diverge por opção fora das opções atuais", () => {
+    const d = run({
+      fields: [field("opts", { type: "multi", options: ["x"] })],
+      documents: [doc("A")],
+      responses: [
+        { document_id: "A", respondent_name: "R1", respondent_type: "codificacao", answers: { opts: ["x", "z"] } },
+        { document_id: "A", respondent_name: "R2", respondent_type: "codificacao", answers: { opts: ["x"] } },
+      ],
+    });
+    expect(d.verdicts.rows).toHaveLength(0);
+  });
 });
 
 // --- Prioridade veredicto > concordância > vazio ---

--- a/frontend/src/lib/compare-divergence.ts
+++ b/frontend/src/lib/compare-divergence.ts
@@ -6,6 +6,10 @@ import {
   type EquivalencePair,
 } from "@/lib/equivalence";
 import { fieldExistedWhenCoded } from "@/lib/answer-staleness";
+import {
+  multiSelectionSets,
+  multiSelectionsAgree,
+} from "@/lib/compare-multi-options";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 interface ResponseLike {
@@ -51,25 +55,12 @@ export function computeDivergentFieldNames(
     if (applicable.length < 2) continue;
 
     if (field.type === "multi" && field.options?.length) {
-      const opts = new Set<string>(field.options);
-      const responseSets = applicable.map((r) => {
-        const arr = (r.answers as Record<string, unknown>)?.[field.name];
-        return new Set(
-          Array.isArray(arr) ? arr.filter((v): v is string => typeof v === "string") : [],
-        );
-      });
-      for (const set of responseSets) {
-        for (const v of set) opts.add(v);
+      const responseSets = multiSelectionSets(
+        applicable.map((r) => (r.answers as Record<string, unknown>)?.[field.name]),
+      );
+      if (!multiSelectionsAgree(field.options, responseSets)) {
+        divergent.push(field.name);
       }
-      let hasDivergence = false;
-      for (const opt of opts) {
-        const sels = responseSets.map((s) => s.has(opt));
-        if (sels.length > 0 && !sels.every((s) => s === sels[0])) {
-          hasDivergence = true;
-          break;
-        }
-      }
-      if (hasDivergence) divergent.push(field.name);
       continue;
     }
 

--- a/frontend/src/lib/compare-multi-options.ts
+++ b/frontend/src/lib/compare-multi-options.ts
@@ -1,0 +1,60 @@
+// Regra das "opções comparáveis" de um campo `multi`.
+//
+// Um multi não é comparado pelo array cru: duas respostas com o mesmo conjunto
+// em ordens diferentes concordam. A comparação é feita opção a opção — e o
+// conjunto de opções a considerar é a UNIÃO das opções atuais do schema com
+// tudo que as respostas efetivamente marcaram. A união é o que faz uma opção
+// removida do schema (mas ainda marcada por alguém) continuar sendo comparada,
+// em vez de sumir e fabricar uma concordância que não existe.
+//
+// Vive aqui porque a mesma regra era reimplementada em `compare-divergence`
+// (polaridade "diverge") e em `export/assemble` (polaridade "concorda"), sem
+// teste em nenhum dos dois — e porque o `MultiOptionReview` precisa dela para
+// renderizar as opções que a comparação de fato considera (#484). O filtro de
+// aplicabilidade (staleness, condicional, aridade mínima) fica nos chamadores,
+// que divergem legitimamente.
+
+// Conjuntos de seleção por resposta. Valor não-array (ou ausente) vira conjunto
+// vazio: é "não marcou nada", não um erro.
+export function multiSelectionSets(answers: unknown[]): Set<string>[] {
+  return answers.map(
+    (arr) =>
+      new Set(
+        Array.isArray(arr) ? arr.filter((v): v is string => typeof v === "string") : [],
+      ),
+  );
+}
+
+// União das opções do schema com as efetivamente marcadas. Preserva a ordem do
+// schema e acrescenta as demais na ordem em que aparecem — assim as opções
+// atuais mantêm a posição (e, na UI, o atalho numérico) e as fora do schema
+// entram no fim.
+export function comparableMultiOptions(
+  options: string[],
+  selectionSets: Set<string>[],
+): string[] {
+  const seen = new Set(options);
+  const extra: string[] = [];
+  for (const set of selectionSets) {
+    for (const v of set) {
+      if (seen.has(v)) continue;
+      seen.add(v);
+      extra.push(v);
+    }
+  }
+  return [...options, ...extra];
+}
+
+// True quando toda opção comparável tem seleção uniforme entre as respostas.
+// Sem respostas, concorda vacuamente — os chamadores é que aplicam o mínimo de
+// respondentes.
+export function multiSelectionsAgree(
+  options: string[],
+  selectionSets: Set<string>[],
+): boolean {
+  for (const opt of comparableMultiOptions(options, selectionSets)) {
+    const selections = selectionSets.map((s) => s.has(opt));
+    if (!selections.every((s) => s === selections[0])) return false;
+  }
+  return true;
+}

--- a/frontend/src/lib/compare-multi-options.ts
+++ b/frontend/src/lib/compare-multi-options.ts
@@ -29,20 +29,24 @@ export function multiSelectionSets(answers: unknown[]): Set<string>[] {
 // schema e acrescenta as demais na ordem em que aparecem — assim as opções
 // atuais mantêm a posição (e, na UI, o atalho numérico) e as fora do schema
 // entram no fim.
+//
+// O resultado é sem repetição mesmo quando o schema traz uma opção duplicada:
+// a UI usa a opção como `key` de lista, e duas linhas com a mesma key seriam
+// um erro de render por causa de um schema mal montado.
 export function comparableMultiOptions(
   options: string[],
   selectionSets: Set<string>[],
 ): string[] {
-  const seen = new Set(options);
-  const extra: string[] = [];
-  for (const set of selectionSets) {
-    for (const v of set) {
-      if (seen.has(v)) continue;
-      seen.add(v);
-      extra.push(v);
-    }
-  }
-  return [...options, ...extra];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  const push = (v: string) => {
+    if (seen.has(v)) return;
+    seen.add(v);
+    result.push(v);
+  };
+  for (const opt of options) push(opt);
+  for (const set of selectionSets) for (const v of set) push(v);
+  return result;
 }
 
 // True quando toda opção comparável tem seleção uniforme entre as respostas.

--- a/frontend/src/lib/export/assemble.ts
+++ b/frontend/src/lib/export/assemble.ts
@@ -12,6 +12,10 @@
 
 import type { DocumentMetadata, PydanticField } from "@/lib/types";
 import { normalizeForComparison } from "@/lib/utils";
+import {
+  multiSelectionSets,
+  multiSelectionsAgree,
+} from "@/lib/compare-multi-options";
 import { formatExportValue, formatVerdict } from "./format";
 
 export interface ExportSheet {
@@ -152,21 +156,10 @@ function multiFieldAgrees(
   fieldName: string,
   options: string[]
 ): boolean {
-  const comparableOptions = new Set(options);
-  const responseSets = docResponses.map((r) => {
-    const arr = r.answers?.[fieldName];
-    return new Set(
-      Array.isArray(arr)
-        ? arr.filter((v): v is string => typeof v === "string")
-        : []
-    );
-  });
-  for (const set of responseSets) for (const v of set) comparableOptions.add(v);
-  for (const opt of comparableOptions) {
-    const selections = responseSets.map((s) => s.has(opt));
-    if (!selections.every((s) => s === selections[0])) return false;
-  }
-  return true;
+  return multiSelectionsAgree(
+    options,
+    multiSelectionSets(docResponses.map((r) => r.answers?.[fieldName]))
+  );
 }
 
 // Valor concordante de um campo entre as respostas de um documento, ou null se


### PR DESCRIPTION
Uma opção de campo `multi` removida do schema depois da codificação deixava o campo **divergente e irresolvível** na Comparação. Achado na revisão da #486, mas independente dela: é um travamento ativo hoje.

## Causa

Duas metades que discordam sobre o que é uma opção:

1. **A comparação considera a união** (`compare-divergence.ts`): as opções comparáveis são as do schema **mais tudo que as respostas marcaram**. Uma opção que saiu do schema, mas que só um respondente marcou, mantém o campo divergente — corretamente.
2. **A UI renderiza só as atuais** (`MultiOptionReview` via `ComparisonPanel` ← `currentField?.options`). A opção divergente não tem linha na tela.

O revisor abre o campo, vê todas as checkboxes concordando, e não tem como expressar decisão sobre a opção que causa a divergência. O campo volta para a fila, sempre; só `ambíguo`/`pular` o tiram de lá.

Efeito colateral, e independente da fila: `isAnswerCorrect` (`reviews/queries.ts`) compara o **conjunto** do veredito com o da resposta. Como a opção nunca é renderizada, ela nunca entra no veredito — e a resposta que a marcou não tem como ser julgada correta.

## Correção

A união passa a ser calculada no `ComparisonPanel`, onde as respostas já estão, e alimenta **os dois** consumidores: as linhas do `MultiOptionReview` e o `optionCount` dos atalhos de teclado. Calcular no componente deixaria o `optionCount` recomputando a mesma união e sujeito a dessincronizar.

As opções do schema **mantêm a posição** — e portanto o atalho numérico; as que saíram entram no fim. Pré-preenchimento segue a **mesma regra de maioria** para toda opção: uma regra só, previsível.

Sobre `isAnswerCorrect`: o ganho é de **agência**, não automático. Com o pré-preenchimento de maioria, uma opção marcada por 1 de 2 respondentes sai `false` no veredito, e a resposta que a marcou continua classificada como incorreta — o que é o julgamento correto da maioria. O que muda é que o revisor agora **pode** marcá-la; antes a chave nem era oferecida.

O gate `isMulti` (`fieldOptions?.length`) fica como está de propósito: `compare-divergence` gateia igual (`field.options?.length`), então um multi cujo schema zerou as opções cai no caminho scalar nos **dois** lados. Mexer só na UI dessincronizaria.

**Seguro do lado do dado** (verificado): o veredito de multi já é `JSON.stringify(Record<string, boolean>)` numa coluna de texto livre (`actions/reviews.ts`), sem validação contra `options`; todos os consumidores fazem parse defensivo e `compare-sync` sequer lê o `verdict`. Só o conjunto de chaves muda.

## Segunda causa raiz, da mesma família

`handleSubmit` gravava `JSON.stringify(choices)`, e `choices` é inicializado **uma vez** (o reset é por `key` no pai). Uma opção que entra em `options` sem troca de documento/campo — a união recalcula quando as respostas são refetchadas — aparecia na tela com valor `?? false` e mesmo assim saía **sem chave** do veredito. Idem para veredito salvo antes desta correção. Como `isAnswerCorrect` compara conjuntos, chave ausente é a mesma classe de bug, em escala menor. O veredito agora é materializado sobre `options`: o valor exibido é o valor gravado.

## Simplificação: `lib/compare-multi-options.ts`

A regra da união estava reimplementada em dois lugares com polaridade invertida — `compare-divergence` ("diverge") e `export/assemble.ts` ("concorda") — e **o caminho da união não tinha teste em nenhum dos dois**. Agora é uma primitiva só; o filtro de aplicabilidade (staleness, condicional, aridade) fica nos chamadores, que divergem legitimamente. A primitiva também dedupa opção repetida no próprio schema — a UI usa a opção como `key` de lista.

Nota sobre o conjunto de entrada: a primitiva é a mesma da divergência, mas o conjunto de respostas é deliberadamente mais amplo no painel (`computeDivergentFieldNames` filtra por staleness e visibilidade condicional; o painel exibe as respostas stale, então exibe as opções delas). O conjunto do painel **contém** o da divergência: nunca falta linha para uma opção que divergiu; pode sobrar linha para uma opção que só uma resposta stale marcou — e sobrar é coerente com exibir a resposta stale.

## Verificação

- Suíte completa: **1744 testes**, todos passando; typecheck limpo; todos os gates de pre-push verdes.
- **Prova do vermelho, mutação a mutação**: revertida a correção central, caem 4 testes do painel; revertido o veredito completo, caem 2 do `MultiOptionReview`; revertida a dedupe, cai 1 da primitiva; neutralizada a divergência de multi, caem 2 de `compare-divergence`. Re-provadas depois do rebase, que é onde uma correção some na resolução de conflito.
- Rebaseada sobre a main atual: a branch estava 14 commits atrás, e a main havia reescrito `useCompareFieldData.ts`, `equivalence.ts` e `AgreementGroup.tsx`.
- **Não validei em runtime**: o repro exigiria remover uma opção de um campo num projeto com respostas, e o `.env.local` aponta para produção. A cobertura é de teste de componente no ponto exato da composição.

Refs #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)