### PR TITLE
fix(worktree): fonte canônica de .env + provisionamento automático

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,11 @@
 #   pre-commit (todo commit, leve / file-scoped): gitleaks, ruff, actionlint,
 #                                                deploy notifier, react-doctor
 #   pre-push   (todo push,  pesado / grafo):       typecheck, vitest, e2e-smoke, lint:types, fallow, semgrep, backend-pytest, mypy
+#   post-checkout (informativo, nunca bloqueia):   worktree-env
 #
 # O CI roda o mesmo gitleaks em todo PR e push para `main` via
 # .github/workflows/secret-scan.yml — este hook e a primeira barreira local.
-default_install_hook_types: [pre-commit, pre-push]
+default_install_hook_types: [pre-commit, pre-push, post-checkout]
 # Hook sem `stages:` proprio roda so no pre-commit (os leves: gitleaks, ruff,
 # actionlint, deploy notifier, react-doctor). Os pesados sobrescrevem com
 # `stages: [pre-push]`. Sem este
@@ -137,6 +138,27 @@ repos:
         pass_filenames: false
         require_serial: true
         stages: [pre-push]
+
+      # Provisiona .env.local/.env.e2e da worktree a partir da fonte canônica
+      # (~/.config/dataframeitGUI/frontend por default). `git worktree add` e
+      # `git checkout` disparam post-checkout, então uma worktree nova já nasce
+      # com o ambiente ligado — antes isso dependia de lembrar de rodar o
+      # bootstrap à mão, e o resultado era um parque com quatro estados
+      # diferentes (link ok, link quebrado apontando para worktree removida,
+      # ausente, e cópia real do arquivo com segredo dentro).
+      #
+      # NUNCA bloqueia: post-checkout roda depois de o checkout já ter ocorrido,
+      # então falhar aqui só produz ruído — quem barra de verdade é o
+      # assertRequiredPrePushEnv no e2e-smoke. Daí o `|| true`; o script
+      # imprime o motivo (ex.: fonte canônica inexistente) e segue.
+      - id: worktree-env
+        name: provisiona .env da worktree (post-checkout)
+        entry: bash -c './frontend/scripts/worktree-env/bootstrap.sh || true'
+        language: system
+        always_run: true
+        pass_filenames: false
+        require_serial: true
+        stages: [post-checkout]
 
       # typescript-eslint type-checked (no-floating-promises / no-misused-promises).
       # File-scoped via sed (strip do prefixo frontend/) → grandfathers os ~59

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -149,8 +149,14 @@ repos:
       #
       # NUNCA bloqueia: post-checkout roda depois de o checkout já ter ocorrido,
       # então falhar aqui só produz ruído — quem barra de verdade é o
-      # assertRequiredPrePushEnv no e2e-smoke. Daí o `|| true`; o script
-      # imprime o motivo (ex.: fonte canônica inexistente) e segue.
+      # assertRequiredPrePushEnv no e2e-smoke. Daí o `|| true`.
+      #
+      # Silencioso por design: com `|| true` o hook sempre "passa", e o
+      # pre-commit suprime a saída de hook que passa — logo a mensagem do script
+      # (ex.: "fonte canônica inexistente") NÃO aparece aqui, e nem deve, para
+      # não poluir todo `git checkout`. O diagnóstico do link pendente / alvo
+      # morto é responsabilidade do gate de pre-push (assertRequiredPrePushEnv),
+      # que nomeia o symlink e o alvo inexistente na hora em que de fato importa.
       - id: worktree-env
         name: provisiona .env da worktree (post-checkout)
         entry: bash -c './frontend/scripts/worktree-env/bootstrap.sh || true'

--- a/README.md
+++ b/README.md
@@ -31,15 +31,26 @@ npm --prefix frontend run dev
 
 ### Provisionamento de worktrees
 
-Depois de criar uma worktree, execute na raiz dela um único comando e informe explicitamente um checkout cujo diretório `frontend/` já contenha `.env.local` e `.env.e2e` válidos:
+Os arquivos de ambiente vivem num diretório **fonte canônico**, fora de qualquer checkout ou worktree:
 
-```bash
-./frontend/scripts/worktree-env/bootstrap.sh --source /caminho/do/checkout-fonte/frontend
+```
+~/.config/dataframeitGUI/frontend/{.env.local,.env.e2e}
 ```
 
-O bootstrap valida as atribuições não comentadas de `.env.local.example` e `.env.e2e.example`, cria symlinks para os dois arquivos da fonte e falha antes de alterar a worktree se a fonte estiver incompleta ou se algum destino já existir. Ele não copia credenciais, não sobrescreve arquivos e não tenta descobrir outro checkout pelo layout dos diretórios.
+Crie-o uma única vez, a partir dos `.example`, e preencha com os valores reais. Para manter os segredos noutro lugar, aponte `DATAFRAMEITGUI_ENV_HOME` para o diretório desejado.
 
-Nunca adicione `.env.local`, `.env.e2e` ou seus symlinks ao Git. Somente os arquivos `.example`, mantidos sem valores reais, são versionados; o checkout usado como fonte precisa permanecer no mesmo caminho enquanto as worktrees utilizarem os links.
+A partir daí **não há passo manual**: o hook de `post-checkout` (instalado por `pre-commit install`, junto dos demais) roda o bootstrap a cada `git worktree add` e `git checkout`, e a worktree nova já nasce com os symlinks ligados. Para provisionar ou reparar à mão:
+
+```bash
+./frontend/scripts/worktree-env/bootstrap.sh                    # fonte canônica
+./frontend/scripts/worktree-env/bootstrap.sh --source /outro/frontend
+```
+
+O bootstrap valida as atribuições não comentadas de `.env.local.example` e `.env.e2e.example`, cria os symlinks e falha antes de alterar a worktree se a fonte estiver incompleta. É **idempotente e reparador**: link já correto é no-op, link quebrado ou apontando para outra fonte é refeito, e arquivo real no destino faz o script recusar — nunca sobrescreve conteúdo, que pode ser a única cópia de um segredo. Ele não copia credenciais e não descobre checkouts pelo layout dos diretórios.
+
+A fonte é canônica justamente porque worktree é efêmera: apontar o link de uma worktree para outra faz `git worktree remove` quebrar o ambiente de quem apontava para ela — e o sintoma aparece longe da causa, como "faltando N variáveis" no gate de pre-push. Quando isso acontece, a mensagem do gate agora nomeia o link pendente e o alvo morto.
+
+Nunca adicione `.env.local`, `.env.e2e` ou seus symlinks ao Git. Somente os arquivos `.example`, mantidos sem valores reais, são versionados.
 
 ### Backend
 

--- a/frontend/playwright-pre-push-env.ts
+++ b/frontend/playwright-pre-push-env.ts
@@ -1,12 +1,40 @@
+import { existsSync, lstatSync, readlinkSync } from "node:fs";
+import { join } from "node:path";
 import {
+  environmentFiles,
   hasConfiguredEnvironmentValue,
   requiredEnvironmentNames,
 } from "./scripts/worktree-env/env-contract.mjs";
 
 export const requiredPrePushEnv = requiredEnvironmentNames(__dirname);
 
+/**
+ * Arquivos de ambiente cujo symlink aponta para um alvo que não existe mais.
+ *
+ * A causa dominante é um link para outra worktree, removida depois. Sem esta
+ * checagem a única pista é "faltando <N> variáveis", que manda investigar
+ * credencial, tenant e porta — três saltos longe de um link pendente. Este é o
+ * diagnóstico, não o gate: o gate continua sendo a ausência das variáveis.
+ */
+export function danglingEnvironmentLinks(
+  frontendDirectory: string = __dirname,
+): { file: string; target: string }[] {
+  return environmentFiles.flatMap((filename) => {
+    const path = join(frontendDirectory, filename);
+    let entry;
+    try {
+      entry = lstatSync(path);
+    } catch {
+      return [];
+    }
+    if (!entry.isSymbolicLink() || existsSync(path)) return [];
+    return [{ file: filename, target: readlinkSync(path) }];
+  });
+}
+
 export function assertRequiredPrePushEnv(
   env: Readonly<Record<string, string | undefined>>,
+  frontendDirectory: string = __dirname,
 ): void {
   const missing = requiredPrePushEnv.filter(
     (name) => !hasConfiguredEnvironmentValue(env[name]),
@@ -14,11 +42,23 @@ export function assertRequiredPrePushEnv(
 
   if (missing.length === 0) return;
 
+  const dangling = danglingEnvironmentLinks(frontendDirectory);
+
   throw new Error(
     [
       "e2e-smoke pre-push sem variáveis obrigatórias.",
       `Faltando: ${missing.join(", ")}`,
-      "Configure as variáveis não comentadas de frontend/.env.local.example e frontend/.env.e2e.example nos respectivos arquivos locais.",
+      ...(dangling.length > 0
+        ? [
+            "",
+            "Causa provável — symlink de ambiente apontando para alvo inexistente:",
+            ...dangling.map(({ file, target }) => `  ${file} -> ${target}`),
+            "Repare com: ./frontend/scripts/worktree-env/bootstrap.sh",
+          ]
+        : [
+            "Configure as variáveis não comentadas de frontend/.env.local.example e frontend/.env.e2e.example nos respectivos arquivos locais.",
+            "Numa worktree nova: ./frontend/scripts/worktree-env/bootstrap.sh",
+          ]),
       "Bypass intencional neste push: SKIP=e2e-smoke git push",
     ].join("\n"),
   );

--- a/frontend/scripts/worktree-env/bootstrap.mjs
+++ b/frontend/scripts/worktree-env/bootstrap.mjs
@@ -202,8 +202,13 @@ try {
   for (const destination of createdDestinations) {
     rmSync(destination, { force: true });
   }
+  // Desfaz só os symlinks criados NESTA execução. Um `relink` já removeu o
+  // link antigo (quebrado ou apontando para outra fonte) antes desta falha, e
+  // ele não é restaurado — recriar um link inválido não teria sentido. Por
+  // isso a mensagem não promete atomicidade ("nenhuma alteração"): manda
+  // reprovisionar, que a idempotência do bootstrap cobre.
   fail(
-    `não foi possível criar frontend/${pendingFilename} (${filesystemErrorCode(error)}); nenhuma alteração foi mantida`,
+    `não foi possível criar frontend/${pendingFilename} (${filesystemErrorCode(error)}); os symlinks criados nesta execução foram desfeitos — rode o bootstrap de novo para reprovisionar`,
   );
 }
 

--- a/frontend/scripts/worktree-env/bootstrap.mjs
+++ b/frontend/scripts/worktree-env/bootstrap.mjs
@@ -6,10 +6,13 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  unlinkSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  canonicalEnvironmentDirectory,
+  canonicalEnvironmentHomeVariable,
   environmentFiles,
   hasConfiguredEnvironmentValue,
   readEnvironmentFile,
@@ -64,24 +67,97 @@ function readSource(path, filename) {
   }
 }
 
+/**
+ * Estado de um destino, que decide a acao:
+ *
+ * - `missing`  — nao existe: criar o symlink;
+ * - `linked`   — ja aponta para o arquivo da fonte: no-op (idempotencia);
+ * - `relink`   — symlink para outro alvo, ou quebrado: refazer. Substituir um
+ *                symlink nunca destroi conteudo, e e o unico jeito de REPARAR
+ *                uma worktree cujo alvo foi removido — o caso que motivou tudo
+ *                isto;
+ * - `occupied` — arquivo ou diretorio real: recusar, pode ser a unica copia do
+ *                segredo.
+ *
+ * @param {string} destination @param {string} source @param {string} filename
+ * @returns {"missing" | "linked" | "relink" | "occupied"}
+ */
+function classifyDestination(destination, source, filename) {
+  let entry;
+  try {
+    entry = lstatSync(destination);
+  } catch (error) {
+    if (isMissingPathError(error)) return "missing";
+    return fail(
+      `não foi possível validar o destino frontend/${filename} (${filesystemErrorCode(error)})`,
+    );
+  }
+
+  if (!entry.isSymbolicLink()) return "occupied";
+
+  try {
+    // realpath dos dois lados: um link que chega ao mesmo arquivo por outro
+    // caminho (relativo, ou via diretorio symlinkado) ja esta provisionado.
+    return realpathSync(destination) === realpathSync(source)
+      ? "linked"
+      : "relink";
+  } catch (error) {
+    // Link quebrado (o alvo sumiu) cai aqui — e e exatamente o que refazemos.
+    if (isMissingPathError(error)) return "relink";
+    return fail(
+      `não foi possível resolver o destino frontend/${filename} (${filesystemErrorCode(error)})`,
+    );
+  }
+}
+
+/** @type {Map<string, "missing" | "linked" | "relink" | "occupied">} */
+const destinationStates = new Map();
+
 const [, , option, sourceArgument, ...extraArguments] = process.argv;
-if (option !== "--source" || !sourceArgument || extraArguments.length > 0) {
+// `--source` continua aceito para quem mantem os segredos noutro lugar; sem ele
+// a fonte e a canonica. O default existe porque escolher a fonte a cada
+// invocacao era o que permitia apontar para uma worktree irma — que some no
+// `git worktree remove` e leva junto o ambiente de quem apontava para ela.
+const usesExplicitSource = option === "--source";
+const missingSourceArgument = usesExplicitSource && !sourceArgument;
+const unexpectedArguments =
+  extraArguments.length > 0 || (!usesExplicitSource && option !== undefined);
+
+if (missingSourceArgument || unexpectedArguments) {
   console.error(
-    "Uso: ./frontend/scripts/worktree-env/bootstrap.sh --source <diretorio-frontend-fonte>",
+    "Uso: ./frontend/scripts/worktree-env/bootstrap.sh [--source <diretorio-frontend-fonte>]",
+  );
+  console.error(
+    `Sem --source, a fonte e ${canonicalEnvironmentDirectory()} (ajustavel por ${canonicalEnvironmentHomeVariable}).`,
   );
   process.exit(2);
 }
 
+const requestedSource = usesExplicitSource
+  ? sourceArgument
+  : canonicalEnvironmentDirectory();
+
 let sourceDirectory;
 try {
-  sourceDirectory = realpathSync(sourceArgument);
+  sourceDirectory = realpathSync(requestedSource);
   if (!statSync(sourceDirectory).isDirectory()) {
-    fail(`fonte não é um diretório: ${sourceArgument}`);
+    fail(`fonte não é um diretório: ${requestedSource}`);
   }
 } catch (error) {
-  if (isMissingPathError(error)) fail(`fonte inexistente: ${sourceArgument}`);
+  if (isMissingPathError(error)) {
+    if (usesExplicitSource) fail(`fonte inexistente: ${requestedSource}`);
+    fail(
+      [
+        `fonte canônica inexistente: ${requestedSource}`,
+        "Crie-a uma única vez com os arquivos reais (fora de qualquer worktree):",
+        `  mkdir -p ${requestedSource}`,
+        `  cp frontend/.env.local.example ${requestedSource}/.env.local  # e preencha`,
+        `  cp frontend/.env.e2e.example ${requestedSource}/.env.e2e      # e preencha`,
+      ].join("\n"),
+    );
+  }
   fail(
-    `não foi possível acessar a fonte (${filesystemErrorCode(error)}): ${sourceArgument}`,
+    `não foi possível acessar a fonte (${filesystemErrorCode(error)}): ${requestedSource}`,
   );
 }
 
@@ -96,16 +172,26 @@ for (const filename of environmentFiles) {
     );
   }
 
-  try {
-    lstatSync(join(frontendDirectory, filename));
-    fail(`destino já existe: frontend/${filename}`);
-  } catch (error) {
-    if (!isMissingPathError(error)) {
-      fail(
-        `não foi possível validar o destino frontend/${filename} (${filesystemErrorCode(error)})`,
-      );
-    }
-  }
+  destinationStates.set(
+    filename,
+    classifyDestination(join(frontendDirectory, filename), source, filename),
+  );
+}
+
+const occupied = environmentFiles.filter(
+  (filename) => destinationStates.get(filename) === "occupied",
+);
+if (occupied.length > 0) {
+  // Arquivo real no destino nunca e sobrescrito: pode ser a unica copia de um
+  // segredo. O provisionamento e que cede, nao o dado.
+  fail(
+    [
+      `destino é arquivo real, não symlink: ${occupied
+        .map((filename) => `frontend/${filename}`)
+        .join(", ")}`,
+      "Mova-o para a fonte canônica (ou remova-o, se for cópia) antes de provisionar.",
+    ].join("\n"),
+  );
 }
 
 const missingNames = [];
@@ -134,7 +220,18 @@ let pendingFilename;
 try {
   for (const filename of environmentFiles) {
     pendingFilename = filename;
+    const state = destinationStates.get(filename);
+    if (state === "linked") continue;
+
     const destination = join(frontendDirectory, filename);
+    // `relink` remove só um symlink — nunca um arquivo real, que o guard de
+    // `occupied` já barrou acima.
+    //
+    // `unlinkSync`, e não `rmSync(..., { force: true })`: com `force`, o rm
+    // decide pela existência do ALVO (via stat), então num symlink pendente —
+    // exatamente o caso que estamos reparando — ele conclui "não existe" e vira
+    // no-op silencioso; o erro só aparece depois, como EEXIST no symlinkSync.
+    if (state === "relink") unlinkSync(destination);
     symlinkSync(join(sourceDirectory, filename), destination);
     createdDestinations.push(destination);
   }
@@ -144,6 +241,15 @@ try {
   }
   fail(
     `não foi possível criar frontend/${pendingFilename} (${filesystemErrorCode(error)}); nenhuma alteração foi mantida`,
+  );
+}
+
+const repaired = environmentFiles.filter(
+  (filename) => destinationStates.get(filename) === "relink",
+);
+if (repaired.length > 0) {
+  console.log(
+    `Ambiente reapontado para ${sourceDirectory}: ${repaired.join(", ")}`,
   );
 }
 

--- a/frontend/scripts/worktree-env/bootstrap.mjs
+++ b/frontend/scripts/worktree-env/bootstrap.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import {
-  lstatSync,
   realpathSync,
   rmSync,
   statSync,
@@ -10,6 +9,7 @@ import {
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { classifyDestination } from "./destination-state.mjs";
 import {
   canonicalEnvironmentDirectory,
   canonicalEnvironmentHomeVariable,
@@ -63,49 +63,6 @@ function readSource(path, filename) {
   } catch (error) {
     fail(
       `não foi possível ler a fonte ${filename} (${filesystemErrorCode(error)})`,
-    );
-  }
-}
-
-/**
- * Estado de um destino, que decide a acao:
- *
- * - `missing`  — nao existe: criar o symlink;
- * - `linked`   — ja aponta para o arquivo da fonte: no-op (idempotencia);
- * - `relink`   — symlink para outro alvo, ou quebrado: refazer. Substituir um
- *                symlink nunca destroi conteudo, e e o unico jeito de REPARAR
- *                uma worktree cujo alvo foi removido — o caso que motivou tudo
- *                isto;
- * - `occupied` — arquivo ou diretorio real: recusar, pode ser a unica copia do
- *                segredo.
- *
- * @param {string} destination @param {string} source @param {string} filename
- * @returns {"missing" | "linked" | "relink" | "occupied"}
- */
-function classifyDestination(destination, source, filename) {
-  let entry;
-  try {
-    entry = lstatSync(destination);
-  } catch (error) {
-    if (isMissingPathError(error)) return "missing";
-    return fail(
-      `não foi possível validar o destino frontend/${filename} (${filesystemErrorCode(error)})`,
-    );
-  }
-
-  if (!entry.isSymbolicLink()) return "occupied";
-
-  try {
-    // realpath dos dois lados: um link que chega ao mesmo arquivo por outro
-    // caminho (relativo, ou via diretorio symlinkado) ja esta provisionado.
-    return realpathSync(destination) === realpathSync(source)
-      ? "linked"
-      : "relink";
-  } catch (error) {
-    // Link quebrado (o alvo sumiu) cai aqui — e e exatamente o que refazemos.
-    if (isMissingPathError(error)) return "relink";
-    return fail(
-      `não foi possível resolver o destino frontend/${filename} (${filesystemErrorCode(error)})`,
     );
   }
 }
@@ -172,10 +129,16 @@ for (const filename of environmentFiles) {
     );
   }
 
-  destinationStates.set(
-    filename,
-    classifyDestination(join(frontendDirectory, filename), source, filename),
-  );
+  try {
+    destinationStates.set(
+      filename,
+      classifyDestination(join(frontendDirectory, filename), source),
+    );
+  } catch (error) {
+    fail(
+      `não foi possível validar o destino frontend/${filename} (${filesystemErrorCode(error)})`,
+    );
+  }
 }
 
 const occupied = environmentFiles.filter(

--- a/frontend/scripts/worktree-env/destination-state.mjs
+++ b/frontend/scripts/worktree-env/destination-state.mjs
@@ -1,0 +1,59 @@
+import { lstatSync, realpathSync } from "node:fs";
+
+/**
+ * Estado de um destino de provisionamento, que decide a acao do bootstrap:
+ *
+ * - `missing`  — nao existe: criar o symlink;
+ * - `linked`   — ja aponta para o arquivo da fonte: no-op (idempotencia, de que
+ *                o hook de post-checkout depende para poder rodar sempre);
+ * - `relink`   — symlink para outro alvo, ou pendente: refazer. Substituir um
+ *                symlink nunca destroi conteudo, e e o unico jeito de REPARAR
+ *                uma worktree cujo alvo foi removido;
+ * - `occupied` — arquivo ou diretorio real: recusar, pode ser a unica copia do
+ *                segredo.
+ *
+ * Vive separado do bootstrap por ser logica pura: aqui ela e testada nos quatro
+ * estados diretamente, sem subprocesso.
+ *
+ * @typedef {"missing" | "linked" | "relink" | "occupied"} DestinationState
+ */
+
+function isMissingPathError(error) {
+  const code = Reflect.get(Object(error), "code");
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+/**
+ * `null` quando o caminho nao existe. Erro de outra natureza (permissao, por
+ * exemplo) sobe: nao pode ser confundido com ausencia, sob pena de o bootstrap
+ * "reparar" o que na verdade nao conseguiu ler.
+ *
+ * @param {() => T} read @returns {T | null}
+ * @template T
+ */
+function missingAsNull(read) {
+  try {
+    return read();
+  } catch (error) {
+    if (isMissingPathError(error)) return null;
+    throw error;
+  }
+}
+
+/**
+ * @param {string} destination @param {string} source
+ * @returns {DestinationState}
+ */
+export function classifyDestination(destination, source) {
+  const entry = missingAsNull(() => lstatSync(destination));
+  if (entry === null) return "missing";
+  if (!entry.isSymbolicLink()) return "occupied";
+
+  // Link pendente (o alvo sumiu) resolve para `null` — exatamente o caso que
+  // refazemos. Fora dele, comparamos o realpath dos DOIS lados: um link que
+  // chega ao mesmo arquivo por outro caminho (relativo, ou via diretorio
+  // symlinkado) ja esta provisionado.
+  const resolved = missingAsNull(() => realpathSync(destination));
+  if (resolved === null) return "relink";
+  return resolved === realpathSync(source) ? "linked" : "relink";
+}

--- a/frontend/scripts/worktree-env/env-contract.mjs
+++ b/frontend/scripts/worktree-env/env-contract.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 // parseEnv deixou de ser experimental exatamente em v24.10.0 ("This API is no
 // longer experimental", historico de node:util) — e por isso, e nao por
 // alinhamento com o Docker, que engines fixa >=24.10.0. Relaxar aquele piso
@@ -7,6 +8,38 @@ import { join } from "node:path";
 import { parseEnv } from "node:util";
 
 export const environmentFiles = Object.freeze([".env.local", ".env.e2e"]);
+
+/**
+ * Variavel que sobrescreve o diretorio-fonte canonico (usada pelos testes e por
+ * quem mantem os segredos noutro lugar).
+ */
+export const canonicalEnvironmentHomeVariable = "DATAFRAMEITGUI_ENV_HOME";
+
+/**
+ * Diretorio-fonte canonico dos arquivos de ambiente.
+ *
+ * Fica FORA de qualquer checkout ou worktree de proposito. Worktree e efemera
+ * por construcao — `git worktree remove` apaga o diretorio — entao apontar o
+ * symlink de uma worktree para outra transforma a remocao de uma em quebra
+ * silenciosa da outra. O sintoma aparece longe da causa: o guard de pre-push
+ * acusa "faltando 10 variaveis", e nao "o link aponta para um diretorio que
+ * nao existe mais". Com a fonte fora da arvore, esse estado deixa de ser
+ * construivel pelo caminho normal.
+ *
+ * @param {Readonly<Record<string, string | undefined>>} [environment]
+ * @returns {string}
+ */
+export function canonicalEnvironmentDirectory(environment = process.env) {
+  const explicit = environment[canonicalEnvironmentHomeVariable];
+  if (hasConfiguredEnvironmentValue(explicit)) return resolve(explicit);
+
+  const xdgConfigHome = environment.XDG_CONFIG_HOME;
+  const configurationBase = hasConfiguredEnvironmentValue(xdgConfigHome)
+    ? resolve(xdgConfigHome)
+    : join(homedir(), ".config");
+
+  return join(configurationBase, "dataframeitGUI", "frontend");
+}
 
 /** @param {string} path @returns {Record<string, string>} */
 export function readEnvironmentFile(path) {

--- a/frontend/src/lib/__tests__/playwright-pre-push-env.test.ts
+++ b/frontend/src/lib/__tests__/playwright-pre-push-env.test.ts
@@ -1,8 +1,10 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import {
   assertRequiredPrePushEnv,
+  danglingEnvironmentLinks,
   requiredPrePushEnv,
 } from "../../../playwright-pre-push-env";
 import {
@@ -85,4 +87,56 @@ describe("assertRequiredPrePushEnv", () => {
       );
     },
   );
+
+  // Symlink de ambiente apontando para worktree removida era diagnosticado como
+  // "faltando 10 variáveis" — três saltos longe da causa. A mensagem agora
+  // nomeia o link e o alvo morto.
+  describe("diagnóstico de symlink de ambiente pendente", () => {
+    function withFixture(run: (frontend: string) => void) {
+      const root = mkdtempSync(join(tmpdir(), "pre-push-env-"));
+      try {
+        const frontend = join(root, "frontend");
+        mkdirSync(frontend, { recursive: true });
+        run(frontend);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }
+
+    it("nomeia o arquivo e o alvo inexistente na mensagem", () => {
+      withFixture((frontend) => {
+        const removed = join(frontend, "..", "worktree-removida", ".env.local");
+        symlinkSync(removed, join(frontend, ".env.local"));
+
+        expect(() =>
+          assertRequiredPrePushEnv(
+            { ...completeRequiredEnv, CLERK_SECRET_KEY: undefined },
+            frontend,
+          ),
+        ).toThrow(/symlink de ambiente apontando para alvo inexistente/);
+        expect(danglingEnvironmentLinks(frontend)).toEqual([
+          { file: ".env.local", target: removed },
+        ]);
+      });
+    });
+
+    it("não acusa link pendente quando o alvo existe", () => {
+      withFixture((frontend) => {
+        const source = join(frontend, "..", "fonte");
+        mkdirSync(source, { recursive: true });
+        writeFileSync(join(source, ".env.local"), "X=1\n");
+        symlinkSync(join(source, ".env.local"), join(frontend, ".env.local"));
+
+        expect(danglingEnvironmentLinks(frontend)).toEqual([]);
+      });
+    });
+
+    it("não acusa link pendente quando o arquivo é real", () => {
+      withFixture((frontend) => {
+        writeFileSync(join(frontend, ".env.local"), "X=1\n");
+
+        expect(danglingEnvironmentLinks(frontend)).toEqual([]);
+      });
+    });
+  });
 });

--- a/frontend/src/lib/__tests__/worktree-env-bootstrap.test.ts
+++ b/frontend/src/lib/__tests__/worktree-env-bootstrap.test.ts
@@ -3,12 +3,14 @@ import {
   appendFileSync,
   chmodSync,
   copyFileSync,
+  existsSync,
   lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -159,14 +161,16 @@ describe("bootstrap de ambiente para worktrees", () => {
     },
   );
 
-  it("falha antes de criar o segundo destino quando um destino já existe", () => {
+  it("falha antes de criar o segundo destino quando um destino é arquivo real", () => {
     writeCompleteSource();
     writeFileSync(join(fixtureFrontend, ".env.local"), "original-local\n");
 
     const result = runBootstrap();
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("destino já existe: frontend/.env.local");
+    expect(result.stderr).toContain(
+      "destino é arquivo real, não symlink: frontend/.env.local",
+    );
     expect(readFileSync(join(fixtureFrontend, ".env.local"), "utf8")).toBe(
       "original-local\n",
     );
@@ -246,6 +250,112 @@ describe("bootstrap de ambiente para worktrees", () => {
     expect(readFileSync(join(fixtureFrontend, ".env.e2e"), "utf8")).toBe(
       "keep-e2e\n",
     );
+  });
+
+  // O provisionamento precisa ser seguro de repetir: e o hook de post-checkout
+  // que o dispara a cada `git worktree add`/`git checkout`.
+  it("é idempotente — repetir não altera os symlinks já corretos", () => {
+    writeCompleteSource();
+    expect(runBootstrap().status).toBe(0);
+    const before = envFiles.map((filename) =>
+      readlinkSync(join(fixtureFrontend, filename)),
+    );
+
+    const result = runBootstrap();
+
+    expect(result.status).toBe(0);
+    expect(
+      envFiles.map((filename) =>
+        readlinkSync(join(fixtureFrontend, filename)),
+      ),
+    ).toEqual(before);
+  });
+
+  // O bug que motivou a fonte canônica: o alvo era outra worktree, que foi
+  // removida. Antes, o bootstrap recusava ("destino já existe") e a worktree
+  // ficava sem conserto pelo próprio script; o sintoma só aparecia no pre-push,
+  // como "faltando 10 variáveis".
+  it("repara symlink quebrado, cujo alvo deixou de existir", () => {
+    writeCompleteSource();
+    const removedSource = join(temporaryRoot, "worktree-irma-removida");
+    mkdirSync(removedSource, { recursive: true });
+    for (const filename of envFiles) {
+      writeFileSync(join(removedSource, filename), "irrelevante\n");
+      symlinkSync(
+        join(removedSource, filename),
+        join(fixtureFrontend, filename),
+      );
+    }
+    rmSync(removedSource, { recursive: true, force: true });
+    for (const filename of envFiles) {
+      expect(existsSync(join(fixtureFrontend, filename))).toBe(false);
+      expect(lstatSync(join(fixtureFrontend, filename)).isSymbolicLink()).toBe(
+        true,
+      );
+    }
+
+    const result = runBootstrap();
+
+    expect(result.status).toBe(0);
+    for (const filename of envFiles) {
+      const destination = join(fixtureFrontend, filename);
+      expect(lstatSync(destination).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(destination)).toBe(join(sourceFrontend, filename));
+      expect(existsSync(destination)).toBe(true);
+    }
+  });
+
+  it("reaponta symlink que apontava para outra fonte válida", () => {
+    writeCompleteSource();
+    const otherSource = join(temporaryRoot, "outra-fonte");
+    mkdirSync(otherSource, { recursive: true });
+    for (const filename of envFiles) {
+      writeFileSync(join(otherSource, filename), "outra\n");
+      symlinkSync(join(otherSource, filename), join(fixtureFrontend, filename));
+    }
+
+    expect(runBootstrap().status).toBe(0);
+
+    for (const filename of envFiles) {
+      expect(readlinkSync(join(fixtureFrontend, filename))).toBe(
+        join(sourceFrontend, filename),
+      );
+    }
+    // A fonte antiga não é tocada: o bootstrap mexe em link, nunca em conteúdo.
+    expect(readFileSync(join(otherSource, ".env.local"), "utf8")).toBe(
+      "outra\n",
+    );
+  });
+
+  describe("fonte canônica (sem --source)", () => {
+    function runWithoutSource(environmentHome: string) {
+      return spawnSync("bash", [bootstrap], {
+        cwd: repository,
+        encoding: "utf8",
+        env: { ...process.env, DATAFRAMEITGUI_ENV_HOME: environmentHome },
+      });
+    }
+
+    it("provisiona a partir do diretório canônico", () => {
+      writeCompleteSource();
+
+      const result = runWithoutSource(sourceFrontend);
+
+      expect(result.status).toBe(0);
+      for (const filename of envFiles) {
+        expect(readlinkSync(join(fixtureFrontend, filename))).toBe(
+          join(sourceFrontend, filename),
+        );
+      }
+    });
+
+    it("explica como criar a fonte canônica quando ela não existe", () => {
+      const result = runWithoutSource(join(temporaryRoot, "inexistente"));
+
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain("fonte canônica inexistente");
+      expectNoDestinations();
+    });
   });
 
   it("mantém o status do Git limpo após o provisionamento", () => {

--- a/frontend/src/lib/__tests__/worktree-env-bootstrap.test.ts
+++ b/frontend/src/lib/__tests__/worktree-env-bootstrap.test.ts
@@ -66,7 +66,11 @@ describe("bootstrap de ambiente para worktrees", () => {
       resolve(trackedFrontend, "scripts/worktree-env/bootstrap.sh"),
       bootstrap,
     );
-    for (const filename of ["bootstrap.mjs", "env-contract.mjs"]) {
+    for (const filename of [
+      "bootstrap.mjs",
+      "env-contract.mjs",
+      "destination-state.mjs",
+    ]) {
       copyFileSync(
         resolve(trackedFrontend, "scripts/worktree-env", filename),
         join(fixtureFrontend, "scripts/worktree-env", filename),

--- a/frontend/src/lib/__tests__/worktree-env-destination-state.test.ts
+++ b/frontend/src/lib/__tests__/worktree-env-destination-state.test.ts
@@ -1,0 +1,76 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { classifyDestination } from "../../../scripts/worktree-env/destination-state.mjs";
+
+// A classificação decide se o bootstrap cria, ignora, refaz ou recusa. Testada
+// aqui diretamente — sem subprocesso — porque cada estado corresponde a uma
+// situação real do parque de worktrees, e "relink" em particular é o que
+// permite CONSERTAR uma worktree cujo alvo foi removido.
+describe("classifyDestination", () => {
+  let root: string;
+  let source: string;
+  let destination: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "destination-state-"));
+    mkdirSync(join(root, "fonte"), { recursive: true });
+    mkdirSync(join(root, "worktree"), { recursive: true });
+    source = join(root, "fonte", ".env.local");
+    destination = join(root, "worktree", ".env.local");
+    writeFileSync(source, "X=1\n");
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it("missing — destino não existe", () => {
+    expect(classifyDestination(destination, source)).toBe("missing");
+  });
+
+  it("linked — symlink já aponta para a fonte", () => {
+    symlinkSync(source, destination);
+    expect(classifyDestination(destination, source)).toBe("linked");
+  });
+
+  it("linked — caminho diferente que resolve para o mesmo arquivo", () => {
+    // O link chega à fonte por um diretório symlinkado: já está provisionado, e
+    // recriá-lo seria trabalho inútil a cada post-checkout.
+    const alias = join(root, "alias");
+    symlinkSync(join(root, "fonte"), alias);
+    symlinkSync(join(alias, ".env.local"), destination);
+
+    expect(classifyDestination(destination, source)).toBe("linked");
+  });
+
+  it("relink — symlink pendente, alvo removido", () => {
+    const removed = join(root, "removida", ".env.local");
+    symlinkSync(removed, destination);
+
+    expect(classifyDestination(destination, source)).toBe("relink");
+  });
+
+  it("relink — symlink para outra fonte existente", () => {
+    const other = join(root, "outra.env");
+    writeFileSync(other, "X=2\n");
+    symlinkSync(other, destination);
+
+    expect(classifyDestination(destination, source)).toBe("relink");
+  });
+
+  it("occupied — arquivo real, que nunca pode ser sobrescrito", () => {
+    writeFileSync(destination, "X=3\n");
+    expect(classifyDestination(destination, source)).toBe("occupied");
+  });
+
+  it("occupied — diretório no lugar do arquivo", () => {
+    mkdirSync(destination);
+    expect(classifyDestination(destination, source)).toBe("occupied");
+  });
+});


### PR DESCRIPTION
Provisionar o ambiente de uma worktree dependia de escolher a fonte a cada invocação (`bootstrap.sh --source <dir>`) e de lembrar de rodar o script. O resultado, medido no parque local de 11 worktrees, foram **quatro estados diferentes**:

| estado | ocorrências |
|---|---|
| symlink ok | 7 |
| symlink quebrado (alvo era uma worktree já removida) | 1 |
| ausente | 2 |
| cópia real do arquivo | 1 |

A cópia real estava **em drift**: faltava `E2E_CODING_PROJECT_ID`, obrigatória desde a fixture do `coding-save`. Ou seja, aquela worktree falharia no gate por um motivo invisível.

E o sintoma aparecia longe da causa: com o link pendente, o gate acusa `faltando 10 variáveis`, o que manda investigar credencial, tenant e porta — três saltos de distância de um symlink apontando para o vazio. Foi exatamente o que aconteceu ao depurar o e2e do #493.

## Correção de raiz

Em vez de mais uma instrução a lembrar:

- **Fonte canônica fora da árvore** — `~/.config/dataframeitGUI/frontend`, ajustável por `DATAFRAMEITGUI_ENV_HOME`. Worktree é efêmera por construção; enquanto a fonte pudesse ser outra worktree, `git worktree remove` continuaria quebrando o ambiente de quem apontava para ela. `--source` segue aceito, mas deixou de ser o caminho normal.
- **Bootstrap idempotente e reparador** — link correto vira no-op; link pendente ou apontando para outra fonte é refeito; arquivo real faz o script recusar, nunca sobrescrever (pode ser a única cópia de um segredo: o provisionamento é que cede, não o dado). Antes ele recusava qualquer destino existente, então worktree quebrada não era consertável pelo próprio script.
- **Hook de `post-checkout`** — `git worktree add` e `git checkout` disparam, então a worktree nasce provisionada. Nunca bloqueia: post-checkout roda depois do checkout, e falhar ali só faria ruído; quem barra continua sendo o `e2e-smoke`.
- **Diagnóstico no gate** — `assertRequiredPrePushEnv` agora nomeia o link pendente e o alvo morto, além de listar as variáveis.

## Bug encontrado ao escrever o teste do reparo

`rmSync(path, { force: true })` **não remove symlink pendente**. Com `force`, o rm decide pela existência do *alvo* (via `stat`), então num link cujo alvo sumiu ele conclui "não existe" e vira no-op silencioso — o erro só reaparece adiante, como `EEXIST` no `symlinkSync`. Trocado por `unlinkSync`, que age no link.

## Verificação

- Suíte: **1771 testes**, verde; typecheck limpo; todos os gates de pre-push passaram (incluindo e2e e fallow).
- Cada comportamento novo **provado vermelho** contra a mutação da sua própria correção: `unlinkSync`→`rmSync force` derruba o reparo; remover o `continue` derruba a idempotência; tirar o default da fonte derruba o provisionamento canônico; neutralizar `danglingEnvironmentLinks` derruba o diagnóstico; trocar o ramo de link pendente derruba o unitário **e** o de integração.
- **Hook validado de ponta a ponta**: `git worktree add` numa worktree nova provisionou os dois symlinks sozinho.
- `classifyDestination` saiu do executável para `destination-state.mjs` porque o fallow acusava CRAP 56 — o estimador infere cobertura por referências de export e não enxergava os testes por subprocesso. A correção foi dar cobertura real (7 unitários, um por estado), não suprimir o aviso.

## Nota de operação

O parque local já foi migrado: os 11 checkouts apontam para a fonte canônica, com backup das cópias reais. Quem tiver worktree antiga sem o hook instalado roda uma vez `pre-commit install` (o `default_install_hook_types` já inclui `post-checkout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)