### PR TITLE
fix(codificação): promove colunas de versão só quando a codificação é revisada (#529)

### DIFF
--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -418,8 +418,11 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(payload).not.toHaveProperty("schema_version_minor");
     expect(payload).not.toHaveProperty("schema_version_patch");
     expect(payload).not.toHaveProperty("version_inferred_from");
-    // O resto do save segue normal.
+    // O resto do save segue normal. E o ramo legacy de buildReconciledFieldHashes
+    // NAO recarimba hash (conserva o sentinela `{}`), mesmo com revisao real de
+    // valor — liga o mapa per-campo as colunas preservadas no mesmo caso.
     expect(payload.answers).toEqual({ q1: "b" });
+    expect(payload.answer_field_hashes).toEqual({});
   });
 
   it("response com proveniencia per-campo promove as colunas ao REVISAR um valor", async () => {

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -422,10 +422,11 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(payload.answers).toEqual({ q1: "b" });
   });
 
-  it("response com proveniencia per-campo promove as colunas de versao", async () => {
-    // Controle do guard acima: com o mapa herdado nao vazio, a leitura de
-    // staleness usa o snapshot per-campo e as colunas de versao devem
-    // acompanhar o schema de hoje como sempre.
+  it("response com proveniencia per-campo promove as colunas ao REVISAR um valor", async () => {
+    // Com o mapa herdado nao vazio, a leitura de staleness usa o snapshot
+    // per-campo (nao `pydantic_hash`), entao promover as colunas de versao aqui
+    // e seguro. E `q1` mudou de "a" para "b": houve revisao real, entao as
+    // colunas avancam para o schema de hoje.
     state.pydanticFields = [
       { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
     ];
@@ -442,6 +443,35 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(state.responseUpdatePayload?.pydantic_hash).toBe("hash-1");
     expect(state.responseUpdatePayload?.schema_version_major).toBe(1);
     expect(state.responseUpdatePayload?.version_inferred_from).toBe("live_save");
+  });
+
+  it("toque sem revisao preserva as colunas de versao da epoca (#529)", async () => {
+    // Prova do vermelho do #529: o pesquisador reabre um doc codificado sob a
+    // versao anterior e re-submete o MESMO valor (auto-save por navegacao, sem
+    // editar nada). Nenhum campo e revisado, entao o mapa per-campo (#528) ja
+    // conserva a epoca — as colunas de versao devem acompanhar e NAO promover
+    // para o schema de hoje. Antes deste fix, `buildResponsePayload` promovia em
+    // todo save, deixando a linha assimetrica (hashes de epoca x versao de hoje)
+    // e fazendo-a contar como da versao corrente no gate `latest_major`.
+    state.pydanticFields = [
+      { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: { q1: "h1" },
+    };
+
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+
+    const payload = state.responseUpdatePayload ?? {};
+    expect(payload).not.toHaveProperty("pydantic_hash");
+    expect(payload).not.toHaveProperty("schema_version_major");
+    expect(payload).not.toHaveProperty("schema_version_minor");
+    expect(payload).not.toHaveProperty("schema_version_patch");
+    expect(payload).not.toHaveProperty("version_inferred_from");
   });
 
   it("codificacao nova com mapa vazio ainda promove as colunas de versao (INSERT)", async () => {

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -138,10 +138,12 @@ function resolveSchemaProvenance({
   // O fallback {major 0, minor 1, patch 0} é canônico e vive uma única vez em
   // `deriveProjectVersionContext` — reusá-lo evita a duplicação que o cabeçalho
   // de compare-version.ts sinaliza como load-bearing (uma cópia "corrigida" para
-  // minor 0 aqui dessincronizaria a fila/fecho da Comparação).
-  const { version } = deriveProjectVersionContext(project ?? {});
+  // minor 0 aqui dessincronizaria a fila/fecho da Comparação). O `ctx.pydanticHash`
+  // do MESMO helper é `pydantic_hash ?? null`, então hash e versão vêm de uma
+  // fonte única — não re-derivar o hash à parte.
+  const { version, ctx } = deriveProjectVersionContext(project ?? {});
   return {
-    pydantic_hash: project?.pydantic_hash ?? null,
+    pydantic_hash: ctx.pydanticHash,
     schema_version_major: version.major,
     schema_version_minor: version.minor,
     schema_version_patch: version.patch,

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -5,6 +5,7 @@ import { resolveProjectMemberActor } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
 import { syncCodingAssignmentStatus } from "@/lib/coding-sync";
+import { deriveProjectVersionContext } from "@/lib/compare-version";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 export interface SaveResponseOpts {
@@ -81,15 +82,77 @@ interface SaveResponseProjectFields {
 interface BuildResponsePayloadParams {
   answersToPersist: Record<string, unknown>;
   answerFieldHashes: Exclude<AnswerFieldHashes, null>;
+  hasRevision: boolean;
   project: SaveResponseProjectFields | null | undefined;
   existing: { is_partial: boolean | null } | null | undefined;
   isAutoSave: boolean;
   notes?: string;
 }
 
+// Decide as colunas de versão (`pydantic_hash`, `schema_version_*`,
+// `version_inferred_from`) a gravar. Devolve `{}` — omitindo-as do UPDATE, o que
+// PRESERVA os valores já na linha — quando o save não deve promover a
+// proveniência ao schema de hoje. Duas razões, cada uma um gatilho independente
+// (só para UPDATE — no INSERT não há proveniência anterior a preservar, e mapa
+// vazio ali significa projeto sem campos, não legacy):
+//
+// 1. STALENESS (legacy, #520/#528). Response que conservou o sentinela `{}`
+//    (ver buildReconciledFieldHashes): sem snapshot per-campo, `isFieldStale`
+//    cai no fallback do schema INTEIRO e compara `pydantic_hash`. Promovê-lo
+//    aqui tornaria o fallback permissivo — a codificação antiga passaria a ser
+//    lida como feita contra o schema de hoje e nenhum campo apareceria stale,
+//    reintroduzindo o falso "(vazio)" divergente de answer-staleness.ts.
+//    Preservar mantém o fallback conservador. Fica INDEPENDENTE do gatilho 2
+//    porque uma response legacy pode ter revisão real neste save e ainda assim
+//    conservar `{}` (o ramo legacy nunca carimba chave).
+//
+// 2. SEMÂNTICA DE VERSÃO (#529). Sem nenhuma revisão real de valor
+//    (`!hasRevision` — auto-save/toque, ou re-confirmar o mesmo valor), a linha
+//    não foi codificada sob o schema de hoje: seus valores seguem sendo da época
+//    anterior, e o mapa per-campo (#528) já conserva essa época. Promover só as
+//    colunas deixaria a linha assimétrica — hashes de época × versão de hoje — e
+//    a faria contar como da versão corrente no gate `latest_major` da Comparação
+//    sem que valor algum tenha sido revisado. Preservar mantém as colunas
+//    simétricas ao mapa: só avançam quando algum valor é de fato escrito sob o
+//    schema atual.
+//
+// Custo assumido (#548): preservar prende a linha fora do gate `latest_major`
+// até que ela seja de fato revisada. `responseQualifiesForVersion`
+// (compare-version.ts) curto-circuita em `pydantic_hash === null` e, adiante,
+// compara `schema_version_major` com o piso — então uma legacy pode ficar fora
+// da fila mesmo recodificada por inteiro (inerte hoje; medido em 2026-07-23: 8
+// responses legacy, todas já com a major do projeto). Para o #529 isso é o
+// comportamento desejado: uma codificação não revisada sob o novo schema não
+// deve contar como da versão nova. A raiz é `pydantic_hash` servir a dois
+// consumidores com necessidades opostas — o staleness quer o hash da época, o
+// gate de versão quer o de hoje.
+function resolveSchemaProvenance({
+  project,
+  answerFieldHashes,
+  hasRevision,
+  existing,
+}: Pick<BuildResponsePayloadParams, "project" | "answerFieldHashes" | "hasRevision" | "existing">) {
+  const keepsProvenance =
+    !!existing && (Object.keys(answerFieldHashes).length === 0 || !hasRevision);
+  if (keepsProvenance) return {};
+  // O fallback {major 0, minor 1, patch 0} é canônico e vive uma única vez em
+  // `deriveProjectVersionContext` — reusá-lo evita a duplicação que o cabeçalho
+  // de compare-version.ts sinaliza como load-bearing (uma cópia "corrigida" para
+  // minor 0 aqui dessincronizaria a fila/fecho da Comparação).
+  const { version } = deriveProjectVersionContext(project ?? {});
+  return {
+    pydantic_hash: project?.pydantic_hash ?? null,
+    schema_version_major: version.major,
+    schema_version_minor: version.minor,
+    schema_version_patch: version.patch,
+    version_inferred_from: "live_save",
+  };
+}
+
 function buildResponsePayload({
   answersToPersist,
   answerFieldHashes,
+  hasRevision,
   project,
   existing,
   isAutoSave,
@@ -109,43 +172,11 @@ function buildResponsePayload({
   // 20260425000000 vale so para o fluxo LLM.
   const isPartialToWrite = isAutoSave && existing?.is_partial !== false;
 
-  // Response legacy que conservou o sentinela `{}` (ver buildReconciledFieldHashes,
-  // #520): sem snapshot per-campo, `isFieldStale` cai no fallback do schema
-  // INTEIRO e compara `pydantic_hash`. Promover a coluna aqui tornaria esse
-  // fallback permissivo — a codificação antiga passaria a ser lida como feita
-  // contra o schema de hoje e nenhum campo apareceria stale, reintroduzindo o
-  // falso "(vazio)" divergente que answer-staleness.ts descreve. Preservar o
-  // valor gravado mantém o fallback conservador — é a outra metade do par que
-  // `isFieldStale` sustenta. `version_inferred_from` acompanha pelo mesmo
-  // motivo: carimbar "live_save" fixaria uma versão que este save não prova.
-  // Só vale para UPDATE: numa codificação nova não há proveniência anterior a
-  // preservar, e mapa vazio ali significa projeto sem campos, não legacy.
-  //
-  // Custo assumido (#548): em troca, a response legacy deixa de ser promovida à
-  // versão corrente por um save. `responseQualifiesForVersion` (compare-version.ts)
-  // curto-circuita em `pydantic_hash === null` e, adiante, compara
-  // `schema_version_major` com o piso — então ela pode ficar fora da fila
-  // `latest_major` mesmo depois de recodificada por inteiro. Hoje isso é inerte
-  // (medido em 2026-07-23: 8 responses legacy, todas já com a major do projeto);
-  // passa a importar no próximo bump MAJOR. A raiz é `pydantic_hash` servir a
-  // dois consumidores com necessidades opostas — o staleness quer o hash da
-  // época, o gate de versão quer o de hoje.
-  const keepsLegacyProvenance = !!existing && Object.keys(answerFieldHashes).length === 0;
-  const schemaProvenance = keepsLegacyProvenance
-    ? {}
-    : {
-        pydantic_hash: project?.pydantic_hash ?? null,
-        schema_version_major: project?.schema_version_major ?? 0,
-        schema_version_minor: project?.schema_version_minor ?? 1,
-        schema_version_patch: project?.schema_version_patch ?? 0,
-        version_inferred_from: "live_save",
-      };
-
   const payload = {
     answers: answersToPersist,
     justifications,
     answer_field_hashes: answerFieldHashes,
-    ...schemaProvenance,
+    ...resolveSchemaProvenance({ project, answerFieldHashes, hasRevision, existing }),
     round_id: roundIdToPersist,
     is_partial: isPartialToWrite,
     // Marca a codificacao do pesquisador no tempo — alimenta a ordenacao
@@ -260,6 +291,7 @@ export async function saveResponse(
     const payload = buildResponsePayload({
       answersToPersist: snapshot.persistedAnswers,
       answerFieldHashes: snapshot.answerFieldHashes,
+      hasRevision: snapshot.hasRevision,
       project,
       existing,
       isAutoSave,

--- a/frontend/src/lib/__tests__/response-snapshot.test.ts
+++ b/frontend/src/lib/__tests__/response-snapshot.test.ts
@@ -403,3 +403,65 @@ describe("buildPersistedResponseSnapshot", () => {
     expect(result.answerFieldHashes).toEqual({ legado: "hash-antigo" });
   });
 });
+
+describe("buildPersistedResponseSnapshot — hasRevision (#529)", () => {
+  const single = (name: string, hash: string): PydanticField =>
+    field({ name, type: "single", options: ["a", "b"], hash });
+
+  it("false quando o pesquisador re-confirma o mesmo valor (toque/auto-save)", () => {
+    // O sinal que autoriza promover as colunas de versão. Re-submeter o valor
+    // já apresentado não é revisão: `samePresentedValue` o exclui de
+    // changedFieldNames, então nenhum campo ganha o hash de hoje.
+    const result = buildPersistedResponseSnapshot({
+      fields: [single("q1", "h1")],
+      existing: { answers: { q1: "a" }, hashes: { q1: "h1" } },
+      rawSubmittedAnswers: { q1: "a" },
+    });
+
+    expect(result.hasRevision).toBe(false);
+  });
+
+  it("true quando um valor é de fato alterado", () => {
+    const result = buildPersistedResponseSnapshot({
+      fields: [single("q1", "h1")],
+      existing: { answers: { q1: "a" }, hashes: { q1: "h1" } },
+      rawSubmittedAnswers: { q1: "b" },
+    });
+
+    expect(result.hasRevision).toBe(true);
+  });
+
+  it("true quando um campo criado depois é de fato respondido", () => {
+    // Simétrico com o hash: o campo novo ganha o hash de hoje, e o save promove.
+    const result = buildPersistedResponseSnapshot({
+      fields: [single("antigo", "antigo-hash"), single("novo", "novo-hash")],
+      existing: { answers: { antigo: "a" }, hashes: { antigo: "antigo-hash" } },
+      rawSubmittedAnswers: { antigo: "a", novo: "b" },
+    });
+
+    expect(result.hasRevision).toBe(true);
+  });
+
+  it("false quando a revisão apenas apaga o valor (fora de persistedAnswers)", () => {
+    // Limpar um campo muda changedFieldNames, mas o valor não persiste — nada
+    // é escrito sob o schema de hoje, então a linha conserva a época.
+    const result = buildPersistedResponseSnapshot({
+      fields: [single("q1", "h1")],
+      existing: { answers: { q1: "a" }, hashes: { q1: "h1" } },
+      rawSubmittedAnswers: {},
+    });
+
+    expect(result.persistedAnswers).toEqual({});
+    expect(result.hasRevision).toBe(false);
+  });
+
+  it("codificação nova com resposta real é revisão", () => {
+    const result = buildPersistedResponseSnapshot({
+      fields: [single("q1", "h1")],
+      existing: null,
+      rawSubmittedAnswers: { q1: "a" },
+    });
+
+    expect(result.hasRevision).toBe(true);
+  });
+});

--- a/frontend/src/lib/response-snapshot.ts
+++ b/frontend/src/lib/response-snapshot.ts
@@ -57,6 +57,14 @@ export interface PersistedResponseSnapshot {
   submittedAnswers: Record<string, unknown>;
   persistedAnswers: Record<string, unknown>;
   answerFieldHashes: Exclude<AnswerFieldHashes, null>;
+  // True quando ao menos um campo teve o VALOR escrito/alterado sob o schema de
+  // hoje neste save — exatamente o conjunto que ganha o hash de hoje no ramo de
+  // herança de `buildReconciledFieldHashes` (`changedFieldNames ∩
+  // persistedAnswers`). "Trafegou no formulário" ou re-confirmar o mesmo valor
+  // NÃO conta (`samePresentedValue` os exclui de `changedFieldNames`). É o sinal
+  // que autoriza promover as colunas de versão da response (ver
+  // `buildResponsePayload`, #529): sem revisão real, a linha conserva a época.
+  hasRevision: boolean;
 }
 
 /**
@@ -184,6 +192,18 @@ function withAnswerProvenanceFallback(
 // bump "passar a dever" os campos novos e reaparecer como pendente sem o
 // pesquisador ter feito nada (#520). Um campo novo só entra quando é de fato
 // respondido — aí a chave é verdadeira e o hash atual é a proveniência correta.
+// Nomes dos campos revisados neste save cujo valor persiste — o conjunto que
+// ganha o hash de HOJE no ramo de herança de `buildReconciledFieldHashes`. Um
+// campo revisado que ficou oculto/apagado (fora de `persistedAnswers`) não
+// entra. Fonte única do sinal de "houve revisão real": consumido pela herança
+// de hashes e por `hasRevision` (colunas de versão, #529).
+function revisedPersistedFieldNames(
+  persistedAnswers: Record<string, unknown>,
+  changedFieldNames: Set<string>,
+): string[] {
+  return [...changedFieldNames].filter((fieldName) => hasOwn(persistedAnswers, fieldName));
+}
+
 function buildReconciledFieldHashes(
   fields: PydanticField[],
   existing: ExistingResponseSnapshot | null,
@@ -207,8 +227,7 @@ function buildReconciledFieldHashes(
   const hashes: Exclude<AnswerFieldHashes, null> = { ...storedHashes };
   // Só o que o pesquisador revisou neste save ganha a proveniência de hoje;
   // o resto conserva a versão contra a qual foi respondido.
-  for (const fieldName of changedFieldNames) {
-    if (!hasOwn(persistedAnswers, fieldName)) continue;
+  for (const fieldName of revisedPersistedFieldNames(persistedAnswers, changedFieldNames)) {
     hashes[fieldName] = hasOwn(currentHashes, fieldName) ? currentHashes[fieldName] : null;
   }
   return withAnswerProvenanceFallback(hashes, persistedAnswers);
@@ -245,6 +264,8 @@ export function buildPersistedResponseSnapshot({
     persistedAnswers,
     reconciled.changedFieldNames,
   );
+  const hasRevision =
+    revisedPersistedFieldNames(persistedAnswers, reconciled.changedFieldNames).length > 0;
 
-  return { submittedAnswers, persistedAnswers, answerFieldHashes };
+  return { submittedAnswers, persistedAnswers, answerFieldHashes, hasRevision };
 }


### PR DESCRIPTION
## Problema

Desdobramento do #520/#528. Depois do #528, `answer_field_hashes` registra a **época real** de cada resposta — o hash de um campo só é recarimbado quando ele é de fato revisado. Mas `buildResponsePayload` (`frontend/src/actions/responses.ts`) continuava promovendo `pydantic_hash`, `schema_version_*` e `version_inferred_from: "live_save"` para a versão corrente do projeto em **todo save**, inclusive auto-save por navegação sem edição.

Consequência: uma codificação v1 apenas reaberta e tocada virava "v2" nas colunas, enquanto os hashes seguiam dizendo "v1" — linha assimétrica (**hashes de época × colunas promovidas**) que a fazia contar como da versão corrente no gate `latest_major` da Comparação sem revisão alguma.

## Decisão de semântica

Conforme discutido, a semântica correta é: as colunas de versão só avançam quando **ao menos um campo tem valor efetivamente escrito/alterado neste save** — o mesmo conjunto (`changedFieldNames ∩ persistedAnswers`) que já ganha o hash de hoje no mapa per-campo do #528. Toque/auto-save sem edição, e re-confirmar o mesmo valor, deixam de promover. As colunas ficam simétricas ao mapa: "a versão mais nova sob a qual algum valor desta linha foi de fato escrito".

## O que muda

- Generaliza o guard do #528. Além do gatilho de staleness (mapa legacy `{}`), `resolveSchemaProvenance` passa a omitir as 5 colunas de versão do UPDATE quando `!hasRevision`. Os dois gatilhos ficam **independentes** (uma legacy pode ter revisão real e ainda conservar `{}`).
- `hasRevision` é exposto por `buildPersistedResponseSnapshot` (`response-snapshot.ts`) como **fonte única**, derivado do mesmo `revisedPersistedFieldNames` que decide quais campos ganham o hash de hoje.
- INSERT (codificação nova) segue sempre carimbando o schema de hoje — não há proveniência anterior a preservar.
- Extrai `resolveSchemaProvenance` e reusa `deriveProjectVersionContext` para o fallback `{0,1,0}`, removendo a duplicação que o cabeçalho de `compare-version.ts` marca como load-bearing.

**Seguro para staleness:** em responses não-legacy, `isFieldStale` usa o mapa per-campo, **nunca** `pydantic_hash` — então preservar as colunas não afeta a detecção de stale (diferente do caso legacy do #528/#548). Para não-legacy, as colunas servem só ao gate de versão da Comparação; o novo comportamento é o desejado: codificação não revisada sob o novo schema não conta como da versão nova.

## Verificação (tier 1 — write path de codificações + membership da Comparação)

- **Prova do vermelho:** revertendo só o código de produção contra `origin/main`, os **6 testes novos** do #529 falham (1 em `responses.test.ts` + 5 em `response-snapshot.test.ts`); os 41 pré-existentes passam.
- **Mutação dos dois gatilhos na versão final**, um a um: remover `|| !hasRevision` → 1 vermelho (o teste #529 do toque sem revisão); remover `Object.keys(...).length === 0 ||` → 1 vermelho (o teste legacy #520). Ambos load-bearing.
- **Suíte completa** 1829/1829, typecheck, `lint:types` (só 2 warnings pré-existentes, 0 errors), fallow new-only (exit 0), semgrep — todos verdes no pre-push. E2E `coding-save.smoke` OK (a 1ª run a frio bateu no flakiness já rastreado #550; a 2ª passou limpa).
- **Resíduo em produção (read-only, 2026-07-23):** 856 responses `is_latest`; **34 assimétricas** (promovidas + com campo de época anterior), todas no projeto Zolgensma `0c6394da` (v0.20.0). Por ser major-0, o piso `latest_major` = {0,20,0}, então essas 34 hoje entram na fila por causa da promoção espúria. Este PR **impede novas**; não repara as existentes — o reparo de dado das 34 fica na #579 (não embutido aqui, como combinado, pois exige re-inferir a versão via schema-backfill).

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)
