### PR TITLE
fix(coding): unifica régua de completude UI×servidor no submit (#519)

### DIFF
--- a/frontend/src/components/coding/SortableQuestion.tsx
+++ b/frontend/src/components/coding/SortableQuestion.tsx
@@ -69,7 +69,11 @@ export function SortableQuestion({
             <GripVertical className="size-3.5" />
           </button>
         )}
-        <div className="flex-1 min-w-0">
+        {/* `data-question-body` marca o corpo da resposta (label + controle),
+            irmão do drag-handle. A validação de submit foca o primeiro controle
+            focável DENTRO deste container, para o cursor cair na pergunta
+            pendente e não no botão de reordenar (que precede o corpo no card). */}
+        <div className="flex-1 min-w-0" data-question-body>
           <FieldHeaderLabel
             prefix={`${index + 1}.`}
             helpText={field.help_text}

--- a/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
+++ b/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
@@ -245,3 +245,31 @@ describe("QuestionsPanel — pergunta fora do escopo", () => {
     ).toBe(true);
   });
 });
+
+describe("QuestionsPanel — contagem de obrigatórias no header", () => {
+  it("denominador exclui llm_only (mesma régua do servidor)", () => {
+    const humano: PydanticField = {
+      name: "humano",
+      type: "single",
+      options: ["a", "b"],
+      description: "Pergunta humana",
+    };
+    const soLlm: PydanticField = {
+      name: "so_llm",
+      type: "single",
+      options: ["a", "b"],
+      description: "Só LLM",
+      target: "llm_only",
+    };
+    render(
+      <QuestionsPanel
+        fields={[humano, soLlm]}
+        answers={{ humano: "a" }}
+        onAnswer={vi.fn()}
+        onSubmit={vi.fn()}
+      />,
+    );
+    // 1 humana respondida de 1 obrigatória; o campo llm_only não infla o denominador.
+    expect(screen.getByText(/1\/1 obrigatórias respondidas/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/coding/__tests__/useQuestionValidation.test.ts
+++ b/frontend/src/components/coding/__tests__/useQuestionValidation.test.ts
@@ -22,16 +22,25 @@ function field(partial: Partial<PydanticField> & { name: string }): PydanticFiel
   } as PydanticField;
 }
 
-// Monta um RefObject de cards com um input focável dentro de cada, na ordem de
-// `visibleFields`, para exercitar scroll + foco.
+// Monta um RefObject de cards que espelham a estrutura real de `SortableQuestion`
+// no fluxo de codificação (arrastável): o drag-handle é o PRIMEIRO focável do
+// card, seguido do corpo da resposta `[data-question-body]` com o input. Isso é
+// necessário para provar o vermelho do foco — com o seletor escopado ao card
+// inteiro, o `.focus()` cairia no handle; escopado ao corpo, cai no input.
 function refsFor(fields: PydanticField[]): RefObject<(HTMLDivElement | null)[]> {
   const ref = createRef<(HTMLDivElement | null)[]>() as {
     current: (HTMLDivElement | null)[];
   };
   ref.current = fields.map(() => {
     const card = document.createElement("div");
+    const handle = document.createElement("button");
+    handle.setAttribute("aria-label", "Arrastar para reordenar pergunta");
+    card.appendChild(handle);
+    const body = document.createElement("div");
+    body.setAttribute("data-question-body", "");
     const input = document.createElement("input");
-    card.appendChild(input);
+    body.appendChild(input);
+    card.appendChild(body);
     document.body.appendChild(card);
     return card;
   });
@@ -87,10 +96,15 @@ describe("useQuestionValidation — envio", () => {
     expect(onSubmit).not.toHaveBeenCalled();
     expect(view.result.current.highlightedFields).toEqual(new Set(["q2"]));
     expect(warn).toHaveBeenCalledWith("Preencha todas as perguntas obrigatórias");
-    // q2 é o índice 1 em visibleFields; scroll no card e foco no input dentro dele.
+    // q2 é o índice 1 em visibleFields; scroll no card e foco no input do corpo
+    // da resposta — NÃO no drag-handle, que é o primeiro focável do card.
     const secondCard = refs.current![1]!;
     expect(secondCard.scrollIntoView).toHaveBeenCalled();
-    expect(document.activeElement).toBe(secondCard.querySelector("input"));
+    const bodyInput = secondCard.querySelector("[data-question-body] input");
+    expect(document.activeElement).toBe(bodyInput);
+    expect(document.activeElement).not.toBe(
+      secondCard.querySelector('[aria-label="Arrastar para reordenar pergunta"]'),
+    );
   });
 
   it("submitting/outOfScopeBlocked → nunca envia nem avisa", () => {

--- a/frontend/src/components/coding/__tests__/useQuestionValidation.test.ts
+++ b/frontend/src/components/coding/__tests__/useQuestionValidation.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { createRef, type RefObject } from "react";
+import { useQuestionValidation } from "@/components/coding/useQuestionValidation";
+import type { PydanticField } from "@/lib/types";
+
+const warn = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    warning: (...args: unknown[]) => warn(...args),
+  },
+}));
+
+// Helper: PydanticField com defaults mínimos (mesmo shape do coding-completeness.test).
+function field(partial: Partial<PydanticField> & { name: string }): PydanticField {
+  return {
+    type: "single",
+    options: ["a", "b"],
+    description: "",
+    ...partial,
+  } as PydanticField;
+}
+
+// Monta um RefObject de cards com um input focável dentro de cada, na ordem de
+// `visibleFields`, para exercitar scroll + foco.
+function refsFor(fields: PydanticField[]): RefObject<(HTMLDivElement | null)[]> {
+  const ref = createRef<(HTMLDivElement | null)[]>() as {
+    current: (HTMLDivElement | null)[];
+  };
+  ref.current = fields.map(() => {
+    const card = document.createElement("div");
+    const input = document.createElement("input");
+    card.appendChild(input);
+    document.body.appendChild(card);
+    return card;
+  });
+  return ref as RefObject<(HTMLDivElement | null)[]>;
+}
+
+beforeEach(() => {
+  warn.mockClear();
+  Element.prototype.scrollIntoView = vi.fn();
+  window.matchMedia = vi.fn().mockReturnValue({ matches: false }) as never;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+function setup(
+  visibleFields: PydanticField[],
+  answers: Record<string, unknown>,
+  overrides: { submitting?: boolean; outOfScopeBlocked?: boolean } = {},
+) {
+  const onSubmit = vi.fn();
+  const onAnswer = vi.fn();
+  const refs = refsFor(visibleFields);
+  const view = renderHook(() =>
+    useQuestionValidation(
+      visibleFields,
+      answers,
+      onAnswer,
+      onSubmit,
+      overrides.submitting ?? false,
+      overrides.outOfScopeBlocked ?? false,
+      refs,
+    ),
+  );
+  return { view, onSubmit, onAnswer, refs };
+}
+
+describe("useQuestionValidation — envio", () => {
+  it("tudo preenchido → chama onSubmit, sem aviso", () => {
+    const fields = [field({ name: "q1" }), field({ name: "q2" })];
+    const { view, onSubmit } = setup(fields, { q1: "a", q2: "b" });
+    act(() => view.result.current.handleSubmitWithValidation());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("obrigatória visível vazia → bloqueia, destaca, rola/foca o 1º pendente e avisa", () => {
+    const fields = [field({ name: "q1" }), field({ name: "q2" })];
+    const { view, onSubmit, refs } = setup(fields, { q1: "a" });
+    act(() => view.result.current.handleSubmitWithValidation());
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(view.result.current.highlightedFields).toEqual(new Set(["q2"]));
+    expect(warn).toHaveBeenCalledWith("Preencha todas as perguntas obrigatórias");
+    // q2 é o índice 1 em visibleFields; scroll no card e foco no input dentro dele.
+    const secondCard = refs.current![1]!;
+    expect(secondCard.scrollIntoView).toHaveBeenCalled();
+    expect(document.activeElement).toBe(secondCard.querySelector("input"));
+  });
+
+  it("submitting/outOfScopeBlocked → nunca envia nem avisa", () => {
+    const fields = [field({ name: "q1" })];
+    const a = setup(fields, { q1: "a" }, { submitting: true });
+    act(() => a.view.result.current.handleSubmitWithValidation());
+    expect(a.onSubmit).not.toHaveBeenCalled();
+
+    const b = setup(fields, {}, { outOfScopeBlocked: true });
+    act(() => b.view.result.current.handleSubmitWithValidation());
+    expect(b.onSubmit).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe("useQuestionValidation — régua única (coding-completeness)", () => {
+  // Prova do vermelho: com a régua antiga (`visibleFields.filter(resolveRequired)`),
+  // o campo llm_only entrava no denominador da contagem e o header mostrava 1/2
+  // para sempre, embora o submit já o ignorasse. Ao delegar a `requiredHumanFields`,
+  // contagem e bloqueio passam a excluí-lo igualmente.
+  it("campo obrigatório llm_only não entra na contagem nem bloqueia o envio", () => {
+    const fields = [
+      field({ name: "humano" }),
+      field({ name: "so_llm", target: "llm_only" }),
+    ];
+    const { view, onSubmit } = setup(fields, { humano: "a" });
+    expect(view.result.current.requiredFields.map((f) => f.name)).toEqual(["humano"]);
+    expect(view.result.current.answeredRequiredCount).toBe(1);
+    act(() => view.result.current.handleSubmitWithValidation());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("'Outro: ' incompleto e multi vazio contam como não respondidos (delega isFieldAnswered)", () => {
+    const fields = [
+      field({ name: "q1", allow_other: true }),
+      field({ name: "q2", type: "multi", allow_other: true }),
+    ];
+    const { view, onSubmit } = setup(fields, { q1: "Outro: ", q2: [] });
+    expect(view.result.current.answeredRequiredCount).toBe(0);
+    act(() => view.result.current.handleSubmitWithValidation());
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(view.result.current.highlightedFields).toEqual(new Set(["q1", "q2"]));
+  });
+});

--- a/frontend/src/components/coding/useQuestionValidation.ts
+++ b/frontend/src/components/coding/useQuestionValidation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState, type RefObject } from "react";
+import { useCallback, useMemo, useState, type RefObject } from "react";
 import { toast } from "sonner";
 import { getScrollBehavior } from "@/lib/scroll";
 import { isFieldAnswered, requiredHumanFields } from "@/lib/coding-completeness";
@@ -34,10 +34,16 @@ export function useQuestionValidation(
   // (coding-sync.ts). Antes esta contagem usava `visibleFields.filter(resolveRequired)`,
   // que incluía `llm_only` no denominador (o bloqueio já o excluía), fazendo o
   // header mostrar "N-1/N" para sempre com o submit liberado.
-  const requiredFields = requiredHumanFields(visibleFields, answers);
-  const answeredRequiredCount = requiredFields.filter((f) =>
-    isFieldAnswered(f, answers[f.name]),
-  ).length;
+  // Memoizado para estabilizar a identidade de `requiredFields` (dep de
+  // `handleSubmitWithValidation`) entre renders sem mudança de campos/respostas.
+  const requiredFields = useMemo(
+    () => requiredHumanFields(visibleFields, answers),
+    [visibleFields, answers],
+  );
+  const answeredRequiredCount = useMemo(
+    () => requiredFields.filter((f) => isFieldAnswered(f, answers[f.name])).length,
+    [requiredFields, answers],
+  );
 
   const isAnswered = useCallback(
     (field: PydanticField) => isFieldAnswered(field, answers[field.name]),
@@ -71,9 +77,14 @@ export function useQuestionValidation(
       const firstIdx = visibleFields.findIndex((f) => unansweredSet.has(f.name));
       const firstEl = questionRefs.current[firstIdx];
       firstEl?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" });
-      // O ref é o card da pergunta (HTMLDivElement), não o input — focar o
-      // primeiro controle focável dentro dele leva o cursor direto à pendência.
-      firstEl
+      // O ref é o card da pergunta (HTMLDivElement), não o input. Focar o
+      // primeiro controle dentro de `[data-question-body]` (o corpo da resposta)
+      // — não do card inteiro — leva o cursor à pendência e evita cair no
+      // drag-handle de reordenar, que precede o corpo quando o card é arrastável
+      // (o caso normal na codificação). Fallback para o card se o marcador faltar.
+      const focusRoot =
+        firstEl?.querySelector<HTMLElement>("[data-question-body]") ?? firstEl;
+      focusRoot
         ?.querySelector<HTMLElement>(
           'input, textarea, select, button, [tabindex]:not([tabindex="-1"])',
         )

--- a/frontend/src/components/coding/useQuestionValidation.ts
+++ b/frontend/src/components/coding/useQuestionValidation.ts
@@ -1,19 +1,8 @@
 import { useCallback, useState, type RefObject } from "react";
 import { toast } from "sonner";
-import { isIncompleteOther } from "@/lib/other-option";
 import { getScrollBehavior } from "@/lib/scroll";
-import { resolveRequired, resolveTarget } from "@/lib/pydantic-field";
+import { isFieldAnswered, requiredHumanFields } from "@/lib/coding-completeness";
 import type { PydanticField } from "@/lib/types";
-
-const isAnsweredValue = (field: PydanticField, val: unknown): boolean => {
-  if (val === undefined || val === null || val === "") return false;
-  if (field.type === "single" && isIncompleteOther(val)) return false;
-  if (field.type === "multi" && Array.isArray(val)) {
-    if (val.length === 0) return false;
-    if (val.some(isIncompleteOther)) return false;
-  }
-  return true;
-};
 
 /**
  * Estado de destaque de obrigatórias faltantes + validação de envio. O
@@ -39,13 +28,19 @@ export function useQuestionValidation(
 } {
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
 
-  const requiredFields = visibleFields.filter((f) => resolveRequired(f.required));
+  // Contagem e bloqueio derivam da MESMA régua canônica do servidor
+  // (`requiredHumanFields`/`isFieldAnswered`, coding-completeness.ts). Sem
+  // `answerFieldHashes` = staleness-blind, igual ao gate inline de saveResponse
+  // (coding-sync.ts). Antes esta contagem usava `visibleFields.filter(resolveRequired)`,
+  // que incluía `llm_only` no denominador (o bloqueio já o excluía), fazendo o
+  // header mostrar "N-1/N" para sempre com o submit liberado.
+  const requiredFields = requiredHumanFields(visibleFields, answers);
   const answeredRequiredCount = requiredFields.filter((f) =>
-    isAnsweredValue(f, answers[f.name]),
+    isFieldAnswered(f, answers[f.name]),
   ).length;
 
   const isAnswered = useCallback(
-    (field: PydanticField) => isAnsweredValue(field, answers[field.name]),
+    (field: PydanticField) => isFieldAnswered(field, answers[field.name]),
     [answers],
   );
 
@@ -65,13 +60,8 @@ export function useQuestionValidation(
   const handleSubmitWithValidation = useCallback(() => {
     if (submitting || outOfScopeBlocked) return;
 
-    const unanswered = visibleFields
-      .filter(
-        (f) =>
-          resolveTarget(f.target) !== "llm_only" &&
-          resolveRequired(f.required) &&
-          !isAnswered(f),
-      )
+    const unanswered = requiredFields
+      .filter((f) => !isAnswered(f))
       .map((f) => f.name);
 
     if (unanswered.length > 0) {
@@ -79,13 +69,21 @@ export function useQuestionValidation(
       const unansweredSet = new Set(unanswered);
       setHighlightedFields(unansweredSet);
       const firstIdx = visibleFields.findIndex((f) => unansweredSet.has(f.name));
-      questionRefs.current[firstIdx]?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" });
+      const firstEl = questionRefs.current[firstIdx];
+      firstEl?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" });
+      // O ref é o card da pergunta (HTMLDivElement), não o input — focar o
+      // primeiro controle focável dentro dele leva o cursor direto à pendência.
+      firstEl
+        ?.querySelector<HTMLElement>(
+          'input, textarea, select, button, [tabindex]:not([tabindex="-1"])',
+        )
+        ?.focus({ preventScroll: true });
       toast.warning("Preencha todas as perguntas obrigatórias");
       return;
     }
 
     onSubmit();
-  }, [visibleFields, isAnswered, onSubmit, submitting, outOfScopeBlocked, questionRefs]);
+  }, [requiredFields, visibleFields, isAnswered, onSubmit, submitting, outOfScopeBlocked, questionRefs]);
 
   return {
     highlightedFields,

--- a/frontend/src/lib/__tests__/coding-completeness.test.ts
+++ b/frontend/src/lib/__tests__/coding-completeness.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { isCodingComplete } from "@/lib/coding-completeness";
+import {
+  isCodingComplete,
+  isFieldAnswered,
+  requiredHumanFields,
+} from "@/lib/coding-completeness";
 import type { PydanticField } from "@/lib/types";
 
 // Helper: monta um PydanticField com defaults mínimos.
@@ -139,5 +143,59 @@ describe("isCodingComplete — staleness-aware", () => {
     const hashes = { q1: "h1", q2: "h2" };
     // q1/q2 respondidos, medicamento (novo) ausente → completo
     expect(isCodingComplete(fields, { q1: "a", q2: "b" }, hashes)).toBe(true);
+  });
+});
+
+// Primitivas exportadas para que a UI (useQuestionValidation) derive contagem e
+// bloqueio desta mesma fonte, em vez de manter uma cópia paralela que pode divergir.
+describe("isFieldAnswered", () => {
+  it("vazio (undefined/null/'') → false", () => {
+    const f = field({ name: "q1" });
+    expect(isFieldAnswered(f, undefined)).toBe(false);
+    expect(isFieldAnswered(f, null)).toBe(false);
+    expect(isFieldAnswered(f, "")).toBe(false);
+  });
+
+  it("single com valor → true; 'Outro: ' incompleto → false", () => {
+    const f = field({ name: "q1", allow_other: true });
+    expect(isFieldAnswered(f, "a")).toBe(true);
+    expect(isFieldAnswered(f, "Outro: ")).toBe(false);
+    expect(isFieldAnswered(f, "Outro: x")).toBe(true);
+  });
+
+  it("multi vazio → false; com item → true; com 'Outro: ' incompleto → false", () => {
+    const f = field({ name: "q1", type: "multi", allow_other: true });
+    expect(isFieldAnswered(f, [])).toBe(false);
+    expect(isFieldAnswered(f, ["a"])).toBe(true);
+    expect(isFieldAnswered(f, ["a", "Outro: "])).toBe(false);
+  });
+});
+
+describe("requiredHumanFields", () => {
+  it("exclui llm_only, none e required:false; inclui obrigatório visível", () => {
+    const fields = [
+      field({ name: "humano" }),
+      field({ name: "so_llm", target: "llm_only" }),
+      field({ name: "oculto", target: "none" }),
+      field({ name: "opcional", required: false }),
+    ];
+    const names = requiredHumanFields(fields, {}).map((f) => f.name);
+    expect(names).toEqual(["humano"]);
+  });
+
+  it("condicional só é exigido quando visível", () => {
+    const fields = [
+      field({ name: "q1" }),
+      field({ name: "q2", condition: { field: "q1", equals: "sim" } }),
+    ];
+    expect(requiredHumanFields(fields, { q1: "nao" }).map((f) => f.name)).toEqual(["q1"]);
+    expect(requiredHumanFields(fields, { q1: "sim" }).map((f) => f.name)).toEqual(["q1", "q2"]);
+  });
+
+  it("sem answerFieldHashes = staleness-blind (todos os campos existentes contam)", () => {
+    const fields = [field({ name: "q1" }), field({ name: "novo", type: "multi" })];
+    expect(requiredHumanFields(fields, {}).map((f) => f.name)).toEqual(["q1", "novo"]);
+    // Com hashes da época sem "novo", ele deixa de ser exigido.
+    expect(requiredHumanFields(fields, {}, { q1: "h1" }).map((f) => f.name)).toEqual(["q1"]);
   });
 });

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -9,8 +9,10 @@ import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 // satisfeita pelas respostas atuais e — quando `answerFieldHashes` é fornecido —
 // que já existiam no schema contra o qual a resposta foi codificada
 // (staleness-aware). Os defaults de `target` e `required` saem dos resolvedores
-// de pydantic-field, nunca de uma re-derivação local.
-function requiredHumanFields(
+// de pydantic-field, nunca de uma re-derivação local. Exportado para que a régua
+// de completude da UI (useQuestionValidation) derive a contagem e o bloqueio de
+// submit desta MESMA fonte, em vez de reimplementar os filtros e divergir.
+export function requiredHumanFields(
   fields: PydanticField[],
   answers: Record<string, unknown>,
   answerFieldHashes?: AnswerFieldHashes,
@@ -23,6 +25,21 @@ function requiredHumanFields(
       isFieldVisible(f, answers) &&
       fieldExistedWhenCoded(answerFieldHashes, f.name),
   );
+}
+
+// Predicado por-campo: `true` quando o valor conta como resposta válida para
+// fins de completude. Trata vazio (`undefined`/`null`/`""`), "Outro:" incompleto
+// em `single` e `multi` vazio/com "Outro:" incompleto como NÃO respondido. Fonte
+// única desse check — consumido por `isCodingComplete` (aqui) e pela régua da UI
+// (useQuestionValidation), para que a UI não mantenha uma cópia que possa derivar.
+export function isFieldAnswered(field: PydanticField, value: unknown): boolean {
+  if (value === undefined || value === null || value === "") return false;
+  if (field.type === "single" && isIncompleteOther(value)) return false;
+  if (field.type === "multi" && Array.isArray(value)) {
+    if (value.length === 0) return false;
+    if (value.some(isIncompleteOther)) return false;
+  }
+  return true;
 }
 
 // True quando todos os campos obrigatórios e visíveis para o humano estão
@@ -45,14 +62,5 @@ export function isCodingComplete(
   answerFieldHashes?: AnswerFieldHashes,
 ): boolean {
   const required = requiredHumanFields(fields, answers, answerFieldHashes);
-  return required.every((f) => {
-    const v = answers[f.name];
-    if (v === undefined || v === null || v === "") return false;
-    if (f.type === "single" && isIncompleteOther(v)) return false;
-    if (f.type === "multi" && Array.isArray(v)) {
-      if (v.length === 0) return false;
-      if (v.some(isIncompleteOther)) return false;
-    }
-    return true;
-  });
+  return required.every((f) => isFieldAnswered(f, answers[f.name]));
 }


### PR DESCRIPTION
## Contexto

A #519 relata que um submit de codificação incompleta seria indistinguível de conclusão (mesmo toast de sucesso, doc reaparece na fila). Ao verificar o código, a **premissa estava substancialmente desatualizada**: o bloqueio de submit incompleto (highlight + scroll + `toast.warning` + `return`) já existe desde `61412dc` (mar/2026), em `useQuestionValidation.handleSubmitWithValidation`, e é equivalente ao gate do servidor.

O defeito real é arquitetural: **existiam duas réguas de completude independentes**. A UI reimplementava `isAnsweredValue` + filtros próprios; o servidor usa `isCodingComplete` (`coding-completeness.ts`, "fonte única da regra"). Elas divergiam na contagem do header — `visibleFields.filter(resolveRequired)` incluía `llm_only` no denominador (que o bloqueio já excluía), mostrando "N-1/N obrigatórias" para sempre com o submit liberado. É exatamente o tipo de divergência que faz a UI parecer "não terminou" enquanto o servidor considera completo.

## Mudança (causa raiz — fonte única)

Colapsa as duas réguas em uma, em vez de empilhar guarda nova:

- `coding-completeness.ts`: expõe `requiredHumanFields` e extrai `isFieldAnswered` (fonte única do predicado por-campo). `isCodingComplete` passa a consumir `isFieldAnswered` — refactor byte-equivalente.
- `useQuestionValidation.ts`: **deleta** a cópia local `isAnsweredValue`; contagem, `isAnswered` e o conjunto de bloqueio derivam de `requiredHumanFields`/`isFieldAnswered` (chamados sem `answerFieldHashes` = staleness-blind, idêntico ao gate inline de `saveResponse` em `coding-sync.ts`). Corrige a divergência do `llm_only`.
- Adiciona `.focus()` no primeiro obrigatório pendente ao enviar (antes só `scrollIntoView`) — item 3 da issue.

O conjunto de campos que **bloqueia** o submit é inalterado; só a contagem do header deixa de inflar com `llm_only`. Escopo mantido no frontend (write path de `responses` não tocado).

## Testes

- Novo `useQuestionValidation.test.ts`: envio bloqueado/liberado, highlight, scroll + **foco** no 1º pendente, e a **prova do vermelho** — com a régua antiga o teste do `llm_only` falha (denominador 2); com a correção passa (denominador 1).
- Cobertura direta de `isFieldAnswered` e `requiredHumanFields` em `coding-completeness.test.ts`.
- Caso em `QuestionsPanel.test.tsx` afirmando que o denominador do header exclui `llm_only`.

Local: 41 testes-alvo verdes; suíte completa, typecheck, e2e-smoke, lint:types, fallow e semgrep verdes no pre-push.

## Nota

A premissa original (submit incompleto avança com toast de sucesso) já estava coberta pelo bloqueio de março; a entrega real é a unificação da régua + foco + cobertura de teste. Os casos históricos de 2026-07 têm causa em #484 (resolvido) e #520/#528 (em andamento).

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159jNJYAG1KE1dZUWvLRqL3