### PR TITLE
fix(test-db): revive schema_revision_serialization e sana leak de GRANT

### DIFF
--- a/frontend/supabase/tests/schema_revision_serialization.test.sql
+++ b/frontend/supabase/tests/schema_revision_serialization.test.sql
@@ -13,6 +13,12 @@
 -- `postgres` e assumem `authenticated` via SET LOCAL ROLE, exatamente como a
 -- suíte irmã — o caminho de RLS exercitado é o mesmo.
 --
+-- Identidade canônica (migration 20260716155000, #440): `clerk_uid()` só resolve
+-- o autor quando o JWT carrega `sub` E `supabase_uid` casando com uma linha ativa
+-- de `clerk_user_mapping` (access_sync_version >= 1, não deletada). Por isso a
+-- fixture cria esse mapeamento e as sessões setam ambos os claims — sem ele o
+-- gate devolve `not_found` e T1 nem chega a salvar.
+--
 -- Por que este arquivo existe separado de `schema_revision_rpcs.test.sql`:
 -- aquele roda inteiro num BEGIN ... ROLLBACK, numa conexão só. Um lock nunca
 -- colide consigo mesmo, então lá o `FOR UPDATE` nunca é disputado — apagar a
@@ -31,13 +37,36 @@
 
 CREATE EXTENSION IF NOT EXISTS dblink;
 
--- ----- Fixtures (commitados: as sessões concorrentes precisam enxergá-los) -----
--- Idempotente, para o arquivo poder rodar duas vezes seguidas sem db reset.
+-- ----- Auto-limpeza preventiva (idempotente) -----
+-- O arquivo roda fora de BEGIN/ROLLBACK (as sessões concorrentes precisam de
+-- fixtures commitadas), então um RAISE no meio aborta antes do teardown final e
+-- deixa resíduo no container local compartilhado entre worktrees. Limpar aqui,
+-- no topo, garante que a próxima rodada comece de um estado limpo — sobretudo
+-- os GRANTs de DML em `authenticated`, que persistem no catálogo e, vazados,
+-- afrouxam a RLS que as outras suítes assumem. REVOKE de privilégio não
+-- concedido é no-op (warning, não erro sob ON_ERROR_STOP). O DELETE do projeto
+-- cascateia para project_members e schema_change_log (FK ON DELETE CASCADE); o
+-- mapeamento de identidade fica em tabela à parte e é apagado explicitamente.
+REVOKE SELECT, UPDATE ON public.projects FROM authenticated;
+REVOKE SELECT, INSERT ON public.schema_change_log FROM authenticated;
+REVOKE SELECT ON public.project_members FROM authenticated;
 DELETE FROM public.projects WHERE id = '86000000-0000-0000-0000-000000000001';
 DELETE FROM auth.users WHERE id = '86000000-0000-0000-0000-000000000002';
+DELETE FROM public.clerk_user_mapping
+  WHERE supabase_user_id = '86000000-0000-0000-0000-000000000002';
 
 INSERT INTO auth.users (id, email) VALUES
   ('86000000-0000-0000-0000-000000000002', 'schema-serialization@example.test');
+
+-- Mapeamento de identidade canônica: sem ele `clerk_uid()` devolve NULL e o gate
+-- responde `not_found`. clerk_user_id = supabase_user_id, como nas suítes do #440.
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version) VALUES
+  (
+    '86000000-0000-0000-0000-000000000002',
+    '86000000-0000-0000-0000-000000000002',
+    1
+  );
 
 INSERT INTO public.projects (
   id, name, created_by, pydantic_fields, pydantic_code, pydantic_hash
@@ -78,7 +107,7 @@ SELECT dblink_exec('writer_one', 'BEGIN');
 SELECT dblink_exec(
   'writer_one',
   $cmd$SET LOCAL "request.jwt.claims" =
-    '{"supabase_uid":"86000000-0000-0000-0000-000000000002"}'$cmd$
+    '{"sub":"86000000-0000-0000-0000-000000000002","supabase_uid":"86000000-0000-0000-0000-000000000002"}'$cmd$
 );
 SELECT dblink_exec('writer_one', 'SET LOCAL ROLE authenticated');
 
@@ -120,7 +149,7 @@ SELECT dblink_exec('writer_two', 'BEGIN');
 SELECT dblink_exec(
   'writer_two',
   $cmd$SET LOCAL "request.jwt.claims" =
-    '{"supabase_uid":"86000000-0000-0000-0000-000000000002"}'$cmd$
+    '{"sub":"86000000-0000-0000-0000-000000000002","supabase_uid":"86000000-0000-0000-0000-000000000002"}'$cmd$
 );
 SELECT dblink_exec('writer_two', $cmd$SET LOCAL lock_timeout = '10s'$cmd$);
 SELECT dblink_exec('writer_two', 'SET LOCAL ROLE authenticated');
@@ -254,6 +283,8 @@ DROP TABLE serialization_result;
 DROP TABLE writer_one_result;
 DELETE FROM public.projects WHERE id = '86000000-0000-0000-0000-000000000001';
 DELETE FROM auth.users WHERE id = '86000000-0000-0000-0000-000000000002';
+DELETE FROM public.clerk_user_mapping
+  WHERE supabase_user_id = '86000000-0000-0000-0000-000000000002';
 
 REVOKE SELECT, UPDATE ON public.projects FROM authenticated;
 REVOKE SELECT, INSERT ON public.schema_change_log FROM authenticated;

--- a/frontend/supabase/tests/schema_revision_serialization.test.sql
+++ b/frontend/supabase/tests/schema_revision_serialization.test.sql
@@ -46,7 +46,9 @@ CREATE EXTENSION IF NOT EXISTS dblink;
 -- afrouxam a RLS que as outras suítes assumem. REVOKE de privilégio não
 -- concedido é no-op (warning, não erro sob ON_ERROR_STOP). O DELETE do projeto
 -- cascateia para project_members e schema_change_log (FK ON DELETE CASCADE); o
--- mapeamento de identidade fica em tabela à parte e é apagado explicitamente.
+-- mapeamento de identidade é apagado explicitamente por garantia (também
+-- cascatearia via `profiles`, que herda a exclusão de `auth.users` — a FK de
+-- clerk_user_mapping.supabase_user_id aponta para profiles ON DELETE CASCADE).
 REVOKE SELECT, UPDATE ON public.projects FROM authenticated;
 REVOKE SELECT, INSERT ON public.schema_change_log FROM authenticated;
 REVOKE SELECT ON public.project_members FROM authenticated;


### PR DESCRIPTION
## Contexto

A suíte ungated `frontend/supabase/tests/schema_revision_serialization.test.sql` tinha **dois** defeitos compostos, ambos herdados de mudanças que aterrissaram depois que o #454 a criou:

1. **Vazamento de GRANT (bullet do #506).** A suíte roda fora de `BEGIN/ROLLBACK` — as duas sessões `dblink` concorrentes precisam de fixtures *commitadas* — então o teardown final (REVOKEs, DELETEs, disconnects) só executa se o arquivo chegar ao fim. Sob `ON_ERROR_STOP=1`, um `RAISE` no meio aborta antes do REVOKE e deixa o `GRANT SELECT/UPDATE/INSERT ... TO authenticated` vazado no **container Supabase local, compartilhado entre worktrees** — afrouxando a RLS que as outras suítes assumem (elas partem do princípio de que `authenticated` não tem DML por default no ambiente local).

2. **Suíte 100% morta pelo #440.** Investigando, a suíte nem chegava ao teardown: `commit_project_schema` de T1 devolvia `not_found`. O `clerk_uid()` redefinido em `20260716155000_canonical_project_identity_rls.sql` (#440) passou a resolver o autor via `clerk_user_mapping`, exigindo `sub` **e** `supabase_uid` no JWT casando com uma linha ativa. A fixture (anterior ao #440) só setava `supabase_uid`.

## Mudança

- **Auto-limpeza preventiva no topo** (padrão do #507): REVOKEs idempotentes + DELETE do mapeamento antes de recriar as fixtures. A próxima rodada sempre começa limpa, mesmo após um abort. `REVOKE` de privilégio não concedido é no-op sob `ON_ERROR_STOP`.
- **Fixture de identidade canônica:** cria `clerk_user_mapping (clerk_user_id = supabase_user_id, access_sync_version = 1)` e adiciona `sub` aos claims das duas sessões — mesmo padrão das suítes do #440.

Escopo mantido conforme combinado: **só a higiene + causa-raiz da serialization**; sem gate de CI novo e sem mudar o estilo de conexão dblink (segue `supabase_admin`, hand-run).

## Verificação (Supabase local)

- Run completo: 4 asserções `OK serialização`, exit 0.
- **Idempotência:** 2º run sem `db reset` → verde de novo.
- **Limpeza do leak:** injetei `GRANT UPDATE ... TO authenticated` (`has_table_privilege` = true), rodei o arquivo → ao fim `has_table_privilege` = false; sem resíduo de projeto/mapeamento.

## Follow-up

A suíte irmã `schema_revision_rpcs.test.sql` está morta pela mesma causa-raiz do #440 (4 identidades, caminhos positivos e negativos): rastreada em #508. Os demais bullets do #506 (assert de `approve_schema_suggestion`, mock de `SchemaEditorBanners`, `deleteDraftIfTokenMatches`, toggle do `ModelConfigCard`, duplicações, `useMemo` de `guiErrors`) seguem abertos — este PR trata só o bullet da `serialization`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)