### PR TITLE
feat(verificacao): checker de invariantes de banco + smoke E2E do salvamento

### DIFF
--- a/frontend/.env.e2e.example
+++ b/frontend/.env.e2e.example
@@ -49,6 +49,15 @@ E2E_PROJECT_ID=
 # pular.
 E2E_LOTTERY_PROJECT_ID=
 
+# Obrigatório no pre-push: projeto dedicado ao smoke de salvamento de
+# codificação (coding-save.smoke.spec.ts) — schema pequeno (2 campos text),
+# automation_mode='none', com o usuário E2E_MEMBER_* como "pesquisador" e um
+# assignment de codificação para ele. O spec reseta a response e o status do
+# assignment do membro a cada run (idempotente), por isso o projeto precisa
+# ser exclusivo desse spec — não reutilizar o de config-guard/export nem o da
+# Comparação.
+E2E_CODING_PROJECT_ID=
+
 # Opcional: URL base do Playwright.
 # - Manual (`npm run test:e2e`): default http://localhost:3000 e pode
 #   reaproveitar um dev server existente.

--- a/frontend/.env.e2e.example
+++ b/frontend/.env.e2e.example
@@ -56,6 +56,9 @@ E2E_LOTTERY_PROJECT_ID=
 # assignment do membro a cada run (idempotente), por isso o projeto precisa
 # ser exclusivo desse spec — não reutilizar o de config-guard/export nem o da
 # Comparação.
+#
+# Para provisionar (idempotente, imprime o id no fim):
+#   cd frontend && npm run e2e:fixture:coding
 E2E_CODING_PROJECT_ID=
 
 # Opcional: URL base do Playwright.

--- a/frontend/.fallowrc.jsonc
+++ b/frontend/.fallowrc.jsonc
@@ -3,11 +3,16 @@
   // CLI chamado pelo wrapper shell; declarar o entry point mantém o grafo
   // correto sem ignorar o arquivo nem fingir um import JavaScript inexistente.
   "entry": ["scripts/worktree-env/bootstrap.mjs"],
-  // scripts/comentarios-relatorio/* (skill local, ver #352) e
+  // scripts/comentarios-relatorio/* (skill local, ver #352),
   // scripts/invariants/* (checker de invariantes de banco, `npm run
-  // invariants`) rodam manualmente via `tsx`, nunca sao importados por um
-  // entry point do Next - falso-positivo de unused-files.
-  "ignorePatterns": ["scripts/comentarios-relatorio/**", "scripts/invariants/**"],
+  // invariants`) e scripts/e2e-fixtures/* (provisionamento dos projetos de
+  // teste do Playwright) rodam manualmente via `tsx`, nunca sao importados por
+  // um entry point do Next - falso-positivo de unused-files.
+  "ignorePatterns": [
+    "scripts/comentarios-relatorio/**",
+    "scripts/invariants/**",
+    "scripts/e2e-fixtures/**"
+  ],
   "ignoreExports": [
     // Primitivas shadcn/Radix exportam a API completa do primitive kit por
     // convencao do gerador shadcn; a maior parte nao tem consumidor hoje sem

--- a/frontend/.fallowrc.jsonc
+++ b/frontend/.fallowrc.jsonc
@@ -3,10 +3,11 @@
   // CLI chamado pelo wrapper shell; declarar o entry point mantém o grafo
   // correto sem ignorar o arquivo nem fingir um import JavaScript inexistente.
   "entry": ["scripts/worktree-env/bootstrap.mjs"],
-  // scripts/comentarios-relatorio/* rodam manualmente via `tsx` (skill local,
-  // ver #352), nunca sao importados por um entry point do Next -
-  // falso-positivo de unused-files.
-  "ignorePatterns": ["scripts/comentarios-relatorio/**"],
+  // scripts/comentarios-relatorio/* (skill local, ver #352) e
+  // scripts/invariants/* (checker de invariantes de banco, `npm run
+  // invariants`) rodam manualmente via `tsx`, nunca sao importados por um
+  // entry point do Next - falso-positivo de unused-files.
+  "ignorePatterns": ["scripts/comentarios-relatorio/**", "scripts/invariants/**"],
   "ignoreExports": [
     // Primitivas shadcn/Radix exportam a API completa do primitive kit por
     // convencao do gerador shadcn; a maior parte nao tem consumidor hoje sem

--- a/frontend/e2e/coding-save.smoke.spec.ts
+++ b/frontend/e2e/coding-save.smoke.spec.ts
@@ -63,6 +63,15 @@ test("codificação: enviar respostas persiste response e conclui assignment", a
 
   // Resolve o profile do membro e o documento do fixture pelo título — o
   // reset e as asserções de banco precisam dos dois ids.
+  //
+  // O lookup por TÍTULO EXATO é o interlock de segurança deste spec, não uma
+  // conveniência: o reset abaixo apaga linhas de `responses` com a service key
+  // contra o banco de produção, a cada `git push`. Se E2E_CODING_PROJECT_ID
+  // apontar para um projeto real (id colado errado, .env.e2e copiado de outra
+  // máquina), nenhum documento se chama DOC_TITLE, o expect logo abaixo falha e
+  // o teste aborta ANTES de qualquer DELETE. Não trocar por lookup posicional
+  // (`.limit(1)`, primeiro doc do projeto): isso remove a trava e faz o raio do
+  // DELETE passar a ser "qualquer projeto que o id apontar".
   const [{ data: member }, { data: doc }] = await Promise.all([
     admin.from("profiles").select("id").eq("email", email!).single(),
     admin

--- a/frontend/e2e/coding-save.smoke.spec.ts
+++ b/frontend/e2e/coding-save.smoke.spec.ts
@@ -1,0 +1,200 @@
+import { test, expect } from "@playwright/test";
+import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
+import { createClient } from "@supabase/supabase-js";
+import { withClerkCleanup } from "./clerk-cleanup";
+
+// Smoke do fluxo de SALVAMENTO de codificação — proteção de regressão da
+// família de bugs "codificação não salva" (#425, dedup de responses). O
+// coração do spec é a asserção NO BANCO das duas pontas do par cuja
+// dessincronia é o bug histórico: a linha de `responses` (is_latest,
+// is_partial, answers) E o `assignments.status` — um toast de sucesso na UI
+// não conta como prova de escrita.
+//
+// Diferente dos demais smokes (read-only), este MUTA o projeto de teste
+// dedicado E2E_CODING_PROJECT_ID (criado por
+// harness/2026-07-23-e2e-coding-fixture/create-fixture.mts, fora do repo):
+// automation_mode='none', 2 campos text ("resumo"/"observacao"), 1 assignment
+// de codificação do "Doc E2E save 1" para E2E_MEMBER_EMAIL. Para ser
+// idempotente entre runs, o teste faz reset no banco ANTES de navegar —
+// via service key (SUPABASE_SERVICE_ROLE_KEY, que playwright.config.ts já
+// carrega de .env.local), um mecanismo que os specs existentes não usam:
+// eles só leem a UI, este precisa preparar e inspecionar estado do Postgres
+// em contexto Node.
+//
+// Autentica como PESQUISADOR (E2E_MEMBER_EMAIL) via login-por-ticket, como os
+// demais smokes. Roda serial dentro do arquivo (mode default) — issue #198.
+test.describe.configure({ mode: "default" });
+
+const hasClerkTestingEnv =
+  !!process.env.CLERK_SECRET_KEY &&
+  !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+const hasSupabaseAdminEnv =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const RESUMO_VALUE = "valor-e2e-resumo";
+const OBSERVACAO_VALUE = "valor-e2e-observacao";
+const DOC_TITLE = "Doc E2E save 1";
+
+function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+test("codificação: enviar respostas persiste response e conclui assignment", async ({
+  page,
+}) => {
+  // Primeira visita compila /analyze/code no dev server; o fluxo tem login +
+  // submit + renavegação — folga bem acima dos 30s default.
+  test.setTimeout(120_000);
+
+  const email = process.env.E2E_MEMBER_EMAIL;
+  const projectId = process.env.E2E_CODING_PROJECT_ID;
+  test.skip(
+    !hasClerkTestingEnv || !hasSupabaseAdminEnv || !email || !projectId,
+    "defina CLERK_SECRET_KEY, NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, " +
+      "NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, " +
+      "E2E_MEMBER_EMAIL e E2E_CODING_PROJECT_ID",
+  );
+
+  const admin = createAdminClient();
+
+  // Resolve o profile do membro e o documento do fixture pelo título — o
+  // reset e as asserções de banco precisam dos dois ids.
+  const [{ data: member }, { data: doc }] = await Promise.all([
+    admin.from("profiles").select("id").eq("email", email!).single(),
+    admin
+      .from("documents")
+      .select("id")
+      .eq("project_id", projectId!)
+      .eq("title", DOC_TITLE)
+      .single(),
+  ]);
+  expect(
+    member,
+    `profile de ${email} não encontrado — confira o fixture E2E_CODING_PROJECT_ID`,
+  ).toBeTruthy();
+  expect(
+    doc,
+    `documento "${DOC_TITLE}" não encontrado no projeto ${projectId}`,
+  ).toBeTruthy();
+  const memberId = member!.id as string;
+  const documentId = doc!.id as string;
+
+  // Reset idempotente: apaga as responses do membro no doc e devolve o
+  // assignment a "pendente" — o run anterior (verde) deixa response
+  // submetida + assignment concluído, e sem reset o doc nem apareceria na
+  // fila padrão (filtro "current" esconde current_done).
+  const { error: delErr } = await admin
+    .from("responses")
+    .delete()
+    .eq("project_id", projectId!)
+    .eq("document_id", documentId)
+    .eq("respondent_id", memberId)
+    .eq("respondent_type", "humano");
+  expect(delErr, `reset de responses falhou: ${delErr?.message}`).toBeNull();
+  const { error: assignErr } = await admin
+    .from("assignments")
+    .update({ status: "pendente", completed_at: null })
+    .eq("project_id", projectId!)
+    .eq("document_id", documentId)
+    .eq("user_id", memberId)
+    .eq("type", "codificacao");
+  expect(assignErr, `reset do assignment falhou: ${assignErr?.message}`).toBeNull();
+
+  await setupClerkTestingToken({ page });
+  await page.goto("/auth/login");
+  // Estratégia ticket: dispensa senha e a verificação de "novo dispositivo"
+  // da instância dev (ver lottery.smoke.spec.ts).
+  await clerk.signIn({ page, emailAddress: email! });
+
+  await withClerkCleanup({
+    page,
+    context: "coding-save",
+    run: async () => {
+      await page.goto(`/projects/${projectId}/analyze/code`);
+
+      // Doc do fixture na fila de Atribuídos, com as duas perguntas do schema.
+      await expect(
+        page.getByText("Resumo do documento"),
+        "pergunta 'Resumo do documento' não apareceu — confira o fixture e o reset",
+      ).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByText("Observação livre")).toBeVisible();
+
+      // Campos text renderizam como Textarea com placeholder fixo
+      // (FieldRenderer); a ordem na página segue a ordem dos campos no
+      // schema do projeto: resumo (1ª) e observacao (2ª).
+      const textareas = page.getByPlaceholder("Digite sua resposta...");
+      await expect(textareas).toHaveCount(2);
+      await textareas.nth(0).fill(RESUMO_VALUE);
+      await textareas.nth(1).fill(OBSERVACAO_VALUE);
+
+      await page.getByRole("button", { name: "Enviar respostas" }).click();
+      await expect(
+        page.getByText("Respostas salvas!"),
+        "toast de sucesso não apareceu após Enviar respostas",
+      ).toBeVisible({ timeout: 15_000 });
+
+      // === Coração do spec: asserção no BANCO. O toast acima só prova que a
+      // Server Action retornou success; aqui provamos que ela ESCREVEU. O
+      // saveResponse conclui o upsert e o sync do assignment ANTES de
+      // retornar success, então a leitura é determinística (sem poll).
+      const { data: response, error: respErr } = await admin
+        .from("responses")
+        .select("answers, is_latest, is_partial")
+        .eq("project_id", projectId!)
+        .eq("document_id", documentId)
+        .eq("respondent_id", memberId)
+        .eq("respondent_type", "humano")
+        .maybeSingle();
+      expect(respErr, `leitura de responses falhou: ${respErr?.message}`).toBeNull();
+      expect(
+        response,
+        "a UI reportou sucesso mas NENHUMA response foi escrita no banco — " +
+          "regressão do salvamento de codificação",
+      ).toBeTruthy();
+      expect(response!.is_latest).toBe(true);
+      expect(response!.is_partial).toBe(false);
+      const answers = response!.answers as Record<string, unknown>;
+      expect(answers.resumo).toBe(RESUMO_VALUE);
+      expect(answers.observacao).toBe(OBSERVACAO_VALUE);
+
+      const { data: assignment, error: readAssignErr } = await admin
+        .from("assignments")
+        .select("status, completed_at")
+        .eq("project_id", projectId!)
+        .eq("document_id", documentId)
+        .eq("user_id", memberId)
+        .eq("type", "codificacao")
+        .single();
+      expect(
+        readAssignErr,
+        `leitura do assignment falhou: ${readAssignErr?.message}`,
+      ).toBeNull();
+      expect(
+        assignment!.status,
+        "response escrita mas assignment não concluiu — dessincronia do par " +
+          "responses×assignments (família #425)",
+      ).toBe("concluido");
+      expect(assignment!.completed_at).toBeTruthy();
+
+      // Round-trip pela UI: recarrega com ?round=all (o filtro padrão
+      // "current" esconde docs concluídos da rodada atual) e confere que os
+      // valores persistidos voltam pré-preenchidos no formulário.
+      await page.goto(`/projects/${projectId}/analyze/code?round=all`);
+      const reloaded = page.getByPlaceholder("Digite sua resposta...");
+      await expect(reloaded.nth(0)).toHaveValue(RESUMO_VALUE, {
+        timeout: 30_000,
+      });
+      await expect(reloaded.nth(1)).toHaveValue(OBSERVACAO_VALUE);
+    },
+    // signOut direto na página de codificação pode travar no waitForFunction
+    // de window.Clerk.loaded (mesmo padrão do lottery.smoke) — voltar ao
+    // dashboard antes.
+    prepareSignOut: async () => {
+      await page.goto("/dashboard");
+    },
+  });
+});

--- a/frontend/e2e/config-guard.smoke.spec.ts
+++ b/frontend/e2e/config-guard.smoke.spec.ts
@@ -35,5 +35,13 @@ test("pesquisador é redirecionado de config/* para analyze/code", async ({
         new RegExp(`/projects/${projectId}/analyze/code`),
       );
     },
+    // signOut na própria página de análise trava no waitForFunction de
+    // window.Clerk.loaded (mesmo padrão do lottery.smoke). Passava por
+    // coincidência de timing enquanto este era o primeiro spec a compilar a
+    // rota; com o coding-save.smoke aquecendo /analyze/code antes, o hang
+    // ficou determinístico — voltar ao dashboard antes do signOut.
+    prepareSignOut: async () => {
+      await page.goto("/dashboard");
+    },
   });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,9 +7,6 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
-      "engines": {
-        "node": ">=24.10.0"
-      },
       "dependencies": {
         "@clerk/localizations": "^4.13.1",
         "@clerk/nextjs": "^7.5.15",
@@ -56,13 +53,14 @@
         "react-scan": "0.5.7",
         "shadcn": "^4.13.0",
         "tailwindcss": "^4",
+        "tsx": "^4.23.1",
         "tw-animate-css": "^1.4.0",
         "typescript": "~6.0",
         "typescript-eslint": "8.63.0",
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.10.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1152,6 +1150,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -9505,6 +9945,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -17051,6 +17533,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "invariants": "npx tsx scripts/invariants/check-invariants.ts"
   },
   "dependencies": {
     "@clerk/localizations": "^4.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,8 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "invariants": "npx tsx scripts/invariants/check-invariants.ts"
+    "invariants": "tsx scripts/invariants/check-invariants.ts",
+    "e2e:fixture:coding": "tsx scripts/e2e-fixtures/create-coding-save-fixture.mts"
   },
   "dependencies": {
     "@clerk/localizations": "^4.13.1",
@@ -79,6 +80,7 @@
     "react-scan": "0.5.7",
     "shadcn": "^4.13.0",
     "tailwindcss": "^4",
+    "tsx": "^4.23.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "~6.0",
     "typescript-eslint": "8.63.0",

--- a/frontend/scripts/e2e-fixtures/create-coding-save-fixture.mts
+++ b/frontend/scripts/e2e-fixtures/create-coding-save-fixture.mts
@@ -1,0 +1,191 @@
+// Cria o projeto E2E dedicado ao smoke do fluxo de SALVAMENTO de codificação
+// (frontend/e2e/coding-save.smoke.spec.ts) e imprime o E2E_CODING_PROJECT_ID
+// para colar no .env.e2e. Estrutura replicada do projeto de referência
+// 1d8afb23 ("Comparação #430 — teste E2E"), com automation_mode 'none' (o
+// smoke testa só o par responses×assignments, sem automação).
+//
+// Idempotente: reutiliza projeto, documentos, membros e assignment pelo nome/
+// título, então rodar de novo é seguro e devolve sempre o mesmo id.
+//
+// Versionado (e não deixado no harness local) porque E2E_CODING_PROJECT_ID é
+// obrigatória no gate de pre-push: sem a receita no repo, um clone novo trava
+// no gate sem caminho para destravar.
+//
+// Rodar de frontend/:  npm run e2e:fixture:coding
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@supabase/supabase-js";
+import {
+  applyEnvironment,
+  readOptionalEnvironmentFile,
+} from "../worktree-env/env-contract.mjs";
+
+// Mesmo par de arquivos, na mesma ordem de precedência, que o
+// playwright.config.ts carrega: as credenciais Supabase vêm de .env.local e os
+// usuários de teste de .env.e2e, que sobrescreve. Ancorado no diretório do
+// próprio script (não no cwd) pelo mesmo motivo documentado lá — rodar da raiz
+// do repo acharia o contrato e nenhum valor.
+const frontendDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+applyEnvironment(process.env, readOptionalEnvironmentFile(join(frontendDir, ".env.local")));
+applyEnvironment(process.env, readOptionalEnvironmentFile(join(frontendDir, ".env.e2e")), {
+  override: true,
+});
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) {
+  throw new Error("NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY ausentes");
+}
+const supabase = createClient(url, key);
+
+const PROJECT_NAME = "Codificação (save path) — teste E2E";
+
+// Lidos do ambiente, nunca hardcoded: a fixture precisa valer para qualquer
+// instância Clerk (dev de outro contribuidor, instância nova), não só para os
+// usuários de teste desta máquina. São as mesmas variáveis que o Playwright já
+// exige — ver .env.e2e.example.
+const COORDINATOR_EMAIL = process.env.E2E_COORDINATOR_EMAIL;
+const MEMBER_EMAIL = process.env.E2E_MEMBER_EMAIL;
+if (!COORDINATOR_EMAIL || !MEMBER_EMAIL) {
+  throw new Error(
+    "E2E_COORDINATOR_EMAIL / E2E_MEMBER_EMAIL ausentes — configure frontend/.env.e2e (ver .env.e2e.example)",
+  );
+}
+
+async function profileIdByEmail(email: string): Promise<string> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("email", email)
+    .single();
+  if (error || !data) throw new Error(`profile não encontrado para ${email}: ${error?.message}`);
+  return data.id as string;
+}
+
+const coordinatorId = await profileIdByEmail(COORDINATOR_EMAIL);
+const memberId = await profileIdByEmail(MEMBER_EMAIL);
+
+// 1. Projeto (reutiliza pelo nome)
+const { data: existingProject, error: findErr } = await supabase
+  .from("projects")
+  .select("id")
+  .eq("name", PROJECT_NAME)
+  .maybeSingle();
+if (findErr) throw findErr;
+
+let projectId: string;
+if (existingProject) {
+  projectId = existingProject.id as string;
+  console.log(`Projeto já existe, reutilizando: ${projectId}`);
+} else {
+  const { data: project, error } = await supabase
+    .from("projects")
+    .insert({
+      name: PROJECT_NAME,
+      description:
+        "Projeto sintético para o smoke E2E do salvamento de codificação (responses×assignments). Pode ser apagado.",
+      created_by: coordinatorId,
+      automation_mode: "none",
+      pydantic_hash: "e2e-coding-save-schema-hash",
+      pydantic_fields: [
+        {
+          hash: "e2e-coding-f1",
+          name: "resumo",
+          type: "text",
+          options: null,
+          description: "Resumo do documento",
+        },
+        {
+          hash: "e2e-coding-f2",
+          name: "observacao",
+          type: "text",
+          options: null,
+          description: "Observação livre",
+        },
+      ],
+      schema_version_major: 1,
+      schema_version_minor: 0,
+      schema_version_patch: 0,
+    })
+    .select("id")
+    .single();
+  if (error || !project) throw new Error(`insert projects falhou: ${error?.message}`);
+  projectId = project.id as string;
+  console.log(`Projeto criado: ${projectId}`);
+}
+
+// 2. Documentos
+const LOREM =
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\n\n" +
+  "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n" +
+  "Curabitur pretium tincidunt lacus, at facilisis mi porta vitae. Nulla facilisi. Integer lacinia sollicitudin massa, non tristique sapien dictum quis. Cras ornare arcu sed viverra placerat.";
+
+const docIds: string[] = [];
+for (const n of [1, 2]) {
+  const title = `Doc E2E save ${n}`;
+  const { data: existingDoc } = await supabase
+    .from("documents")
+    .select("id")
+    .eq("project_id", projectId)
+    .eq("title", title)
+    .maybeSingle();
+  if (existingDoc) {
+    docIds.push(existingDoc.id as string);
+    continue;
+  }
+  const { data: doc, error } = await supabase
+    .from("documents")
+    .insert({
+      project_id: projectId,
+      external_id: `E2E-CODING-SAVE-${n}`,
+      title,
+      text: LOREM,
+    })
+    .select("id")
+    .single();
+  if (error || !doc) throw new Error(`insert documents ${n} falhou: ${error?.message}`);
+  docIds.push(doc.id as string);
+}
+console.log(`Documentos: ${docIds.join(", ")}`);
+
+// 3. Membros
+for (const [userId, role] of [
+  [coordinatorId, "coordenador"],
+  [memberId, "pesquisador"],
+] as const) {
+  const { data: existing } = await supabase
+    .from("project_members")
+    .select("id")
+    .eq("project_id", projectId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (existing) continue;
+  const { error } = await supabase
+    .from("project_members")
+    .insert({ project_id: projectId, user_id: userId, role });
+  if (error) throw new Error(`insert project_members (${role}) falhou: ${error.message}`);
+}
+console.log("Membros ok (coordenador + pesquisador)");
+
+// 4. Assignment de codificação do doc 1 para o membro
+const { data: existingAssign } = await supabase
+  .from("assignments")
+  .select("id")
+  .eq("project_id", projectId)
+  .eq("document_id", docIds[0])
+  .eq("user_id", memberId)
+  .eq("type", "codificacao")
+  .maybeSingle();
+if (!existingAssign) {
+  const { error } = await supabase.from("assignments").insert({
+    project_id: projectId,
+    document_id: docIds[0],
+    user_id: memberId,
+    type: "codificacao",
+    status: "pendente",
+  });
+  if (error) throw new Error(`insert assignments falhou: ${error.message}`);
+}
+console.log("Assignment de codificação ok");
+
+console.log(`\nE2E_CODING_PROJECT_ID=${projectId}`);

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -40,17 +40,22 @@ const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
 
 // Paginação manual: PostgREST corta em 1000 linhas por default; sem isso uma
 // tabela grande passaria "limpa" por truncamento silencioso.
-type SelectBuilder = ReturnType<ReturnType<typeof supabase.from>["select"]>;
+// O builder fica `any` de propósito: o PostgrestFilterBuilder muda de tipo a
+// cada método encadeado e, num helper genérico por nome de tabela, o tsc
+// estoura em TS2589 (instanciação excessivamente profunda) antes de qualquer
+// checagem útil. A tipagem do resultado vem do parâmetro T de cada chamada.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type UntypedSelectBuilder = any;
 
 async function fetchAll<T>(
   table: string,
   columns: string,
-  filter?: (q: SelectBuilder) => SelectBuilder,
+  filter?: (q: UntypedSelectBuilder) => UntypedSelectBuilder,
 ): Promise<T[]> {
   const PAGE = 1000;
   const rows: T[] = [];
   for (let from = 0; ; from += PAGE) {
-    let q = supabase.from(table).select(columns).range(from, from + PAGE - 1);
+    let q: UntypedSelectBuilder = supabase.from(table).select(columns).range(from, from + PAGE - 1);
     if (filter) q = filter(q);
     const { data, error } = await q;
     if (error) throw new Error(`${table}: ${error.message}`);

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -1,0 +1,264 @@
+/**
+ * check-invariants.ts — asserções de consistência READ-ONLY contra o banco.
+ *
+ * Verifica ESTADO, não código: pega drift que nenhum gate estático vê (dado
+ * inconsistente deixado por corrida, script de manutenção ou canal de escrita
+ * que contorna uma regra da UI). Rodar: `npm run invariants` (cwd frontend/;
+ * o alias @/ do import de coding-completeness resolve pelo tsconfig daqui).
+ * Precisa de NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY no
+ * .env.local (ou SUPABASE_ENV_PATH). Só SELECTs; um FAIL é evidência para
+ * investigação — nunca gatilho de correção automática de dado.
+ *
+ * Quando rodar: após mudança em write path de codificação/comparação, após
+ * migration aplicada no remoto, e ao investigar relato de "não salvou".
+ *
+ * Cada invariante nomeia o bug histórico que a motivou — se ela falhar, a
+ * regressão é da mesma família. Origem: diagnóstico de 2026-07-23, em que a
+ * primeira execução (então em harness local) encontrou 4 codificações
+ * completas presas em "em_andamento" após o dedup de documentos de 2026-06-23.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { isCodingComplete } from "@/lib/coding-completeness";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
+import { loadEnv } from "../comentarios-relatorio/load-env";
+
+loadEnv();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!SUPABASE_URL || !SERVICE_KEY) {
+  console.error(
+    "Faltam NEXT_PUBLIC_SUPABASE_URL e/ou SUPABASE_SERVICE_ROLE_KEY (frontend/.env.local ou SUPABASE_ENV_PATH).",
+  );
+  process.exit(2);
+}
+
+const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { persistSession: false },
+});
+
+// Paginação manual: PostgREST corta em 1000 linhas por default; sem isso uma
+// tabela grande passaria "limpa" por truncamento silencioso.
+type SelectBuilder = ReturnType<ReturnType<typeof supabase.from>["select"]>;
+
+async function fetchAll<T>(
+  table: string,
+  columns: string,
+  filter?: (q: SelectBuilder) => SelectBuilder,
+): Promise<T[]> {
+  const PAGE = 1000;
+  const rows: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    let q = supabase.from(table).select(columns).range(from, from + PAGE - 1);
+    if (filter) q = filter(q);
+    const { data, error } = await q;
+    if (error) throw new Error(`${table}: ${error.message}`);
+    rows.push(...((data ?? []) as T[]));
+    if (!data || data.length < PAGE) return rows;
+  }
+}
+
+// Documentos soft-deletados ficam fora das invariantes de fila/status: o dedup
+// de 2026-06 deixa de propósito, na cópia excluída, linhas que conflitariam
+// com UNIQUE na sobrevivente (ver pipeline-processos/dedup, local). Elas são
+// inertes — a UI não as mostra — e não são violação.
+async function activeDocIds(): Promise<Set<string>> {
+  const docs = await fetchAll<{ id: string }>("documents", "id", (q) => q.is("excluded_at", null));
+  return new Set(docs.map((d) => d.id));
+}
+
+type Violation = { key: string; detail: string };
+type Invariant = { name: string; motivation: string; run: () => Promise<Violation[]> };
+
+const invariants: Invariant[] = [
+  {
+    name: "responses-is-latest-unica",
+    motivation:
+      "família de duplicatas por corrida/re-import (#490, dedup Zolgensma): no máximo 1 response is_latest por (documento, respondente)",
+    run: async () => {
+      const rows = await fetchAll<{
+        id: string;
+        document_id: string;
+        respondent_type: string;
+        respondent_id: string | null;
+        respondent_name: string | null;
+      }>(
+        "responses",
+        "id, document_id, respondent_type, respondent_id, respondent_name",
+        (q) => q.eq("is_latest", true),
+      );
+      const byKey = new Map<string, string[]>();
+      for (const r of rows) {
+        const key = `${r.document_id}|${r.respondent_type}|${r.respondent_id ?? r.respondent_name ?? "?"}`;
+        byKey.set(key, [...(byKey.get(key) ?? []), r.id]);
+      }
+      return [...byKey.entries()]
+        .filter(([, ids]) => ids.length > 1)
+        .map(([key, ids]) => ({ key, detail: `${ids.length} responses is_latest: ${ids.join(", ")}` }));
+    },
+  },
+  {
+    name: "comparacao-ativa-unica-por-documento",
+    motivation:
+      "invariante do índice assignments_one_active_comparacao_per_doc (#490/PR #496); FAIL aqui = índice dropado ou canal de escrita que o contorna",
+    run: async () => {
+      const rows = await fetchAll<{ id: string; document_id: string; status: string | null }>(
+        "assignments",
+        "id, document_id, status",
+        (q) => q.eq("type", "comparacao"),
+      );
+      // inclui status NULL, como o predicado IS DISTINCT FROM do índice
+      const active = rows.filter((r) => r.status !== "concluido");
+      const byDoc = new Map<string, string[]>();
+      for (const r of active) byDoc.set(r.document_id, [...(byDoc.get(r.document_id) ?? []), r.id]);
+      return [...byDoc.entries()]
+        .filter(([, ids]) => ids.length > 1)
+        .map(([doc, ids]) => ({ key: doc, detail: `${ids.length} comparações ativas: ${ids.join(", ")}` }));
+    },
+  },
+  {
+    name: "review-chosen-response-do-mesmo-documento",
+    motivation:
+      "FK garante existência mas não coerência: chosen_response_id apontando para response de OUTRO documento é corrupção silenciosa do write path (família #425/#427 de identidade trocada)",
+    run: async () => {
+      const [reviews, responses] = await Promise.all([
+        fetchAll<{ id: string; document_id: string; chosen_response_id: string | null }>(
+          "reviews",
+          "id, document_id, chosen_response_id",
+          (q) => q.not("chosen_response_id", "is", null),
+        ),
+        fetchAll<{ id: string; document_id: string }>("responses", "id, document_id"),
+      ]);
+      const docOf = new Map(responses.map((r) => [r.id, r.document_id]));
+      return reviews
+        .filter((rv) => docOf.get(rv.chosen_response_id!) !== rv.document_id)
+        .map((rv) => ({
+          key: rv.id,
+          detail: `review do doc ${rv.document_id} escolheu response do doc ${docOf.get(rv.chosen_response_id!) ?? "INEXISTENTE"}`,
+        }));
+    },
+  },
+  {
+    name: "codificacao-concluida-tem-response",
+    motivation:
+      "discriminador escrita-vs-exibição (#425): assignment de codificação 'concluido' em doc ATIVO sem response humana do mesmo usuário = ou escrita perdida, ou status gravado por canal que não exige response",
+    run: async () => {
+      const active = await activeDocIds();
+      const [assignments, responses] = await Promise.all([
+        fetchAll<{ id: string; document_id: string; user_id: string }>(
+          "assignments",
+          "id, document_id, user_id",
+          (q) => q.eq("type", "codificacao").eq("status", "concluido"),
+        ),
+        fetchAll<{ document_id: string; respondent_id: string | null }>(
+          "responses",
+          "document_id, respondent_id",
+          (q) => q.eq("respondent_type", "humano"),
+        ),
+      ]);
+      const has = new Set(responses.map((r) => `${r.document_id}|${r.respondent_id}`));
+      return assignments
+        .filter((a) => active.has(a.document_id) && !has.has(`${a.document_id}|${a.user_id}`))
+        .map((a) => ({ key: a.id, detail: `assignment concluído sem response (doc ${a.document_id}, user ${a.user_id})` }));
+    },
+  },
+  {
+    name: "codificacao-completa-marcada-pendente",
+    motivation:
+      "inversa da anterior — o sintoma que o pesquisador vê como 'não salvou' (caso Naomi/dedup 2026-07-23): response submetida (is_partial=false) e completa pelo critério real do produto (isCodingComplete), em doc ativo, com assignment != concluido. Foi o estado deixado pelo dedup nos 4 casos reparados em 2026-07-23",
+    run: async () => {
+      const active = await activeDocIds();
+      const [projects, responses, assignments] = await Promise.all([
+        fetchAll<{ id: string; pydantic_fields: PydanticField[] | null }>("projects", "id, pydantic_fields"),
+        fetchAll<{ id: string; project_id: string; document_id: string; respondent_id: string | null }>(
+          "responses",
+          "id, project_id, document_id, respondent_id",
+          (q) => q.eq("respondent_type", "humano").eq("is_latest", true).eq("is_partial", false),
+        ),
+        fetchAll<{ document_id: string; user_id: string; status: string | null }>(
+          "assignments",
+          "document_id, user_id, status",
+          (q) => q.eq("type", "codificacao"),
+        ),
+      ]);
+      const fieldsOf = new Map(projects.map((p) => [p.id, p.pydantic_fields ?? []]));
+      const statusOf = new Map(assignments.map((a) => [`${a.document_id}|${a.user_id}`, a.status]));
+
+      // Fase 1 (metadados leves): candidato = doc ativo + assignment existente não-concluído.
+      const candidates = responses.filter((r) => {
+        if (!active.has(r.document_id)) return false;
+        const st = statusOf.get(`${r.document_id}|${r.respondent_id}`);
+        return st !== undefined && st !== "concluido";
+      });
+
+      // Fase 2 (campos pesados só dos candidatos): answers/hashes para o replay
+      // da regra real de completude do produto — a mesma que gateia o submit.
+      const violations: Violation[] = [];
+      for (const c of candidates) {
+        const { data, error } = await supabase
+          .from("responses")
+          .select("answers, answer_field_hashes")
+          .eq("id", c.id)
+          .single();
+        if (error) throw new Error(`responses(${c.id}): ${error.message}`);
+        const fields = fieldsOf.get(c.project_id) ?? [];
+        if (
+          fields.length > 0 &&
+          isCodingComplete(
+            fields,
+            (data.answers ?? {}) as Record<string, unknown>,
+            (data.answer_field_hashes ?? undefined) as AnswerFieldHashes | undefined,
+          )
+        ) {
+          violations.push({
+            key: c.id,
+            detail: `codificação completa com assignment '${statusOf.get(`${c.document_id}|${c.respondent_id}`)}' (doc ${c.document_id}, user ${c.respondent_id})`,
+          });
+        }
+      }
+      return violations;
+    },
+  },
+  {
+    name: "arbitragem-perdida-exige-sugestao",
+    motivation:
+      "regra de fluxo da migration 20260513000001: final_verdict='llm' (humano perdeu) exige question_improvement_suggestion; violação = canal de escrita pulando a regra da UI (família 'regra duplicada por fronteira', #486)",
+    run: async () => {
+      const rows = await fetchAll<{ id: string; question_improvement_suggestion: string | null }>(
+        "field_reviews",
+        "id, question_improvement_suggestion",
+        (q) => q.eq("final_verdict", "llm"),
+      );
+      return rows
+        .filter((r) => !r.question_improvement_suggestion?.trim())
+        .map((r) => ({ key: r.id, detail: "final_verdict=llm sem question_improvement_suggestion" }));
+    },
+  },
+];
+
+async function main() {
+  let failures = 0;
+  console.log(`Invariantes contra ${SUPABASE_URL}\n`);
+  for (const inv of invariants) {
+    try {
+      const violations = await inv.run();
+      if (violations.length === 0) {
+        console.log(`PASS  ${inv.name}`);
+      } else {
+        failures++;
+        console.log(`FAIL  ${inv.name} — ${violations.length} violação(ões)`);
+        console.log(`      motivação: ${inv.motivation}`);
+        for (const v of violations.slice(0, 10)) console.log(`      - [${v.key}] ${v.detail}`);
+        if (violations.length > 10) console.log(`      ... e mais ${violations.length - 10}`);
+      }
+    } catch (err) {
+      failures++;
+      console.log(`ERRO  ${inv.name} — ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+  console.log(`\n${invariants.length - failures}/${invariants.length} invariantes OK`);
+  process.exit(failures > 0 ? 1 : 0);
+}
+
+void main();

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -39,7 +39,24 @@ const supabase = createClient(SUPABASE_URL, SERVICE_KEY, {
 });
 
 // Paginação manual: PostgREST corta em 1000 linhas por default; sem isso uma
-// tabela grande passaria "limpa" por truncamento silencioso.
+// tabela grande passaria "limpa" por truncamento silencioso. `responses`,
+// `assignments` e `reviews` já cruzam a página, então este caminho roda sempre.
+//
+// O `.order("id")` é requisito da paginação, não estética: sem ORDER BY o
+// Postgres não garante a mesma ordem entre a consulta da página 1 e a da
+// página 2, e as duas quebras conhecidas produzem FALSO POSITIVO, o pior
+// resultado possível aqui (a regra do framework é "FAIL vira issue no mesmo
+// dia"). Uma linha pulada entre páginas some do mapa `docOf` e vira
+// "chosen_response de doc INEXISTENTE"; uma linha lida duas vezes vira
+// "2 responses is_latest: X, X", com o mesmo id repetido. Medido em
+// 2026-07-23: 15 passadas sem ORDER BY devolveram o conjunto completo — hoje a
+// leitura cai em seq scan de tabela pequena e quiescente, cuja ordem física é
+// estável na prática. É hazard latente, não defeito ativo: passa a morder sob
+// UPDATE concorrente (que move a versão da linha) — justamente o cenário de
+// rodar o checker enquanto pesquisadores codificam — e quando a tabela crescer
+// o bastante para o synchronize_seqscans fazer varreduras concorrentes
+// começarem em posições diferentes.
+//
 // O builder fica `any` de propósito: o PostgrestFilterBuilder muda de tipo a
 // cada método encadeado e, num helper genérico por nome de tabela, o tsc
 // estoura em TS2589 (instanciação excessivamente profunda) antes de qualquer
@@ -55,7 +72,11 @@ async function fetchAll<T>(
   const PAGE = 1000;
   const rows: T[] = [];
   for (let from = 0; ; from += PAGE) {
-    let q: UntypedSelectBuilder = supabase.from(table).select(columns).range(from, from + PAGE - 1);
+    let q: UntypedSelectBuilder = supabase
+      .from(table)
+      .select(columns)
+      .order("id", { ascending: true })
+      .range(from, from + PAGE - 1);
     if (filter) q = filter(q);
     const { data, error } = await q;
     if (error) throw new Error(`${table}: ${error.message}`);
@@ -199,14 +220,30 @@ const invariants: Invariant[] = [
 
       // Fase 2 (campos pesados só dos candidatos): answers/hashes para o replay
       // da regra real de completude do produto — a mesma que gateia o submit.
-      const violations: Violation[] = [];
-      for (const c of candidates) {
+      // Em lote, não uma consulta por candidato. O bloco é pequeno porque o
+      // filtro `in` viaja na query string e cada id é um UUID de 36 caracteres:
+      // com 500 a URL passa de 18 mil chars e o fetch falha (medido em
+      // 2026-07-23, mutando o filtro de candidatos para exercitar este caminho).
+      // 100 ids ≈ 3,7 kB de URL, com folga confortável.
+      const CHUNK = 100;
+      const heavyOf = new Map<
+        string,
+        { answers: unknown; answer_field_hashes: unknown }
+      >();
+      for (let i = 0; i < candidates.length; i += CHUNK) {
+        const ids = candidates.slice(i, i + CHUNK).map((c) => c.id);
         const { data, error } = await supabase
           .from("responses")
-          .select("answers, answer_field_hashes")
-          .eq("id", c.id)
-          .single();
-        if (error) throw new Error(`responses(${c.id}): ${error.message}`);
+          .select("id, answers, answer_field_hashes")
+          .in("id", ids);
+        if (error) throw new Error(`responses(lote de ${ids.length}): ${error.message}`);
+        for (const row of data ?? []) heavyOf.set(row.id as string, row);
+      }
+
+      const violations: Violation[] = [];
+      for (const c of candidates) {
+        const data = heavyOf.get(c.id);
+        if (!data) throw new Error(`responses(${c.id}): sumiu entre as duas fases`);
         const fields = fieldsOf.get(c.project_id) ?? [];
         if (
           fields.length > 0 &&

--- a/frontend/src/lib/__tests__/playwright-pre-push-env.test.ts
+++ b/frontend/src/lib/__tests__/playwright-pre-push-env.test.ts
@@ -15,7 +15,7 @@ const completeRequiredEnv = Object.fromEntries(
 );
 
 describe("assertRequiredPrePushEnv", () => {
-  it("deriva as nove variáveis obrigatórias dos exemplos canônicos", () => {
+  it("deriva as dez variáveis obrigatórias dos exemplos canônicos", () => {
     expect(requiredPrePushEnv).toEqual(
       [
         "NEXT_PUBLIC_SUPABASE_URL",
@@ -27,6 +27,8 @@ describe("assertRequiredPrePushEnv", () => {
         "E2E_MEMBER_EMAIL",
         "E2E_PROJECT_ID",
         "E2E_LOTTERY_PROJECT_ID",
+        // coding-save.smoke.spec.ts — projeto dedicado do smoke de salvamento
+        "E2E_CODING_PROJECT_ID",
       ].sort(),
     );
   });


### PR DESCRIPTION
## O que este PR entrega

Duas camadas de prevenção para a família de bugs "codificação não salva", derivadas do diagnóstico de 2026-07-23 (o dedup de documentos de 2026-06-23 deixou 4 codificações completas presas em `em_andamento`; o reparo de dados foi aplicado à parte, fora do repo).

### 1. Checker de invariantes de banco — `npm run invariants`

`frontend/scripts/invariants/check-invariants.ts`: 6 asserções read-only de consistência contra o banco (service key, só SELECTs), cada uma ancorada no bug histórico que a motivou:

- `responses-is-latest-unica` — família de duplicatas por corrida/re-import (#490)
- `comparacao-ativa-unica-por-documento` — vigia o invariante do índice `assignments_one_active_comparacao_per_doc` (#490/#496)
- `review-chosen-response-do-mesmo-documento` — coerência que a FK não garante (#425/#427)
- `codificacao-concluida-tem-response` — discriminador escrita-vs-exibição (#425), só docs ativos
- `codificacao-completa-marcada-pendente` — a inversa, com replay do `isCodingComplete` real (fetch em 2 fases); é o sintoma "terminei e voltou pra fila". Na primeira execução já encontrou um caso real fora do Zolgensma (#521)
- `arbitragem-perdida-exige-sugestao` — regra de fluxo da migration 20260513000001 (família "regra duplicada por fronteira", #486)

Verifica ESTADO, não código: pega drift que nenhum gate estático alcança, independentemente de qual código o causou. Agendamento automático fica na #516.

### 2. Smoke E2E do fluxo de salvamento — `frontend/e2e/coding-save.smoke.spec.ts`

Primeiro smoke que MUTA um projeto de teste dedicado (`E2E_CODING_PROJECT_ID`, novo contrato obrigatório em `.env.e2e.example` + teste de contrato atualizado): codifica os 2 campos, envia, e prova **no banco** as duas pontas do par `responses`×`assignments` (response `is_latest`/`is_partial=false`/answers exatos E assignment `concluido`), mais o round-trip pela UI. Reset idempotente via service key a cada run.

**Prova do vermelho:** com uma sabotagem que retorna sucesso sem escrever (`return { success: true }` antes do upsert), o spec falha exatamente na asserção de banco — "a UI reportou sucesso mas NENHUMA response foi escrita".

### 3. Fix de hang pré-existente no config-guard

O spec novo, rodando antes por ordem alfabética, aquecia a compilação de `/analyze/code` e tornava determinístico um hang de `clerk.signOut` que já existia no `config-guard.smoke` (mesmo sintoma documentado no `lottery.smoke`). Corrigido com o padrão da casa: `prepareSignOut` → `/dashboard`.

## Achados de produto derivados (issues, fora deste PR)

- #519 — submit incompleto indistinguível de conclusão (provável causa das reclamações vivas)
- #520 — auto-save reescreve `answer_field_hashes` e derrota o guard de staleness
- #521 — sorteio cria assignment `pendente` para doc já codificado (caso PIBIC que o checker acusou)

## Verificação

- Gates completos do pre-push verdes (typecheck, vitest 1334 testes, e2e-smoke com os 5 specs, lint:types, fallow, semgrep).
- `npm run invariants` roda e reporta 5/6 PASS — o FAIL restante é o caso real da #521, deliberadamente não mascarado.
- Spec E2E provado vermelho contra sabotagem e verde 3× em sequência.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FaFcWmCiCaeqx8hfdkigqV