### PR TITLE
fix(codificação): promove response legacy à versão corrente na recodificação completa (#548)

### DIFF
--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { isCodingComplete } from "@/lib/coding-completeness";
+import { responseQualifiesForVersion } from "@/lib/compare-version";
+import type { VersionedResponse } from "@/lib/compare-version";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 const drainAutoReviewReconciliationRequests = vi.hoisted(() => vi.fn(async () => ({
@@ -458,6 +460,53 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(state.responseInsertPayload?.pydantic_hash).toBe("hash-1");
     expect(state.responseInsertPayload?.schema_version_major).toBe(1);
     expect(state.responseInsertPayload?.version_inferred_from).toBe("live_save");
+  });
+
+  it("submit que recodifica a response legacy por completo a devolve à fila latest_major (#548)", async () => {
+    // Critério de aceite da #548, acoplando saveResponse a
+    // responseQualifiesForVersion: uma response legacy (sentinela) recodificada
+    // por inteiro num submit explícito precisa (a) estampar a proveniência
+    // corrente, (b) promover pydantic_hash + schema_version e (c) voltar a
+    // qualificar para o piso `latest_major`. Antes do #548 o mapa saía `{}`, as
+    // colunas eram omitidas e o gate curto-circuitava em `pydantic_hash === null`.
+    state.pydanticFields = [
+      { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: null,
+    };
+
+    const saveResponse = await loadSaveResponse();
+    // Submit explícito (isAutoSave default = false) completando o schema atual.
+    await saveResponse("proj-1", "doc-1", { q1: "b" });
+
+    // (a) proveniência corrente estampada — deixa de ser o sentinela.
+    expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({ q1: "h1" });
+    // (b) colunas de versão promovidas.
+    expect(state.responseUpdatePayload?.pydantic_hash).toBe("hash-1");
+    expect(state.responseUpdatePayload?.schema_version_major).toBe(1);
+    expect(state.responseUpdatePayload?.version_inferred_from).toBe("live_save");
+
+    // (c) o payload gravado qualifica para o piso da major corrente.
+    const payload = state.responseUpdatePayload as Record<string, unknown>;
+    const versioned: VersionedResponse = {
+      respondent_type: "humano",
+      is_latest: true,
+      pydantic_hash: payload.pydantic_hash as string,
+      schema_version_major: payload.schema_version_major as number,
+      schema_version_minor: payload.schema_version_minor as number,
+      schema_version_patch: payload.schema_version_patch as number,
+    };
+    expect(
+      responseQualifiesForVersion(
+        versioned,
+        { major: 1, minor: 0, patch: 0 },
+        { pydanticHash: "hash-1", version: { major: 1, minor: 0, patch: 0 } },
+      ),
+    ).toBe(true);
   });
 
   it("auto-save com campo obrigatorio vazio mantem pendente em em_andamento", async () => {

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -87,6 +87,48 @@ interface BuildResponsePayloadParams {
   notes?: string;
 }
 
+// Colunas de proveniência de schema (`pydantic_hash`, `schema_version_*`,
+// `version_inferred_from`) que este save grava — ou nenhuma, quando a response
+// conserva o sentinela legacy.
+//
+// Response legacy que conservou o sentinela `{}` (ver buildReconciledFieldHashes,
+// #520): sem snapshot per-campo, `isFieldStale` cai no fallback do schema
+// INTEIRO e compara `pydantic_hash`. Promover a coluna aqui tornaria esse
+// fallback permissivo — a codificação antiga passaria a ser lida como feita
+// contra o schema de hoje e nenhum campo apareceria stale, reintroduzindo o
+// falso "(vazio)" divergente que answer-staleness.ts descreve. Preservar o
+// valor gravado mantém o fallback conservador — é a outra metade do par que
+// `isFieldStale` sustenta. `version_inferred_from` acompanha pelo mesmo motivo:
+// carimbar "live_save" fixaria uma versão que este save não prova. Só vale para
+// UPDATE: numa codificação nova não há proveniência anterior a preservar, e
+// mapa vazio ali significa projeto sem campos, não legacy.
+//
+// Via de saída (#548): a promoção volta a acontecer, mas só no momento
+// legítimo — quando um submit explícito recodifica a response legacy por
+// completo contra o schema atual, `buildReconciledFieldHashes` estampa o mapa
+// corrente inteiro (deixa de ser `{}`), `keepsLegacy` fica `false` e
+// `pydantic_hash` + `schema_version_*` são promovidos. Aí não há tensão: como
+// tudo foi recodificado, o staleness ser permissivo é o correto. Fora desse
+// momento (parcial ou auto-save) o mapa segue `{}` e a proveniência gravada é
+// preservada. A raiz do conflito permanece `pydantic_hash` servir a dois
+// consumidores com necessidades opostas — o staleness quer o hash da época, o
+// gate de versão quer o de hoje —, mas a recodificação completa é o instante em
+// que os dois lados coincidem.
+function buildSchemaProvenance(
+  project: SaveResponseProjectFields | null | undefined,
+  keepsLegacy: boolean,
+): Record<string, unknown> {
+  if (keepsLegacy) return {};
+  const p: Partial<SaveResponseProjectFields> = project ?? {};
+  return {
+    pydantic_hash: p.pydantic_hash ?? null,
+    schema_version_major: p.schema_version_major ?? 0,
+    schema_version_minor: p.schema_version_minor ?? 1,
+    schema_version_patch: p.schema_version_patch ?? 0,
+    version_inferred_from: "live_save",
+  };
+}
+
 function buildResponsePayload({
   answersToPersist,
   answerFieldHashes,
@@ -109,37 +151,8 @@ function buildResponsePayload({
   // 20260425000000 vale so para o fluxo LLM.
   const isPartialToWrite = isAutoSave && existing?.is_partial !== false;
 
-  // Response legacy que conservou o sentinela `{}` (ver buildReconciledFieldHashes,
-  // #520): sem snapshot per-campo, `isFieldStale` cai no fallback do schema
-  // INTEIRO e compara `pydantic_hash`. Promover a coluna aqui tornaria esse
-  // fallback permissivo — a codificação antiga passaria a ser lida como feita
-  // contra o schema de hoje e nenhum campo apareceria stale, reintroduzindo o
-  // falso "(vazio)" divergente que answer-staleness.ts descreve. Preservar o
-  // valor gravado mantém o fallback conservador — é a outra metade do par que
-  // `isFieldStale` sustenta. `version_inferred_from` acompanha pelo mesmo
-  // motivo: carimbar "live_save" fixaria uma versão que este save não prova.
-  // Só vale para UPDATE: numa codificação nova não há proveniência anterior a
-  // preservar, e mapa vazio ali significa projeto sem campos, não legacy.
-  //
-  // Custo assumido (#548): em troca, a response legacy deixa de ser promovida à
-  // versão corrente por um save. `responseQualifiesForVersion` (compare-version.ts)
-  // curto-circuita em `pydantic_hash === null` e, adiante, compara
-  // `schema_version_major` com o piso — então ela pode ficar fora da fila
-  // `latest_major` mesmo depois de recodificada por inteiro. Hoje isso é inerte
-  // (medido em 2026-07-23: 8 responses legacy, todas já com a major do projeto);
-  // passa a importar no próximo bump MAJOR. A raiz é `pydantic_hash` servir a
-  // dois consumidores com necessidades opostas — o staleness quer o hash da
-  // época, o gate de versão quer o de hoje.
   const keepsLegacyProvenance = !!existing && Object.keys(answerFieldHashes).length === 0;
-  const schemaProvenance = keepsLegacyProvenance
-    ? {}
-    : {
-        pydantic_hash: project?.pydantic_hash ?? null,
-        schema_version_major: project?.schema_version_major ?? 0,
-        schema_version_minor: project?.schema_version_minor ?? 1,
-        schema_version_patch: project?.schema_version_patch ?? 0,
-        version_inferred_from: "live_save",
-      };
+  const schemaProvenance = buildSchemaProvenance(project, keepsLegacyProvenance);
 
   const payload = {
     answers: answersToPersist,
@@ -255,6 +268,9 @@ export async function saveResponse(
         ? { answers: existing.answers, hashes: existing.answer_field_hashes }
         : null,
       rawSubmittedAnswers: answers,
+      // Só um submit explícito atesta a codificação inteira; auto-save não pode
+      // promover uma response legacy à versão corrente (#548).
+      promoteLegacyIfComplete: !isAutoSave,
     });
 
     const payload = buildResponsePayload({

--- a/frontend/src/lib/__tests__/response-snapshot.test.ts
+++ b/frontend/src/lib/__tests__/response-snapshot.test.ts
@@ -131,6 +131,7 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: storedAnswers, hashes: storedHashes },
       rawSubmittedAnswers,
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -170,6 +171,7 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", detalhe: "d-old" },
       },
       rawSubmittedAnswers: { gatilho: "nao" },
+      promoteLegacyIfComplete: false,
     });
 
     // Só o gatilho foi revisado, então só ele ganha a proveniência de hoje. O
@@ -198,6 +200,7 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", detalhe: "d-old" },
       },
       rawSubmittedAnswers: { gatilho: "nao" },
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.submittedAnswers).toEqual({ gatilho: "nao" });
@@ -229,6 +232,7 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", filho: "f-old", neto: "n-old" },
       },
       rawSubmittedAnswers: { gatilho: "nao" },
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({ gatilho: "nao" });
@@ -267,6 +271,7 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", intermediario: "i-old", descendente: "d-old" },
       },
       rawSubmittedAnswers: { gatilho: "B", intermediario: "ocultar" },
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -295,6 +300,7 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", detalhe: "d-old" },
       },
       rawSubmittedAnswers: { outro: "novo" },
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -326,12 +332,67 @@ describe("buildPersistedResponseSnapshot", () => {
         fields,
         existing: { answers: { stale: "A" }, hashes: storedHashes },
         rawSubmittedAnswers: { outro: "novo" },
+        promoteLegacyIfComplete: false,
       });
 
       expect(result.persistedAnswers).toEqual({ stale: "A", outro: "novo" });
       expect(result.answerFieldHashes).toEqual({});
     },
   );
+
+  it("submit explícito que recodifica a response legacy por completo estampa o schema atual (#548)", () => {
+    // Único momento em que dá para afirmar que todos os campos de hoje existiam:
+    // o submit está completo contra o schema atual. Estampar o mapa inteiro
+    // desliga o sentinela e habilita a promoção de versão em buildResponsePayload.
+    const fields = [
+      field({ name: "q1", type: "single", options: ["a", "b"], hash: "h1" }),
+      field({ name: "q2", hash: "h2" }),
+    ];
+
+    const result = buildPersistedResponseSnapshot({
+      fields,
+      existing: { answers: { q1: "a", q2: "velho" }, hashes: null },
+      rawSubmittedAnswers: { q1: "b", q2: "novo" },
+      promoteLegacyIfComplete: true,
+    });
+
+    expect(result.answerFieldHashes).toEqual({ q1: "h1", q2: "h2" });
+  });
+
+  it("submit incompleto de response legacy conserva o sentinela mesmo com promoção habilitada (#548)", () => {
+    // q2 é obrigatório e ficou em branco: a codificação NÃO está completa contra
+    // o schema atual, então não dá para afirmar proveniência — mantém `{}`.
+    const fields = [
+      field({ name: "q1", type: "single", options: ["a", "b"], hash: "h1" }),
+      field({ name: "q2", hash: "h2" }),
+    ];
+
+    const result = buildPersistedResponseSnapshot({
+      fields,
+      existing: { answers: { q1: "a" }, hashes: null },
+      rawSubmittedAnswers: { q1: "b" },
+      promoteLegacyIfComplete: true,
+    });
+
+    expect(result.answerFieldHashes).toEqual({});
+  });
+
+  it("auto-save de response legacy nunca promove, ainda que completa (#548)", () => {
+    // Auto-save não atesta a codificação inteira: mesmo com todos os obrigatórios
+    // respondidos, `promoteLegacyIfComplete: false` conserva o sentinela.
+    const fields = [
+      field({ name: "q1", type: "single", options: ["a", "b"], hash: "h1" }),
+    ];
+
+    const result = buildPersistedResponseSnapshot({
+      fields,
+      existing: { answers: { q1: "a" }, hashes: null },
+      rawSubmittedAnswers: { q1: "b" },
+      promoteLegacyIfComplete: false,
+    });
+
+    expect(result.answerFieldHashes).toEqual({});
+  });
 
   it("codificação nova estampa o schema atual inteiro", () => {
     // Não há response anterior: o schema de hoje É o schema da codificação, e
@@ -346,6 +407,7 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: null,
       rawSubmittedAnswers: { respondido: "x" },
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.answerFieldHashes).toEqual({
@@ -368,6 +430,7 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: { antigo: "a" }, hashes: { antigo: "antigo-hash" } },
       rawSubmittedAnswers: { antigo: "b" },
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({ antigo: "b" });
@@ -384,6 +447,7 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: { antigo: "a" }, hashes: { antigo: "antigo-hash" } },
       rawSubmittedAnswers: { antigo: "a", novo_obrigatorio: "resposta" },
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.answerFieldHashes).toEqual({
@@ -397,6 +461,7 @@ describe("buildPersistedResponseSnapshot", () => {
       fields: [],
       existing: { answers: { legado: "valor" }, hashes: { legado: "hash-antigo" } },
       rawSubmittedAnswers: {},
+      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({ legado: "valor" });

--- a/frontend/src/lib/__tests__/response-snapshot.test.ts
+++ b/frontend/src/lib/__tests__/response-snapshot.test.ts
@@ -4,6 +4,7 @@ import {
   sanitizeStoredAnswers,
 } from "@/lib/response-snapshot";
 import { OTHER_PREFIX } from "@/lib/other-option";
+import { buildFieldHashMap, isFieldStale } from "@/lib/answer-staleness";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 const field = (input: Partial<PydanticField> & { name: string }): PydanticField =>
@@ -357,6 +358,40 @@ describe("buildPersistedResponseSnapshot", () => {
     });
 
     expect(result.answerFieldHashes).toEqual({ q1: "h1", q2: "h2" });
+  });
+
+  it("a proveniência promovida não marca nenhum campo falsamente stale (#548)", () => {
+    // Outra metade do par que answer-staleness.ts sustenta: depois que a
+    // recodificação completa desliga o sentinela, `isFieldStale` sai do fallback
+    // do schema INTEIRO e passa a comparar per-campo. Como o mapa estampado é o
+    // schema corrente, todo campo bate consigo mesmo e nada aparece stale — o
+    // que é o correto, já que tudo foi recodificado contra o schema de hoje.
+    const fields = [
+      field({ name: "q1", type: "single", options: ["a", "b"], hash: "h1" }),
+      field({ name: "q2", hash: "h2" }),
+    ];
+
+    const { answerFieldHashes } = buildPersistedResponseSnapshot({
+      fields,
+      existing: { answers: { q1: "a", q2: "velho" }, hashes: null },
+      rawSubmittedAnswers: { q1: "b", q2: "novo" },
+      promoteLegacyIfComplete: true,
+    });
+
+    const currentFieldHashes = buildFieldHashMap(fields);
+    for (const f of fields) {
+      expect(
+        isFieldStale({
+          answerFieldHashes,
+          // O pydantic_hash antigo (legacy) divergiria do atual: se o snapshot
+          // per-campo NÃO tivesse sido promovido, o fallback marcaria stale.
+          pydanticHash: "hash-legacy",
+          fieldName: f.name,
+          currentFieldHashes,
+          projectPydanticHash: "hash-atual",
+        }),
+      ).toBe(false);
+    }
   });
 
   it("submit incompleto de response legacy conserva o sentinela mesmo com promoção habilitada (#548)", () => {

--- a/frontend/src/lib/response-snapshot.ts
+++ b/frontend/src/lib/response-snapshot.ts
@@ -1,4 +1,5 @@
 import { buildFieldHashMap } from "@/lib/answer-staleness";
+import { isCodingComplete } from "@/lib/coding-completeness";
 import { dropHiddenConditionals, isFieldVisible } from "@/lib/conditional";
 import { isOtherValue } from "@/lib/other-option";
 import { resolveAllowOther, resolveTarget } from "@/lib/pydantic-field";
@@ -76,6 +77,10 @@ interface BuildPersistedResponseSnapshotParams {
   fields: PydanticField[];
   existing: ExistingResponseSnapshot | null;
   rawSubmittedAnswers: Record<string, unknown>;
+  // Submit explícito (não auto-save): habilita a promoção de uma response
+  // legacy à proveniência corrente quando este save a recodifica por completo
+  // contra o schema atual (#548). Auto-save nunca promove — não atesta nada.
+  promoteLegacyIfComplete: boolean;
 }
 
 function samePresentedValue(
@@ -189,6 +194,7 @@ function buildReconciledFieldHashes(
   existing: ExistingResponseSnapshot | null,
   persistedAnswers: Record<string, unknown>,
   changedFieldNames: Set<string>,
+  promoteLegacyIfComplete: boolean,
 ): Exclude<AnswerFieldHashes, null> {
   const currentHashes = buildFieldHashMap(fields);
 
@@ -202,7 +208,21 @@ function buildReconciledFieldHashes(
   // inverteria o sentinela em "só estes existiam", perdoando obrigatórios que
   // ficaram em branco de verdade. Permanece grosseiro até que uma codificação
   // nova estabeleça proveniência.
-  if (!storedHashes || Object.keys(storedHashes).length === 0) return {};
+  //
+  // Via de saída (#548): uma recodificação COMPLETA — submit explícito
+  // (`promoteLegacyIfComplete`) cuja codificação fica completa contra o schema
+  // ATUAL — é o único momento em que dá para afirmar que todos os campos de
+  // hoje existiam. Aí estampamos o schema inteiro como uma codificação nova,
+  // desligando o sentinela. Isso libera `keepsLegacyProvenance` em
+  // `buildResponsePayload` a promover `pydantic_hash` + `schema_version_*`, e a
+  // response volta à fila `latest_major`. Fora daí (parcial ou auto-save) o
+  // sentinela é conservado, mantendo o fallback de staleness conservador.
+  if (!storedHashes || Object.keys(storedHashes).length === 0) {
+    if (promoteLegacyIfComplete && isCodingComplete(fields, persistedAnswers)) {
+      return withAnswerProvenanceFallback(currentHashes, persistedAnswers);
+    }
+    return {};
+  }
 
   const hashes: Exclude<AnswerFieldHashes, null> = { ...storedHashes };
   // Só o que o pesquisador revisou neste save ganha a proveniência de hoje;
@@ -221,6 +241,7 @@ export function buildPersistedResponseSnapshot({
   fields,
   existing,
   rawSubmittedAnswers,
+  promoteLegacyIfComplete,
 }: BuildPersistedResponseSnapshotParams): PersistedResponseSnapshot {
   const storedAnswers = existing?.answers;
   // A leitura sem schema expõe o JSON bruto por compatibilidade, mas não há
@@ -244,6 +265,7 @@ export function buildPersistedResponseSnapshot({
     existing,
     persistedAnswers,
     reconciled.changedFieldNames,
+    promoteLegacyIfComplete,
   );
 
   return { submittedAnswers, persistedAnswers, answerFieldHashes };


### PR DESCRIPTION
## Contexto

Follow-up do #528. O guard daquele PR omite `pydantic_hash` + `schema_version_*` do UPDATE enquanto uma response conserva o sentinela legacy (`answer_field_hashes` vazio) — necessário para manter conservador o fallback de `isFieldStale` (`answer-staleness.ts`). Mas `buildReconciledFieldHashes` retornava `{}` **incondicionalmente** para legacy, então o sentinela nunca desligava: `keepsLegacyProvenance` ficava `true` para sempre e a response não era promovida à versão corrente **nem quando o pesquisador recodificava todos os campos**. Consequência: `responseQualifiesForVersion` a mantinha fora da fila `latest_major` (curto-circuita em `pydantic_hash === null` / compara `schema_version_major`).

A raiz (issue): `pydantic_hash` serve a dois consumidores opostos — o staleness quer o hash *da época*, o gate de versão quer o de *hoje*.

## Correção (path 3 da issue — raiz, não fallback)

Existe **um único momento** em que dá para afirmar que todos os campos atuais existiam na codificação: quando um **submit explícito** recodifica a response **de modo que ela fique completa** contra o schema de hoje (o predicado real é `isCodingComplete` contra o schema atual, não "cada campo re-tocado neste submit" — o formulário devolve o snapshot completo, então um submit explícito completo certifica a codificação inteira). Aí `buildReconciledFieldHashes` estampa o mapa de proveniência corrente inteiro (como uma codificação nova), o que:

- desliga o sentinela → `isFieldStale` usa o caminho per-campo; nada aparece stale (correto, tudo foi recodificado);
- libera `keepsLegacyProvenance` a promover `pydantic_hash` + `schema_version_*`;
- devolve a response à fila `latest_major`.

Edições **parciais** e **auto-save** conservam o sentinela — o fallback segue conservador nos campos não revisados. O gatilho é `!isAutoSave`: auto-save não atesta a codificação inteira.

As 4 responses legacy com `pydantic_hash` nulo do Zolgensma (efeito inerte hoje) ficam como estão — curam-se se/quando forem recodificadas por completo. Sem migration de dados.

## Arquivos

- `frontend/src/lib/response-snapshot.ts` — via de saída no ramo legacy de `buildReconciledFieldHashes`, gated por `promoteLegacyIfComplete && isCodingComplete(...)`.
- `frontend/src/actions/responses.ts` — `saveResponse` passa `promoteLegacyIfComplete: !isAutoSave`; comentário do custo atualizado; `schemaProvenance` extraído em `buildSchemaProvenance` (helper puro).

## Verificação (tier 1 — write path de responses)

- **Prova do vermelho + mutação:** neutralizar a via de saída mata os 2 testes de promoção; remover a checagem do flag mata o caso auto-save + os sentinela; remover a checagem de completude mata o caso do submit incompleto. Cada cláusula do guard morde independentemente.
- **Teste de acoplamento (critério de aceite):** novo teste liga `saveResponse` a `responseQualifiesForVersion` — response legacy recodificada por completo qualifica para o piso `latest_major`.
- **Par de invariantes fechado:** novo teste de integração alimenta a proveniência promovida em `isFieldStale` e prova que nenhum campo aparece falsamente stale após a promoção (a outra metade do par que `answer-staleness.ts` sustenta). Prova do vermelho: sem a via de saída, o mapa vazio cai no fallback de `pydanticHash` e marca stale.
- Suíte verde, typecheck, lint:types, fallow, semgrep e e2e smoke verdes.

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)
