### PR TITLE
fix(comparação): explicita regressão bloqueada de parecer concluído

### DIFF
--- a/frontend/src/actions/equivalences.ts
+++ b/frontend/src/actions/equivalences.ts
@@ -177,6 +177,7 @@ export async function unmarkEquivalencePair(
   if (!user) return { error: "Não autenticado" };
 
   const supabase = await createSupabaseServer();
+  let syncDocumentId: string | null = null;
 
   try {
     const { data: row } = await supabase
@@ -207,10 +208,24 @@ export async function unmarkEquivalencePair(
         .eq("field_name", row.field_name)
         .eq("reviewer_id", user.id);
 
-      await syncCompareAssignment(supabase, projectId, row.document_id, user.id);
+      syncDocumentId = row.document_id;
     }
   } catch (e) {
     return { error: errorMessage(e) || "Falha ao desfazer equivalência." };
+  }
+
+  // Pós-commit best-effort: a equivalência e o review já foram apagados. Uma
+  // falha do sync não deve virar { error } — a revisora veria "falha ao
+  // desfazer" para uma operação já persistida e tentaria de novo, sobre uma
+  // linha que não existe mais. Loga e segue para a revalidação.
+  if (syncDocumentId) {
+    try {
+      await syncCompareAssignment(supabase, projectId, syncDocumentId, user.id);
+    } catch (e) {
+      console.error(
+        `[unmarkEquivalencePair] falha ao sincronizar o assignment: ${errorMessage(e)}`,
+      );
+    }
   }
 
   revalidatePath(`/projects/${projectId}/analyze/compare`);

--- a/frontend/src/lib/__tests__/compare-sync.test.ts
+++ b/frontend/src/lib/__tests__/compare-sync.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { PydanticField } from "@/lib/types";
 import {
   callsOf,
   makeFilterAwareSupabaseMock,
+  type QueryError,
   type WriteCall,
 } from "@/test-utils/supabase-mock";
 import { CURRENT_HASH } from "@/test-utils/comparison-fixtures";
@@ -13,11 +14,12 @@ vi.mock("server-only", () => ({}));
 
 let writeCalls: WriteCall[];
 let tableData: Record<string, unknown[]>;
+let queryErrors: Record<string, QueryError | null>;
 
 const updateCallsOf = (table?: string) => callsOf(writeCalls, "update", table);
 
 function makeClient() {
-  return makeFilterAwareSupabaseMock({ tableData, writeCalls });
+  return makeFilterAwareSupabaseMock({ tableData, writeCalls, queryErrors });
 }
 
 const FIELDS: PydanticField[] = [
@@ -72,6 +74,7 @@ const assignment = (status: string) => ({
 
 beforeEach(() => {
   writeCalls = [];
+  queryErrors = {};
   tableData = {
     projects: [projectRow()],
     assignments: [assignment("pendente")],
@@ -79,6 +82,10 @@ beforeEach(() => {
     reviews: [],
     response_equivalences: [],
   };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 async function loadLib() {
@@ -160,5 +167,138 @@ describe("syncCompareAssignment — guarda de <2 respostas qualificadas (#286)",
     const client = makeClient();
     await syncCompareAssignment(client as never, "p1", "doc1", "rev1");
     expect(updateCallsOf("assignments")).toHaveLength(0);
+  });
+});
+
+describe("syncCompareAssignment — regressão de comparação histórica (#497)", () => {
+  it("mantém a concluída e loga o 23505 quando outra comparação está ativa", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.assignments = [
+      assignment("concluido"),
+      {
+        ...assignment("pendente"),
+        id: "a2",
+        user_id: "rev2",
+      },
+    ];
+    tableData.responses = [resp("a", "proc"), resp("b", "improc")];
+    queryErrors["assignments:update"] = {
+      message:
+        'duplicate key value violates unique constraint "assignments_one_active_comparacao_per_doc"',
+      code: "23505",
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = makeClient();
+
+    await expect(
+      syncCompareAssignment(client as never, "p1", "doc1", "rev1"),
+    ).resolves.toBeUndefined();
+
+    expect(updateCallsOf("assignments")).toHaveLength(1);
+    expect(updateCallsOf("assignments")[0].payload).toEqual({
+      status: "pendente",
+      completed_at: null,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const line = warnSpy.mock.calls[0][0] as string;
+    expect(line.startsWith("[compare-sync] ")).toBe(true);
+    expect(JSON.parse(line.slice("[compare-sync] ".length))).toEqual({
+      event: "regression_blocked_by_active_assignment",
+      projectId: "p1",
+      documentId: "doc1",
+      assignmentId: "a1",
+      userId: "rev1",
+      previousStatus: "concluido",
+      intendedStatus: "pendente",
+      errorCode: "23505",
+    });
+  });
+
+  it("também preserva a concluída quando a regressão pretendida é em_andamento", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.projects = [
+      projectRow({
+        pydantic_fields: [
+          ...FIELDS,
+          {
+            name: "fundamento",
+            type: "text",
+            description: "",
+            target: "all",
+          },
+        ],
+      }),
+    ];
+    tableData.assignments = [
+      assignment("concluido"),
+      {
+        ...assignment("pendente"),
+        id: "a2",
+        user_id: "rev2",
+      },
+    ];
+    tableData.responses = [
+      resp("a", "proc", { answers: { decisao: "proc", fundamento: "A" } }),
+      resp("b", "improc", {
+        answers: { decisao: "improc", fundamento: "B" },
+      }),
+    ];
+    tableData.reviews = [
+      {
+        project_id: "p1",
+        document_id: "doc1",
+        reviewer_id: "rev1",
+        field_name: "decisao",
+      },
+    ];
+    queryErrors["assignments:update"] = {
+      message:
+        'duplicate key value violates unique constraint "assignments_one_active_comparacao_per_doc"',
+      code: "23505",
+    };
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const client = makeClient();
+
+    await expect(
+      syncCompareAssignment(client as never, "p1", "doc1", "rev1"),
+    ).resolves.toBeUndefined();
+
+    expect(updateCallsOf("assignments")[0].payload).toEqual({
+      status: "em_andamento",
+      completed_at: null,
+    });
+    expect(warnSpy.mock.calls[0][0]).toContain(
+      '"intendedStatus":"em_andamento"',
+    );
+  });
+
+  it("propaga erro de UPDATE diferente de violação única", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.assignments = [assignment("concluido")];
+    tableData.responses = [resp("a", "proc"), resp("b", "improc")];
+    queryErrors["assignments:update"] = {
+      message: "permission denied for table assignments",
+      code: "42501",
+    };
+    const client = makeClient();
+
+    await expect(
+      syncCompareAssignment(client as never, "p1", "doc1", "rev1"),
+    ).rejects.toThrow("permission denied for table assignments");
+  });
+
+  it("não trata 23505 como skip fora da regressão de uma concluída", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.assignments = [assignment("pendente")];
+    tableData.responses = [resp("a", "proc"), resp("b", "proc")];
+    queryErrors["assignments:update"] = {
+      message: "unexpected unique violation",
+      code: "23505",
+    };
+    const client = makeClient();
+
+    await expect(
+      syncCompareAssignment(client as never, "p1", "doc1", "rev1"),
+    ).rejects.toThrow("unexpected unique violation");
   });
 });

--- a/frontend/src/lib/__tests__/compare-sync.test.ts
+++ b/frontend/src/lib/__tests__/compare-sync.test.ts
@@ -173,6 +173,9 @@ describe("syncCompareAssignment — guarda de <2 respostas qualificadas (#286)",
 describe("syncCompareAssignment — regressão de comparação histórica (#497)", () => {
   it("mantém a concluída e loga o 23505 quando outra comparação está ativa", async () => {
     const { syncCompareAssignment } = await loadLib();
+    // `a2` documenta o cenário (o documento já tem outra comparação ativa), não
+    // o produz: o mock não modela o índice parcial — quem força o 23505 é o
+    // `queryErrors` abaixo.
     tableData.assignments = [
       assignment("concluido"),
       {
@@ -285,6 +288,22 @@ describe("syncCompareAssignment — regressão de comparação histórica (#497)
     await expect(
       syncCompareAssignment(client as never, "p1", "doc1", "rev1"),
     ).rejects.toThrow("permission denied for table assignments");
+  });
+
+  it("propaga 23505 de outra constraint mesmo na regressão de uma concluída", async () => {
+    const { syncCompareAssignment } = await loadLib();
+    tableData.assignments = [assignment("concluido")];
+    tableData.responses = [resp("a", "proc"), resp("b", "improc")];
+    queryErrors["assignments:update"] = {
+      message:
+        'duplicate key value violates unique constraint "assignments_document_id_user_id_type_key"',
+      code: "23505",
+    };
+    const client = makeClient();
+
+    await expect(
+      syncCompareAssignment(client as never, "p1", "doc1", "rev1"),
+    ).rejects.toThrow("assignments_document_id_user_id_type_key");
   });
 
   it("não trata 23505 como skip fora da regressão de uma concluída", async () => {

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -3,13 +3,68 @@ import "server-only";
 import type { SupabaseServerClient } from "@/lib/supabase/server";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
-import { resolveCompareStatus } from "@/lib/compare-assignment-status";
+import {
+  resolveCompareStatus,
+  type CompareAssignmentStatus,
+} from "@/lib/compare-assignment-status";
 import {
   responseQualifiesForVersion,
   versionGate,
   type VersionedResponse,
 } from "@/lib/compare-version";
 import type { EquivalencePair } from "@/lib/equivalence";
+
+const PG_UNIQUE_VIOLATION = "23505";
+
+interface UpdateCompareAssignmentStatusParams {
+  supabase: SupabaseServerClient;
+  projectId: string;
+  documentId: string;
+  userId: string;
+  assignment: { id: string; status: string };
+  next: CompareAssignmentStatus;
+}
+
+async function updateCompareAssignmentStatus({
+  supabase,
+  projectId,
+  documentId,
+  userId,
+  assignment,
+  next,
+}: UpdateCompareAssignmentStatusParams): Promise<void> {
+  const { error } = await supabase
+    .from("assignments")
+    .update({
+      status: next,
+      completed_at: next === "concluido" ? new Date().toISOString() : null,
+    })
+    .eq("id", assignment.id);
+
+  if (!error) return;
+
+  if (
+    error.code === PG_UNIQUE_VIOLATION &&
+    assignment.status === "concluido" &&
+    next !== "concluido"
+  ) {
+    console.warn(
+      `[compare-sync] ${JSON.stringify({
+        event: "regression_blocked_by_active_assignment",
+        projectId,
+        documentId,
+        assignmentId: assignment.id,
+        userId,
+        previousStatus: assignment.status,
+        intendedStatus: next,
+        errorCode: error.code,
+      })}`,
+    );
+    return;
+  }
+
+  throw new Error(error.message, { cause: error });
+}
 
 // Recomputes assignment status (pendente / em_andamento / concluido) for the
 // reviewer's "comparacao" assignment on this document, taking into account
@@ -149,14 +204,19 @@ export async function syncCompareAssignment(
   // todas as divergências fundidas por equivalência): vira `concluido` em vez de
   // ficar preso. Atualiza só quando o status muda, limpando `completed_at` em
   // qualquer regressão (ex.: desmarcar uma equivalência reabre a divergência).
+  // Uma comparação concluída pertence ao histórico da rodada. Se já houver
+  // outra comparação ativa para o documento, o índice parcial do banco impede
+  // atomicamente que a antiga seja reaberta; nesse caso preservamos a concluída
+  // de propósito e `updateCompareAssignmentStatus` registra o bloqueio (#497).
   const next = resolveCompareStatus(divergentFields, reviewedFields);
   if (assignment.status !== next) {
-    await supabase
-      .from("assignments")
-      .update({
-        status: next,
-        completed_at: next === "concluido" ? new Date().toISOString() : null,
-      })
-      .eq("id", assignment.id);
+    await updateCompareAssignmentStatus({
+      supabase,
+      projectId,
+      documentId,
+      userId,
+      assignment,
+      next,
+    });
   }
 }

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -15,6 +15,13 @@ import {
 import type { EquivalencePair } from "@/lib/equivalence";
 
 const PG_UNIQUE_VIOLATION = "23505";
+// O índice parcial criado pelo #490 (uma comparação ATIVA por documento;
+// concluídas ficam fora do predicado). É o único unique de `assignments`
+// alcançável por um UPDATE que só toca status/completed_at — a outra,
+// UNIQUE(document_id, user_id, type), tem colunas que este UPDATE não mexe.
+// Casar pelo nome mantém o skip preso a ESTA regra: um índice futuro sobre
+// `status` propaga em vez de ser engolido junto.
+const ACTIVE_COMPARACAO_INDEX = "assignments_one_active_comparacao_per_doc";
 
 interface UpdateCompareAssignmentStatusParams {
   supabase: SupabaseServerClient;
@@ -45,6 +52,7 @@ async function updateCompareAssignmentStatus({
 
   if (
     error.code === PG_UNIQUE_VIOLATION &&
+    error.message.includes(ACTIVE_COMPARACAO_INDEX) &&
     assignment.status === "concluido" &&
     next !== "concluido"
   ) {

--- a/frontend/src/test-utils/supabase-mock.ts
+++ b/frontend/src/test-utils/supabase-mock.ts
@@ -13,6 +13,11 @@ export type RpcResult = {
   error?: { message: string } | null;
 };
 
+export type QueryError = {
+  message: string;
+  code?: string;
+};
+
 function makeRpc(state: {
   rpcCalls?: RpcCall[];
   rpcResults?: Record<string, RpcResult>;
@@ -99,6 +104,7 @@ export function makeFilterAwareSupabaseMock(state: {
   writeCalls: WriteCall[];
   rpcCalls?: RpcCall[];
   rpcResults?: Record<string, RpcResult>;
+  queryErrors?: Record<string, QueryError | null>;
 }) {
   return {
     rpc: makeRpc(state),
@@ -143,7 +149,7 @@ export function makeFilterAwareSupabaseMock(state: {
         });
         return limitN != null ? filtered.slice(0, limitN) : filtered;
       };
-      const err = () => state.tableData[`__error:${table}:${opRef.current}`] ?? null;
+      const err = () => state.queryErrors?.[`${table}:${opRef.current}`] ?? null;
       builder.single = () =>
         Promise.resolve({ data: rows()[0] ?? null, error: err() });
       builder.maybeSingle = () =>
@@ -163,6 +169,7 @@ export function makeSimpleSupabaseMock(state: {
   writeCalls: WriteCall[];
   rpcCalls?: RpcCall[];
   rpcResults?: Record<string, RpcResult>;
+  queryErrors?: Record<string, QueryError | null>;
 }) {
   return {
     rpc: makeRpc(state),
@@ -179,7 +186,7 @@ export function makeSimpleSupabaseMock(state: {
             state.tableData[`${table}:${opRef.current}`] ??
             state.tableData[table] ??
             null,
-          error: state.tableData[`__error:${table}:${opRef.current}`] ?? null,
+          error: state.queryErrors?.[`${table}:${opRef.current}`] ?? null,
         });
       return builder;
     },


### PR DESCRIPTION
## Problema

O `syncCompareAssignment` descartava o erro retornado pelo Supabase ao tentar regredir uma comparação concluída. Quando outra comparação do documento já estava ativa, o índice parcial `assignments_one_active_comparacao_per_doc` devolvia `23505`; a comparação histórica permanecia concluída por acidente, sem diagnóstico.

## Mudanças

- Separa a persistência do status do cálculo das divergências.
- Trata como `skip` somente o `23505` de uma transição `concluido` → `pendente`/`em_andamento`, preservando o parecer histórico e a comparação ativa.
- Emite log estruturado com projeto, documento, assignment, usuário e status pretendido.
- Propaga erros diferentes e violações únicas fora desse caso.
- Estende o mock Supabase para injetar erros por operação e cobre as duas regressões, erros inesperados e o limite do tratamento.

## Impacto

A semântica deixa de ser um efeito colateral silencioso do índice: pareceres concluídos permanecem históricos enquanto existir uma comparação ativa para o documento. Não há mudança de schema, RLS, API pública ou interface.

## Validação

- Vitest: 136 arquivos e 1.337 testes verdes.
- Typecheck, ESLint e lint tipado: passaram.
- React Doctor: 100/100.
- `fallow audit`: zero achados novos.
- Semgrep: passou.
- Smoke Playwright não executado: a worktree não possui as variáveis E2E e a mudança não toca UI nem fluxo de navegador.

Closes #497
