### PR TITLE
fix(test-db): runner via TCP e teardown do llm_rate_limit fora da transação

### DIFF
--- a/frontend/scripts/run-sql-test.sh
+++ b/frontend/scripts/run-sql-test.sh
@@ -44,8 +44,14 @@ echo "▸ ${SQL_FILE}"
 # trust, e dblink chamado por não-superuser (postgres não é superuser na
 # imagem do Supabase) exige que a senha seja efetivamente usada — só as rotas
 # privadas (172.16/12 etc.) autenticam por scram. PGPASSWORD idem.
+#
+# Assume o container numa única rede roteável (o caso do Supabase local). Se
+# estiver em mais de uma, `println` emite um IP por linha e `grep -m1 .` pega o
+# primeiro não-vazio — sem o `println`, o `range` concatenaria os IPs sem
+# separador e produziria um host inválido.
 CONTAINER_IP="$(docker inspect -f \
-  '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${CONTAINER}")"
+  '{{range .NetworkSettings.Networks}}{{println .IPAddress}}{{end}}' "${CONTAINER}" \
+  | grep -m1 .)"
 
 docker exec -e PGPASSWORD=postgres -i "${CONTAINER}" \
   psql -h "${CONTAINER_IP}" -p 5432 -U postgres -d postgres \

--- a/frontend/scripts/run-sql-test.sh
+++ b/frontend/scripts/run-sql-test.sh
@@ -37,6 +37,17 @@ fi
 
 echo "▸ ${SQL_FILE}"
 
-docker exec -i "${CONTAINER}" \
-  psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+# TCP no IP roteável do container em vez do socket unix, por dois motivos
+# compostos das suítes com dblink (llm_rate_limit): (1) sobre socket,
+# inet_server_addr()/inet_server_port() são NULL e a conexão derivada vira
+# "port=", falhando em qualquer ambiente; (2) sobre 127.0.0.1 o pg_hba é
+# trust, e dblink chamado por não-superuser (postgres não é superuser na
+# imagem do Supabase) exige que a senha seja efetivamente usada — só as rotas
+# privadas (172.16/12 etc.) autenticam por scram. PGPASSWORD idem.
+CONTAINER_IP="$(docker inspect -f \
+  '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "${CONTAINER}")"
+
+docker exec -e PGPASSWORD=postgres -i "${CONTAINER}" \
+  psql -h "${CONTAINER_IP}" -p 5432 -U postgres -d postgres \
+  -X -v ON_ERROR_STOP=1 \
   < "${SQL_FILE}"

--- a/frontend/supabase/tests/llm_rate_limit.test.sql
+++ b/frontend/supabase/tests/llm_rate_limit.test.sql
@@ -8,6 +8,20 @@
 -- section uses two dblink sessions because one SQL session cannot prove the row
 -- lock; its committed fixture is explicitly deleted before the final rollback.
 
+-- Fora da transação, de propósito: o teardown roda após o ROLLBACK e ainda
+-- precisa das funções de dblink — criada dentro do BEGIN, a extensão seria
+-- desfeita junto num banco recém-resetado. Idempotente.
+CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA extensions;
+
+-- Auto-limpeza preventiva: os escritos das sessões dblink são commitados fora
+-- da transação externa, então uma rodada anterior interrompida (deadlock,
+-- kill, falha de teardown) deixa resíduo que quebraria o INSERT abaixo com
+-- duplicate key. Idempotente num banco limpo.
+DELETE FROM public.projects
+  WHERE id = '55555555-5555-5555-5555-555555555135';
+DELETE FROM auth.users
+  WHERE id = '66666666-6666-6666-6666-666666666135';
+
 BEGIN;
 
 INSERT INTO auth.users (id, email) VALUES
@@ -222,7 +236,6 @@ END $$;
 
 -- Real two-session proof: session B remains blocked while session A owns the
 -- new bucket row, then observes A's committed count and rejects at limit 1.
-CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA extensions;
 CREATE TEMP TABLE concurrent_results (
   session_name text PRIMARY KEY,
   allowed boolean NOT NULL,
@@ -326,6 +339,14 @@ BEGIN
   END IF;
 END $$;
 
+ROLLBACK;
+
+-- Teardown DEPOIS do ROLLBACK externo, de propósito: as fixtures da transação
+-- externa seguram o advisory lock global de identidade (triggers de
+-- 20260716155000 em project_members/auth.users), e cada dblink_exec roda em
+-- autocommit pedindo o MESMO lock — teardown dentro da transação externa é
+-- deadlock que o Postgres não detecta (a espera atravessa o dblink). Com o
+-- ROLLBACK antes, o lock já foi solto quando as deleções rodam.
 SELECT extensions.dblink_exec(
   'rate_limit_a',
   $$DELETE FROM public.projects
@@ -338,5 +359,3 @@ SELECT extensions.dblink_exec(
 );
 SELECT extensions.dblink_disconnect('rate_limit_a');
 SELECT extensions.dblink_disconnect('rate_limit_b');
-
-ROLLBACK;

--- a/frontend/supabase/tests/llm_rate_limit.test.sql
+++ b/frontend/supabase/tests/llm_rate_limit.test.sql
@@ -1,12 +1,18 @@
 -- Runtime contract for 20260715170000_llm_rate_limit.sql (#135).
 --
--- Run after `npx supabase db reset`:
---   psql "$(npx supabase status -o env | grep DB_URL | cut -d= -f2- | tr -d '\"')" \
---     -v ON_ERROR_STOP=1 -f supabase/tests/llm_rate_limit.test.sql
+-- Run after `npx supabase db reset`, via the shared runner (from frontend/):
+--   ./scripts/run-sql-test.sh supabase/tests/llm_rate_limit.test.sql
+--   # or the whole chain: npm run test:db
+--
+-- Do NOT run this file directly against the DB_URL from `supabase status`: that
+-- URL points at 127.0.0.1, whose pg_hba route is trust, and dblink called by a
+-- non-superuser is refused there ("password required"). The runner connects
+-- over the container's routable IP (scram), which is why the dblink section
+-- only passes through it.
 --
 -- The first transaction rolls back all ordinary fixtures. The concurrency
 -- section uses two dblink sessions because one SQL session cannot prove the row
--- lock; its committed fixture is explicitly deleted before the final rollback.
+-- lock; its committed fixture is explicitly deleted after the final rollback.
 
 -- Fora da transação, de propósito: o teardown roda após o ROLLBACK e ainda
 -- precisa das funções de dblink — criada dentro do BEGIN, a extensão seria


### PR DESCRIPTION
Follow-up do #440: o gate ampliado de suítes SQL (workflow \"Database contracts\") expôs que a suíte `llm_rate_limit` nunca funcionou pelo runner compartilhado — e, depois de consertada a conexão, um deadlock novo introduzido pelos triggers de identidade do #440. Três defeitos compostos:

1. **Runner por socket unix**: `inet_server_addr()`/`inet_server_port()` são NULL sobre socket, então a conexão dblink derivada virava `"port="` inválido (a falha do CI no push do #440).
2. **`127.0.0.1` é *trust* no pg_hba**: dblink chamado por não-superuser (`postgres` não é superuser na imagem do Supabase) exige senha efetivamente usada — o runner agora conecta pelo IP roteável do container, que cai na rota scram.
3. **Deadlock invisível ao Postgres**: o teardown via dblink rodava dentro da transação externa, que segura o advisory lock global `canonical-project-identity` (triggers do #440); a sessão interna pedia o mesmo lock e a espera atravessa o dblink. Teardown movido para depois do `ROLLBACK`, com `CREATE EXTENSION` e auto-limpeza preventiva fora da transação (resíduo de rodada interrompida não quebra mais a próxima).

Validação: cadeia `npm run test:db` completa (9 suítes, exit 0, 93 asserções OK) — primeira execução de ponta a ponta incluindo `member_permission_rpcs` e `project_members_column_guard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KX7aDoeKdtLyioSBj93gkM