### PR TITLE
fix(deploy): falha o build com chave vazia e separa a mensagem de autosave

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -29,8 +29,16 @@ ARG NEXT_DEPLOYMENT_ID
 # chave no historico do comando.
 # O Next a incorpora por design no manifesto server-only do build, copiado para
 # a imagem final. O SHA identifica assets e navegacoes desta release.
+#
+# `test -s` (e nao apenas `required=true`): o mount so garante que o secret foi
+# FORNECIDO, nao que tem conteudo. Com o secret ausente no repositorio, a env
+# expande vazia, `--build-secret K=` satisfaz o mount, e o Next trata a chave
+# vazia como ausente — volta a gerar uma chave aleatoria por build, os IDs das
+# Server Actions voltam a girar e o deploy passa verde. Falhar aqui e a unica
+# forma de esse caso nao passar em silencio.
 RUN --mount=type=secret,id=NEXT_SERVER_ACTIONS_ENCRYPTION_KEY,required=true \
     test -n "$NEXT_DEPLOYMENT_ID" \
+    && test -s /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY \
     && NEXT_SERVER_ACTIONS_ENCRYPTION_KEY="$(cat /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY)" npm run build
 
 # --- Runtime ---

--- a/frontend/src/lib/__tests__/coding-autosave.test.ts
+++ b/frontend/src/lib/__tests__/coding-autosave.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { saveResponse } from "@/actions/responses";
+import { toast } from "sonner";
+import {
+  autosaveDirtyDoc,
+  saveCodingResponse,
+  CODING_SAVE_TRANSPORT_ERROR,
+  CODING_AUTOSAVE_TRANSPORT_ERROR,
+} from "@/lib/coding-autosave";
+
+vi.mock("@/actions/responses", () => ({ saveResponse: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mockSave = vi.mocked(saveResponse);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("saveCodingResponse", () => {
+  it("normaliza a rejeição de transporte para o contrato de falha", async () => {
+    mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
+
+    const result = await saveCodingResponse("p1", "d1", { q: "sim" });
+
+    expect(result).toEqual({
+      success: false,
+      error: CODING_SAVE_TRANSPORT_ERROR,
+    });
+  });
+
+  it("devolve a falha do handler sem reescrevê-la como erro de transporte", async () => {
+    mockSave.mockResolvedValue({
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    });
+
+    const result = await saveCodingResponse("p1", "d1", { q: "sim" });
+
+    expect(result).toEqual({
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    });
+  });
+});
+
+// Este é o único caminho fire-and-forget: a navegação acontece de qualquer
+// forma, então a falha não pode limpar a sujeira do documento — é ela que
+// mantém o doc na fila para uma nova tentativa.
+describe("autosaveDirtyDoc", () => {
+  const params = () => ({
+    projectId: "p1",
+    docId: "d1",
+    answers: { q: "sim" },
+    notes: "nota",
+    markClean: vi.fn(),
+  });
+
+  it("não limpa a sujeira e usa a mensagem de navegação quando o transporte rejeita", async () => {
+    mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
+    const p = params();
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    expect(p.markClean).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(CODING_AUTOSAVE_TRANSPORT_ERROR);
+    // A mensagem do save aguardado ("continuam nesta página") apontaria para o
+    // documento que o pesquisador acabou de deixar.
+    expect(toast.error).not.toHaveBeenCalledWith(CODING_SAVE_TRANSPORT_ERROR);
+  });
+
+  it("propaga a mensagem do handler quando a falha não é de transporte", async () => {
+    mockSave.mockResolvedValue({
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    });
+    const p = params();
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
+
+    expect(p.markClean).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      "Documento removido do escopo do projeto",
+    );
+  });
+
+  it("limpa a sujeira e salva como autosave no sucesso", async () => {
+    mockSave.mockResolvedValue({ success: true });
+    const p = params();
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(p.markClean).toHaveBeenCalledWith("d1"));
+
+    expect(mockSave).toHaveBeenCalledWith(
+      "p1",
+      "d1",
+      { q: "sim" },
+      { notes: "nota", isAutoSave: true },
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("não deixa unhandled rejection se um efeito posterior ao save falhar", async () => {
+    mockSave.mockResolvedValue({ success: true });
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    const p = {
+      ...params(),
+      markClean: vi.fn(() => {
+        throw new Error("markClean explodiu");
+      }),
+    };
+
+    autosaveDirtyDoc(p);
+    await vi.waitFor(() => expect(p.markClean).toHaveBeenCalled());
+    await new Promise((r) => setImmediate(r));
+
+    process.off("unhandledRejection", unhandled);
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/coding-autosave.ts
+++ b/frontend/src/lib/coding-autosave.ts
@@ -5,22 +5,35 @@ import {
 } from "@/actions/responses";
 import { toast } from "sonner";
 
+// Duas mensagens porque os dois caminhos deixam o pesquisador em lugares
+// diferentes quando o transporte falha. No save aguardado (Enviar / Voltar) ele
+// continua no documento, e pedir retry sem recarregar é a instrução correta. No
+// autosave de navegação (`autosaveDirtyDoc`) o save é fire-and-forget e a troca
+// de documento já aconteceu quando o toast aparece — dizer "nesta página"
+// apontaria para o lugar errado.
 export const CODING_SAVE_TRANSPORT_ERROR =
   "Não foi possível salvar suas respostas. Suas alterações continuam nesta página. Tente novamente sem recarregar.";
+
+export const CODING_AUTOSAVE_TRANSPORT_ERROR =
+  "Não foi possível salvar automaticamente. As respostas continuam no documento, que segue pendente. Volte a ele e envie novamente, sem recarregar.";
 
 // Server Actions rejeitam a Promise quando o transporte falha antes de o
 // handler executar. Normalizar essa rejeição preserva um único contrato para
 // todos os callers: o rascunho só é limpo quando `success` é true.
+//
+// `transportError` é parâmetro porque só o caller sabe onde o pesquisador vai
+// estar quando o toast aparecer — ver o comentário das duas constantes acima.
 export async function saveCodingResponse(
   projectId: string,
   documentId: string,
   answers: Record<string, unknown>,
   opts: SaveResponseOpts = {},
+  transportError: string = CODING_SAVE_TRANSPORT_ERROR,
 ): Promise<SaveResponseResult> {
   try {
     return await saveResponse(projectId, documentId, answers, opts);
   } catch {
-    return { success: false, error: CODING_SAVE_TRANSPORT_ERROR };
+    return { success: false, error: transportError };
   }
 }
 
@@ -48,14 +61,23 @@ export function autosaveDirtyDoc({
   notes,
   markClean,
 }: AutosaveDirtyDocParams): void {
-  void saveCodingResponse(projectId, docId, answers, {
-    notes,
-    isAutoSave: true,
-  }).then((result) => {
-    if (result.success) {
-      markClean(docId);
-    } else {
-      toast.error(result.error);
-    }
-  });
+  void saveCodingResponse(
+    projectId,
+    docId,
+    answers,
+    { notes, isAutoSave: true },
+    CODING_AUTOSAVE_TRANSPORT_ERROR,
+  )
+    .then((result) => {
+      if (result.success) {
+        markClean(docId);
+      } else {
+        toast.error(result.error);
+      }
+    })
+    // `saveCodingResponse` não rejeita — este `catch` cobre o que vem DEPOIS do
+    // save (`markClean` do caller, render do toast). Sem ele vira unhandled
+    // rejection, e o `void` já satisfaz o `no-floating-promises`, então nenhum
+    // gate reclamaria. O doc simplesmente segue sujo, que é o estado seguro.
+    .catch(() => {});
 }

--- a/frontend/src/tooling/__tests__/deployment-versioning.test.ts
+++ b/frontend/src/tooling/__tests__/deployment-versioning.test.ts
@@ -32,6 +32,16 @@ describe("versionamento do build do frontend", () => {
     );
   });
 
+  // `required=true` cobre o secret AUSENTE; nao cobre o secret vazio, que o
+  // Next trata como chave nao fornecida (volta a gerar uma por build). Os dois
+  // `test` sao o que faz esse caso falhar em vez de passar verde.
+  it("falha o build quando o SHA ou a chave chegam vazios", () => {
+    expect(dockerfile).toContain('test -n "$NEXT_DEPLOYMENT_ID"');
+    expect(dockerfile).toContain(
+      "test -s /run/secrets/NEXT_SERVER_ACTIONS_ENCRYPTION_KEY",
+    );
+  });
+
   it("nao declara a chave em diretivas ARG ou ENV do Dockerfile", () => {
     expect(dockerfile).not.toMatch(
       /^(?:ARG|ENV) NEXT_SERVER_ACTIONS_ENCRYPTION_KEY/m,


### PR DESCRIPTION
Ajustes da revisão do #511, empilhados sobre a branch daquele PR. Três achados, cada um com o vermelho provado antes do fix (revertendo só o código e mantendo os testes: falharam exatamente as 3 asserções correspondentes; a quarta, de controle, seguiu verde nos dois estados).

## 1. `required=true` não protege contra secret vazio (bloqueante)

O mount garante que o secret foi **fornecido**, não que tem conteúdo. Se `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` for apagado ou renomeado nas configurações do repositório, a env expande vazia, `--build-secret "K="` satisfaz o mount, e `""` é falsy em `generateEncryptionKeyBase64` (`next/dist/server/app-render/encryption-utils-server.js:96`) — o Next volta a gerar chave aleatória por build, os IDs das Server Actions voltam a girar e o deploy passa verde. O incidente que o #511 corrige reaparece sem sinal.

`test -s /run/secrets/...` na mesma cadeia, mantendo a validação única no ponto de consumo. O gate em `deployment-versioning.test.ts` passa a exigir os dois `test`.

## 2. A mensagem de transporte apontava para o lugar errado no autosave

`CODING_SAVE_TRANSPORT_ERROR` diz "suas alterações continuam nesta página" — correto no save aguardado (`handleSubmit`, `handleBrowseBack`), onde o pesquisador segue no documento. Mas `autosaveDirtyDoc` é chamado de `handleDocNavigate` e `handleSortChange`: ali o save é fire-and-forget e a navegação acontece de qualquer forma, então quando o toast aparece ele já está em outro documento. Os dados não se perdem (o doc segue sujo), mas a instrução apontava para o documento que ele acabou de deixar.

Segunda constante, `CODING_AUTOSAVE_TRANSPORT_ERROR`, escolhida pelo caller via o parâmetro `transportError` — só o caller sabe onde o pesquisador vai estar quando o toast renderizar.

## 3. O `.catch` removido cobria o que vem depois do save

`saveCodingResponse` de fato não rejeita, mas `markClean` e o render do toast, dentro do `.then`, podem lançar — e aí vira unhandled rejection. O `void` já satisfaz o `no-floating-promises`, então nenhum gate reclamaria. Restaurado com comentário nomeando o que ele cobre (efeito posterior, não transporte, que o adapter já normaliza).

## Sobre o resto do #511

A revisão confirmou o mecanismo central lendo o Next 16.2.9 instalado: `serverReferenceHashSalt` **é** o `encryptionKey` (`build/webpack-config.js:417,443,1921`), então fixar a chave fixa os IDs — não é efeito colateral, é o mecanismo, e vale também no Turbopack (`turbopack-build/impl.js:63,109,184`). A chave literal entra só no manifesto server (`flight-client-entry-plugin.js:717-724`); a variante edge grava a referência de env. Confirmado também que o servidor em self-host **não** compara `x-deployment-id` — o `NEXT_DEPLOYMENT_ID` aqui faz cache-busting de asset (`?dpl=`), como o corpo do #511 já descreve.

## Follow-up sugerido (fora deste PR)

Documentar a rotação da chave: ela vive em claro no `server-reference-manifest.json` dentro da imagem — mesma superfície de antes, mas agora duradoura — e trocá-la muda todos os IDs de action, ou seja, é um deploy com skew planejado.

## Validação

- suíte Vitest completa: 165 arquivos, 1734 testes;
- `typecheck`, `lint`, `lint:types` e react-doctor (100/100) limpos;
- todos os hooks de pre-push passaram, incluindo o smoke E2E autenticado;
- vermelho provado antes de cada fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ji18uiKqdcKeE1i398C2zy