### PR TITLE
fix(invariants): cobre 'concluido' sobre response nunca enviada (#552)

### DIFF
--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -274,16 +274,19 @@ const invariants: Invariant[] = [
           "id, document_id, user_id",
           (q) => q.eq("type", "codificacao").eq("status", "concluido"),
         ),
-        fetchAll<{ document_id: string; respondent_id: string | null; is_partial: boolean }>(
+        fetchAll<{ document_id: string; respondent_id: string | null; is_partial: boolean | null }>(
           "responses",
           "document_id, respondent_id, is_partial",
           (q) => q.eq("respondent_type", "humano").eq("is_latest", true),
         ),
       ]);
       // is_partial da response is_latest do par (única por (doc, respondente),
-      // garantida por 'responses-is-latest-unica'). `undefined` = sem is_latest
-      // humana → caso de 'concluida-tem-response', não deste; `false` = submetida
-      // → saudável. Só `=== true` (rascunho, nunca enviado) é violação aqui.
+      // garantida por 'responses-is-latest-unica'). Quatro estados possíveis, só
+      // um é violação: `undefined` = sem is_latest humana no par → caso de
+      // 'concluida-tem-response', não deste; `false` = submetida → saudável;
+      // `null` = row legada sem o sinal (a coluna é nullable, ver responses.ts) →
+      // cai no ramo saudável por design, conservador para não falso-positivar sem
+      // prova de rascunho. Só `=== true` (rascunho, nunca enviado) é violação.
       const partialOf = new Map(
         responses.map((r) => [`${r.document_id}|${r.respondent_id}`, r.is_partial]),
       );

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -263,6 +263,43 @@ const invariants: Invariant[] = [
     },
   },
   {
+    name: "codificacao-concluida-response-so-rascunho",
+    motivation:
+      "vão entre as duas invariantes pareadas acima (#552): assignment 'concluido' em doc ATIVO cuja response humana is_latest do par nunca foi submetida (is_partial=true). 'concluida-tem-response' só vê ausência de response; 'completa-marcada-pendente' só olha response submetida (is_partial=false) — nenhuma cobre o rascunho promovido a concluído. Estado que o guard do #538 fechou na criação e do qual keepCodingAssignmentInProgress não regride; FAIL aqui = canal de escrita futuro reintroduziu o vão",
+    run: async () => {
+      const active = await activeDocIds();
+      const [assignments, responses] = await Promise.all([
+        fetchAll<{ id: string; document_id: string; user_id: string }>(
+          "assignments",
+          "id, document_id, user_id",
+          (q) => q.eq("type", "codificacao").eq("status", "concluido"),
+        ),
+        fetchAll<{ document_id: string; respondent_id: string | null; is_partial: boolean }>(
+          "responses",
+          "document_id, respondent_id, is_partial",
+          (q) => q.eq("respondent_type", "humano").eq("is_latest", true),
+        ),
+      ]);
+      // is_partial da response is_latest do par (única por (doc, respondente),
+      // garantida por 'responses-is-latest-unica'). `undefined` = sem is_latest
+      // humana → caso de 'concluida-tem-response', não deste; `false` = submetida
+      // → saudável. Só `=== true` (rascunho, nunca enviado) é violação aqui.
+      const partialOf = new Map(
+        responses.map((r) => [`${r.document_id}|${r.respondent_id}`, r.is_partial]),
+      );
+      return assignments
+        .filter(
+          (a) =>
+            active.has(a.document_id) &&
+            partialOf.get(`${a.document_id}|${a.user_id}`) === true,
+        )
+        .map((a) => ({
+          key: a.id,
+          detail: `assignment concluído cuja response is_latest é rascunho, nunca submetida (doc ${a.document_id}, user ${a.user_id})`,
+        }));
+    },
+  },
+  {
     name: "arbitragem-perdida-exige-sugestao",
     motivation:
       "regra de fluxo da migration 20260513000001: final_verdict='llm' (humano perdeu) exige question_improvement_suggestion; violação = canal de escrita pulando a regra da UI (família 'regra duplicada por fronteira', #486)",


### PR DESCRIPTION
## Contexto

As duas invariantes pareadas de codificação em `frontend/scripts/invariants/check-invariants.ts` deixavam um estado **descoberto**:

- `codificacao-concluida-tem-response` só dispara quando **não existe nenhuma** response humana do par;
- `codificacao-completa-marcada-pendente` só examina responses **já submetidas** (`is_partial = false`).

Ficava no vão entre as duas o assignment `concluido` em documento ativo cuja response humana `is_latest` do par **existe mas é rascunho** (`is_partial = true` — auto-save, o pesquisador nunca clicou em Enviar). É o estado que o guard do #538 fechou na criação e do qual não se sai sozinho — `keepCodingAssignmentInProgress` nunca regride de `concluido`.

O resíduo em produção hoje é **zero**: o estado só era construível pelo caminho que o #538 fechou antes de ir a produção. A issue é sobre a **rede de detecção**, não sobre dado sujo — se um canal de escrita futuro reintroduzir o estado, hoje ninguém avisa.

## Mudança

Adiciona a terceira invariante `codificacao-concluida-response-so-rascunho`, clone estrutural de `codificacao-concluida-tem-response`. Em vez de checar *ausência* de response num `Set`, ela consulta um `Map` par→`is_partial` da response `is_latest` humana e dispara apenas quando o valor é `=== true`.

O lookup carrega três estados que mantêm as três invariantes **disjuntas, sem dupla contagem**:

- `undefined` — sem response `is_latest` humana no par → caso de `concluida-tem-response`, não deste;
- `false` — response submetida → saudável;
- `true` — rascunho nunca enviado → **violação** (o vão da #552).

A unicidade do `is_latest` por `(documento, respondente)` que torna o `Map` bem-definido já é garantida pela invariante `responses-is-latest-unica`. O critério é puramente estrutural (`is_partial`), então não precisa da fase 2 / `isCodingComplete` da invariante inversa — basta uma coluna leve a mais na query de responses.

## Verificação

- **Verde em produção** (`npm run invariants`): `PASS codificacao-concluida-response-so-rascunho`, 7/7 invariantes OK — resíduo zero, como a issue previa.
- **Prova do vermelho por mutação temporária do predicado** (mesmo precedente do comentário da linha 226 do arquivo; não escreve nenhum dado): invertendo `=== true` → `=== false`, a invariante casa com os assignments concluídos+submetidos saudáveis e imprime `FAIL — 589 violação(ões)`, exit 1. Revertido para `=== true`, volta a `PASS`. Isso comprova que o caminho de detecção morde quando a condição é satisfeita.
- `tsc --noEmit` limpo; pre-push (typecheck, vitest full, e2e-smoke, lint:types, fallow, semgrep) todos verdes.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HjHSH9R5s5ikiJ3N2bgg4U