### PR TITLE
fix(codificação): sinal de submissão derivado do que foi gravado (#519)

### DIFF
--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { revalidatePath, revalidateTag } from "next/cache";
+import { isCodingComplete } from "@/lib/coding-completeness";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 const drainAutoReviewReconciliationRequests = vi.hoisted(() => vi.fn(async () => ({
   processed: 1,
@@ -297,6 +299,98 @@ describe("saveResponse — auto-save vs submit explicito", () => {
       q_txt: "h-text",
     });
     expect(state.assignmentUpdatePayload?.status).toBe("em_andamento");
+  });
+
+  it("auto-save em doc codificado antes do bump NAO passa a dever o campo novo (#520)", async () => {
+    // Critério de aceite da #520: a codificação foi completa à época; o schema
+    // ganhou um obrigatório depois. Basta o pesquisador reabrir o doc e tocar
+    // qualquer coisa para o save reestampar o mapa — e a leitura retroativa
+    // (backlog, reconciliação) passar a considerar a codificação incompleta.
+    state.pydanticFields = [
+      { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
+      { name: "q_novo", type: "single", required: true, options: ["x"], hash: "h-novo" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: { q1: "h1" },
+    };
+
+    const saveResponse = await loadSaveResponse();
+    const result = await saveResponse(
+      "proj-1",
+      "doc-1",
+      { q1: "b" },
+      { isAutoSave: true },
+    );
+
+    expect(result.success).toBe(true);
+    const gravado = state.responseUpdatePayload?.answer_field_hashes as AnswerFieldHashes;
+    expect(gravado).toEqual({ q1: "h1" });
+    // A leitura retroativa continua enxergando a codificação como completa.
+    expect(
+      isCodingComplete(
+        state.pydanticFields as PydanticField[],
+        state.responseUpdatePayload?.answers as Record<string, unknown>,
+        gravado,
+      ),
+    ).toBe(true);
+  });
+
+  it("campo criado depois entra no mapa quando o pesquisador o responde (#520)", async () => {
+    state.pydanticFields = [
+      { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
+      { name: "q_novo", type: "single", required: true, options: ["x"], hash: "h-novo" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: { q1: "h1" },
+    };
+
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a", q_novo: "x" });
+
+    expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({
+      q1: "h1",
+      q_novo: "h-novo",
+    });
+    expect(state.assignmentUpdatePayload?.status).toBe("concluido");
+  });
+
+  it("response legacy conserva o sentinela em vez de ganhar chaves (#520)", async () => {
+    state.pydanticFields = [
+      { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
+      { name: "q_novo", type: "single", required: true, options: ["x"], hash: "h-novo" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: null,
+    };
+
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "b" }, { isAutoSave: true });
+
+    expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({});
+  });
+
+  it("codificacao nova estampa o schema atual inteiro (INSERT)", async () => {
+    state.pydanticFields = [
+      { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
+      { name: "q2", type: "text", required: true, hash: "h2" },
+    ];
+
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+
+    expect(state.responseInsertPayload?.answer_field_hashes).toEqual({
+      q1: "h1",
+      q2: "h2",
+    });
   });
 
   it("auto-save com campo obrigatorio vazio mantem pendente em em_andamento", async () => {

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -239,6 +239,60 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(state.assignmentUpdatePayload).toBeNull();
   });
 
+  it("submit explicito com obrigatoria em branco grava is_partial=true", async () => {
+    // O sinal descreve o conjunto GRAVADO, nao o canal da escrita: sem isso, um
+    // envio incompleto ficava indistinguivel de uma conclusao — o documento
+    // voltava a fila e o pesquisador lia como "nao salvou" (#519).
+    state.pydanticFields = [
+      { name: "q1", type: "text", hash: "h-q1" },
+      { name: "q2", type: "text", hash: "h-q2" },
+    ];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+    expect(state.responseInsertPayload?.is_partial).toBe(true);
+    // E o cliente recebe a contagem para diferenciar o feedback.
+    expect(r.missingRequired).toBe(1);
+  });
+
+  it("auto-save que ENCOLHE uma response submetida devolve is_partial=true", async () => {
+    // A heranca do sinal ("ja foi submetida uma vez") sobrevivia a uma escrita
+    // posterior com menos respostas, carimbando de submetido um conjunto
+    // incompleto. Distinto do caso vizinho, onde o conjunto continua completo.
+    state.pydanticFields = [
+      { name: "q1", type: "text", hash: "h-q1" },
+      { name: "q2", type: "text", hash: "h-q2" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a", q2: "b" },
+      answer_field_hashes: { q1: "h-q1", q2: "h-q2" },
+    };
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    expect(state.responseUpdatePayload?.answers).toEqual({ q1: "a" });
+    expect(state.responseUpdatePayload?.is_partial).toBe(true);
+  });
+
+  it("campo obrigatorio criado depois NAO rebaixa codificacao antiga em auto-save", async () => {
+    // Espelho do caso real: a codificacao estava completa contra o schema da
+    // epoca; o campo novo so entra na regua se o carimbo provar que ele existia.
+    state.pydanticFields = [
+      { name: "q1", type: "text", hash: "h-q1" },
+      { name: "q_novo", type: "text", hash: "h-novo" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: { q1: "h-q1" },
+    };
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    expect(state.responseUpdatePayload?.is_partial).toBe(false);
+    expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({ q1: "h-q1" });
+  });
+
   it("auto-save em response já submetida invalida imediatamente a auto-revisão", async () => {
     state.existingResponse = { id: "resp-1", is_partial: false };
     state.currentAssignmentStatus = "concluido";

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -221,6 +221,7 @@ export async function saveResponse(
       storedAnswers: existing?.answers,
       storedHashes: existing?.answer_field_hashes,
       rawSubmittedAnswers: answers,
+      isNewResponse: !existing,
     });
 
     const payload = buildResponsePayload({

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -4,8 +4,16 @@ import { createSupabaseServer, type SupabaseServerClient } from "@/lib/supabase/
 import { resolveProjectMemberActor } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
+import { isCodingComplete, missingRequiredHumanFields } from "@/lib/coding-completeness";
 import { syncCodingAssignmentStatus } from "@/lib/coding-sync";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
+
+export interface SaveResponseResult {
+  success: boolean;
+  error?: string;
+  /** Obrigatórias ainda em branco no conjunto gravado (0 = codificação completa). */
+  missingRequired?: number;
+}
 
 export interface SaveResponseOpts {
   notes?: string;
@@ -75,6 +83,7 @@ interface SaveResponseProjectFields {
 }
 
 interface BuildResponsePayloadParams {
+  fields: PydanticField[];
   answersToPersist: Record<string, unknown>;
   answerFieldHashes: Exclude<AnswerFieldHashes, null>;
   project: SaveResponseProjectFields | null | undefined;
@@ -84,6 +93,7 @@ interface BuildResponsePayloadParams {
 }
 
 function buildResponsePayload({
+  fields,
   answersToPersist,
   answerFieldHashes,
   project,
@@ -96,14 +106,24 @@ function buildResponsePayload({
   const roundIdToPersist =
     project?.round_strategy === "manual" ? (project?.current_round_id ?? null) : null;
 
-  // Para humanos is_partial e mutavel: auto-save grava true (segue como
-  // current_pending em classifyDocStatus) e submit explicito grava false.
-  // Excecao: auto-save em response ja submetida (is_partial=false) NAO
-  // rebaixa o sinal — combinado com o guard que preserva assignment.status
-  // = "concluido", esse rebaixamento faria um doc ja concluido reaparecer
-  // como pendente em classifyDocStatus. A imutabilidade descrita na migration
-  // 20260425000000 vale so para o fluxo LLM.
-  const isPartialToWrite = isAutoSave && existing?.is_partial !== false;
+  // Para humanos is_partial descreve O QUE FOI GRAVADO, não por qual canal a
+  // escrita chegou: uma resposta só deixa de ser parcial quando o pesquisador
+  // envia (submit explícito) E o conjunto gravado satisfaz a régua de
+  // completude. Enquanto o sinal era função apenas do canal, um auto-save
+  // herdava o `false` de um submit anterior e podia carimbar "submetida" um
+  // conjunto que já não estava completo — o estado que fazia o documento voltar
+  // à fila com aparência de concluído (#519).
+  //
+  // Staleness-aware de propósito: avaliar contra o carimbo per-campo da própria
+  // resposta impede que um campo obrigatório criado depois rebaixe uma
+  // codificação que estava completa quando foi feita.
+  // O auto-save continua sem promover nada por conta própria — quem nunca
+  // enviou segue parcial mesmo com tudo preenchido (o guard de assignment em
+  // coding-sync faz o espelho disso para `status`).
+  const submittedBefore = existing?.is_partial === false;
+  const isPartialToWrite =
+    !isCodingComplete(fields, answersToPersist, answerFieldHashes) ||
+    (isAutoSave && !submittedBefore);
 
   const payload = {
     answers: answersToPersist,
@@ -180,7 +200,7 @@ export async function saveResponse(
   documentId: string,
   answers: Record<string, unknown>,
   opts: SaveResponseOpts = {},
-): Promise<{ success: boolean; error?: string }> {
+): Promise<SaveResponseResult> {
   const { notes, isAutoSave = false } = opts;
   try {
     const actor = await resolveProjectMemberActor(projectId);
@@ -225,6 +245,7 @@ export async function saveResponse(
     });
 
     const payload = buildResponsePayload({
+      fields,
       answersToPersist: snapshot.persistedAnswers,
       answerFieldHashes: snapshot.answerFieldHashes,
       project,
@@ -259,7 +280,19 @@ export async function saveResponse(
     }
 
     revalidateAfterSave(projectId, isAutoSave);
-    return { success: true };
+    // Quantas obrigatórias o conjunto GRAVADO ainda deixa em aberto. Vai para o
+    // cliente porque o formulário decide o que exibir a partir do schema que ele
+    // carregou; se o schema mudou desde então, é esta contagem — a mesma que
+    // decide `is_partial` — que impede o feedback de sucesso de anunciar uma
+    // conclusão que não houve (#519).
+    return {
+      success: true,
+      missingRequired: missingRequiredHumanFields(
+        fields,
+        snapshot.persistedAnswers,
+        snapshot.answerFieldHashes,
+      ).length,
+    };
   } catch (e) {
     return { success: false, error: e instanceof Error ? e.message : "Erro desconhecido" };
   }

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -66,6 +66,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     handleSubmitWithValidation,
     requiredFields,
     answeredRequiredCount,
+    missingRequiredCount,
   } = useQuestionValidation(
     visibleFields,
     answers,
@@ -185,6 +186,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         outOfScopeBlocked={outOfScopeBlocked}
         readOnly={readOnly}
         submitting={submitting}
+        missingRequiredCount={missingRequiredCount}
         onClick={handleSubmitWithValidation}
       />
     </div>

--- a/frontend/src/components/coding/SubmitBar.tsx
+++ b/frontend/src/components/coding/SubmitBar.tsx
@@ -1,37 +1,68 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
 
 interface SubmitBarProps {
   outOfScopeBlocked: boolean;
   readOnly: boolean;
   submitting: boolean;
+  /** Obrigatórias visíveis ainda em branco, pela régua de `isCodingComplete`. */
+  missingRequiredCount: number;
   onClick: () => void;
 }
 
-/** Rodapé do painel de perguntas: botão de envio, com texto/estado derivados
- *  de sinalização "fora do escopo" > somente leitura > salvando > normal. */
-export function SubmitBar({ outOfScopeBlocked, readOnly, submitting, onClick }: SubmitBarProps) {
+interface SubmitBarState {
+  label: string;
+  /** Pendência do formulário: neutra, para o botão não convidar ao clique. */
+  pending: boolean;
+  spinner: boolean;
+}
+
+// Estado do botão em ordem de precedência: sinalização "fora do escopo" >
+// somente leitura > salvando > pendências > normal.
+function resolveSubmitBarState({
+  outOfScopeBlocked,
+  readOnly,
+  submitting,
+  missingRequiredCount,
+}: Omit<SubmitBarProps, "onClick">): SubmitBarState {
+  if (outOfScopeBlocked) {
+    return { label: "Aguardando revisão do coordenador", pending: false, spinner: false };
+  }
+  if (readOnly) return { label: "Somente leitura", pending: false, spinner: false };
+  if (submitting) return { label: "Salvando…", pending: false, spinner: true };
+  if (missingRequiredCount > 0) {
+    return {
+      label:
+        missingRequiredCount === 1
+          ? "Falta 1 obrigatória"
+          : `Faltam ${missingRequiredCount} obrigatórias`,
+      pending: true,
+      spinner: false,
+    };
+  }
+  return { label: "Enviar respostas", pending: false, spinner: false };
+}
+
+/** Rodapé do painel de perguntas. A contagem de pendências sai da mesma régua
+ *  que o servidor usa para concluir a codificação: antes de existir, o botão
+ *  prometia "Enviar respostas" a quem ainda não podia enviar, e o pesquisador só
+ *  descobria a pendência depois do clique (#519). O botão segue habilitado —
+ *  quem clica recebe o destaque e o rolamento até o primeiro campo em branco. */
+export function SubmitBar({ onClick, ...state }: SubmitBarProps) {
+  const { label, pending, spinner } = resolveSubmitBarState(state);
   return (
     <div className="border-t px-4 py-3 shrink-0">
       <Button
         onClick={onClick}
-        disabled={submitting || readOnly || outOfScopeBlocked}
-        className="w-full bg-brand hover:bg-brand/90 text-brand-foreground"
+        disabled={state.submitting || state.readOnly || state.outOfScopeBlocked}
+        variant={pending ? "outline" : "default"}
+        className={cn("w-full", !pending && "bg-brand hover:bg-brand/90 text-brand-foreground")}
       >
-        {outOfScopeBlocked ? (
-          "Aguardando revisão do coordenador"
-        ) : readOnly ? (
-          "Somente leitura"
-        ) : submitting ? (
-          <>
-            <Loader2 className="size-4 animate-spin" />
-            Salvando…
-          </>
-        ) : (
-          "Enviar respostas"
-        )}
+        {spinner && <Loader2 className="size-4 animate-spin" />}
+        {label}
       </Button>
     </div>
   );

--- a/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
+++ b/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
@@ -195,8 +195,10 @@ describe("QuestionsPanel — pergunta fora do escopo", () => {
       />,
     );
     expect(screen.getByRole("switch")).toBeTruthy();
-    // Formulário não bloqueado: botão de envio normal.
-    expect(screen.getByRole("button", { name: /Enviar respostas/ })).toBeTruthy();
+    // Formulário não bloqueado: o botão reporta as pendências do próprio
+    // formulário, não o bloqueio por sinalização de fora do escopo.
+    expect(screen.queryByRole("button", { name: /Aguardando revisão/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /Faltam 2 obrigatórias/ })).toBeTruthy();
   });
 
   it("pendente: perguntas inertes e envio substituído por aviso", () => {

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -4,6 +4,7 @@ import { useCallback, useMemo, useReducer, useRef } from "react";
 import { saveResponse } from "@/actions/responses";
 import { sortByRecent } from "@/lib/coding-sort";
 import { autosaveDirtyDoc } from "@/lib/coding-autosave";
+import { notifySaved } from "@/lib/coding-save-feedback";
 import { clearHiddenConditionalAnswers } from "@/lib/conditional";
 import { toast } from "sonner";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
@@ -176,7 +177,7 @@ export function useAssignedCoding({
       });
       if (result.success) {
         markClean(currentDoc.id);
-        toast.success("Respostas salvas!");
+        notifySaved(result.missingRequired);
         if (docIndex < sortedDocuments.length - 1) {
           const nextIndex = docIndex + 1;
           dispatch({ type: "index", index: nextIndex });

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useRef } from "react";
 import { saveResponse } from "@/actions/responses";
+import { notifySaved } from "@/lib/coding-save-feedback";
 import { toast } from "sonner";
 import { useBrowseDocuments } from "@/hooks/useBrowseDocuments";
 import { useDocumentForCoding } from "@/hooks/useDocumentForCoding";
@@ -120,7 +121,7 @@ export function useBrowseCoding({
         });
         if (result.success) {
           markClean(browseDocId);
-          toast.success("Respostas salvas!");
+          notifySaved(result.missingRequired);
           markResponded(browseDocId);
           browseDraftRef.current = null;
           // Zera o ?doc= ANTES de invalidar: com browseDocId já null o hook não

--- a/frontend/src/components/coding/useQuestionValidation.ts
+++ b/frontend/src/components/coding/useQuestionValidation.ts
@@ -1,19 +1,12 @@
-import { useCallback, useState, type RefObject } from "react";
+import { useCallback, useMemo, useState, type RefObject } from "react";
 import { toast } from "sonner";
-import { isIncompleteOther } from "@/lib/other-option";
+import {
+  isAnsweredValue,
+  missingRequiredHumanFields,
+  requiredHumanFields,
+} from "@/lib/coding-completeness";
 import { getScrollBehavior } from "@/lib/scroll";
-import { resolveRequired, resolveTarget } from "@/lib/pydantic-field";
 import type { PydanticField } from "@/lib/types";
-
-const isAnsweredValue = (field: PydanticField, val: unknown): boolean => {
-  if (val === undefined || val === null || val === "") return false;
-  if (field.type === "single" && isIncompleteOther(val)) return false;
-  if (field.type === "multi" && Array.isArray(val)) {
-    if (val.length === 0) return false;
-    if (val.some(isIncompleteOther)) return false;
-  }
-  return true;
-};
 
 /**
  * Estado de destaque de obrigatórias faltantes + validação de envio. O
@@ -36,13 +29,21 @@ export function useQuestionValidation(
   handleSubmitWithValidation: () => void;
   requiredFields: PydanticField[];
   answeredRequiredCount: number;
+  missingRequiredCount: number;
 } {
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
 
-  const requiredFields = visibleFields.filter((f) => resolveRequired(f.required));
-  const answeredRequiredCount = requiredFields.filter((f) =>
-    isAnsweredValue(f, answers[f.name]),
-  ).length;
+  // Régua do servidor, avaliada no cliente: o que falta aqui é exatamente o que
+  // impede `isCodingComplete` de promover a codificação a concluída.
+  const requiredFields = useMemo(
+    () => requiredHumanFields(visibleFields, answers),
+    [visibleFields, answers],
+  );
+  const missingRequired = useMemo(
+    () => missingRequiredHumanFields(visibleFields, answers),
+    [visibleFields, answers],
+  );
+  const answeredRequiredCount = requiredFields.length - missingRequired.length;
 
   const isAnswered = useCallback(
     (field: PydanticField) => isAnsweredValue(field, answers[field.name]),
@@ -65,25 +66,21 @@ export function useQuestionValidation(
   const handleSubmitWithValidation = useCallback(() => {
     if (submitting || outOfScopeBlocked) return;
 
-    const unanswered = visibleFields
-      .filter(
-        (f) =>
-          resolveTarget(f.target) !== "llm_only" &&
-          resolveRequired(f.required) &&
-          !isAnswered(f),
-      )
-      .map((f) => f.name);
-
-    if (unanswered.length > 0) {
-      setHighlightedFields(new Set(unanswered));
-      const firstIdx = visibleFields.findIndex((f) => unanswered.includes(f.name));
+    if (missingRequired.length > 0) {
+      const unanswered = new Set(missingRequired.map((f) => f.name));
+      setHighlightedFields(unanswered);
+      const firstIdx = visibleFields.findIndex((f) => unanswered.has(f.name));
       questionRefs.current[firstIdx]?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" });
-      toast.warning("Preencha todas as perguntas obrigatórias");
+      toast.warning(
+        missingRequired.length === 1
+          ? "Falta 1 pergunta obrigatória para enviar"
+          : `Faltam ${missingRequired.length} perguntas obrigatórias para enviar`,
+      );
       return;
     }
 
     onSubmit();
-  }, [visibleFields, isAnswered, onSubmit, submitting, outOfScopeBlocked, questionRefs]);
+  }, [visibleFields, missingRequired, onSubmit, submitting, outOfScopeBlocked, questionRefs]);
 
   return {
     highlightedFields,
@@ -92,5 +89,6 @@ export function useQuestionValidation(
     handleSubmitWithValidation,
     requiredFields,
     answeredRequiredCount,
+    missingRequiredCount: missingRequired.length,
   };
 }

--- a/frontend/src/lib/__tests__/coding-save-signal.test.ts
+++ b/frontend/src/lib/__tests__/coding-save-signal.test.ts
@@ -1,0 +1,88 @@
+// Guards do sinal de submissão de uma codificação: o carimbo de proveniência
+// (`answer_field_hashes`) e o `is_partial` derivado dele. Juntos, esses dois
+// pontos decidem se um documento já codificado volta ou não para a fila — a
+// família de bugs que o pesquisador lê como "minha codificação não salvou"
+// (#519/#520).
+import { describe, it, expect } from "vitest";
+import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
+import { isCodingComplete, missingRequiredHumanFields } from "@/lib/coding-completeness";
+import type { PydanticField } from "@/lib/types";
+
+const field = (partial: Partial<PydanticField> & { name: string }): PydanticField =>
+  ({ type: "text", options: null, ...partial }) as PydanticField;
+
+// Schema de 2 campos contra o qual a codificação foi feita.
+const schemaAntigo = [
+  field({ name: "q1", type: "single", options: ["a", "b"], hash: "h-q1" }),
+  field({ name: "q2", hash: "h-q2" }),
+];
+// Campo obrigatório criado DEPOIS: o caso do `medicamento` no Zolgensma.
+const schemaAtual = [...schemaAntigo, field({ name: "q3_novo", hash: "h-q3" })];
+
+const codificacaoCompleta = { q1: "a", q2: "texto" };
+const carimboDaEpoca = { q1: "h-q1", q2: "h-q2" };
+
+describe("proveniência preservada mantém a codificação completa", () => {
+  // O guard do carimbo em si vive no #528 (response-snapshot); aqui fixamos a
+  // consequência da qual a régua desta issue depende: enquanto o mapa herdado
+  // não afirmar que o campo novo já existia, a codificação antiga continua
+  // completa e o documento não volta para a fila.
+  it("auto-save de passagem não torna a codificação antiga incompleta", () => {
+    const snapshot = buildPersistedResponseSnapshot({
+      fields: schemaAtual,
+      storedAnswers: codificacaoCompleta,
+      storedHashes: carimboDaEpoca,
+      isNewResponse: false,
+      rawSubmittedAnswers: codificacaoCompleta,
+    });
+
+    expect(
+      isCodingComplete(schemaAtual, snapshot.persistedAnswers, snapshot.answerFieldHashes),
+    ).toBe(true);
+  });
+
+  it("primeira escrita cobra o schema inteiro — nada fica isento da régua", () => {
+    const snapshot = buildPersistedResponseSnapshot({
+      fields: schemaAtual,
+      storedAnswers: null,
+      storedHashes: undefined,
+      isNewResponse: true,
+      rawSubmittedAnswers: { q1: "a" },
+    });
+
+    expect(
+      isCodingComplete(schemaAtual, snapshot.persistedAnswers, snapshot.answerFieldHashes),
+    ).toBe(false);
+  });
+});
+
+describe("missingRequiredHumanFields — régua única de UI e servidor", () => {
+  it("conta apenas obrigatórias visíveis para humano", () => {
+    const fields = [
+      field({ name: "obrigatoria" }),
+      field({ name: "opcional", required: false }),
+      field({ name: "so_llm", target: "llm_only" }),
+      field({ name: "oculta", condition: { field: "obrigatoria", equals: "x" } }),
+    ];
+    expect(missingRequiredHumanFields(fields, {}).map((f) => f.name)).toEqual(["obrigatoria"]);
+  });
+
+  it("não cobra campo que ainda não existia quando a resposta foi codificada", () => {
+    expect(missingRequiredHumanFields(schemaAtual, codificacaoCompleta, carimboDaEpoca)).toEqual([]);
+    // Sem o carimbo (avaliação staleness-blind), o campo novo é cobrado.
+    expect(
+      missingRequiredHumanFields(schemaAtual, codificacaoCompleta).map((f) => f.name),
+    ).toEqual(["q3_novo"]);
+  });
+
+  it("'Outro:' pela metade e multi vazio contam como faltantes", () => {
+    const fields = [
+      field({ name: "single", type: "single", options: ["a"], allow_other: true }),
+      field({ name: "multi", type: "multi", options: ["a"] }),
+    ];
+    expect(
+      missingRequiredHumanFields(fields, { single: "Outro: ", multi: [] }).map((f) => f.name),
+    ).toEqual(["single", "multi"]);
+    expect(missingRequiredHumanFields(fields, { single: "Outro: x", multi: ["a"] })).toEqual([]);
+  });
+});

--- a/frontend/src/lib/__tests__/response-snapshot.test.ts
+++ b/frontend/src/lib/__tests__/response-snapshot.test.ts
@@ -132,6 +132,7 @@ describe("buildPersistedResponseSnapshot", () => {
       storedAnswers,
       storedHashes,
       rawSubmittedAnswers,
+      isNewResponse: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -169,10 +170,14 @@ describe("buildPersistedResponseSnapshot", () => {
       storedAnswers: { gatilho: "sim", detalhe: "texto" },
       storedHashes: { gatilho: "g-old", detalhe: "d-old" },
       rawSubmittedAnswers: { gatilho: "nao" },
+      isNewResponse: false,
     });
 
+    // Só o gatilho foi revisado, então só ele ganha a proveniência de hoje. O
+    // filho foi invalidado por consequência, com o formulário já o ocultando:
+    // carimbar `d-new` afirmaria que o pesquisador viu a versão nova do campo.
     expect(result.persistedAnswers).toEqual({ gatilho: "nao" });
-    expect(result.answerFieldHashes).toEqual({ gatilho: "g-new", detalhe: "d-new" });
+    expect(result.answerFieldHashes).toEqual({ gatilho: "g-new", detalhe: "d-old" });
   });
 
   it("remove filho stale oculto da projeção quando o gatilho muda", () => {
@@ -192,11 +197,12 @@ describe("buildPersistedResponseSnapshot", () => {
       storedAnswers: { gatilho: "sim", detalhe: "antigo" },
       storedHashes: { gatilho: "g-old", detalhe: "d-old" },
       rawSubmittedAnswers: { gatilho: "nao" },
+      isNewResponse: false,
     });
 
     expect(result.submittedAnswers).toEqual({ gatilho: "nao" });
     expect(result.persistedAnswers).toEqual({ gatilho: "nao" });
-    expect(result.answerFieldHashes).toEqual({ gatilho: "g-new", detalhe: "d-new" });
+    expect(result.answerFieldHashes).toEqual({ gatilho: "g-new", detalhe: "d-old" });
   });
 
   it("remove em cascata condicionais ocultadas pela mudança deliberada", () => {
@@ -221,13 +227,14 @@ describe("buildPersistedResponseSnapshot", () => {
       storedAnswers: { gatilho: "sim", filho: "antigo", neto: "texto" },
       storedHashes: { gatilho: "g-old", filho: "f-old", neto: "n-old" },
       rawSubmittedAnswers: { gatilho: "nao" },
+      isNewResponse: false,
     });
 
     expect(result.persistedAnswers).toEqual({ gatilho: "nao" });
     expect(result.answerFieldHashes).toEqual({
       gatilho: "g-new",
-      filho: "f-new",
-      neto: "n-new",
+      filho: "f-old",
+      neto: "n-old",
     });
   });
 
@@ -257,6 +264,7 @@ describe("buildPersistedResponseSnapshot", () => {
       },
       storedHashes: { gatilho: "g-old", intermediario: "i-old", descendente: "d-old" },
       rawSubmittedAnswers: { gatilho: "B", intermediario: "ocultar" },
+      isNewResponse: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -283,6 +291,7 @@ describe("buildPersistedResponseSnapshot", () => {
       storedAnswers: { gatilho: "sim", detalhe: "texto" },
       storedHashes: { gatilho: "g-old", detalhe: "d-old" },
       rawSubmittedAnswers: { outro: "novo" },
+      isNewResponse: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -298,8 +307,13 @@ describe("buildPersistedResponseSnapshot", () => {
   });
 
   it.each<AnswerFieldHashes>([null, {}])(
-    "representa proveniência legacy como null por campo (%j)",
+    "mantém o sentinela legacy de uma response já existente (%j)",
     (storedHashes) => {
+      // `null`/`{}` significam "não dá para inferir quais campos existiam" e
+      // `fieldExistedWhenCoded` os lê como "todos existiam". Estampar chaves aqui
+      // inverteria o sentinela em "só os campos que estampei existiam", tornando
+      // qualquer codificação antiga trivialmente completa — inclusive as que de
+      // fato ficaram com obrigatórios em branco. Ver #520.
       const fields = [
         field({ name: "stale", type: "single", options: ["X"], hash: "stale-new" }),
         field({ name: "outro", hash: "outro-new" }),
@@ -310,12 +324,78 @@ describe("buildPersistedResponseSnapshot", () => {
         storedAnswers: { stale: "A" },
         storedHashes,
         rawSubmittedAnswers: { outro: "novo" },
+        isNewResponse: false,
       });
 
       expect(result.persistedAnswers).toEqual({ stale: "A", outro: "novo" });
-      expect(result.answerFieldHashes).toEqual({ stale: null, outro: "outro-new" });
+      expect(result.answerFieldHashes).toEqual({});
     },
   );
+
+  it("codificação nova estampa o schema atual inteiro", () => {
+    // Não há response anterior: o schema de hoje É o schema da codificação, e
+    // todo campo obrigatório dele deve ser cobrado (nada a perdoar).
+    const fields = [
+      field({ name: "respondido", hash: "r-hash" }),
+      field({ name: "em_branco", hash: "b-hash" }),
+      field({ name: "sem_hash" }),
+    ];
+
+    const result = buildPersistedResponseSnapshot({
+      fields,
+      storedAnswers: undefined,
+      storedHashes: undefined,
+      rawSubmittedAnswers: { respondido: "x" },
+      isNewResponse: true,
+    });
+
+    expect(result.answerFieldHashes).toEqual({
+      respondido: "r-hash",
+      em_branco: "b-hash",
+      sem_hash: null,
+    });
+  });
+
+  it("não estampa campo criado depois da codificação (#520)", () => {
+    // O pesquisador reabre um doc codificado antes do bump e toca um campo
+    // qualquer. O campo novo nunca foi respondido: estampá-lo faria a
+    // codificação antiga "passar a dever" e voltar para a fila de pendentes.
+    const fields = [
+      field({ name: "antigo", hash: "antigo-hash" }),
+      field({ name: "novo_obrigatorio", hash: "novo-hash" }),
+    ];
+
+    const result = buildPersistedResponseSnapshot({
+      fields,
+      storedAnswers: { antigo: "a" },
+      storedHashes: { antigo: "antigo-hash" },
+      rawSubmittedAnswers: { antigo: "b" },
+      isNewResponse: false,
+    });
+
+    expect(result.persistedAnswers).toEqual({ antigo: "b" });
+    expect(result.answerFieldHashes).toEqual({ antigo: "antigo-hash" });
+  });
+
+  it("campo criado depois entra quando o pesquisador de fato o responde", () => {
+    const fields = [
+      field({ name: "antigo", hash: "antigo-hash" }),
+      field({ name: "novo_obrigatorio", hash: "novo-hash" }),
+    ];
+
+    const result = buildPersistedResponseSnapshot({
+      fields,
+      storedAnswers: { antigo: "a" },
+      storedHashes: { antigo: "antigo-hash" },
+      rawSubmittedAnswers: { antigo: "a", novo_obrigatorio: "resposta" },
+      isNewResponse: false,
+    });
+
+    expect(result.answerFieldHashes).toEqual({
+      antigo: "antigo-hash",
+      novo_obrigatorio: "novo-hash",
+    });
+  });
 
   it("preserva o snapshot bruto quando não há controles no schema", () => {
     const result = buildPersistedResponseSnapshot({
@@ -323,6 +403,7 @@ describe("buildPersistedResponseSnapshot", () => {
       storedAnswers: { legado: "valor" },
       storedHashes: { legado: "hash-antigo" },
       rawSubmittedAnswers: {},
+      isNewResponse: false,
     });
 
     expect(result.persistedAnswers).toEqual({ legado: "valor" });

--- a/frontend/src/lib/__tests__/viewas-no-write.test.ts
+++ b/frontend/src/lib/__tests__/viewas-no-write.test.ts
@@ -114,7 +114,9 @@ describe("saveResponse — escrita persiste o ator real, nunca o viewAs", () => 
       "member-viewed",
     );
 
-    expect(result).toEqual({ success: true });
+    // `missingRequired` acompanha todo save bem-sucedido: é a contagem de
+    // obrigatórias em aberto no conjunto GRAVADO (0 = codificação completa).
+    expect(result).toEqual({ success: true, missingRequired: 0 });
     // A identidade veio do ator autenticado (por projectId), não de input do caller.
     expect(resolveMemberUserId).toHaveBeenCalledWith("project-1");
 

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -10,7 +10,7 @@ import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 // que já existiam no schema contra o qual a resposta foi codificada
 // (staleness-aware). Os defaults de `target` e `required` saem dos resolvedores
 // de pydantic-field, nunca de uma re-derivação local.
-function requiredHumanFields(
+export function requiredHumanFields(
   fields: PydanticField[],
   answers: Record<string, unknown>,
   answerFieldHashes?: AnswerFieldHashes,
@@ -22,6 +22,36 @@ function requiredHumanFields(
       resolveRequired(f.required) &&
       isFieldVisible(f, answers) &&
       fieldExistedWhenCoded(answerFieldHashes, f.name),
+  );
+}
+
+// Um campo conta como respondido quando tem valor e esse valor não é um
+// "Outro:" pela metade nem uma seleção múltipla vazia. Exportado porque a UI de
+// codificação marca pergunta a pergunta com a MESMA régua que decide completude
+// — duas cópias da regra é o que deixava "o que o botão exige" divergir de "o
+// que o servidor considera concluído" (#519).
+export function isAnsweredValue(field: PydanticField, value: unknown): boolean {
+  if (value === undefined || value === null || value === "") return false;
+  if (field.type === "single" && isIncompleteOther(value)) return false;
+  if (field.type === "multi" && Array.isArray(value)) {
+    if (value.length === 0) return false;
+    if (value.some(isIncompleteOther)) return false;
+  }
+  return true;
+}
+
+// Campos obrigatórios que ainda faltam — a régua de completude na forma que a UI
+// precisa (quantos e quais), com `isCodingComplete` derivado dela. A UI de
+// codificação consome esta primitiva em vez de reimplementar a regra: enquanto
+// existiam duas cópias, "o que o botão exige" e "o que o servidor considera
+// concluído" podiam divergir sem nenhum gate reclamar (ver #519).
+export function missingRequiredHumanFields(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+  answerFieldHashes?: AnswerFieldHashes,
+): PydanticField[] {
+  return requiredHumanFields(fields, answers, answerFieldHashes).filter(
+    (f) => !isAnsweredValue(f, answers[f.name]),
   );
 }
 
@@ -44,15 +74,5 @@ export function isCodingComplete(
   answers: Record<string, unknown>,
   answerFieldHashes?: AnswerFieldHashes,
 ): boolean {
-  const required = requiredHumanFields(fields, answers, answerFieldHashes);
-  return required.every((f) => {
-    const v = answers[f.name];
-    if (v === undefined || v === null || v === "") return false;
-    if (f.type === "single" && isIncompleteOther(v)) return false;
-    if (f.type === "multi" && Array.isArray(v)) {
-      if (v.length === 0) return false;
-      if (v.some(isIncompleteOther)) return false;
-    }
-    return true;
-  });
+  return missingRequiredHumanFields(fields, answers, answerFieldHashes).length === 0;
 }

--- a/frontend/src/lib/coding-save-feedback.ts
+++ b/frontend/src/lib/coding-save-feedback.ts
@@ -1,0 +1,24 @@
+import { toast } from "sonner";
+
+// Feedback de um save bem-sucedido de codificação. Salvar com sucesso e
+// concluir a codificação são coisas diferentes, e o toast precisa distingui-las:
+// enquanto os dois casos diziam "Respostas salvas!", um envio que deixou
+// obrigatórias em aberto — porque o schema mudou entre o carregamento do
+// formulário e o envio — devolvia ao pesquisador o mesmo sinal de conclusão, e o
+// documento reaparecia na fila depois. Quem lê isso conclui que a codificação
+// não salvou (#519).
+//
+// `missingRequired` vem do servidor e conta o conjunto GRAVADO, não o que a tela
+// mostrava; `undefined` é o caso legacy (resposta sem schema), tratado como
+// completo por não haver régua a aplicar.
+export function notifySaved(missingRequired: number | undefined): void {
+  if (!missingRequired) {
+    toast.success("Respostas salvas!");
+    return;
+  }
+  toast.warning(
+    missingRequired === 1
+      ? "Salvo — o documento segue pendente (falta 1 obrigatória)"
+      : `Salvo — o documento segue pendente (faltam ${missingRequired} obrigatórias)`,
+  );
+}

--- a/frontend/src/lib/response-snapshot.ts
+++ b/frontend/src/lib/response-snapshot.ts
@@ -64,6 +64,12 @@ interface BuildPersistedResponseSnapshotParams {
   storedAnswers: Record<string, unknown> | null | undefined;
   storedHashes: AnswerFieldHashes | undefined;
   rawSubmittedAnswers: Record<string, unknown>;
+  /**
+   * True quando não existe response anterior deste respondente para o
+   * documento. Explícito porque `storedHashes` ausente é ambíguo: vale tanto
+   * para uma codificação que começa agora quanto para uma response legacy.
+   */
+  isNewResponse: boolean;
 }
 
 function samePresentedValue(
@@ -153,22 +159,53 @@ function dropConditionalsAffectedByChanges(
   return persistedAnswers;
 }
 
-function buildReconciledFieldHashes(
-  fields: PydanticField[],
-  storedAnswers: Record<string, unknown> | null | undefined,
-  storedHashes: AnswerFieldHashes | undefined,
+function withAnswerProvenanceFallback(
+  hashes: Exclude<AnswerFieldHashes, null>,
   persistedAnswers: Record<string, unknown>,
-  changedFieldNames: Set<string>,
 ): Exclude<AnswerFieldHashes, null> {
-  const hashes = buildFieldHashMap(fields);
-  for (const fieldName of Object.keys(storedAnswers ?? {})) {
-    if (changedFieldNames.has(fieldName) || !hasOwn(persistedAnswers, fieldName)) continue;
-    hashes[fieldName] = storedHashes && hasOwn(storedHashes, fieldName) ? storedHashes[fieldName] : null;
-  }
+  // Resposta preservada de um campo que saiu do schema: a chave prova que ele
+  // existia, o `null` admite que a proveniência não é mais reconstruível.
   for (const fieldName of Object.keys(persistedAnswers)) {
     if (!hasOwn(hashes, fieldName)) hashes[fieldName] = null;
   }
   return hashes;
+}
+
+// O conjunto de CHAVES responde "quais campos existiam quando esta codificação
+// foi feita" (`fieldExistedWhenCoded`); o VALOR responde "contra qual versão do
+// campo esta resposta foi dada" (`isFieldStale`). Por isso o mapa é herdado, não
+// recarimbado: partir do schema de hoje faria toda codificação anterior a um
+// bump "passar a dever" os campos novos e reaparecer como pendente sem o
+// pesquisador ter feito nada (#520). Um campo novo só entra quando é de fato
+// respondido — aí a chave é verdadeira e o hash atual é a proveniência correta.
+function buildReconciledFieldHashes(
+  fields: PydanticField[],
+  storedHashes: AnswerFieldHashes | undefined,
+  persistedAnswers: Record<string, unknown>,
+  changedFieldNames: Set<string>,
+  isNewResponse: boolean,
+): Exclude<AnswerFieldHashes, null> {
+  const currentHashes = buildFieldHashMap(fields);
+
+  // Codificação nova: o schema de hoje É o schema da codificação, então todo
+  // campo dele existia e nenhum obrigatório em branco deve ser perdoado.
+  if (isNewResponse) return withAnswerProvenanceFallback(currentHashes, persistedAnswers);
+
+  // `null`/`{}` são o sentinela legacy — "não dá para inferir quais campos
+  // existiam", lido como "todos existiam". Herdar dele e acrescentar chaves
+  // inverteria o sentinela em "só estes existiam", perdoando obrigatórios que
+  // ficaram em branco de verdade. Permanece grosseiro até que uma codificação
+  // nova estabeleça proveniência.
+  if (!storedHashes || Object.keys(storedHashes).length === 0) return {};
+
+  const hashes: Exclude<AnswerFieldHashes, null> = { ...storedHashes };
+  // Só o que o pesquisador revisou neste save ganha a proveniência de hoje;
+  // o resto conserva a versão contra a qual foi respondido.
+  for (const fieldName of changedFieldNames) {
+    if (!hasOwn(persistedAnswers, fieldName)) continue;
+    hashes[fieldName] = hasOwn(currentHashes, fieldName) ? currentHashes[fieldName] : null;
+  }
+  return withAnswerProvenanceFallback(hashes, persistedAnswers);
 }
 
 // Reconcilia o snapshot armazenado com o formulário atual sem confundir
@@ -179,6 +216,7 @@ export function buildPersistedResponseSnapshot({
   storedAnswers,
   storedHashes,
   rawSubmittedAnswers,
+  isNewResponse,
 }: BuildPersistedResponseSnapshotParams): PersistedResponseSnapshot {
   // A leitura sem schema expõe o JSON bruto por compatibilidade, mas não há
   // controles capazes de representar essas chaves no formulário. Portanto,
@@ -198,10 +236,10 @@ export function buildPersistedResponseSnapshot({
   );
   const answerFieldHashes = buildReconciledFieldHashes(
     fields,
-    storedAnswers,
     storedHashes,
     persistedAnswers,
     reconciled.changedFieldNames,
+    isNewResponse,
   );
 
   return { submittedAnswers, persistedAnswers, answerFieldHashes };


### PR DESCRIPTION
## ⛔ Bloqueado por #528 — não mergear antes

Esta branch é **empilhada** sobre `fix/520-answer-field-hashes-merge` (#528) e o `base` do PR aponta para ela: o diff próprio é só o commit de cima (12 arquivos). O #528 precisa entrar primeiro, e depois esta base migra para `main`.

A dependência é **de comportamento, não só de merge**. A derivação de `is_partial` introduzida aqui avalia `isCodingComplete` de forma staleness-aware, contra o carimbo per-campo (`answer_field_hashes`) da própria response. Sem o #528, esse carimbo continua sendo refeito com o schema atual a cada save — então a derivação passaria a marcar `is_partial=true` em toda codificação antiga tocada por um auto-save de navegação, devolvendo à fila documentos que estavam concluídos. Fora de ordem, isto troca um rótulo errado silencioso por uma regressão visível.

Ordem completa (correção + reparo dos dados históricos) na issue #547.

## Problema

A issue afirma que o botão "Enviar respostas" não exige completude. **A premissa está desatualizada**: `useQuestionValidation` bloqueia o envio incompleto desde 2026-03-20 (`61412dc`). O sintoma, porém, é real — e a investigação mostrou que ele não vem do botão.

Levantamento read-only no Zolgensma: **95 respostas humanas com `is_partial=false` e obrigatórias em branco**. Duas causas, nenhuma delas "o submit não valida":

| causa | casos |
|---|---|
| recarimbo de `answer_field_hashes` — o único campo faltante é `medicamento`, criado em 2026-06-11 | **48** |
| opção removida do schema derrubava a resposta na leitura (corrigido pelo #484) | 47 |

O mecanismo: o auto-save ao navegar entre documentos recarimbava a proveniência com o schema de hoje, e `is_partial` era função do **canal** da escrita (`isAutoSave && existing?.is_partial !== false`) — herdando o `false` de um submit anterior. O resultado é um registro que afirma "submetida" sobre um conjunto que a régua considera incompleto: o assignment fica em `em_andamento`, o documento volta para a fila, e o pesquisador lê como "minha codificação não salvou".

As rajadas de 3–6 escritas por segundo do mesmo pesquisador em 15–18/06 são exatamente esses auto-saves de navegação.

## O que muda

**1. `is_partial` descreve o que foi gravado, não o canal.** Sai de `isCodingComplete(fields, answersToPersist, answerFieldHashes)` — staleness-aware, contra o carimbo da própria response, para não rebaixar codificação que estava completa à época. O auto-save continua sem promover por conta própria: quem nunca enviou segue parcial mesmo com tudo preenchido (espelha o guard de assignment em `coding-sync`).

**2. Régua única entre cliente e servidor.** A cópia da regra em `useQuestionValidation` (`isAnsweredValue` local) deu lugar a `missingRequiredHumanFields`/`requiredHumanFields`/`isAnsweredValue`, exportadas de `coding-completeness`. Enquanto eram duas cópias, "o que o botão exige" podia divergir de "o que o servidor considera concluído" sem nenhum gate reclamar — a família do #486/#493/#495.

**3. Feedback que não mente.** `saveResponse` devolve `missingRequired` (contagem no conjunto **gravado**, não no que a tela mostrava) e o toast diferencia "Respostas salvas!" de "Salvo — o documento segue pendente (faltam N)". O `SubmitBar` anuncia a pendência **antes** do clique ("Faltam N obrigatórias"), em variante neutra.

Mantido o bloqueio duro do envio incompleto: a confirmação "enviar mesmo assim" proposta na issue reintroduziria por opção o estado que a mudança (1) torna irrepresentável.

## Verificação

- **Prova do vermelho por mutação**, guard a guard: revertida a derivação de `is_partial`, caem os dois testes novos da action; revertida a herança do carimbo, cai o guard de staleness. Nenhum guard passou sem morder.
- Vitest **164 arquivos / 1737 testes** verdes; typecheck, eslint, `lint:types`, fallow (complexidade do `SubmitBar` refatorada em vez de suprimida), semgrep e react-doctor (100/100 nas linhas alteradas) verdes.
- **e2e**: 5 specs passaram; `config-guard.smoke` falha — e falha **igual com este diff fora**, na base limpa. É o hang pré-existente cujo fix está nos PRs #522/#523. Push com `SKIP=e2e-smoke` autorizado explicitamente por causa disso.

## Fora do escopo

Reparo dos registros históricos (as 95 respostas) não entra aqui — é decisão sua, com os casos já levantados.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G48eb43rAyzhtyRvygFwvU
