### PR TITLE
fix(coding): estabiliza salvamento entre deploys

### DIFF
--- a/.github/workflows/frontend-fly-deploy.yml
+++ b/.github/workflows/frontend-fly-deploy.yml
@@ -32,12 +32,22 @@ jobs:
           # FLY_API_TOKEN compartilhado com o backend tem escopo do app da API
           # e dava `unauthorized` aqui — tokens de deploy do Fly sao por app.
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_FRONTEND }}
+          # Chave AES base64 estavel entre builds. O BuildKit a entrega sem
+          # diretivas Dockerfile ARG/ENV persistentes nem registro no historico.
+          NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
         run: |
+          deploy_args=(
+            --remote-only
+            -a gui-analise-sistematica-frontend
+            --build-arg "NEXT_DEPLOYMENT_ID=${GITHUB_SHA}"
+            --build-secret "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${NEXT_SERVER_ACTIONS_ENCRYPTION_KEY}"
+          )
+
           # Retry: o builder remoto (Depot, via --remote-only) as vezes encerra
           # a conexao no meio do build (rpc "goaway"/"graceful_stop") por causa
           # transitoria do lado do provedor, sem relacao com o codigo do app.
           for attempt in 1 2 3; do
-            if flyctl deploy --remote-only -a gui-analise-sistematica-frontend; then
+            if flyctl deploy "${deploy_args[@]}"; then
               exit 0
             fi
             echo "flyctl deploy falhou (tentativa $attempt/3)"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:24-alpine AS base
 
 # --- Dependencies ---
@@ -21,8 +23,15 @@ ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ARG NEXT_PUBLIC_CLERK_SIGN_IN_URL
 ARG NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL
+ARG NEXT_DEPLOYMENT_ID
 
-RUN npm run build
+# O secret mount evita diretivas Dockerfile ARG/ENV persistentes e registro da
+# chave no historico do comando.
+# O Next a incorpora por design no manifesto server-only do build, copiado para
+# a imagem final. O SHA identifica assets e navegacoes desta release.
+RUN --mount=type=secret,id=NEXT_SERVER_ACTIONS_ENCRYPTION_KEY,required=true \
+    test -n "$NEXT_DEPLOYMENT_ID" \
+    && NEXT_SERVER_ACTIONS_ENCRYPTION_KEY="$(cat /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY)" npm run build
 
 # --- Runtime ---
 FROM base AS runner

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,8 +29,16 @@ ARG NEXT_DEPLOYMENT_ID
 # chave no historico do comando.
 # O Next a incorpora por design no manifesto server-only do build, copiado para
 # a imagem final. O SHA identifica assets e navegacoes desta release.
+#
+# `test -s` (e nao apenas `required=true`): o mount so garante que o secret foi
+# FORNECIDO, nao que tem conteudo. Com o secret ausente no repositorio, a env
+# expande vazia, `--build-secret K=` satisfaz o mount, e o Next trata a chave
+# vazia como ausente — volta a gerar uma chave aleatoria por build, os IDs das
+# Server Actions voltam a girar e o deploy passa verde. Falhar aqui e a unica
+# forma de esse caso nao passar em silencio.
 RUN --mount=type=secret,id=NEXT_SERVER_ACTIONS_ENCRYPTION_KEY,required=true \
     test -n "$NEXT_DEPLOYMENT_ID" \
+    && test -s /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY \
     && NEXT_SERVER_ACTIONS_ENCRYPTION_KEY="$(cat /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY)" npm run build
 
 # --- Runtime ---

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -343,8 +343,10 @@ describe("saveResponse — documento excluído (fora do escopo aprovado)", () =>
     state.documentExcludedAt = "2026-07-01T00:00:00Z";
     const saveResponse = await loadSaveResponse();
     const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
-    expect(r.success).toBe(false);
-    expect(r.error).toContain("removido do escopo");
+    expect(r).toEqual({
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    });
     expect(state.responseInsertPayload).toBeNull();
     expect(state.responseUpdatePayload).toBeNull();
   });

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -12,6 +12,10 @@ export interface SaveResponseOpts {
   isAutoSave?: boolean;
 }
 
+export type SaveResponseResult =
+  | { success: true }
+  | { success: false; error: string };
+
 // Response já existente do mesmo respondente para o mesmo documento. `answers`
 // e `answer_field_hashes` são lidos porque o save PRESERVA o que a leitura
 // descartou (#484) — ver `answersToPersist` em saveResponse.
@@ -180,8 +184,9 @@ export async function saveResponse(
   documentId: string,
   answers: Record<string, unknown>,
   opts: SaveResponseOpts = {},
-): Promise<{ success: boolean; error?: string }> {
+): Promise<SaveResponseResult> {
   const { notes, isAutoSave = false } = opts;
+
   try {
     const actor = await resolveProjectMemberActor(projectId);
     if (!actor.ok) return { success: false, error: actor.error };
@@ -260,6 +265,9 @@ export async function saveResponse(
     revalidateAfterSave(projectId, isAutoSave);
     return { success: true };
   } catch (e) {
-    return { success: false, error: e instanceof Error ? e.message : "Erro desconhecido" };
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : "Erro desconhecido",
+    };
   }
 }

--- a/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor, cleanup } from "@testing-library/react";
 import { saveResponse } from "@/actions/responses";
+import { toast } from "sonner";
+import { CODING_SAVE_TRANSPORT_ERROR } from "@/lib/coding-autosave";
 import { useAssignedCoding } from "../useAssignedCoding";
 import type { Document, Assignment, PydanticField } from "@/lib/types";
 
@@ -92,6 +94,29 @@ describe("useAssignedCoding", () => {
     expect(params.markClean).toHaveBeenCalledWith("d1");
     expect(view.result.current.currentDoc?.id).toBe("d2");
     expect(params.updateDocParam).toHaveBeenCalledWith("d2");
+  });
+
+  it("mantém respostas e documento atual, e permite retry após rejeição de transporte", async () => {
+    mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
+    const { view, params } = setup();
+    act(() => view.result.current.handleAnswer("q1", "sim"));
+
+    await act(async () => {
+      await view.result.current.handleSubmit();
+    });
+
+    expect(view.result.current.docAnswers).toEqual({ q1: "sim" });
+    expect(view.result.current.currentDoc?.id).toBe("d1");
+    expect(params.updateDocParam).not.toHaveBeenCalled();
+    expect(params.setSubmitting).toHaveBeenLastCalledWith(false);
+    expect(toast.error).toHaveBeenCalledWith(CODING_SAVE_TRANSPORT_ERROR);
+
+    mockSave.mockResolvedValue({ success: true });
+    await act(async () => {
+      await view.result.current.handleSubmit();
+    });
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(view.result.current.currentDoc?.id).toBe("d2");
   });
 
   it("handleSubmit marca allDone no último documento", async () => {
@@ -192,9 +217,9 @@ describe("useAssignedCoding", () => {
   });
 
   it("duplo-clique em Enviar não duplica saveResponse (guarda de reentrância)", async () => {
-    let resolveSave: (v: { success: boolean }) => void = () => {};
+    let resolveSave: (v: { success: true }) => void = () => {};
     mockSave.mockReturnValue(
-      new Promise<{ success: boolean }>((r) => {
+      new Promise<{ success: true }>((r) => {
         resolveSave = r;
       }),
     );
@@ -214,9 +239,9 @@ describe("useAssignedCoding", () => {
   });
 
   it("congela a edição enquanto submitting (não perde teclas no save em voo)", async () => {
-    let resolveSave: (v: { success: boolean }) => void = () => {};
+    let resolveSave: (v: { success: true }) => void = () => {};
     mockSave.mockReturnValue(
-      new Promise<{ success: boolean }>((r) => {
+      new Promise<{ success: true }>((r) => {
         resolveSave = r;
       }),
     );

--- a/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, cleanup } from "@testing-library/react";
 import { saveResponse } from "@/actions/responses";
+import { toast } from "sonner";
+import { CODING_SAVE_TRANSPORT_ERROR } from "@/lib/coding-autosave";
 import { useBrowseDocuments } from "@/hooks/useBrowseDocuments";
 import { useDocumentForCoding } from "@/hooks/useDocumentForCoding";
 import type { BrowseDocument } from "@/actions/documents";
@@ -107,10 +109,41 @@ describe("useBrowseCoding", () => {
     expect(params.updateDocParam).toHaveBeenCalledWith(null);
   });
 
+  it("submit mantém rascunho e seleção, e permite retry após rejeição de transporte", async () => {
+    mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
+    const dirty = new Set<string>();
+    const { view, params } = setup("b1", dirty);
+    const draft = { answers: { q: "sim" }, notes: "n" };
+    act(() => view.result.current.handleDraftChange(draft));
+
+    await act(async () => {
+      await view.result.current.handleBrowseSubmit(draft);
+    });
+
+    expect(view.result.current.getPayload()).toEqual({
+      projectId: "p1",
+      documentId: "b1",
+      answers: { q: "sim" },
+      notes: "n",
+    });
+    expect(markResponded).not.toHaveBeenCalled();
+    expect(invalidate).not.toHaveBeenCalled();
+    expect(params.updateDocParam).not.toHaveBeenCalled();
+    expect(params.setSubmitting).toHaveBeenLastCalledWith(false);
+    expect(toast.error).toHaveBeenCalledWith(CODING_SAVE_TRANSPORT_ERROR);
+
+    mockSave.mockResolvedValue({ success: true });
+    await act(async () => {
+      await view.result.current.handleBrowseSubmit(draft);
+    });
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(params.updateDocParam).toHaveBeenCalledWith(null);
+  });
+
   it("nº3: duplo-clique em Enviar não duplica saveResponse (guarda de reentrância)", async () => {
-    let resolveSave: (v: { success: boolean }) => void = () => {};
+    let resolveSave: (v: { success: true }) => void = () => {};
     mockSave.mockReturnValue(
-      new Promise<{ success: boolean }>((r) => {
+      new Promise<{ success: true }>((r) => {
         resolveSave = r;
       }),
     );
@@ -181,6 +214,34 @@ describe("useBrowseCoding", () => {
       notes: "nota",
     });
     expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it("back mantém o doc aberto e permite retry quando o transporte rejeita o autosave", async () => {
+    mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
+    const dirty = new Set<string>();
+    const { view, params } = setup("b1", dirty);
+    act(() => view.result.current.handleDraftChange({ answers: { q: "x" }, notes: "nota" }));
+
+    await act(async () => {
+      await view.result.current.handleBrowseBack();
+    });
+
+    expect(view.result.current.getPayload()).toEqual({
+      projectId: "p1",
+      documentId: "b1",
+      answers: { q: "x" },
+      notes: "nota",
+    });
+    expect(params.updateDocParam).not.toHaveBeenCalled();
+    expect(params.setSubmitting).toHaveBeenLastCalledWith(false);
+    expect(toast.error).toHaveBeenCalledWith(CODING_SAVE_TRANSPORT_ERROR);
+
+    mockSave.mockResolvedValue({ success: true });
+    await act(async () => {
+      await view.result.current.handleBrowseBack();
+    });
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(params.updateDocParam).toHaveBeenCalledWith(null);
   });
 
   it("expõe error/retry da lista", () => {

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -1,9 +1,11 @@
 "use client";
 
 import { useCallback, useMemo, useReducer, useRef } from "react";
-import { saveResponse } from "@/actions/responses";
 import { sortByRecent } from "@/lib/coding-sort";
-import { autosaveDirtyDoc } from "@/lib/coding-autosave";
+import {
+  autosaveDirtyDoc,
+  saveCodingResponse,
+} from "@/lib/coding-autosave";
 import { clearHiddenConditionalAnswers } from "@/lib/conditional";
 import { toast } from "sonner";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
@@ -133,10 +135,10 @@ export function useAssignedCoding({
   );
   const docNotes = allNotes[currentDoc?.id] ?? "";
 
-  // Guarda de reentrância dos saves: liga ANTES do `await saveResponse` e desliga
-  // no `finally`. Espelha o `browseSavingRef` do modo Explorar, mas serve a dois
+  // Guarda de reentrância dos saves: liga antes do await e desliga no `finally`.
+  // Espelha o `browseSavingRef` do modo Explorar, mas serve a dois
   // propósitos com um só ref síncrono: (1) impede que um duplo-clique em "Enviar"
-  // dispare `saveResponse`/`toast` duas vezes antes do re-render desabilitar o
+  // dispare save/toast duas vezes antes do re-render desabilitar o
   // botão; (2) congela a edição enquanto o save está em voo — o container já tirou
   // o snapshot das respostas que está salvando e, ao concluir, navega para o
   // próximo doc; sem o guard, teclas digitadas durante o save editariam o doc já
@@ -171,7 +173,7 @@ export function useAssignedCoding({
     savingRef.current = true;
     setSubmitting(true);
     try {
-      const result = await saveResponse(projectId, currentDoc.id, docAnswers, {
+      const result = await saveCodingResponse(projectId, currentDoc.id, docAnswers, {
         notes: docNotes,
       });
       if (result.success) {
@@ -188,14 +190,13 @@ export function useAssignedCoding({
           dispatch({ type: "allDone", value: true });
         }
       } else {
-        toast.error(result.error || "Erro ao salvar respostas");
+        toast.error(result.error);
       }
     } finally {
-      // `saveResponse` é Server Action: uma rejeição de transporte (offline /
-      // erro de RPC) rejeita a promessa em vez de devolver `{success:false}`.
-      // O `finally` garante que `submitting`/o ref não fiquem presos `true` —
-      // como `submitting` é estado único compartilhado com o modo Explorar, isso
-      // congelaria a edição lá (guards do `BrowseDocCoder`) até um reload.
+      // O `finally` garante que `submitting`/o ref não fiquem presos `true` se
+      // qualquer efeito posterior ao save falhar. Como `submitting` é estado
+      // compartilhado com o modo Explorar, isso congelaria a edição lá até um
+      // reload.
       setSubmitting(false);
       savingRef.current = false;
     }

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -1,10 +1,10 @@
 "use client";
 
 import { useCallback, useMemo, useRef } from "react";
-import { saveResponse } from "@/actions/responses";
 import { toast } from "sonner";
 import { useBrowseDocuments } from "@/hooks/useBrowseDocuments";
 import { useDocumentForCoding } from "@/hooks/useDocumentForCoding";
+import { saveCodingResponse } from "@/lib/coding-autosave";
 import { type CodingDraft } from "./BrowseDocCoder";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
 import type { AssignedDoc } from "@/lib/types";
@@ -69,7 +69,7 @@ export function useBrowseCoding({
   // Ref (não estado) para não entrar no render.
   const browseDraftRef = useRef<CodingDraft | null>(null);
   // Guarda de reentrância dos saves de browse: impede que um duplo-clique em
-  // "Enviar"/"Voltar" dispare saveResponse/markResponded duas vezes antes do
+  // "Enviar"/"Voltar" dispare save/markResponded duas vezes antes do
   // setSubmitting re-renderizar e desabilitar os botões.
   const browseSavingRef = useRef(false);
 
@@ -115,7 +115,7 @@ export function useBrowseCoding({
       browseSavingRef.current = true;
       setSubmitting(true);
       try {
-        const result = await saveResponse(projectId, browseDocId, answers, {
+        const result = await saveCodingResponse(projectId, browseDocId, answers, {
           notes,
         });
         if (result.success) {
@@ -130,13 +130,11 @@ export function useBrowseCoding({
           updateDocParam(null);
           invalidateBrowseDoc(browseDocId);
         } else {
-          toast.error(result.error || "Erro ao salvar respostas");
+          toast.error(result.error);
         }
       } finally {
-        // `saveResponse` é Server Action: uma rejeição de transporte (offline /
-        // erro de RPC) rejeita a promessa em vez de devolver `{success:false}`.
-        // O `finally` garante que `submitting`/o ref não fiquem presos (o que
-        // congelaria a edição até reload).
+        // Mesmo com a rejeição de transporte normalizada pelo adapter, o
+        // `finally` evita prender o formulário se um efeito posterior falhar.
         setSubmitting(false);
         browseSavingRef.current = false;
       }
@@ -166,15 +164,12 @@ export function useBrowseCoding({
       const { answers, notes } = browseDraftRef.current;
       setSubmitting(true);
       try {
-        const result = await saveResponse(projectId, docId, answers, {
+        const result = await saveCodingResponse(projectId, docId, answers, {
           notes,
           isAutoSave: true,
         });
         if (!result.success) {
-          toast.error(
-            result.error ||
-              "Não foi possível salvar. Suas alterações não foram perdidas.",
-          );
+          toast.error(result.error);
           return;
         }
         markClean(docId);

--- a/frontend/src/lib/__tests__/coding-autosave.test.ts
+++ b/frontend/src/lib/__tests__/coding-autosave.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { saveResponse } from "@/actions/responses";
+import { toast } from "sonner";
+import {
+  autosaveDirtyDoc,
+  saveCodingResponse,
+  CODING_SAVE_TRANSPORT_ERROR,
+  CODING_AUTOSAVE_TRANSPORT_ERROR,
+} from "@/lib/coding-autosave";
+
+vi.mock("@/actions/responses", () => ({ saveResponse: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mockSave = vi.mocked(saveResponse);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("saveCodingResponse", () => {
+  it("normaliza a rejeição de transporte para o contrato de falha", async () => {
+    mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
+
+    const result = await saveCodingResponse("p1", "d1", { q: "sim" });
+
+    expect(result).toEqual({
+      success: false,
+      error: CODING_SAVE_TRANSPORT_ERROR,
+    });
+  });
+
+  it("devolve a falha do handler sem reescrevê-la como erro de transporte", async () => {
+    mockSave.mockResolvedValue({
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    });
+
+    const result = await saveCodingResponse("p1", "d1", { q: "sim" });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    });
+  });
+});
+
+// Este é o único caminho fire-and-forget: a navegação acontece de qualquer
+// forma, então a falha não pode limpar a sujeira do documento — é ela que
+// mantém o doc na fila para uma nova tentativa.
+describe("autosaveDirtyDoc", () => {
+  const params = () => ({
+    projectId: "p1",
+    docId: "d1",
+    answers: { q: "sim" },
+    notes: "nota",
+    markClean: vi.fn(),
+  });
+
+  it("não limpa a sujeira e usa a mensagem de navegação quando o transporte rejeita", async () => {
+    mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
+    const p = params();
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    expect(p.markClean).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(CODING_AUTOSAVE_TRANSPORT_ERROR);
+    // A mensagem do save aguardado ("continuam nesta página") apontaria para o
+    // documento que o pesquisador acabou de deixar.
+    expect(toast.error).not.toHaveBeenCalledWith(CODING_SAVE_TRANSPORT_ERROR);
+  });
+
+  it("propaga a mensagem do handler quando a falha não é de transporte", async () => {
+    mockSave.mockResolvedValue({
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    });
+    const p = params();
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    expect(p.markClean).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Documento removido do escopo do projeto",
+    );
+  });
+
+  it("limpa a sujeira e salva como autosave no sucesso", async () => {
+    mockSave.mockResolvedValue({ success: true });
+    const p = params();
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(p.markClean).toHaveBeenCalledWith("d1"));
+
+    expect(mockSave).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      { q: "sim" },
+      { notes: "nota", isAutoSave: true },
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("não deixa unhandled rejection se um efeito posterior ao save falhar", async () => {
+    mockSave.mockResolvedValue({ success: true });
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    const p = {
+      ...params(),
+      markClean: vi.fn(() => {
+        throw new Error("markClean explodiu");
+      }),
+    };
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(p.markClean).toHaveBeenCalled());
+    await new Promise((r) => setImmediate(r));
+
+    process.off("unhandledRejection", unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/coding-autosave.ts
+++ b/frontend/src/lib/coding-autosave.ts
@@ -5,22 +5,35 @@ import {
 } from "@/actions/responses";
 import { toast } from "sonner";
 
+// Duas mensagens porque os dois caminhos deixam o pesquisador em lugares
+// diferentes quando o transporte falha. No save aguardado (Enviar / Voltar) ele
+// continua no documento, e pedir retry sem recarregar é a instrução correta. No
+// autosave de navegação (`autosaveDirtyDoc`) o save é fire-and-forget e a troca
+// de documento já aconteceu quando o toast aparece — dizer "nesta página"
+// apontaria para o lugar errado.
 export const CODING_SAVE_TRANSPORT_ERROR =
   "Não foi possível salvar suas respostas. Suas alterações continuam nesta página. Tente novamente sem recarregar.";
+
+export const CODING_AUTOSAVE_TRANSPORT_ERROR =
+  "Não foi possível salvar automaticamente. As respostas continuam no documento, que segue pendente. Volte a ele e envie novamente, sem recarregar.";
 
 // Server Actions rejeitam a Promise quando o transporte falha antes de o
 // handler executar. Normalizar essa rejeição preserva um único contrato para
 // todos os callers: o rascunho só é limpo quando `success` é true.
+//
+// `transportError` é parâmetro porque só o caller sabe onde o pesquisador vai
+// estar quando o toast aparecer — ver o comentário das duas constantes acima.
 export async function saveCodingResponse(
   projectId: string,
   documentId: string,
   answers: Record<string, unknown>,
   opts: SaveResponseOpts = {},
+  transportError: string = CODING_SAVE_TRANSPORT_ERROR,
 ): Promise<SaveResponseResult> {
   try {
     return await saveResponse(projectId, documentId, answers, opts);
   } catch {
-    return { success: false, error: CODING_SAVE_TRANSPORT_ERROR };
+    return { success: false, error: transportError };
   }
 }
 
@@ -48,14 +61,23 @@ export function autosaveDirtyDoc({
   notes,
   markClean,
 }: AutosaveDirtyDocParams): void {
-  void saveCodingResponse(projectId, docId, answers, {
-    notes,
-    isAutoSave: true,
-  }).then((result) => {
-    if (result.success) {
-      markClean(docId);
-    } else {
-      toast.error(result.error);
-    }
-  });
+  void saveCodingResponse(
+    projectId,
+    docId,
+    answers,
+    { notes, isAutoSave: true },
+    CODING_AUTOSAVE_TRANSPORT_ERROR,
+  )
+    .then((result) => {
+      if (result.success) {
+        markClean(docId);
+      } else {
+        toast.error(result.error);
+      }
+    })
+    // `saveCodingResponse` não rejeita — este `catch` cobre o que vem DEPOIS do
+    // save (`markClean` do caller, render do toast). Sem ele vira unhandled
+    // rejection, e o `void` já satisfaz o `no-floating-promises`, então nenhum
+    // gate reclamaria. O doc simplesmente segue sujo, que é o estado seguro.
+    .catch(() => {});
 }

--- a/frontend/src/lib/coding-autosave.ts
+++ b/frontend/src/lib/coding-autosave.ts
@@ -1,5 +1,28 @@
-import { saveResponse } from "@/actions/responses";
+import {
+  saveResponse,
+  type SaveResponseOpts,
+  type SaveResponseResult,
+} from "@/actions/responses";
 import { toast } from "sonner";
+
+export const CODING_SAVE_TRANSPORT_ERROR =
+  "Não foi possível salvar suas respostas. Suas alterações continuam nesta página. Tente novamente sem recarregar.";
+
+// Server Actions rejeitam a Promise quando o transporte falha antes de o
+// handler executar. Normalizar essa rejeição preserva um único contrato para
+// todos os callers: o rascunho só é limpo quando `success` é true.
+export async function saveCodingResponse(
+  projectId: string,
+  documentId: string,
+  answers: Record<string, unknown>,
+  opts: SaveResponseOpts = {},
+): Promise<SaveResponseResult> {
+  try {
+    return await saveResponse(projectId, documentId, answers, opts);
+  } catch {
+    return { success: false, error: CODING_SAVE_TRANSPORT_ERROR };
+  }
+}
 
 interface AutosaveDirtyDocParams {
   projectId: string;
@@ -7,8 +30,6 @@ interface AutosaveDirtyDocParams {
   answers: Record<string, unknown>;
   notes: string;
   markClean: (docId: string) => void;
-  /** Executado só no sucesso, após `markClean` (ex.: bump otimista da lista). */
-  onSuccess?: () => void;
 }
 
 /**
@@ -26,18 +47,15 @@ export function autosaveDirtyDoc({
   answers,
   notes,
   markClean,
-  onSuccess,
 }: AutosaveDirtyDocParams): void {
-  saveResponse(projectId, docId, answers, { notes, isAutoSave: true })
-    .then((result) => {
-      if (result.success) {
-        markClean(docId);
-        onSuccess?.();
-      } else {
-        toast.error(result.error || "Erro ao salvar respostas");
-      }
-    })
-    .catch(() => {
-      toast.error("Erro ao salvar respostas");
-    });
+  void saveCodingResponse(projectId, docId, answers, {
+    notes,
+    isAutoSave: true,
+  }).then((result) => {
+    if (result.success) {
+      markClean(docId);
+    } else {
+      toast.error(result.error);
+    }
+  });
 }

--- a/frontend/src/tooling/__tests__/deployment-versioning.test.ts
+++ b/frontend/src/tooling/__tests__/deployment-versioning.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const frontendRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const repositoryRoot = fileURLToPath(new URL("../../../../", import.meta.url));
+
+const dockerfile = fs.readFileSync(`${frontendRoot}/Dockerfile`, "utf8");
+const deployWorkflow = fs.readFileSync(
+  `${repositoryRoot}/.github/workflows/frontend-fly-deploy.yml`,
+  "utf8",
+);
+
+describe("versionamento do build do frontend", () => {
+  it("entrega o SHA e a chave estavel ao build", () => {
+    expect(dockerfile).toMatch(/^ARG NEXT_DEPLOYMENT_ID$/m);
+    expect(deployWorkflow).toContain(
+      '--build-arg "NEXT_DEPLOYMENT_ID=${GITHUB_SHA}"',
+    );
+    expect(dockerfile).toContain(
+      "--mount=type=secret,id=NEXT_SERVER_ACTIONS_ENCRYPTION_KEY,required=true",
+    );
+    expect(dockerfile).toContain(
+      'NEXT_SERVER_ACTIONS_ENCRYPTION_KEY="$(cat /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY)" npm run build',
+    );
+    expect(deployWorkflow).toContain(
+      "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}",
+    );
+    expect(deployWorkflow).toContain(
+      '--build-secret "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${NEXT_SERVER_ACTIONS_ENCRYPTION_KEY}"',
+    );
+  });
+
+  it("nao declara a chave em diretivas ARG ou ENV do Dockerfile", () => {
+    expect(dockerfile).not.toMatch(
+      /^(?:ARG|ENV) NEXT_SERVER_ACTIONS_ENCRYPTION_KEY/m,
+    );
+  });
+});

--- a/frontend/src/tooling/__tests__/deployment-versioning.test.ts
+++ b/frontend/src/tooling/__tests__/deployment-versioning.test.ts
@@ -32,6 +32,16 @@ describe("versionamento do build do frontend", () => {
     );
   });
 
+  // `required=true` cobre o secret AUSENTE; nao cobre o secret vazio, que o
+  // Next trata como chave nao fornecida (volta a gerar uma por build). Os dois
+  // `test` sao o que faz esse caso falhar em vez de passar verde.
+  it("falha o build quando o SHA ou a chave chegam vazios", () => {
+    expect(dockerfile).toContain('test -n "$NEXT_DEPLOYMENT_ID"');
+    expect(dockerfile).toContain(
+      "test -s /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+    );
+  });
+
   it("nao declara a chave em diretivas ARG ou ENV do Dockerfile", () => {
     expect(dockerfile).not.toMatch(
       /^(?:ARG|ENV) NEXT_SERVER_ACTIONS_ENCRYPTION_KEY/m,


### PR DESCRIPTION
## Contexto

Abas abertas durante um deploy continuavam enviando o ID da Server Action `saveResponse` do build anterior. O Next rejeitava a requisição antes de executar o handler, e o recarregamento descartava respostas que ainda existiam apenas no estado React.

## O que mudou

- mantém a chave de criptografia das Server Actions estável entre builds por meio de um BuildKit secret obrigatório;
- identifica cada release com `NEXT_DEPLOYMENT_ID` derivado de `GITHUB_SHA`, usando o suporte nativo do Next;
- normaliza rejeições de transporte para um contrato discriminado: sucesso ou falha com mensagem obrigatória;
- preserva rascunho, dirty state e documento atual quando o transporte falha;
- orienta o pesquisador a tentar novamente sem recarregar;
- mantém uma única validação do secret no ponto de consumo (`required=true` no Dockerfile).

O secret `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` já foi criado nas configurações do repositório. Ele não é declarado como `ARG`/`ENV` persistente nem aparece no histórico do Docker; o Next o incorpora por design ao manifesto server-only copiado para a imagem.

## Decisão de observabilidade

O erro `Failed to find Server Action` ocorre no dispatcher do Next, antes de `saveResponse()` executar. Por isso, removi a máquina de oito estágios adicionada inicialmente ao handler: ela aumentava o código e não observaria o incidente que motivou o PR. O diagnóstico desse caso permanece nos logs do Next/Fly, no ponto em que a rejeição realmente acontece.

## Validação

- 164 arquivos Vitest e 1.727 testes passaram;
- TypeScript, ESLint, ESLint typed, React Doctor (100/100), Fallow e Semgrep passaram;
- actionlint, gitleaks e o teste do notificador de deploy passaram;
- smoke E2E autenticado do hook de pre-push passou;
- dois builds reais com SHAs diferentes e a mesma chave mantiveram os mesmos 85 IDs de Server Actions;
- o build Docker sem o secret falhou no mount obrigatório, como esperado;
- uma imagem construída com chave sintética não expôs o valor em `Config.Env` nem no histórico do Docker.
