### PR TITLE
fix(sorteio): um revisor de comparação por documento (#490)

### DIFF
--- a/frontend/src/actions/__tests__/assignments.test.ts
+++ b/frontend/src/actions/__tests__/assignments.test.ts
@@ -6,11 +6,17 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 // ganho garantindo que essas tabelas não são mais tocadas nesse path.
 import {
   makeSupabaseMock,
+  type RpcCall,
+  type TableResult,
   type TableResults,
+  type WriteCall,
 } from "./supabase-mock";
 
 let serverTableResults: TableResults | undefined;
 let fromCalls: string[];
+let writeCalls: WriteCall[];
+let rpcCalls: RpcCall[];
+let rpcResults: Record<string, TableResult> | undefined;
 
 vi.mock("next/cache", () => ({
   revalidatePath: () => {},
@@ -21,7 +27,12 @@ vi.mock("@/lib/auth", () => ({
 }));
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServer: async () => {
-    const mock = makeSupabaseMock({ tableResults: serverTableResults });
+    const mock = makeSupabaseMock({
+      tableResults: serverTableResults,
+      writeCalls,
+      rpcCalls,
+      rpcResults,
+    });
     return {
       ...mock,
       from: (table: string) => {
@@ -32,11 +43,19 @@ vi.mock("@/lib/supabase/server", () => ({
   },
 }));
 
-import { getLotteryDocStats, previewLottery } from "../assignments";
+import {
+  getLotteryDocStats,
+  previewLottery,
+  smartRandomize,
+  type LotteryParams,
+} from "../assignments";
 
 beforeEach(() => {
   serverTableResults = undefined;
   fromCalls = [];
+  writeCalls = [];
+  rpcCalls = [];
+  rpcResults = undefined;
 });
 
 describe("getLotteryDocStats", () => {
@@ -161,5 +180,150 @@ describe("previewLottery", () => {
     ]);
     expect(fromCalls).toContain("lottery_doc_stats");
     expect(fromCalls).toContain("assignments");
+  });
+});
+
+// Regressão da issue #490: o sorteio de Comparação herdava o default 2 do
+// sorteio de Codificação. A regra é um revisor por documento — o veredito é ato
+// de desempate único.
+describe("sorteio de comparação: um revisor por documento (#490)", () => {
+  // Um doc apto à comparação (2 humanos) e três participantes disponíveis: se o
+  // número de revisores fosse honrado, sobrariam candidatos para uma 2ª vaga.
+  function comparisonFixture(assignments: unknown[] = []): TableResults {
+    return {
+      project_members: { data: [{ user_id: "u1" }, { user_id: "u2" }, { user_id: "u3" }] },
+      lottery_doc_stats: {
+        data: [
+          {
+            id: "d1",
+            external_id: "EXT-1",
+            title: "Doc 1",
+            human_coding_count: 2,
+            has_llm_response: false,
+            active_codificacao: 0,
+            active_comparacao: 0,
+            has_any_assignment_ever: true,
+            batch_ids: [],
+          },
+        ],
+      },
+      assignment_batches: { data: [] },
+      projects: { data: { min_responses_for_comparison: 2, automation_mode: null } },
+      assignments: { data: assignments },
+    };
+  }
+
+  it("ignora researchersPerDoc forjado no payload e atribui um único revisor", async () => {
+    serverTableResults = comparisonFixture();
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "comparacao",
+      mode: "append",
+      balancing: "round",
+      // A união discriminada proíbe este campo no braço "comparacao": o cast é o
+      // teste. Server Action é endpoint HTTP público e o projeto não valida com
+      // zod — o contrato sob prova é o server IGNORAR o que o client pediu, e
+      // não confiar no type-check que só existe em tempo de compilação.
+      researchersPerDoc: 2,
+      participantIds: ["u1", "u2", "u3"],
+    } as unknown as LotteryParams);
+
+    expect(result.error).toBeUndefined();
+    expect(result.preview?.totalNew).toBe(1);
+    expect(
+      result.preview?.participants.filter((p) => p.newDocs > 0),
+    ).toHaveLength(1);
+  });
+
+  it("codificação continua honrando dois pesquisadores por documento", async () => {
+    serverTableResults = comparisonFixture();
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "codificacao",
+      mode: "append",
+      balancing: "round",
+      researchersPerDoc: 2,
+      participantIds: ["u1", "u2", "u3"],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.preview?.totalNew).toBe(2);
+  });
+
+  it("documento com comparação CONCLUÍDA volta a ser sorteável, mas não para quem já comparou", async () => {
+    // Concluída não ocupa a vaga (é o que permite a re-rodada por versão de
+    // schema); o par continua bloqueado pelo preservedSet.
+    serverTableResults = comparisonFixture([
+      { document_id: "d1", user_id: "u1", status: "concluido", type: "comparacao" },
+    ]);
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "comparacao",
+      mode: "append",
+      balancing: "round",
+      participantIds: ["u1", "u2", "u3"],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.preview?.totalNew).toBe(1);
+    const sorteado = result.preview?.participants.find((p) => p.newDocs > 0);
+    expect(sorteado?.userId).not.toBe("u1");
+  });
+
+  it("documento com comparação PENDENTE não recebe um segundo revisor", async () => {
+    serverTableResults = comparisonFixture([
+      { document_id: "d1", user_id: "u1", status: "pendente", type: "comparacao" },
+    ]);
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "comparacao",
+      mode: "append",
+      balancing: "round",
+      // Forjado: é este pedido que, honrado, abriria a 2ª vaga do documento.
+      researchersPerDoc: 2,
+      participantIds: ["u1", "u2", "u3"],
+    } as unknown as LotteryParams);
+
+    // O documento passa nos filtros (o coordenador não filtrou nada), mas a vaga
+    // está ocupada pela comparação ativa: a prévia mostra zero elegíveis em vez
+    // de arranjar um segundo revisor.
+    expect(result.error).toBeUndefined();
+    expect(result.preview?.eligibleDocs).toBe(0);
+    expect(result.preview?.totalNew).toBe(0);
+  });
+
+  it("smartRandomize grava um assignment e registra researchers_per_doc 1 no lote", async () => {
+    serverTableResults = {
+      ...comparisonFixture(),
+      // Fila: a 1ª leitura é a do computeLottery (lista de lotes); a 2ª é o
+      // insert...select("id").single() do lote deste sorteio.
+      assignment_batches: [{ data: [] }, { data: { id: "b1" } }],
+    };
+    rpcResults = { apply_lottery_assignments: { data: 1 } };
+
+    const result = await smartRandomize({
+      projectId: "p1",
+      type: "comparacao",
+      mode: "append",
+      balancing: "round",
+      researchersPerDoc: 2, // forjado — a gravação tem de refletir o efetivo (1)
+      participantIds: ["u1", "u2", "u3"],
+    } as unknown as LotteryParams);
+
+    expect(result.error).toBeUndefined();
+    expect(result.count).toBe(1);
+
+    const rpc = rpcCalls.find((c) => c.fn === "apply_lottery_assignments");
+    expect(rpc?.args).toMatchObject({ p_type: "comparacao" });
+    expect((rpc?.args as { p_assignments: unknown[] }).p_assignments).toHaveLength(1);
+
+    const lote = writeCalls.find(
+      (c) => c.table === "assignment_batches" && c.op === "insert",
+    );
+    expect(lote?.payload).toMatchObject({ researchers_per_doc: 1 });
   });
 });

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -12,6 +12,7 @@ import {
   computeCapacity,
   resolveWeight,
   resolveCap,
+  resolveResearchersPerDoc,
   type LotteryBalancing,
   type LotteryDocStats,
   type LotteryFilters,
@@ -66,6 +67,13 @@ export async function cycleAssignment(
         .from("assignments")
         .update({ type: "comparacao" })
         .eq("id", pendingCod.id);
+      // Este ciclo enxerga só o par (documento, usuário) — não sabe de
+      // comparações de OUTROS usuários no mesmo documento. Quem barra é o índice
+      // assignments_one_active_comparacao_per_doc (um revisor por documento).
+      // Traduzir em vez de vazar o texto do Postgres para o toast do coordenador.
+      if (error?.code === "23505") {
+        return { error: "Este documento já tem um revisor de comparação atribuído." };
+      }
       if (error) throw new Error(error.message);
     } else if (pendingComp && !pendingCod) {
       // comparacao → vazio
@@ -114,14 +122,12 @@ export async function clearPendingAssignments(
 
 // --- Smart Lottery (spec 001) ---
 
-export interface LotteryParams {
+interface LotteryParamsBase {
   projectId: string;
-  type?: "codificacao" | "comparacao";
   mode: LotteryMode;
   balancing: LotteryBalancing;
   /** semente da prévia (research D13); ausente = gerar nova */
   seed?: number;
-  researchersPerDoc: number;
   docsPerResearcher?: number;
   docSubsetSize?: number;
   label?: string;
@@ -135,6 +141,23 @@ export interface LotteryParams {
    */
   participantSettings?: Record<string, { weight?: number; cap?: number | null }>;
 }
+
+/**
+ * União discriminada por `type`: "comparação com 2 revisores" deixa de ser
+ * construível — o braço `comparacao` não tem o campo. A regra é um revisor de
+ * comparação por documento (ver COMPARISON_REVIEWERS_PER_DOC, issue #490).
+ *
+ * ATENÇÃO: isto é garantia de COMPILAÇÃO, para o client. Server Action é
+ * endpoint HTTP público e o projeto não valida com zod — um payload forjado
+ * chega com `{ type: "comparacao", researchersPerDoc: 5 }` sem passar por
+ * type-check nenhum. As garantias de runtime são `resolveResearchersPerDoc` em
+ * computeLottery (que ignora o valor recebido) e, no banco, o índice
+ * assignments_one_active_comparacao_per_doc. O `researchersPerDoc?: never`
+ * existe só para o excess property check pegar o literal no client.
+ */
+export type LotteryParams =
+  | (LotteryParamsBase & { type: "codificacao"; researchersPerDoc: number })
+  | (LotteryParamsBase & { type: "comparacao"; researchersPerDoc?: never });
 
 interface LotteryAssignment {
   document_id: string;
@@ -275,9 +298,20 @@ async function computeLottery(params: LotteryParams): Promise<{
   eligibleCount: number;
   seed: number;
   batchData: Record<string, unknown>;
+  /** tipo normalizado aqui — quem grava reusa em vez de renormalizar */
+  assignmentType: "codificacao" | "comparacao";
 }> {
   const supabase = await createSupabaseServer();
-  const assignmentType = params.type || "codificacao";
+  // Normaliza em vez de confiar no literal: o payload chega por HTTP e não passa
+  // por zod. Qualquer coisa que não seja "comparacao" é codificação.
+  const assignmentType =
+    params.type === "comparacao" ? "comparacao" : "codificacao";
+  // Para comparação o valor pedido é ignorado (sempre 1) — a união discriminada
+  // já proíbe o campo no client, e este é o guard para quem vem de fora dela.
+  const researchersPerDoc = resolveResearchersPerDoc(
+    assignmentType,
+    (params as { researchersPerDoc?: number }).researchersPerDoc,
+  );
   const filters = params.filters || {};
 
   if (filters.batchFilter?.only && filters.batchFilter?.exclude?.length) {
@@ -339,14 +373,37 @@ async function computeLottery(params: LotteryParams): Promise<{
     (a) => a.type === assignmentType && preservedStatuses.includes(a.status)
   );
 
+  // Anti-duplicidade de par: continua derivando de `preserved` (dependente do
+  // modo) — em replace as pendentes são deletadas na mesma transação do RPC,
+  // então o par pode voltar a ser sorteado sem violar UNIQUE(doc, user, type).
   const preservedSet = new Set(preserved.map((a) => `${a.document_id}:${a.user_id}`));
+
+  // Ocupação de vaga ≠ anti-duplicidade de par. Para comparação a vaga só é
+  // ocupada por uma atribuição ATIVA: o invariante é "no máximo 1 comparação
+  // ativa por documento" (o mesmo do guard do gatilho automático e do índice
+  // assignments_one_active_comparacao_per_doc), não "1 comparação na história do
+  // documento". Sem isto, com um revisor por doc, um documento com parecer
+  // concluído jamais voltaria ao sorteio — impedindo a re-rodada por versão de
+  // schema que o índice existe para permitir. Para codificação, `occupying` é o
+  // próprio `preserved`: comportamento idêntico ao anterior (duas codificações
+  // concluídas seguem ocupando o documento).
+  const occupying =
+    assignmentType === "comparacao"
+      ? preserved.filter((a) => a.status !== "concluido")
+      : preserved;
 
   const docAssignedCount: Record<string, number> = {};
   const docAssignedUsers: Record<string, Set<string>> = {};
-  const preservedByUser: Record<string, number> = {};
-  for (const a of preserved) {
+  for (const a of occupying) {
     docAssignedCount[a.document_id] = (docAssignedCount[a.document_id] || 0) + 1;
     (docAssignedUsers[a.document_id] ??= new Set()).add(a.user_id);
+  }
+
+  // Carga acumulada segue em `preserved`: uma comparação concluída é trabalho
+  // feito — conta para o equilíbrio `history` e é o "existing" da prévia, ainda
+  // que não ocupe mais a vaga do documento.
+  const preservedByUser: Record<string, number> = {};
+  for (const a of preserved) {
     preservedByUser[a.user_id] = (preservedByUser[a.user_id] || 0) + 1;
   }
 
@@ -356,7 +413,7 @@ async function computeLottery(params: LotteryParams): Promise<{
 
   // Docs com vaga, considerando o conjunto preservado do modo
   let eligibleDocIds = filteredDocs
-    .filter((d) => (docAssignedCount[d.id] || 0) < params.researchersPerDoc)
+    .filter((d) => (docAssignedCount[d.id] || 0) < researchersPerDoc)
     .map((d) => d.id);
   const eligibleCount = eligibleDocIds.length;
 
@@ -407,7 +464,7 @@ async function computeLottery(params: LotteryParams): Promise<{
     eligibleDocIds,
     participants,
     {
-      researchersPerDoc: params.researchersPerDoc,
+      researchersPerDoc,
       balancing: params.balancing,
       preservedPairs: preservedSet,
       docAssignedUsers: Object.fromEntries(
@@ -423,7 +480,8 @@ async function computeLottery(params: LotteryParams): Promise<{
 
   const batchData = {
     project_id: params.projectId,
-    researchers_per_doc: params.researchersPerDoc,
+    // O lote registra o que aconteceu (o efetivo), não o que foi pedido.
+    researchers_per_doc: researchersPerDoc,
     docs_per_researcher: params.docsPerResearcher || null,
     doc_subset_size: params.docSubsetSize || null,
     label: params.label || null,
@@ -445,6 +503,7 @@ async function computeLottery(params: LotteryParams): Promise<{
     eligibleCount,
     seed,
     batchData,
+    assignmentType,
   };
 }
 
@@ -488,7 +547,6 @@ export async function smartRandomize(
   if (!user) return { error: "Não autenticado" };
 
   const supabase = await createSupabaseServer();
-  const assignmentType = params.type || "codificacao";
 
   let count: number;
   let preserved: number;
@@ -496,7 +554,8 @@ export async function smartRandomize(
   // Operação crítica: computeLottery + registro do lote + RPC transacional. Só
   // um erro aqui (nada gravado, ou gravação abortada) deve virar { error }.
   try {
-    const { newAssignments, preservedCount, batchData } = await computeLottery(params);
+    const { newAssignments, preservedCount, batchData, assignmentType } =
+      await computeLottery(params);
 
     // O batch é criado antes de qualquer mudança em assignments: se falhar
     // (ex.: migration ausente), nada foi deletado ainda
@@ -520,18 +579,26 @@ export async function smartRandomize(
       document_id: a.document_id,
       user_id: a.user_id,
     }));
-    const { error: rpcError } = await supabase.rpc("apply_lottery_assignments", {
-      p_project_id: params.projectId,
-      p_type: assignmentType,
-      p_batch_id: batch.id,
-      p_assignments: assignmentRows,
-      p_replace: params.mode === "replace",
-    });
+    const { data: inserted, error: rpcError } = await supabase.rpc(
+      "apply_lottery_assignments",
+      {
+        p_project_id: params.projectId,
+        p_type: assignmentType,
+        p_batch_id: batch.id,
+        p_assignments: assignmentRows,
+        p_replace: params.mode === "replace",
+      },
+    );
     if (rpcError) {
       throw new Error(`Erro ao gravar as atribuições do sorteio: ${rpcError.message}`);
     }
 
-    count = newAssignments.length;
+    // Contagem REAL do RPC, não o tamanho do que se pretendia gravar: o
+    // ON CONFLICT DO NOTHING pula linhas quando o gatilho automático cria a
+    // comparação do documento entre a leitura do computeLottery (fora da
+    // transação) e este INSERT. Reportar o pretendido faria o coordenador ver
+    // um número que não está no banco.
+    count = typeof inserted === "number" ? inserted : newAssignments.length;
     preserved = preservedCount;
   } catch (e) {
     return { error: errorMessage(e) || "Erro ao sortear" };

--- a/frontend/src/components/assignments/LotteryDistributionSection.tsx
+++ b/frontend/src/components/assignments/LotteryDistributionSection.tsx
@@ -68,22 +68,33 @@ export function LotteryDistributionSection({
     <div className="space-y-4">
       <h4 className="text-sm font-semibold">Distribuição</h4>
 
-      <div>
-        <Label htmlFor="per-doc">
-          {isComparacao ? "Revisores por documento" : "Pesquisadores por documento"}
-        </Label>
-        <Input
-          id="per-doc"
-          type="number"
-          min={1}
-          max={Math.max(1, Math.min(10, membersCount))}
-          value={researchersPerDoc}
-          onChange={(e) =>
-            setResearchersPerDoc(parseInt(e.target.value) || 1)
-          }
-          className="mt-1 w-24"
-        />
-      </div>
+      {/* Comparação não expõe o campo: um revisor por documento é a regra, não
+          uma configuração — deixá-lo editável (ou desabilitado em 1) afirmaria
+          que existe uma escolha a fazer. O valor da codificação continua no
+          state, então voltar para ela restaura o que foi digitado (#490). */}
+      {isComparacao ? (
+        <div>
+          <Label>Revisores por documento</Label>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Um revisor por documento — o veredito é ato de desempate único.
+          </p>
+        </div>
+      ) : (
+        <div>
+          <Label htmlFor="per-doc">Pesquisadores por documento</Label>
+          <Input
+            id="per-doc"
+            type="number"
+            min={1}
+            max={Math.max(1, Math.min(10, membersCount))}
+            value={researchersPerDoc}
+            onChange={(e) =>
+              setResearchersPerDoc(parseInt(e.target.value) || 1)
+            }
+            className="mt-1 w-24"
+          />
+        </div>
+      )}
 
       <div className="flex items-center justify-between">
         <Label htmlFor="docs-per-switch">

--- a/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
+++ b/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
@@ -54,13 +54,13 @@ const previewResult: LotteryPreview = {
 
 // Integra useLotteryParams + useLotteryRun como no LotteryDialog real —
 // o contrato sob teste é o casamento prévia↔configuração (research D13).
-function setup() {
+function setup(statsOverride: LotteryStats = stats) {
   return renderHook(() => {
     const params = useLotteryParams();
     const run = useLotteryRun({
       projectId: "p1",
       members,
-      stats,
+      stats: statsOverride,
       params,
       onLotteryDone: vi.fn(),
     });
@@ -164,5 +164,74 @@ describe("useLotteryRun", () => {
     await act(() => result.current.run.handleRandomize());
     expect(onLotteryDone).toHaveBeenCalledOnce();
     expect(result.current.params.previewState).toBeNull();
+  });
+});
+
+// Regressão da issue #490: o RadioGroup de tipo vive no mesmo dialog montado, e
+// o state de revisores/pesquisadores por documento é o mesmo dos dois lados —
+// marcar "Comparação" levava o default 2 da Codificação junto.
+describe("useLotteryRun: um revisor por documento na comparação (#490)", () => {
+  // A fixture global tem docs com 0/1 codificação e piso 2 → comparação zeraria
+  // os elegíveis e o submit nem sairia. Aqui os docs estão aptos a comparar.
+  const comparableStats: LotteryStats = {
+    ...stats,
+    docs: [
+      doc("d1", { humanCodingCount: 2 }),
+      doc("d2", { humanCodingCount: 2 }),
+      doc("d3", { humanCodingCount: 2 }),
+    ],
+  };
+
+  it("trocar para comparação não herda o valor digitado na codificação", async () => {
+    const { result } = setup(comparableStats);
+    act(() => {
+      result.current.params.setResearchersPerDoc(3);
+      result.current.params.setType("comparacao");
+    });
+
+    await act(() => result.current.run.handleRandomize());
+
+    const enviado = mockRandomize.mock.calls.at(-1)![0];
+    expect(enviado).toMatchObject({ type: "comparacao" });
+    // O braço "comparacao" da união nem carrega o campo: não há valor a herdar.
+    expect(enviado).not.toHaveProperty("researchersPerDoc");
+  });
+
+  it("voltar para codificação restaura o valor digitado", async () => {
+    const { result } = setup(comparableStats);
+    act(() => {
+      result.current.params.setResearchersPerDoc(3);
+      result.current.params.setType("comparacao");
+    });
+    act(() => {
+      result.current.params.setType("codificacao");
+    });
+
+    await act(() => result.current.run.handleRandomize());
+
+    expect(mockRandomize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "codificacao", researchersPerDoc: 3 }),
+    );
+  });
+
+  it("codificação envia o default 2 sem o coordenador tocar no campo", async () => {
+    const { result } = setup(comparableStats);
+    await act(() => result.current.run.handleRandomize());
+
+    expect(mockRandomize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ type: "codificacao", researchersPerDoc: 2 }),
+    );
+  });
+
+  it("a estimativa por participante usa um revisor por documento", () => {
+    const { result } = setup(comparableStats);
+    // Codificação: 3 docs × 2 pesquisadores por doc ÷ 2 participantes = 3.
+    expect(result.current.run.estimatedPerParticipant).toBe(3);
+
+    act(() => {
+      result.current.params.setType("comparacao");
+    });
+    // Comparação: 3 docs × 1 revisor ÷ 2 participantes = 2 (arredondado p/ cima).
+    expect(result.current.run.estimatedPerParticipant).toBe(2);
   });
 });

--- a/frontend/src/components/assignments/useLotteryRun.ts
+++ b/frontend/src/components/assignments/useLotteryRun.ts
@@ -6,6 +6,7 @@ import {
   filterEligibleDocs,
   resolveWeight,
   resolveCap,
+  resolveResearchersPerDoc,
   type LotteryFilters,
 } from "@/lib/lottery-utils";
 import { toast } from "sonner";
@@ -91,6 +92,15 @@ export function useLotteryRun({
 
   const isComparacao = type === "comparacao";
 
+  // Derivado no render, nunca por effect: o state segue 2 (o default correto da
+  // codificação) e é simplesmente ignorado em comparação. Trocar de tipo não
+  // "herda" valor porque nada é herdado — e voltar para codificação restaura o
+  // que o coordenador tinha digitado. Mesma função pura do server (#490).
+  const researchersPerDocEffective = resolveResearchersPerDoc(
+    type,
+    researchersPerDoc,
+  );
+
   const filters = useMemo<LotteryFilters>(() => {
     const f: LotteryFilters = {};
     if (codingsFilterMode === "none") f.maxHumanCodings = 0;
@@ -121,7 +131,7 @@ export function useLotteryRun({
   // buildParams na hora do submit
   const configKey = JSON.stringify({
     type,
-    researchersPerDoc,
+    researchersPerDoc: researchersPerDocEffective,
     docsPerResearcherEnabled,
     docsPerResearcher,
     docSubsetEnabled,
@@ -158,22 +168,27 @@ export function useLotteryRun({
 
   const canSubmit = !blockedMessage && stats !== null;
 
-  const buildParams = (withSeed: boolean): LotteryParams => ({
-    projectId,
-    type,
-    mode,
-    balancing,
-    seed: withSeed && seed !== null ? seed : undefined,
-    researchersPerDoc,
-    docsPerResearcher: docsPerResearcherEnabled
-      ? docsPerResearcher
-      : undefined,
-    docSubsetSize: docSubsetEnabled ? docSubsetSize : undefined,
-    label: label || undefined,
-    filters,
-    participantIds,
-    participantSettings,
-  });
+  const buildParams = (withSeed: boolean): LotteryParams => {
+    const base = {
+      projectId,
+      mode,
+      balancing,
+      seed: withSeed && seed !== null ? seed : undefined,
+      docsPerResearcher: docsPerResearcherEnabled
+        ? docsPerResearcher
+        : undefined,
+      docSubsetSize: docSubsetEnabled ? docSubsetSize : undefined,
+      label: label || undefined,
+      filters,
+      participantIds,
+      participantSettings,
+    };
+    // A união discriminada não tem researchersPerDoc no braço de comparação —
+    // um revisor por documento é a regra, não uma configuração.
+    return type === "comparacao"
+      ? { ...base, type: "comparacao" }
+      : { ...base, type: "codificacao", researchersPerDoc: researchersPerDocEffective };
+  };
 
   const handlePreview = async () => {
     setPreviewing(true);
@@ -216,7 +231,9 @@ export function useLotteryRun({
 
   const estimatedPerParticipant =
     docsConsidered !== null && participantIds.length > 0
-      ? Math.ceil((docsConsidered * researchersPerDoc) / participantIds.length)
+      ? Math.ceil(
+          (docsConsidered * researchersPerDocEffective) / participantIds.length,
+        )
       : 0;
 
   return {

--- a/frontend/src/lib/__tests__/lottery-utils.test.ts
+++ b/frontend/src/lib/__tests__/lottery-utils.test.ts
@@ -7,6 +7,7 @@ import {
   computeCapacity,
   resolveWeight,
   resolveCap,
+  resolveResearchersPerDoc,
   type LotteryBalancing,
   type LotteryDocStats,
   type LotteryParticipant,
@@ -555,6 +556,33 @@ describe("resolveCap", () => {
   it("trunca para inteiro (coluna INTEGER)", () => {
     expect(resolveCap(3)).toBe(3);
     expect(resolveCap(2.9)).toBe(2);
+  });
+});
+
+describe("resolveResearchersPerDoc", () => {
+  // Regressão #490: o sorteio de Comparação herdava o default 2 da Codificação.
+  it("comparação ignora o valor pedido — sempre um revisor por documento", () => {
+    expect(resolveResearchersPerDoc("comparacao", 2)).toBe(1);
+    expect(resolveResearchersPerDoc("comparacao", 5)).toBe(1);
+    expect(resolveResearchersPerDoc("comparacao", undefined)).toBe(1);
+    expect(resolveResearchersPerDoc("comparacao", null)).toBe(1);
+  });
+
+  it("codificação repassa o valor — a dupla independente é o método lá", () => {
+    expect(resolveResearchersPerDoc("codificacao", 2)).toBe(2);
+    expect(resolveResearchersPerDoc("codificacao", 3)).toBe(3);
+  });
+
+  it("codificação sanitiza ausente, NaN, zero e negativo → 1", () => {
+    expect(resolveResearchersPerDoc("codificacao", undefined)).toBe(1);
+    expect(resolveResearchersPerDoc("codificacao", null)).toBe(1);
+    expect(resolveResearchersPerDoc("codificacao", NaN)).toBe(1);
+    expect(resolveResearchersPerDoc("codificacao", 0)).toBe(1);
+    expect(resolveResearchersPerDoc("codificacao", -2)).toBe(1);
+  });
+
+  it("codificação trunca fracionário", () => {
+    expect(resolveResearchersPerDoc("codificacao", 2.9)).toBe(2);
   });
 });
 

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -119,7 +119,7 @@ export function filterComparisonEligible(
  * revisores no mesmo documento não seriam dupla checagem, e sim um segundo
  * desempate sem regra de precedência (issue #490).
  */
-export const COMPARISON_REVIEWERS_PER_DOC = 1;
+const COMPARISON_REVIEWERS_PER_DOC = 1;
 
 /**
  * Revisores/pesquisadores por documento EFETIVO do sorteio. Fonte única da

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -114,6 +114,35 @@ export function filterComparisonEligible(
 }
 
 /**
+ * Um revisor de comparação por documento: o veredito é ato de desempate único,
+ * não codificação em dupla (a dupla independente é da CODIFICAÇÃO). Dois
+ * revisores no mesmo documento não seriam dupla checagem, e sim um segundo
+ * desempate sem regra de precedência (issue #490).
+ */
+export const COMPARISON_REVIEWERS_PER_DOC = 1;
+
+/**
+ * Revisores/pesquisadores por documento EFETIVO do sorteio. Fonte única da
+ * regra, compartilhada pelo client (estimativa/configKey/buildParams) e pelo
+ * server (computeLottery) para que os dois não possam divergir — mesmo motivo
+ * das primitivas puras de schema-utils.ts (#63).
+ *
+ * Para comparação o valor pedido é IGNORADO, não validado: a Server Action é
+ * endpoint HTTP público e este projeto não valida payload com zod, então o
+ * server não pode confiar no client. Espelhado no banco pelo índice
+ * assignments_one_active_comparacao_per_doc.
+ */
+export function resolveResearchersPerDoc(
+  type: "codificacao" | "comparacao",
+  requested?: number | null,
+): number {
+  if (type === "comparacao") return COMPARISON_REVIEWERS_PER_DOC;
+  return requested != null && Number.isFinite(requested) && requested >= 1
+    ? Math.floor(requested)
+    : 1;
+}
+
+/**
  * Pipeline de elegibilidade — interseção em ordem fixa (data-model.md):
  * ativos (garantido no fetch) → manual → codificações → status de
  * atribuição → lote. A exigência mínima de respostas para comparação é

--- a/frontend/supabase/migrations/20260716120000_comparacao_single_reviewer_rpcs.sql
+++ b/frontend/supabase/migrations/20260716120000_comparacao_single_reviewer_rpcs.sql
@@ -1,0 +1,215 @@
+-- Prepara as RPCs de escrita para o índice único parcial
+-- assignments_one_active_comparacao_per_doc, criado na migration seguinte
+-- (issue #490: um revisor de comparação por documento).
+--
+-- ORDEM IMPORTA: esta migration vem ANTES da que cria o índice. As funções
+-- precisam tolerar a restrição antes de ela existir; invertido, haveria uma
+-- janela com índice ativo e RPCs ingênuas — e todas as três abaixo abortam a
+-- transação inteira ao receber um unique_violation não tratado.
+--
+-- As definições originais (20260629120000_atomic_replace_rpcs.sql e
+-- 20260715160000_atomic_member_permission_rpcs.sql) já estão aplicadas no
+-- remoto e não são editadas: redefinição por CREATE OR REPLACE, preservando
+-- assinatura, SECURITY INVOKER e search_path.
+
+-- ========== #181 / #490: sorteio ==========
+-- Muda só o ON CONFLICT. `computeLottery` já garante ausência de duplicatas no
+-- caminho feliz; o DO NOTHING existe para a CORRIDA: a leitura de assignments
+-- acontece FORA desta transação, e entre ela e o INSERT o gatilho automático
+-- (createAutoComparisonIfDiverges, disparado por qualquer saveResponse) pode
+-- criar a comparação ativa do documento. Como o INSERT é set-based, sem isto
+-- UMA linha em conflito abortaria o sorteio INTEIRO de centenas de documentos.
+--
+-- Sem target de propósito: `ON CONFLICT (colunas)` é arbiter-específico e
+-- inferiria apenas assignments_document_id_user_id_type_key, deixando o índice
+-- parcial de fora. Sem target, cobre os dois.
+--
+-- Efeito no retorno: v_inserted passa a ser a contagem REAL de inserções, que
+-- pode ser menor que jsonb_array_length(p_assignments). É o número que o TS
+-- reporta ao coordenador (smartRandomize), e é o correto: o que está no banco.
+CREATE OR REPLACE FUNCTION public.apply_lottery_assignments(
+  p_project_id uuid,
+  p_type text,
+  p_batch_id uuid,
+  p_assignments jsonb,
+  p_replace boolean
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_inserted integer;
+BEGIN
+  IF p_replace THEN
+    DELETE FROM public.assignments
+    WHERE project_id = p_project_id
+      AND status = 'pendente'
+      AND type = p_type;
+  END IF;
+
+  INSERT INTO public.assignments (project_id, document_id, user_id, batch_id, type)
+  SELECT p_project_id,
+         (e->>'document_id')::uuid,
+         (e->>'user_id')::uuid,
+         p_batch_id,
+         p_type
+  FROM jsonb_array_elements(p_assignments) AS e
+  ON CONFLICT DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  RETURN v_inserted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.apply_lottery_assignments(uuid, text, uuid, jsonb, boolean)
+  TO authenticated;
+
+-- ========== #284 / #490: upload replace_and_add ==========
+-- Muda só o WHERE do UPDATE de assignments: não ressuscitar comparações
+-- CONCLUÍDAS. O UPDATE reabre todas as atribuições do documento sem filtrar por
+-- tipo; com o índice, um documento com duas linhas de comparação (ex.: uma
+-- concluída de rodada anterior + uma ativa, combinação que o índice permite por
+-- design) passaria a ter duas ATIVAS no mesmo comando — unique_violation, e o
+-- upload inteiro sofre rollback depois de reviews e responses já apagados.
+--
+-- Sob o invariante "no máximo uma comparação ativa por documento", excluir as
+-- concluídas garante que este UPDATE nunca cria uma segunda ativa: ele só mexe
+-- na que já estava dentro do predicado do índice.
+--
+-- Semanticamente também é o certo: as respostas do documento acabaram de ser
+-- apagadas: um parecer concluído reaberto sobre zero respostas seria um
+-- fantasma que a fila da Comparação nem exibiria.
+CREATE OR REPLACE FUNCTION public.replace_and_add_documents(
+  p_project_id uuid,
+  p_existing_doc_ids uuid[],
+  p_delete_responses boolean,
+  p_duplicate_updates jsonb,
+  p_new_documents jsonb
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_inserted integer := 0;
+BEGIN
+  IF p_delete_responses
+     AND p_existing_doc_ids IS NOT NULL
+     AND array_length(p_existing_doc_ids, 1) > 0 THEN
+    -- reviews antes (FK chosen_response_id -> responses sem CASCADE)
+    DELETE FROM public.reviews
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids);
+
+    DELETE FROM public.responses
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids);
+
+    UPDATE public.assignments
+    SET status = 'pendente'
+    WHERE project_id = p_project_id
+      AND document_id = ANY(p_existing_doc_ids)
+      AND NOT (type = 'comparacao' AND status = 'concluido');
+  END IF;
+
+  IF p_duplicate_updates IS NOT NULL
+     AND jsonb_array_length(p_duplicate_updates) > 0 THEN
+    UPDATE public.documents d
+    SET text = u."text",
+        title = u.title,
+        external_id = u.external_id,
+        text_hash = u.text_hash,
+        metadata = u.metadata
+    FROM jsonb_to_recordset(p_duplicate_updates)
+      AS u(id uuid, "text" text, title text, external_id text,
+           text_hash text, metadata jsonb)
+    WHERE d.id = u.id
+      AND d.project_id = p_project_id;  -- defense-in-depth: escopa ao projeto,
+                                        -- coerente com os DELETE/INSERT acima
+  END IF;
+
+  IF p_new_documents IS NOT NULL
+     AND jsonb_array_length(p_new_documents) > 0 THEN
+    INSERT INTO public.documents
+      (project_id, external_id, title, text, text_hash, metadata)
+    SELECT p_project_id, n.external_id, n.title, n."text", n.text_hash, n.metadata
+    FROM jsonb_to_recordset(p_new_documents)
+      AS n(external_id text, title text, "text" text,
+           text_hash text, metadata jsonb);
+    GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  END IF;
+
+  RETURN v_inserted;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION
+  public.replace_and_add_documents(uuid, uuid[], boolean, jsonb, jsonb)
+  TO authenticated;
+
+-- ========== #490: gatilho automático da comparação ==========
+-- Muda só o ON CONFLICT, pelo mesmo motivo do sorteio: com target, o índice
+-- parcial ficaria de fora e o conflito viraria exceção. O FOR UPDATE existente
+-- trava a membership do revisor (can_compare), não serializa por documento —
+-- então dois revisores distintos para o mesmo documento é exatamente o que
+-- escapa dele.
+--
+-- Com o DO NOTHING sem target, GET DIAGNOSTICS devolve 0 e a função retorna
+-- false, que assignComparisonReviewer (lib/auto-comparison.ts) já interpreta
+-- como "não atribuí" — nenhuma mudança no TS. O guard de idempotência de
+-- createAutoComparisonIfDiverges (que lê fora da transação, TOCTOU) passa a ser
+-- otimização: o árbitro da corrida é o índice.
+--
+-- Preferido a EXCEPTION WHEN unique_violation: o bloco de exceção do plpgsql
+-- abre uma subtransação a cada chamada.
+CREATE OR REPLACE FUNCTION public.assign_comparison_if_eligible(
+  p_project_id uuid,
+  p_document_id uuid,
+  p_user_id uuid
+) RETURNS boolean
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_inserted integer := 0;
+BEGIN
+  PERFORM 1
+  FROM public.project_members AS pm
+  WHERE pm.project_id = p_project_id
+    AND pm.user_id = p_user_id
+    AND pm.can_compare = true
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  INSERT INTO public.assignments (
+    project_id,
+    document_id,
+    user_id,
+    type,
+    status
+  ) VALUES (
+    p_project_id,
+    p_document_id,
+    p_user_id,
+    'comparacao',
+    'pendente'
+  )
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+
+  RETURN v_inserted = 1;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION
+  public.assign_comparison_if_eligible(uuid, uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION
+  public.assign_comparison_if_eligible(uuid, uuid, uuid)
+  TO service_role;

--- a/frontend/supabase/migrations/20260716120100_assignments_one_active_comparacao_per_doc.sql
+++ b/frontend/supabase/migrations/20260716120100_assignments_one_active_comparacao_per_doc.sql
@@ -1,0 +1,46 @@
+-- Invariante do produto: UM revisor de comparação por documento (issue #490).
+-- O veredito da comparação é ato de desempate único — dois revisores no mesmo
+-- documento não são dupla checagem, e sim um segundo desempate sem regra de
+-- precedência. A dupla independente é da CODIFICAÇÃO, e é lá que dois
+-- pesquisadores por documento é o método correto.
+--
+-- Até aqui nada impedia N: a única unicidade era
+-- assignments_document_id_user_id_type_key (20260402100000_assignment_type.sql),
+-- que tem user_id na chave — ela barra o MESMO revisor duas vezes, não dois
+-- revisores distintos no mesmo documento.
+--
+-- ATIVA, não qualquer: comparações CONCLUÍDAS ficam fora do predicado de
+-- propósito e podem acumular. É o que permite re-sortear a comparação de um
+-- documento numa nova rodada (ex.: bump de MAJOR do schema) sem apagar o parecer
+-- anterior. Mesma noção de "ativa" que o guard de idempotência do gatilho
+-- automático (lib/auto-comparison.ts) e a coluna active_comparacao da view
+-- lottery_doc_stats já usam, e que o sorteio manual passou a usar para decidir
+-- ocupação de vaga (computeLottery, `occupying`).
+--
+-- IS DISTINCT FROM e não <>: a coluna status é NULLABLE (001_initial_schema.sql
+-- só define DEFAULT 'pendente', sem NOT NULL). Com `status <> 'concluido'` o
+-- predicado seria NULL para uma linha de status nulo, deixando-a FORA do índice
+-- — um furo silencioso na restrição.
+--
+-- Este índice é CONSTRAINT, não caminho de acesso: o planner praticamente não
+-- consegue provar que uma query implica um predicado com IS DISTINCT FROM, então
+-- ele não vai ser usado em leitura. Isso é esperado — não trocar por <> "para o
+-- índice ser aproveitado".
+--
+-- Pré-requisito de criação (CREATE UNIQUE INDEX falha se o dado violar): a
+-- auditoria de 2026-07-16 encontrou 340 assignments de comparação em 339
+-- documentos, com UM documento em violação (4947230d, projeto 500ea889) — duas
+-- comparações pendentes, nenhuma com veredito. A linha excedente foi removida
+-- por script local antes desta migration; a auditoria repetida devolveu zero
+-- documentos com mais de uma comparação ativa (e zero com mais de uma
+-- concluída, e zero linhas de status nulo).
+--
+-- O que essa violação ensina, e que a #490 não previa: as duas linhas tinham
+-- ORIGENS DIFERENTES — uma do sorteio manual (batch_id do lote "Duda", que já
+-- rodara com researchers_per_doc = 1) e outra do gatilho automático (batch_id
+-- nulo). O default 2 do sorteio não a produziu; ela nasceu da falta de
+-- serialização entre os dois caminhos, que só o banco pode arbitrar. É a razão
+-- de este índice existir, e não apenas o guard no client e no server.
+CREATE UNIQUE INDEX IF NOT EXISTS assignments_one_active_comparacao_per_doc
+  ON assignments (document_id)
+  WHERE type = 'comparacao' AND status IS DISTINCT FROM 'concluido';


### PR DESCRIPTION
## O problema

O sorteio da aba **Comparação** reaproveitava o controle do sorteio de Codificação, onde `researchersPerDoc = 2` é o default correto (dupla codificação independente é o método). Só o rótulo foi traduzido: o state e o default vieram junto. A regra da Comparação é **um revisor por documento** — o veredito é ato de desempate único, não codificação em dupla.

Nada impedia N: nem o client (`useLotteryParams.ts:19`), nem o server (`computeLottery` usava `params.researchersPerDoc` sem olhar o tipo), nem o schema (`UNIQUE(document_id, user_id, type)` tem `user_id` na chave, então dois revisores distintos no mesmo documento eram legais por construção).

## O que a auditoria de produção mostrou — e que muda a leitura da issue

A #490 supunha que o default 2 era "a porta que fabrica o estado". **Os dados dizem outra coisa.** Dos 340 assignments de comparação (339 documentos), apenas um documento estava em violação — e as duas linhas tinham **origens diferentes**:

| Revisor | `batch_id` | Origem |
|---|---|---|
| Maria Eduarda | `77d682f2` (lote "Duda", 14/06) | Sorteio manual — **já com `researchers_per_doc: 1`** |
| Mariana Chies | `null` | Gatilho automático (`automation_mode: compare_humans`) |

O coordenador **já usava o valor correto**. A duplicata nasceu da falta de serialização entre o sorteio manual e o gatilho automático (cujo guard de idempotência lê fora da transação). Ou seja: **corrigir só o client — o escopo original da issue — não teria evitado o único caso real.** Quem fecha isso é o índice.

A linha excedente (pendente, sem veredito) foi removida antes da migration; a auditoria repetida devolveu zero violações. Também zero documentos com mais de uma comparação concluída e zero linhas de `status` nulo.

## A correção, em três camadas

1. **Tipo** — `LotteryParams` vira união discriminada por `type`; o braço `comparacao` não carrega o campo. Segue o idioma que o codebase já usa (`LotterySummary`). É garantia de **compilação**, e o comentário diz isso: Server Action é endpoint HTTP público e o projeto não valida com zod.
2. **Server** — `computeLottery` deriva o valor por `resolveResearchersPerDoc` (fonte única compartilhada com o client, padrão anti-drift do #63) e **ignora** o que o payload pediu. O lote passa a registrar o que aconteceu, não o que foi pedido.
3. **Banco** — índice único parcial `assignments_one_active_comparacao_per_doc`.

### A parte não óbvia: ocupação de vaga ≠ anti-duplicidade de par

Baixar o número para 1 e parar aí **seria uma regressão**. `preserved` inclui `concluido` nos dois modos, e o filtro de vaga é `docAssignedCount < researchersPerDoc`: com 1, todo documento com parecer concluído ficaria inelegível **para sempre**. Hoje ele ainda é sorteável porque sobra a 2ª vaga — a re-rodada por bump de MAJOR funciona *por acidente do default errado*.

Por isso o PR separa as duas noções: para comparação, só uma atribuição **ativa** ocupa a vaga (mesmo invariante do gatilho automático e do índice); o `preservedSet` segue barrando o mesmo revisor duas vezes; e a carga acumulada continua contando as concluídas, que são trabalho feito.

### Migrations ordenadas (as RPCs antes do índice)

As RPCs precisam tolerar a restrição **antes** de ela existir:

- `apply_lottery_assignments` e `assign_comparison_if_eligible`: `ON CONFLICT DO NOTHING` **sem target**. Com target, o índice parcial não é inferido e o conflito vira exceção — e como o INSERT do sorteio é set-based, **uma** linha em corrida abortaria o sorteio inteiro. Verificado empiricamente (ver abaixo).
- `replace_and_add_documents`: deixa de ressuscitar comparações concluídas — sem isso, um upload em modo replace sobre documento com histórico estouraria e daria rollback depois de reviews/responses já apagados.
- `smartRandomize` passa a reportar a contagem **real** do RPC.
- `cycleAssignment` traduz o 23505 em mensagem em português em vez de vazar o texto do Postgres.

Efeito colateral útil: na janela entre o `db push` e o merge, o código antigo pedindo 2 revisores degrada graciosamente (o banco grava 1) em vez de estourar.

## Verificação

**Testes** (1333 verdes; +14 novos). Cada ponto da correção foi validado por **mutação** — reverti a correção e confirmei qual teste falha:

| Mutação | Teste que pega |
|---|---|
| helper honra o pedido em comparação | 4 testes, incl. o do payload forjado e o do documento pendente |
| `occupying` volta a contar concluídas | teste da re-rodada |
| `buildParams` manda o state cru | "trocar para comparação não herda o valor" |
| estimativa usa o valor cru | "a estimativa usa um revisor por documento" |

**SQL** — validado em Postgres 15 limpo, aplicando o arquivo real da migration:

- segundo revisor no mesmo documento → **barrado** (era o bug);
- documento com comparação concluída → **volta a ser sorteável** (re-rodada preservada), e concluídas acumulam;
- `ON CONFLICT DO NOTHING` sem target → **absorve**; **com** target (como estava) → **estoura** — prova de que a mudança era necessária;
- codificação com 2 pesquisadores → intocada;
- `IS DISTINCT FROM` vs `<>`: com duas linhas ativas de `status` nulo, a variante `<>` **cria feliz** (furo silencioso) e a escolhida **recusa**;
- UPDATE do `replace_and_add_documents` sem o filtro → **estoura**; com o filtro → preserva o invariante.

Gates: typecheck, lint:types, vitest, e2e smoke, fallow, semgrep, react-doctor (100/100) — todos verdes.

## Antes do merge

⚠️ **As duas migrations precisam ser aplicadas no remoto ANTES do merge** (o merge dispara deploy automático). Aguardo sua autorização para o `npx supabase db push`.

Não criei teste de render para `LotteryDistributionSection`: não há teste de componente nessa pasta e o contrato real está no hook.

## Follow-up

`compare-sync.ts:155-161` reabre comparações e **descarta o erro** do supabase-js. Com o índice, reabrir uma concluída num documento que já tem outra ativa vira no-op silencioso — semanticamente desejado, mas por acidente e sem log. Abro issue separada se você concordar.

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)