### PR TITLE
feat(auth): usa o session token do Clerk em vez do JWT template `supabase`

### DIFF
--- a/frontend/src/app/auth/__tests__/access-completion-reason.test.tsx
+++ b/frontend/src/app/auth/__tests__/access-completion-reason.test.tsx
@@ -69,10 +69,9 @@ describe("AccessCompletionCard — motivos apresentados", () => {
     await userEvent.click(screen.getByRole("button"));
 
     await waitFor(() => expect(refresh).toHaveBeenCalledOnce());
-    expect(getToken).toHaveBeenCalledWith({
-      template: "supabase",
-      skipCache: true,
-    });
+    // Sem `template`: o JWT template legado saiu no #348 e o que se renova aqui
+    // é o session token. `skipCache` continua sendo o que força a reemissão.
+    expect(getToken).toHaveBeenCalledWith({ skipCache: true });
     expect(replace).toHaveBeenCalledWith("/projects/abc");
     expect(completeAccess.mock.invocationCallOrder[0]).toBeLessThan(
       getToken.mock.invocationCallOrder[0],
@@ -109,10 +108,7 @@ describe("AccessCompletionCard — motivos apresentados", () => {
     expect(refresh).toHaveBeenCalled();
     // A renovação continua sendo tentada (aquece o cache que o cliente usa) e a
     // falha vai para o log — só não decide mais a navegação.
-    expect(getToken).toHaveBeenCalledWith({
-      template: "supabase",
-      skipCache: true,
-    });
+    expect(getToken).toHaveBeenCalledWith({ skipCache: true });
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
   });

--- a/frontend/src/app/auth/__tests__/access-completion-token-refresh.test.tsx
+++ b/frontend/src/app/auth/__tests__/access-completion-token-refresh.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+/**
+ * #348: o retry da conclusão de acesso renova o token ANTES de navegar — e a
+ * renovação é best-effort, não um portão.
+ *
+ * `completeAccess` grava o `supabase_uid` na metadata do Clerk, mas o token em
+ * cache no cliente foi emitido antes disso. `skipCache: true` força uma nova
+ * emissão; o `template` saiu no #348, então a chamada não pode mais carregá-lo
+ * (voltaria a emitir um token com `aud` e sem os custom claims).
+ *
+ * A política de NÃO bloquear vem do #440 e é deliberada: o vínculo já está
+ * gravado neste ponto e a página de destino minta o próprio token no servidor
+ * (lib/supabase/server.ts). Quem depende deste cache é só o cliente ao chamar o
+ * FastAPI. Barrar a navegação por um blip anunciaria falha sobre um acesso
+ * concluído.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const calls: string[] = [];
+
+const replace = vi.fn(() => void calls.push("replace"));
+const refresh = vi.fn(() => void calls.push("refresh"));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, refresh }),
+}));
+
+/** Espelha a assinatura real do `getToken` do Clerk. O parâmetro é declarado
+ * (mesmo sem uso) para que as asserções possam inspecionar `mock.calls[0][0]` —
+ * é justamente o argumento que este teste existe para vigiar. */
+const getToken = vi.fn(
+  async (_opts?: {
+    skipCache?: boolean;
+    template?: string;
+  }): Promise<string | null> => {
+    calls.push("getToken");
+    return "tok";
+  },
+);
+vi.mock("@clerk/nextjs", () => ({ useAuth: () => ({ getToken }) }));
+
+const completeAccess = vi.fn();
+vi.mock("@/actions/complete-access", () => ({
+  completeAccess: () => completeAccess(),
+}));
+
+import { AccessCompletionCard } from "@/components/auth/AccessCompletionCard";
+
+afterEach(cleanup);
+beforeEach(() => {
+  calls.length = 0;
+  replace.mockClear();
+  refresh.mockClear();
+  getToken.mockReset().mockImplementation(async () => {
+    calls.push("getToken");
+    return "tok";
+  });
+  completeAccess.mockReset().mockResolvedValue({ ok: true });
+});
+
+function renderCard() {
+  render(
+    <AccessCompletionCard
+      reason="link-pending"
+      actorEmail="ana@exemplo.com"
+      nextUrl="/dashboard"
+    />,
+  );
+}
+
+describe("AccessCompletionCard — renovação do token no retry bem-sucedido", () => {
+  it("renova com `skipCache` e SEM `template`", async () => {
+    // As duas metades importam. `skipCache` é o que faz o Clerk reemitir em vez
+    // de servir o token pré-`completeAccess`; a ausência de `template` é a
+    // invariante do #348 — um `{ template: "supabase" }` aqui voltaria a emitir
+    // token com `aud` e sem `supabase_uid`/`role`.
+    renderCard();
+    await userEvent.click(screen.getByRole("button", { name: /tentar/i }));
+
+    await waitFor(() => expect(getToken).toHaveBeenCalled());
+    expect(getToken).toHaveBeenCalledWith({ skipCache: true });
+    expect(getToken.mock.calls[0][0]).not.toHaveProperty("template");
+  });
+
+  it("espera a renovação terminar antes de navegar", async () => {
+    // Segura a renovação em aberto: enquanto ela não resolve, nenhuma navegação
+    // pode ter acontecido. É o que distingue `await getToken(...)` de um
+    // `void getToken(...)` — este último dispara na ordem certa mas navega com
+    // o token velho mesmo assim, e passaria por uma asserção só de ordem.
+    let liberaToken: () => void = () => {};
+    getToken.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          calls.push("getToken");
+          liberaToken = () => resolve("tok");
+        }),
+    );
+
+    renderCard();
+    await userEvent.click(screen.getByRole("button", { name: /tentar/i }));
+
+    await waitFor(() => expect(getToken).toHaveBeenCalled());
+    expect(replace).not.toHaveBeenCalled();
+
+    liberaToken();
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+    expect(calls).toEqual(["getToken", "replace", "refresh"]);
+  });
+
+  it("NAVEGA mesmo quando a renovação falha (best-effort, não portão)", async () => {
+    // O vínculo já está gravado e a página de destino minta o próprio token no
+    // servidor. Prender a pessoa aqui por um blip de rede anunciaria falha sobre
+    // um acesso concluído — a decisão do #440, que este teste protege de ser
+    // silenciosamente revertida.
+    getToken.mockRejectedValue(new Error("network"));
+    renderCard();
+    await userEvent.click(screen.getByRole("button", { name: /tentar/i }));
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith("/dashboard"));
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("retry que não resolve o vínculo nem tenta renovar o token", async () => {
+    // Sem vínculo novo não há claim novo para buscar: a renovação só faz sentido
+    // depois de `completeAccess` ter gravado a metadata.
+    completeAccess.mockResolvedValue({
+      ok: false,
+      reason: "unknown-recoverable",
+    });
+    renderCard();
+    await userEvent.click(screen.getByRole("button", { name: /tentar/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/não conseguimos concluir/i)).toBeDefined(),
+    );
+    expect(getToken).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/auth/AccessCompletionCard.tsx
+++ b/frontend/src/components/auth/AccessCompletionCard.tsx
@@ -95,13 +95,19 @@ export function AccessCompletionCard({
       const result = await completeAccess();
       if (result.ok) {
         // A action atualiza a metadata no backend do Clerk e o vínculo JÁ está
-        // gravado neste ponto. A renovação abaixo é best-effort, não um portão:
-        // a página de destino é renderizada no servidor e minta o próprio token
-        // por request (lib/supabase/server.ts), então quem depende deste cache
-        // é só o cliente ao chamar o FastAPI (lib/api.ts). Bloquear a navegação
-        // por um blip aqui anunciaria falha sobre um acesso concluído.
+        // gravado neste ponto. O token em cache, porém, foi emitido ANTES disso,
+        // e é dele que sai o claim `supabase_uid` — daí o `skipCache`, que a
+        // própria doc do Clerk indica para claims que "depend on data that can
+        // be updated (e.g. user fields)". Sem `template`: o JWT template saiu no
+        // #348 e o que se renova aqui é o session token.
+        //
+        // Best-effort, não um portão: a página de destino é renderizada no
+        // servidor e minta o próprio token por request (lib/supabase/server.ts),
+        // então quem depende deste cache é só o cliente ao chamar o FastAPI
+        // (lib/api.ts). Bloquear a navegação por um blip aqui anunciaria falha
+        // sobre um acesso que já foi concluído.
         try {
-          await getToken({ template: "supabase", skipCache: true });
+          await getToken({ skipCache: true });
         } catch (error) {
           console.error(
             "AccessCompletionCard: falha ao renovar token após concluir acesso",
@@ -109,6 +115,7 @@ export function AccessCompletionCard({
           );
         }
 
+        // Vínculo confirmado: segue para o destino pretendido ou dashboard.
         router.replace(nextUrl);
         router.refresh();
         return;

--- a/frontend/src/components/shared/__tests__/RunLlmButton.test.tsx
+++ b/frontend/src/components/shared/__tests__/RunLlmButton.test.tsx
@@ -11,11 +11,9 @@ const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }));
 
 vi.mock("@/lib/api", () => ({
   fetchFastAPI,
-  // Réplica do real: busca o token do template "supabase" e lança se vier nulo.
-  requireSupabaseToken: async (
-    gt: (opts: { template: string }) => Promise<string | null>,
-  ) => {
-    const t = await gt({ template: "supabase" });
+  // Réplica do real: busca o session token e lança se vier nulo.
+  requireSupabaseToken: async (gt: () => Promise<string | null>) => {
+    const t = await gt();
     if (!t) throw new Error("MissingAuthTokenError");
     return t;
   },
@@ -46,8 +44,10 @@ describe("RunLlmButton", () => {
     await userEvent.click(screen.getByRole("button"));
 
     await waitFor(() => expect(fetchFastAPI).toHaveBeenCalled());
-    // Token buscado com o template "supabase" (não o de sessão default)...
-    expect(getToken).toHaveBeenCalledWith({ template: "supabase" });
+    // Session token, sem template: o JWT template legado saiu (#348). Passar um
+    // `{ template }` aqui voltaria a gerar um token com `aud`, que o backend
+    // (que agora valida `iss`) não espera mais.
+    expect(getToken).toHaveBeenCalledWith();
     // ...e repassado como 3º argumento (Authorization: Bearer) ao fetch.
     const [path, opts, token] = fetchFastAPI.mock.calls[0];
     expect(path).toBe("/api/llm/run");

--- a/frontend/src/hooks/__tests__/useLlmRunProgress.test.ts
+++ b/frontend/src/hooks/__tests__/useLlmRunProgress.test.ts
@@ -20,10 +20,8 @@ const { toastSuccess, toastError } = vi.hoisted(() => ({
 // token do template "supabase" e lança se vier nulo.
 vi.mock("@/lib/api", () => ({
   fetchFastAPI,
-  requireSupabaseToken: async (
-    gt: (opts: { template: string }) => Promise<string | null>,
-  ) => {
-    const t = await gt({ template: "supabase" });
+  requireSupabaseToken: async (gt: () => Promise<string | null>) => {
+    const t = await gt();
     if (!t) throw new Error("MissingAuthTokenError");
     return t;
   },
@@ -165,7 +163,7 @@ describe("useLlmRunProgress", () => {
         "test-token",
       ),
     );
-    // Token buscado com o template "supabase" (não o token de sessão default).
-    expect(getToken).toHaveBeenCalledWith({ template: "supabase" });
+    // Session token, sem template (o JWT template legado saiu — #348).
+    expect(getToken).toHaveBeenCalledWith();
   });
 });

--- a/frontend/src/lib/__tests__/api-server.test.ts
+++ b/frontend/src/lib/__tests__/api-server.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Contrato de `fetchFastAPIServer` (#348) — o caminho server, até aqui sem
+ * cobertura nenhuma.
+ *
+ * `server-only` está aliasado para o `empty.js` do próprio pacote no
+ * `vitest.config.ts`, então o módulo carrega sem o transform do Next.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getToken, fetchFastAPI } = vi.hoisted(() => ({
+  getToken: vi.fn(),
+  fetchFastAPI: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: async () => ({ getToken }) }));
+vi.mock("@/lib/api", () => ({ fetchFastAPI }));
+
+const { fetchFastAPIServer } = await import("../api-server");
+
+beforeEach(() => {
+  getToken.mockReset().mockResolvedValue("tok");
+  fetchFastAPI.mockReset().mockResolvedValue({ ok: true });
+});
+
+describe("fetchFastAPIServer", () => {
+  it("pede o session token SEM argumento (nunca um JWT template)", async () => {
+    // Mesma invariante de `requireSupabaseToken`, do outro lado da fronteira:
+    // um `{ template: "supabase" }` aqui voltaria a emitir token com `aud`, que
+    // o backend — que agora valida `iss` (#487) — não espera mais.
+    await fetchFastAPIServer("/api/pydantic/recover-fields");
+    expect(getToken.mock.calls[0]).toEqual([]);
+  });
+
+  it("repassa path, options e token ao fetchFastAPI", async () => {
+    const options = { method: "POST", body: '{"project_id":"p1"}' };
+    await fetchFastAPIServer("/api/pydantic/recover-fields", options);
+    expect(fetchFastAPI).toHaveBeenCalledWith(
+      "/api/pydantic/recover-fields",
+      options,
+      "tok",
+    );
+  });
+
+  it("token ausente vira `undefined`, nunca `null`", async () => {
+    // É o `token ?? undefined` do arquivo. Sem ele, o `null` chegaria ao
+    // `fetchFastAPI` como valor falsy — hoje inofensivo, mas qualquer helper que
+    // passasse a interpolar o argumento mandaria um `Bearer null` para o
+    // backend, que responderia 401 sem dizer que a sessão é que faltava.
+    getToken.mockResolvedValue(null);
+    await fetchFastAPIServer("/api/llm/cleanup-stale");
+    expect(fetchFastAPI.mock.calls[0][2]).toBeUndefined();
+  });
+
+  it("devolve o resultado do fetchFastAPI ao caller", async () => {
+    fetchFastAPI.mockResolvedValue({ cleaned: 3 });
+    await expect(fetchFastAPIServer("/api/llm/cleanup-stale")).resolves.toEqual({
+      cleaned: 3,
+    });
+  });
+});

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Contrato real de `lib/api.ts` (#348).
+ *
+ * Até aqui estes dois helpers nunca tinham rodado em teste: os testes de
+ * `RunLlmButton` e `useLlmRunProgress` mockam `@/lib/api` com uma réplica manual
+ * de `requireSupabaseToken` ("Réplica do real: ..."). Réplica não é contrato — se
+ * o original mudar, o mock segue verde e o drift passa. Estes testes exercitam o
+ * código de produção, e é assim que a precedência de headers apareceu quebrada.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchFastAPI, requireSupabaseToken } from "../api";
+
+const fetchMock = vi.fn();
+
+/** Init do último `fetch`, já tipado como o objeto plano que o helper monta. */
+function lastInit(): RequestInit & { headers: Record<string, string> } {
+  return fetchMock.mock.calls.at(-1)![1];
+}
+
+function okResponse(body: unknown = { ok: true }) {
+  return { ok: true, json: async () => body };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(okResponse());
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("requireSupabaseToken", () => {
+  it("pede o token SEM argumento (nunca um JWT template)", async () => {
+    // A invariante do #348 no caminho client. `toHaveBeenCalled()` sozinho
+    // aceitaria a volta de `{ template: "supabase" }` — por isso a asserção é
+    // sobre a lista de argumentos, que precisa estar vazia.
+    const getToken = vi.fn().mockResolvedValue("tok");
+    await requireSupabaseToken(getToken);
+    expect(getToken.mock.calls[0]).toEqual([]);
+  });
+
+  it("devolve o token quando a sessão existe", async () => {
+    await expect(
+      requireSupabaseToken(vi.fn().mockResolvedValue("tok")),
+    ).resolves.toBe("tok");
+  });
+
+  it("falha fechado quando o token vem nulo, com causa nomeada", async () => {
+    // Falhar aqui (antes do request sair) é o que dá ao caller uma causa
+    // acionável em vez de um "API error: 401" genérico vindo do backend.
+    await expect(
+      requireSupabaseToken(vi.fn().mockResolvedValue(null)),
+    ).rejects.toMatchObject({ name: "MissingAuthTokenError" });
+  });
+
+  it("a mensagem de erro não menciona mais o template legado", async () => {
+    // O template saiu no #348: instruir o usuário a conferi-lo mandaria o
+    // suporte investigar uma configuração que já não existe.
+    await expect(
+      requireSupabaseToken(vi.fn().mockResolvedValue(null)),
+    ).rejects.toThrow(/^(?!.*template).*$/i);
+  });
+});
+
+describe("fetchFastAPI", () => {
+  it("manda Authorization: Bearer quando recebe token", async () => {
+    await fetchFastAPI("/api/llm/run", { method: "POST" }, "tok");
+    expect(lastInit().headers.Authorization).toBe("Bearer tok");
+  });
+
+  it("não inventa Authorization quando não há token", async () => {
+    await fetchFastAPI("/api/llm/run");
+    expect(lastInit().headers).not.toHaveProperty("Authorization");
+  });
+
+  it("preserva os headers do caller SEM perder Content-Type nem Authorization", async () => {
+    // O par crítico: `...options` precisa vir antes da chave `headers`, porque
+    // spread de objeto substitui a chave inteira em vez de fazer merge. Na ordem
+    // inversa (como o arquivo estava), qualquer `options.headers` apagava o
+    // Authorization montado aqui e o request saía sem token — silenciosamente.
+    await fetchFastAPI(
+      "/api/llm/run",
+      { method: "POST", headers: { "X-Custom": "1" } },
+      "tok",
+    );
+    expect(lastInit().headers).toMatchObject({
+      "Content-Type": "application/json",
+      "X-Custom": "1",
+      Authorization: "Bearer tok",
+    });
+  });
+
+  it("preserva method e body do caller", async () => {
+    // Invariante inversa da anterior: sozinha, cada uma admite uma "correção"
+    // que quebra a outra (headers comendo options, ou options comendo headers).
+    // Juntas, fixam a ordem do spread nos dois sentidos.
+    await fetchFastAPI(
+      "/api/llm/run",
+      { method: "POST", body: JSON.stringify({ a: 1 }) },
+      "tok",
+    );
+    expect(lastInit()).toMatchObject({
+      method: "POST",
+      body: JSON.stringify({ a: 1 }),
+    });
+  });
+
+  it("propaga o `detail` do backend como mensagem de erro", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: async () => ({ detail: "project_id inválido" }),
+    });
+    await expect(fetchFastAPI("/api/llm/run")).rejects.toThrow(
+      "project_id inválido",
+    );
+  });
+
+  it("cai no statusText quando o corpo do erro não é JSON", async () => {
+    // 502 de proxy costuma devolver HTML: sem o catch, o `res.json()` lançaria
+    // um SyntaxError cru no lugar da causa real.
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    });
+    await expect(fetchFastAPI("/api/llm/run")).rejects.toThrow("Bad Gateway");
+  });
+
+  it("devolve o JSON da resposta", async () => {
+    fetchMock.mockResolvedValue(okResponse({ job_id: "j1" }));
+    await expect(fetchFastAPI("/api/llm/run")).resolves.toEqual({
+      job_id: "j1",
+    });
+  });
+});

--- a/frontend/src/lib/__tests__/no-legacy-token-path.test.ts
+++ b/frontend/src/lib/__tests__/no-legacy-token-path.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { readFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { join, relative } from "node:path";
 
 // T028 — RC-003/RC-004 (FR-004, FR-010, FR-014, SC-005/SC-006): gate estrutural
 // que falha se o caminho crítico de autenticação regredir. É a "regressão
@@ -11,6 +11,23 @@ const SRC = join(__dirname, "..", "..");
 
 function read(rel: string): string {
   return readFileSync(join(SRC, rel), "utf8");
+}
+
+/** Todos os `.ts`/`.tsx` de produção sob `src/`, com os testes de fora.
+ *
+ * Exclui tanto os diretórios `__tests__` quanto arquivos `*.test.ts(x)` soltos —
+ * nem todo teste do projeto mora num `__tests__` (ex.: `app/api/webhooks/clerk/
+ * route.test.ts`), e um teste varrido aqui viraria falso-positivo por citar de
+ * propósito a forma que o gate proíbe. */
+function sourceFiles(dir: string = SRC): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return entry.name === "__tests__" ? [] : sourceFiles(full);
+    }
+    if (/\.test\.tsx?$/.test(entry.name)) return [];
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
 }
 
 describe("gate de regressão do render path autenticado", () => {
@@ -48,6 +65,30 @@ describe("gate de regressão do render path autenticado", () => {
     // próprio arquivo cita o nome ao explicar por que não o chama.
     expect(auth).not.toMatch(/syncClerkUserToSupabase\s*\(/);
     expect(auth).not.toContain('import { syncClerkUserToSupabase }');
+  });
+
+  it("#348: nenhuma chamada de getToken passa `template` (JWT template não volta)", () => {
+    // O template `supabase` foi removido do código em favor do session token.
+    // Uma chamada `getToken({ template: "supabase" })` reintroduzida emitiria um
+    // token com `aud` e sem os custom claims — o backend valida `iss` (#487) e a
+    // RLS depende de `supabase_uid`/`role`, então a regressão apareceria como
+    // listas vazias e 401, não como erro de compilação. Este gate torna
+    // permanente o `grep` que hoje se faz à mão a cada revisão.
+    //
+    // O alvo é a propriedade `template`, NÃO o objeto de opções: `getToken({
+    // skipCache: true })` é legítimo e está em uso no AccessCompletionCard (#440)
+    // para reemitir o token depois que `completeAccess` grava a metadata. Um gate
+    // sobre `getToken({` proibiria esse uso junto com o legado.
+    //
+    // Casa a CHAMADA com objeto literal, nunca a passagem da referência
+    // (`requireSupabaseToken(getToken)`), e ignora testes: o contrato do session
+    // token cita a forma legada de propósito, ao explicar por que ela não volta.
+    const offenders = sourceFiles()
+      .filter((file) =>
+        /getToken\s*\(\s*\{[^}]*\btemplate\b/.test(readFileSync(file, "utf8")),
+      )
+      .map((file) => relative(SRC, file));
+    expect(offenders).toEqual([]);
   });
 
   it("FR-010: dashboard e conclusão de acesso não instruem debug de token", () => {

--- a/frontend/src/lib/api-server.ts
+++ b/frontend/src/lib/api-server.ts
@@ -4,15 +4,15 @@ import { auth } from "@clerk/nextjs/server";
 import { fetchFastAPI } from "@/lib/api";
 
 /**
- * Versão de `fetchFastAPI` para Server Actions / RSC: anexa o JWT do Clerk
- * (template "supabase") automaticamente. Em client components use
- * `fetchFastAPI` direto, passando o token de `useAuth().getToken(...)`.
+ * Versão de `fetchFastAPI` para Server Actions / RSC: anexa o session token do
+ * Clerk automaticamente. Em client components use `fetchFastAPI` direto,
+ * passando o token de `useAuth().getToken()`.
  */
 export async function fetchFastAPIServer<T>(
   path: string,
   options?: RequestInit
 ): Promise<T> {
   const { getToken } = await auth();
-  const token = await getToken({ template: "supabase" });
+  const token = await getToken();
   return fetchFastAPI<T>(path, options, token ?? undefined);
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,40 +1,36 @@
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
-/** Token do template "supabase" indisponível (deslogado, sessão expirada ou o
- * template não existe na instância do Clerk). Distinto de um 401 do backend:
- * aqui o request nem chega a sair, então o caller mostra uma causa acionável em
- * vez de um "API error: 401" genérico. */
+/** Session token indisponível (deslogado ou sessão expirada). Distinto de um 401
+ * do backend: aqui o request nem chega a sair, então o caller mostra uma causa
+ * acionável em vez de um "API error: 401" genérico. */
 class MissingAuthTokenError extends Error {
   constructor() {
-    super(
-      "Sessão indisponível ou template 'supabase' não configurado no Clerk.",
-    );
+    super("Sessão indisponível. Faça login novamente.");
     this.name = "MissingAuthTokenError";
   }
 }
 
-type GetToken = (opts: { template: string }) => Promise<string | null>;
+type GetToken = () => Promise<string | null>;
 
-/** Busca o JWT do template "supabase" e falha fechado (lança) quando vem nulo,
- * em vez de mandar um request sem `Authorization` que o backend rejeitaria com
- * um 401 ambíguo. Use em client components antes de cada request/poll. */
+/** Busca o session token do Clerk e falha fechado (lança) quando vem nulo, em
+ * vez de mandar um request sem `Authorization` que o backend rejeitaria com um
+ * 401 ambíguo. Use em client components antes de cada request/poll. */
 export async function requireSupabaseToken(getToken: GetToken): Promise<string> {
-  const token = await getToken({ template: "supabase" });
+  const token = await getToken();
   if (!token) throw new MissingAuthTokenError();
   return token;
 }
 
 /**
  * Chama o backend FastAPI. O backend exige `Authorization: Bearer <jwt>`
- * (token do Clerk, template "supabase") em todas as rotas autenticadas.
+ * (session token do Clerk) em todas as rotas autenticadas.
  *
  * O token NÃO é obtido aqui porque este helper roda tanto em server actions
  * quanto em client components — cada contexto pega o token de um jeito:
  *  - server actions: `fetchFastAPIServer` (lib/api-server.ts) via `auth()`;
- *  - client components: `useAuth().getToken({ template: "supabase" })`,
- *    passando o resultado em `token`.
- * O token do template expira rápido (~60s), então o caller deve buscar um
- * token fresco imediatamente antes de cada request (inclusive a cada poll).
+ *  - client components: `useAuth().getToken()`, passando o resultado em `token`.
+ * O session token expira rápido (~60s), então o caller deve buscar um token
+ * fresco imediatamente antes de cada request (inclusive a cada poll).
  */
 export async function fetchFastAPI<T>(
   path: string,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -38,6 +38,11 @@ export async function fetchFastAPI<T>(
   token?: string
 ): Promise<T> {
   const res = await fetch(`${API_URL}${path}`, {
+    // `...options` vem ANTES de `headers`: spread de objeto substitui a chave
+    // inteira, não faz merge. Na ordem inversa, um caller que passasse
+    // `options.headers` apagaria de uma vez o Content-Type e o Authorization
+    // montados aqui — o token sairia do request sem nenhum sinal.
+    ...options,
     headers: {
       "Content-Type": "application/json",
       ...options?.headers,
@@ -45,7 +50,6 @@ export async function fetchFastAPI<T>(
       // token explícito do caller nunca deve ser sobrescrito por um header solto.
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
-    ...options,
   });
 
   if (!res.ok) {

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -2,6 +2,7 @@ import { currentUser } from "@clerk/nextjs/server";
 import { unstable_rethrow } from "next/navigation";
 import { cache } from "react";
 import { getVerifiedPrimaryEmail } from "@/lib/clerk-primary-email";
+import { readSupabaseUidFromMetadata } from "@/lib/clerk-supabase-uid";
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import type { Project, ProjectMember } from "@/lib/types";
@@ -100,7 +101,7 @@ async function resolveAuthUncached(): Promise<AuthResolution> {
   const user = await currentUser();
   if (!user) return { status: "signed-out" };
 
-  const metadataUid = user.publicMetadata.supabase_uid as string | undefined;
+  const metadataUid = readSupabaseUidFromMetadata(user);
   const email = getVerifiedPrimaryEmail(user);
 
   // AuthUser exige o e-mail primário verificado em qualquer estado do vínculo.

--- a/frontend/src/lib/clerk-supabase-uid.ts
+++ b/frontend/src/lib/clerk-supabase-uid.ts
@@ -1,0 +1,16 @@
+import type { User } from "@clerk/nextjs/server";
+
+/** Chave única do vínculo Clerk↔Supabase na metadata pública da conta.
+ *
+ * A instância Clerk injeta esse mesmo valor no session token como o custom claim
+ * `supabase_uid` (é a fonte de `clerk_uid()` do RLS). Ter a metadata e não ter o
+ * claim é o que denuncia um cutover de instância mal configurado; não ter nem a
+ * metadata é o usuário cujo vínculo ainda não foi reconciliado. `resolveAuth`
+ * (`lib/auth.ts`) e a barreira de contrato em `lib/supabase/server.ts` leem os
+ * dois lados dessa distinção — esta função centraliza o literal para que não
+ * divirjam. */
+export function readSupabaseUidFromMetadata(
+  user: Pick<User, "publicMetadata"> | null,
+): string | undefined {
+  return user?.publicMetadata?.supabase_uid as string | undefined;
+}

--- a/frontend/src/lib/supabase/__tests__/server-token-contract.test.ts
+++ b/frontend/src/lib/supabase/__tests__/server-token-contract.test.ts
@@ -11,6 +11,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 let token: string | null = null;
 const getTokenArgs: unknown[][] = [];
 
+// A metadata do Clerk decide se um token sem claim é config quebrada (uid
+// presente → cutover → lança) ou vínculo ainda pendente (uid ausente → deixa a
+// página redirecionar). Default: uid presente, o estado em que a ausência do
+// claim no token é o bug do cutover que a barreira existe para pegar.
+let metadataUid: string | undefined = "11111111-1111-1111-1111-111111111111";
 vi.mock("@clerk/nextjs/server", () => ({
   auth: async () => ({
     getToken: async (...args: unknown[]) => {
@@ -18,6 +23,7 @@ vi.mock("@clerk/nextjs/server", () => ({
       return token;
     },
   }),
+  currentUser: async () => ({ publicMetadata: { supabase_uid: metadataUid } }),
 }));
 
 const created: Array<{ headers: Record<string, string> }> = [];
@@ -49,6 +55,7 @@ beforeEach(() => {
   created.length = 0;
   getTokenArgs.length = 0;
   token = null;
+  metadataUid = "11111111-1111-1111-1111-111111111111";
 });
 
 describe("createSupabaseServer — contrato do session token", () => {
@@ -67,12 +74,34 @@ describe("createSupabaseServer — contrato do session token", () => {
     expect(getTokenArgs).toEqual([[]]);
   });
 
-  it("lança quando falta supabase_uid (clerk_uid() viraria NULL)", async () => {
+  it("lança quando falta supabase_uid E a metadata TEM o vínculo (cutover)", async () => {
     // O modo de falha de uma troca de instância: o custom claim não foi
-    // replicado no Dashboard novo. Sem esta barreira, a RLS negaria tudo em
+    // replicado no Dashboard novo. Metadata com uid + token sem claim = config
+    // quebrada, não vínculo pendente. Sem esta barreira, a RLS negaria tudo em
     // silêncio e o dashboard apareceria vazio, sem erro nenhum.
     token = jwtWith({ ...VALID, supabase_uid: undefined });
     await expect(createSupabaseServer()).rejects.toThrow(/supabase_uid/);
+  });
+
+  it("NÃO lança quando o vínculo ainda está pendente (link-pending)", async () => {
+    // O bloqueador que esta lógica corrige: um usuário recém-criado, com sessão
+    // Clerk mas sem `supabase_uid` na metadata, chegando por deep-link numa
+    // página protegida. Do token puro é idêntico ao cutover, mas a metadata
+    // ainda não tem o uid. Lançar aqui atropelaria o redirect gracioso da
+    // conclusão de acesso — e como toda página faz
+    // `Promise.all([requirePageAuthUser(), createSupabaseServer()])`, o crash
+    // venceria o redirect. Aqui a barreira se cala e devolve o cliente.
+    metadataUid = undefined;
+    token = jwtWith({ ...VALID, supabase_uid: undefined });
+    await expect(createSupabaseServer()).resolves.toBeDefined();
+  });
+
+  it("NÃO lança quando falta role mas a metadata não tem vínculo", async () => {
+    // Simetria do anterior no ramo do `role`: sem uid na metadata, a conta ainda
+    // está em reparo e a página redireciona; a barreira não atropela.
+    metadataUid = undefined;
+    token = jwtWith({ ...VALID, role: undefined });
+    await expect(createSupabaseServer()).resolves.toBeDefined();
   });
 
   it('lança quando role !== "authenticated" (PostgREST trataria como anon)', async () => {

--- a/frontend/src/lib/supabase/__tests__/server-token-contract.test.ts
+++ b/frontend/src/lib/supabase/__tests__/server-token-contract.test.ts
@@ -103,4 +103,13 @@ describe("createSupabaseServer — contrato do session token", () => {
     token = "isto-nao-e-um-jwt";
     await expect(createSupabaseServer()).rejects.toThrow(/supabase_uid/);
   });
+
+  it("payload JSON válido mas não-objeto também vira erro nomeado", async () => {
+    // O buraco que o `try/catch` sozinho não fecha: `JSON.parse("null")` não
+    // lança, devolve `null`, e a destructuring das claims estouraria com um
+    // TypeError cru — o oposto do erro acionável que esta barreira existe para
+    // produzir.
+    token = jwtWith(null as unknown as Record<string, unknown>);
+    await expect(createSupabaseServer()).rejects.toThrow(/supabase_uid e role/);
+  });
 });

--- a/frontend/src/lib/supabase/__tests__/server-token-contract.test.ts
+++ b/frontend/src/lib/supabase/__tests__/server-token-contract.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Contrato do session token do Clerk exigido pela RLS (#348).
+ *
+ * `createSupabaseServer` é o chokepoint de todo read via RLS. Quando o token não
+ * traz `supabase_uid` ou `role: "authenticated"`, o Postgres NÃO reclama: as
+ * policies simplesmente não casam, e a aplicação renderiza com listas vazias.
+ * Estes testes fixam a única barreira que transforma isso em erro visível.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let token: string | null = null;
+const getTokenArgs: unknown[][] = [];
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: async () => ({
+    getToken: async (...args: unknown[]) => {
+      getTokenArgs.push(args);
+      return token;
+    },
+  }),
+}));
+
+const created: Array<{ headers: Record<string, string> }> = [];
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: (_url: string, _key: string, opts: { global: { headers: Record<string, string> } }) => {
+    created.push({ headers: opts.global.headers });
+    return { __fake: true };
+  },
+}));
+
+const { createSupabaseServer } = await import("../server");
+
+/** JWT sintético: só o payload importa — a assinatura nunca é verificada aqui
+ * (quem verifica é o Supabase, contra o JWKS do Clerk). */
+function jwtWith(claims: Record<string, unknown>): string {
+  const b64 = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64({ alg: "RS256", typ: "JWT" })}.${b64(claims)}.assinatura-nao-verificada`;
+}
+
+const VALID = {
+  sub: "user_2abc",
+  iss: "https://clerk.test",
+  role: "authenticated",
+  supabase_uid: "11111111-1111-1111-1111-111111111111",
+};
+
+beforeEach(() => {
+  created.length = 0;
+  getTokenArgs.length = 0;
+  token = null;
+});
+
+describe("createSupabaseServer — contrato do session token", () => {
+  it("aceita um session token completo e o repassa no Authorization", async () => {
+    token = jwtWith(VALID);
+    await createSupabaseServer();
+    expect(created[0].headers.Authorization).toBe(`Bearer ${token}`);
+  });
+
+  it("pede o session token, nunca um JWT template", async () => {
+    // `getToken({ template: "supabase" })` voltaria a emitir um token com `aud`
+    // e sem os claims default — o backend valida `iss` agora (#487), e o
+    // template está deprecado pelo Supabase desde 01/04/2025.
+    token = jwtWith(VALID);
+    await createSupabaseServer();
+    expect(getTokenArgs).toEqual([[]]);
+  });
+
+  it("lança quando falta supabase_uid (clerk_uid() viraria NULL)", async () => {
+    // O modo de falha de uma troca de instância: o custom claim não foi
+    // replicado no Dashboard novo. Sem esta barreira, a RLS negaria tudo em
+    // silêncio e o dashboard apareceria vazio, sem erro nenhum.
+    token = jwtWith({ ...VALID, supabase_uid: undefined });
+    await expect(createSupabaseServer()).rejects.toThrow(/supabase_uid/);
+  });
+
+  it('lança quando role !== "authenticated" (PostgREST trataria como anon)', async () => {
+    token = jwtWith({ ...VALID, role: undefined });
+    await expect(createSupabaseServer()).rejects.toThrow(/role/);
+  });
+
+  it("nomeia as duas claims quando as duas faltam", async () => {
+    token = jwtWith({ sub: "user_2abc", iss: "https://clerk.test" });
+    await expect(createSupabaseServer()).rejects.toThrow(
+      /supabase_uid e role/,
+    );
+  });
+
+  it("não lança quando não há token: deslogado é anon, não config quebrada", async () => {
+    // Distinção que importa: sem sessão, o cliente sai sem Authorization e a RLS
+    // nega — comportamento correto e esperado. Lançar aqui quebraria toda página
+    // pública/de login.
+    token = null;
+    await expect(createSupabaseServer()).resolves.toBeDefined();
+    expect(created[0].headers).toEqual({});
+  });
+
+  it("token indecifrável cai no mesmo erro (sem claim é sem claim)", async () => {
+    // Não deveria acontecer — o Clerk sempre devolve um JWT. Fixado só para
+    // garantir que o payload malformado vira erro nomeado, e não um SyntaxError
+    // cru vazando de JSON.parse.
+    token = "isto-nao-e-um-jwt";
+    await expect(createSupabaseServer()).rejects.toThrow(/supabase_uid/);
+  });
+});

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -1,9 +1,56 @@
 import { createClient } from "@supabase/supabase-js";
 import { auth } from "@clerk/nextjs/server";
 
+/** O contrato que a RLS exige do session token do Clerk:
+ *  - `supabase_uid`: lido por `clerk_uid()` (migration 20260401200000), que toda
+ *    policy usa como identidade;
+ *  - `role: "authenticated"`: sem ele o PostgREST trata a request como `anon`.
+ *
+ * Os dois são custom claims configurados no Dashboard (Sessions → Customize
+ * session token), não claims default — e o Postgres não reclama quando faltam:
+ * `clerk_uid()` vira NULL e as policies simplesmente não casam. */
+type TokenClaims = { supabase_uid?: string; role?: string };
+
+/** Lê o payload do JWT SEM verificar a assinatura. Não é validação: quem valida
+ * é o Supabase, contra o JWKS do Clerk. É uma asserção de contrato — o token
+ * acabou de vir do `auth()` do Clerk neste mesmo processo. */
+function decodeClaims(token: string): TokenClaims {
+  const payload = token.split(".")[1];
+  if (!payload) return {};
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString());
+  } catch {
+    return {};
+  }
+}
+
+/** Falha alto quando o token não carrega o que a RLS precisa.
+ *
+ * Sem isto, um claim ausente é INVISÍVEL: `resolveAuth` aprova (lê o
+ * `supabase_uid` da metadata do usuário, não do token), a RLS nega tudo, e a
+ * aplicação renderiza normalmente com todas as listas vazias — sem erro em lugar
+ * nenhum. É o modo de falha mais provável de uma troca de instância Clerk, e o
+ * único ponto do read path onde dá para pegá-lo: um SELECT que volta com zero
+ * linhas é indistinguível de "este usuário não tem projeto". */
+function assertTokenContract(token: string): void {
+  const { supabase_uid, role } = decodeClaims(token);
+  const missing = [
+    !supabase_uid && "supabase_uid",
+    role !== "authenticated" && `role="authenticated" (veio ${JSON.stringify(role)})`,
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    throw new Error(
+      `Session token do Clerk sem ${missing.join(" e ")}. A RLS negaria tudo em ` +
+        `silêncio. Conferir os custom claims em Sessions → Customize session ` +
+        `token na instância do Clerk.`,
+    );
+  }
+}
+
 export async function createSupabaseServer() {
   const { getToken } = await auth();
-  const supabaseToken = await getToken({ template: "supabase" });
+  const supabaseToken = await getToken();
+  if (supabaseToken) assertTokenContract(supabaseToken);
 
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -18,7 +18,16 @@ function decodeClaims(token: string): TokenClaims {
   const payload = token.split(".")[1];
   if (!payload) return {};
   try {
-    return JSON.parse(Buffer.from(payload, "base64url").toString());
+    // O `catch` cobre base64/JSON inválido; o teste de tipo cobre o que ele não
+    // pega — JSON válido que não é objeto (`null`, número, string). Sem ele, um
+    // payload `null` passaria daqui e a destructuring em `assertTokenContract`
+    // lançaria um TypeError cru no lugar do erro nomeado.
+    const claims: unknown = JSON.parse(
+      Buffer.from(payload, "base64url").toString(),
+    );
+    return typeof claims === "object" && claims !== null
+      ? (claims as TokenClaims)
+      : {};
   } catch {
     return {};
   }
@@ -31,12 +40,20 @@ function decodeClaims(token: string): TokenClaims {
  * aplicação renderiza normalmente com todas as listas vazias — sem erro em lugar
  * nenhum. É o modo de falha mais provável de uma troca de instância Clerk, e o
  * único ponto do read path onde dá para pegá-lo: um SELECT que volta com zero
- * linhas é indistinguível de "este usuário não tem projeto". */
+ * linhas é indistinguível de "este usuário não tem projeto".
+ *
+ * Ressalva de alcance: `resolveProjectMemberIdentity` e `readProjectAccess`
+ * (`lib/auth.ts`) envolvem a criação do cliente em try/catch e traduzem qualquer
+ * exceção em `{ status: "unavailable" }`. Nesses dois call sites a causa nomeada
+ * sobrevive só no `console.error` deles — a tela mostra indisponibilidade
+ * genérica. Para os demais consumidores o erro sobe de verdade. */
 function assertTokenContract(token: string): void {
   const { supabase_uid, role } = decodeClaims(token);
+  // Não ecoar o valor recebido: ele vem de um token cuja assinatura não foi
+  // verificada aqui, e nomear a claim ausente já basta para agir.
   const missing = [
     !supabase_uid && "supabase_uid",
-    role !== "authenticated" && `role="authenticated" (veio ${JSON.stringify(role)})`,
+    role !== "authenticated" && 'role="authenticated"',
   ].filter(Boolean);
   if (missing.length > 0) {
     throw new Error(

--- a/frontend/src/lib/supabase/server.ts
+++ b/frontend/src/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
-import { auth } from "@clerk/nextjs/server";
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { readSupabaseUidFromMetadata } from "@/lib/clerk-supabase-uid";
 
 /** O contrato que a RLS exige do session token do Clerk:
  *  - `supabase_uid`: lido por `clerk_uid()` (migration 20260401200000), que toda
@@ -33,21 +34,44 @@ function decodeClaims(token: string): TokenClaims {
   }
 }
 
-/** Falha alto quando o token não carrega o que a RLS precisa.
+/** Falha alto quando o token não carrega o que a RLS precisa — MAS só quando a
+ * ausência denuncia config quebrada, não um vínculo ainda pendente.
  *
- * Sem isto, um claim ausente é INVISÍVEL: `resolveAuth` aprova (lê o
- * `supabase_uid` da metadata do usuário, não do token), a RLS nega tudo, e a
- * aplicação renderiza normalmente com todas as listas vazias — sem erro em lugar
- * nenhum. É o modo de falha mais provável de uma troca de instância Clerk, e o
- * único ponto do read path onde dá para pegá-lo: um SELECT que volta com zero
- * linhas é indistinguível de "este usuário não tem projeto".
+ * O modo de falha que isto pega: numa troca de instância Clerk os custom claims
+ * não são replicados, então `resolveAuth` aprova (lê o `supabase_uid` da
+ * metadata do usuário, não do token), a RLS nega tudo, e a aplicação renderiza
+ * com todas as listas vazias — sem erro em lugar nenhum. Um SELECT que volta com
+ * zero linhas é indistinguível de "este usuário não tem projeto", e este é o
+ * único ponto do read path onde dá para pegá-lo.
+ *
+ * Mas do token puro esse cutover é IDÊNTICO a um estado legítimo: o usuário
+ * recém-criado cujo vínculo ainda não foi reconciliado (`link-pending`) também
+ * tem sessão Clerk sem `supabase_uid`. Lançar para ele transformaria o redirect
+ * gracioso da conclusão de acesso num crash — e como toda página protegida faz
+ * `Promise.all([requirePageAuthUser(), createSupabaseServer()])`, a rejeição
+ * rápida daqui venceria o `redirect()` (que espera um round-trip de
+ * `currentUser()`), determinística e em ~17 páginas.
+ *
+ * A metadata pública do Clerk distingue os dois — é a mesma fonte que o token
+ * carrega como claim (ver `readSupabaseUidFromMetadata`): no cutover a metadata
+ * TEM o uid (só o token não replicou), no pending ainda NÃO tem. `currentUser()`
+ * é deduplicado por request pelo Clerk — na página protegida `resolveAuth` já o
+ * buscou, custo ~zero — e só é consultado no caminho degradado (token sem
+ * claim). Ler a metadata em vez de importar `resolveAuth` evita o ciclo de
+ * import (`lib/auth` importa este módulo de volta).
+ *
+ * Ressalva: um `link-divergent` (metadata presente, mas divergente do mapping)
+ * cai no ramo "lança" caso o token traga `supabase_uid` mas não `role` — combinação
+ * improvável (os dois claims saem da mesma config de sessão) e cujo efeito é um
+ * erro VISÍVEL num usuário já em fluxo de reparo, não o silêncio que a barreira
+ * existe para evitar.
  *
  * Ressalva de alcance: `resolveProjectMemberIdentity` e `readProjectAccess`
  * (`lib/auth.ts`) envolvem a criação do cliente em try/catch e traduzem qualquer
  * exceção em `{ status: "unavailable" }`. Nesses dois call sites a causa nomeada
- * sobrevive só no `console.error` deles — a tela mostra indisponibilidade
- * genérica. Para os demais consumidores o erro sobe de verdade. */
-function assertTokenContract(token: string): void {
+ * sobrevive só no `console.error` deles. Para os demais consumidores o erro
+ * sobe de verdade. */
+async function assertTokenContract(token: string): Promise<void> {
   const { supabase_uid, role } = decodeClaims(token);
   // Não ecoar o valor recebido: ele vem de um token cuja assinatura não foi
   // verificada aqui, e nomear a claim ausente já basta para agir.
@@ -55,19 +79,26 @@ function assertTokenContract(token: string): void {
     !supabase_uid && "supabase_uid",
     role !== "authenticated" && 'role="authenticated"',
   ].filter(Boolean);
-  if (missing.length > 0) {
-    throw new Error(
-      `Session token do Clerk sem ${missing.join(" e ")}. A RLS negaria tudo em ` +
-        `silêncio. Conferir os custom claims em Sessions → Customize session ` +
-        `token na instância do Clerk.`,
-    );
-  }
+  if (missing.length === 0) return;
+
+  // Token sem o claim. Só é config quebrada se a conta JÁ tem o vínculo na
+  // metadata (cutover); sem ele, é um usuário cujo acesso ainda não foi
+  // reconciliado, e a página protegida já redireciona para a conclusão de
+  // acesso — lançar aqui atropelaria esse redirect.
+  const user = await currentUser();
+  if (!readSupabaseUidFromMetadata(user)) return;
+
+  throw new Error(
+    `Session token do Clerk sem ${missing.join(" e ")}. A RLS negaria tudo em ` +
+      `silêncio. Conferir os custom claims em Sessions → Customize session ` +
+      `token na instância do Clerk.`,
+  );
 }
 
 export async function createSupabaseServer() {
   const { getToken } = await auth();
   const supabaseToken = await getToken();
-  if (supabaseToken) assertTokenContract(supabaseToken);
+  if (supabaseToken) await assertTokenContract(supabaseToken);
 
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
Segundo PR da #348, originalmente empilhado no #487 — já rebaseado sobre a `main` (o #487 entrou por squash).

> [!NOTE]
> **Desbloqueado em 23/07/2026.** As três condições do bloqueio original foram cumpridas:
>
> 1. **#487 mergeado** (squash, `f87289f`, 16:10 UTC) — `fix(auth): valida iss do Clerk em vez de aud`
> 2. **Deploy concluído** no app `gui-analise-sistematica-api`: workflow *Deploy backend (Fly.io)* com `success` ([run 30023964353](https://github.com/bdcdo/dataframeitGUI/actions/runs/30023964353))
> 3. O `fly secrets unset CLERK_JWKS_URL` **saiu do caminho crítico** e virou a #553. Ele não era pré-requisito: o secret e o `[env]` têm o mesmo valor, então o sombreamento é inofensivo hoje. O que ele previne é a *próxima* troca de instância.
>
> Verificado contra o backend já deployado, não só pela suíte:
>
> | Sonda | Resultado |
> |---|---|
> | `/health` | **200** — e como a guarda de boot do #487 mata o processo quando há JWKS sem issuer, um health verde prova que `CLERK_JWT_ISSUER` chegou ao processo |
> | rota autenticada sem token | **401** `Autenticação necessária` |
> | rota autenticada com `alg=HS256` | **401** `Algoritmo de token não aceito: HS256` — confirma o caminho RS256/JWKS com o downgrade fechado |
>
> Nenhum 503 em nenhuma sonda, que é o sinal que denunciaria issuer ausente ou JWKS irresolvível. **A produção já aceita token sem `aud`.**
>
> **Estado atual: `MERGEABLE`/`CLEAN`.** O rebase sobre a `main` foi feito descartando o commit duplicado do #487 (que já vive na `main` via squash); `git diff origin/main -- backend/` sai vazio, então este PR é hoje **exclusivamente de frontend**. Todos os gates de pre-push passam.
>
> **Reversão** (inalterada): `git revert` deste PR basta. O template `jtmp_3Bjb6H9r…` continua existindo e intocado, e o backend aceita os dois formatos (mesmo `iss`) — não há Dashboard, secret ou Supabase no caminho de volta.

## Por quê

O JWT template Clerk↔Supabase está deprecado desde **01/04/2025**; o caminho atual é o session token com Third-Party Auth — que já está configurado aqui desde a migração RS256 (#299/#309). Na época o template foi **flipado para RS256, não removido**. É esse resto que sai agora.

## O que mudou

`getToken({ template: "supabase" })` → `getToken()` em `supabase/server.ts`, `api.ts` e `api-server.ts`.

Os custom claims foram replicados no session token da instância (Sessions → Customize session token) e **verificados com um token real**:

```
antes: [exp, fva, iat, iss, nbf, sid, sts, sub, v]                      ← sem role, sem supabase_uid
agora: [exp, fva, iat, iss, jti, nbf, role, sid, sts, sub, supabase_uid, v]
```

## Fecha o modo de falha silencioso do RLS

`supabase_uid` e `role` são custom claims configurados no **Dashboard**, e o Postgres **não reclama quando faltam**: `clerk_uid()` vira NULL, as policies não casam, e a aplicação renderiza normalmente com todas as listas vazias. Pior: `resolveAuth` aprova mesmo assim, porque lê o `supabase_uid` da **metadata do usuário**, não do token. Metadata presente + claim ausente = tudo verde, nada funciona.

`createSupabaseServer` é o chokepoint de todo read via RLS e o único lugar onde dá para pegar isso: um SELECT com zero linhas é indistinguível de *"este usuário não tem projeto"* (o `rls-guard.ts` só cobre UPDATE/DELETE). Agora o payload é decodificado (base64, **sem verificar assinatura** — quem valida é o Supabase contra o JWKS; aqui é asserção de contrato, não validação) e a falta de claim lança com a causa nomeada, apontando para onde consertar.

Sem token não lança: deslogado é `anon`, não config quebrada.

### A asserção distingue cutover de vínculo pendente

Uma re-revisão adversarial pegou um bloqueador na primeira versão desta barreira: lançar para *qualquer* token sem `supabase_uid` derruba também o usuário legítimo com vínculo ainda não reconciliado (`link-pending`), que do token puro é idêntico ao cutover. Como toda página protegida faz `Promise.all([requirePageAuthUser(), createSupabaseServer()])` e a rejeição síncrona da asserção vence o `redirect()` (que espera um round-trip de `currentUser()`), isso transformava o redirect gracioso da conclusão de acesso num crash determinístico, em ~17 páginas — exatamente o caso que a arquitetura de acesso recuperável (#187/#418/#440) existe para tratar.

A metadata pública do Clerk separa os dois (é a mesma fonte que alimenta o claim): no **cutover** a metadata TEM o `supabase_uid` e só o token não replicou → config quebrada, a barreira lança; no **pending** a metadata ainda não tem → a página redireciona, a barreira se cala. A leitura foi centralizada em `readSupabaseUidFromMetadata` (`lib/clerk-supabase-uid.ts`), consumida por `resolveAuth` e pela barreira — fonte única, e sem reintroduzir o ciclo de import `auth.ts ↔ server.ts` (`server.ts` não importa mais `auth.ts`).

## Verificação

- **1803 testes** passam; typecheck limpo; lint 0 errors; `fallow` limpo (sem ciclos); `grep 'template: "supabase"'` em `frontend/src` → só comentários em teste (citam a forma legada de propósito).
- **e2e smoke passou** — login real na instância dev, navegando autenticado: a prova de que os claims estão no session token de verdade.
- **Testes de mutação** (nos dois sentidos): reintroduzir `getToken({ template })` deixa o gate estrutural `no-legacy-token-path` vermelho; remover o gate de metadata da asserção deixa os casos `link-pending` e `role-sem-vínculo` vermelhos.

Refs #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)
