### PR TITLE
fix(codificação): sinal de submissão derivado do que foi gravado (#519)

### DIFF
--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -268,6 +268,60 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(state.assignmentUpdatePayload?.status).toBe("concluido");
   });
 
+  it("submit explicito com obrigatoria em branco grava is_partial=true", async () => {
+    // O sinal descreve o conjunto GRAVADO, nao o canal da escrita: sem isso, um
+    // envio incompleto ficava indistinguivel de uma conclusao — o documento
+    // voltava a fila e o pesquisador lia como "nao salvou" (#519).
+    state.pydanticFields = [
+      { name: "q1", type: "text", required: true, hash: "h-q1" },
+      { name: "q2", type: "text", required: true, hash: "h-q2" },
+    ];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+    expect(state.responseInsertPayload?.is_partial).toBe(true);
+    // E o cliente recebe a contagem para diferenciar o feedback.
+    expect(r.success && r.missingRequired).toBe(1);
+  });
+
+  it("auto-save que ENCOLHE uma response submetida devolve is_partial=true", async () => {
+    // A heranca do sinal ("ja foi submetida uma vez") sobrevivia a uma escrita
+    // posterior com menos respostas, carimbando de submetido um conjunto
+    // incompleto. Distinto do caso vizinho, onde o conjunto continua completo.
+    state.pydanticFields = [
+      { name: "q1", type: "text", required: true, hash: "h-q1" },
+      { name: "q2", type: "text", required: true, hash: "h-q2" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a", q2: "b" },
+      answer_field_hashes: { q1: "h-q1", q2: "h-q2" },
+    };
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    expect(state.responseUpdatePayload?.answers).toEqual({ q1: "a" });
+    expect(state.responseUpdatePayload?.is_partial).toBe(true);
+  });
+
+  it("campo obrigatorio criado depois NAO rebaixa codificacao antiga em auto-save", async () => {
+    // Espelho do caso real: a codificacao estava completa contra o schema da
+    // epoca; o campo novo so entra na regua se o carimbo provar que ele existia.
+    state.pydanticFields = [
+      { name: "q1", type: "text", required: true, hash: "h-q1" },
+      { name: "q_novo", type: "text", required: true, hash: "h-novo" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: { q1: "h-q1" },
+    };
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    expect(state.responseUpdatePayload?.is_partial).toBe(false);
+    expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({ q1: "h-q1" });
+  });
+
   it("preserva resposta stale e seu hash sem usá-la para concluir a codificação", async () => {
     state.pydanticFields = [
       {

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -4,6 +4,7 @@ import { createSupabaseServer, type SupabaseServerClient } from "@/lib/supabase/
 import { resolveProjectMemberActor } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
+import { isCodingComplete, missingRequiredHumanFields } from "@/lib/coding-completeness";
 import { syncCodingAssignmentStatus } from "@/lib/coding-sync";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
@@ -13,7 +14,14 @@ export interface SaveResponseOpts {
 }
 
 export type SaveResponseResult =
-  | { success: true }
+  // `missingRequired`: obrigatórias ainda em branco no conjunto GRAVADO (0 =
+  // codificação completa). É a mesma contagem que decide `is_partial`, e vai ao
+  // cliente para o feedback distinguir "salvo" de "concluído" (#519). Opcional
+  // porque só `saveResponse` a computa — o adapter `saveCodingResponse` a repassa
+  // mas seu ramo de erro de transporte não a tem, e `notifySaved` lê `undefined`
+  // como "completo". União (não interface achatada) para manter irrepresentável
+  // o estado `{ success: true, error }`.
+  | { success: true; missingRequired?: number }
   | { success: false; error: string };
 
 // Response já existente do mesmo respondente para o mesmo documento. `answers`
@@ -79,6 +87,7 @@ interface SaveResponseProjectFields {
 }
 
 interface BuildResponsePayloadParams {
+  fields: PydanticField[];
   answersToPersist: Record<string, unknown>;
   answerFieldHashes: Exclude<AnswerFieldHashes, null>;
   project: SaveResponseProjectFields | null | undefined;
@@ -88,6 +97,7 @@ interface BuildResponsePayloadParams {
 }
 
 function buildResponsePayload({
+  fields,
   answersToPersist,
   answerFieldHashes,
   project,
@@ -100,14 +110,28 @@ function buildResponsePayload({
   const roundIdToPersist =
     project?.round_strategy === "manual" ? (project?.current_round_id ?? null) : null;
 
-  // Para humanos is_partial e mutavel: auto-save grava true (segue como
-  // current_pending em classifyDocStatus) e submit explicito grava false.
-  // Excecao: auto-save em response ja submetida (is_partial=false) NAO
-  // rebaixa o sinal — combinado com o guard que preserva assignment.status
-  // = "concluido", esse rebaixamento faria um doc ja concluido reaparecer
-  // como pendente em classifyDocStatus. A imutabilidade descrita na migration
+  // Para humanos is_partial descreve O QUE FOI GRAVADO, não por qual canal a
+  // escrita chegou: uma resposta só deixa de ser parcial quando o conjunto
+  // gravado satisfaz a régua de completude E o pesquisador já enviou (submit
+  // explícito). Enquanto o sinal era função apenas do canal
+  // (`isAutoSave && existing?.is_partial !== false`), um auto-save herdava o
+  // `false` de um submit anterior e podia carimbar "submetida" um conjunto que
+  // já não estava completo — o estado que fazia o documento voltar à fila com
+  // aparência de concluído (#519).
+  //
+  // Staleness-aware de propósito: avaliar contra o carimbo per-campo da própria
+  // resposta (`answerFieldHashes`) impede que um campo obrigatório criado depois
+  // rebaixe uma codificação que estava completa quando foi feita.
+  // O auto-save continua sem promover nada por conta própria — quem nunca enviou
+  // segue parcial mesmo com tudo preenchido; combinado com o guard que preserva
+  // assignment.status = "concluido" em coding-sync, um auto-save posterior a um
+  // submit também não rebaixa um doc já concluído (salvo se o conjunto encolheu
+  // e deixou de estar completo). A imutabilidade descrita na migration
   // 20260425000000 vale so para o fluxo LLM.
-  const isPartialToWrite = isAutoSave && existing?.is_partial !== false;
+  const submittedBefore = existing?.is_partial === false;
+  const isPartialToWrite =
+    !isCodingComplete(fields, answersToPersist, answerFieldHashes) ||
+    (isAutoSave && !submittedBefore);
 
   // Response legacy que conservou o sentinela `{}` (ver buildReconciledFieldHashes,
   // #520): sem snapshot per-campo, `isFieldStale` cai no fallback do schema
@@ -258,6 +282,7 @@ export async function saveResponse(
     });
 
     const payload = buildResponsePayload({
+      fields,
       answersToPersist: snapshot.persistedAnswers,
       answerFieldHashes: snapshot.answerFieldHashes,
       project,
@@ -292,7 +317,18 @@ export async function saveResponse(
     }
 
     revalidateAfterSave(projectId, isAutoSave);
-    return { success: true };
+    // Contagem no conjunto GRAVADO (`snapshot.persistedAnswers`), com o mesmo
+    // carimbo staleness-aware que decidiu `is_partial` — não no que a tela
+    // mostrava. Se o schema mudou desde o carregamento do formulário, é ela que
+    // impede o feedback de sucesso de anunciar uma conclusão que não houve (#519).
+    return {
+      success: true,
+      missingRequired: missingRequiredHumanFields(
+        fields,
+        snapshot.persistedAnswers,
+        snapshot.answerFieldHashes,
+      ).length,
+    };
   } catch (e) {
     return {
       success: false,

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -66,6 +66,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     handleSubmitWithValidation,
     requiredFields,
     answeredRequiredCount,
+    missingRequiredCount,
   } = useQuestionValidation(
     visibleFields,
     answers,
@@ -185,6 +186,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         outOfScopeBlocked={outOfScopeBlocked}
         readOnly={readOnly}
         submitting={submitting}
+        missingRequiredCount={missingRequiredCount}
         onClick={handleSubmitWithValidation}
       />
     </div>

--- a/frontend/src/components/coding/SubmitBar.tsx
+++ b/frontend/src/components/coding/SubmitBar.tsx
@@ -1,37 +1,68 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
 
 interface SubmitBarProps {
   outOfScopeBlocked: boolean;
   readOnly: boolean;
   submitting: boolean;
+  /** Obrigatórias visíveis ainda em branco, pela régua de `isCodingComplete`. */
+  missingRequiredCount: number;
   onClick: () => void;
 }
 
-/** Rodapé do painel de perguntas: botão de envio, com texto/estado derivados
- *  de sinalização "fora do escopo" > somente leitura > salvando > normal. */
-export function SubmitBar({ outOfScopeBlocked, readOnly, submitting, onClick }: SubmitBarProps) {
+interface SubmitBarState {
+  label: string;
+  /** Pendência do formulário: neutra, para o botão não convidar ao clique. */
+  pending: boolean;
+  spinner: boolean;
+}
+
+// Estado do botão em ordem de precedência: sinalização "fora do escopo" >
+// somente leitura > salvando > pendências > normal.
+function resolveSubmitBarState({
+  outOfScopeBlocked,
+  readOnly,
+  submitting,
+  missingRequiredCount,
+}: Omit<SubmitBarProps, "onClick">): SubmitBarState {
+  if (outOfScopeBlocked) {
+    return { label: "Aguardando revisão do coordenador", pending: false, spinner: false };
+  }
+  if (readOnly) return { label: "Somente leitura", pending: false, spinner: false };
+  if (submitting) return { label: "Salvando…", pending: false, spinner: true };
+  if (missingRequiredCount > 0) {
+    return {
+      label:
+        missingRequiredCount === 1
+          ? "Falta 1 obrigatória"
+          : `Faltam ${missingRequiredCount} obrigatórias`,
+      pending: true,
+      spinner: false,
+    };
+  }
+  return { label: "Enviar respostas", pending: false, spinner: false };
+}
+
+/** Rodapé do painel de perguntas. A contagem de pendências sai da mesma régua
+ *  que o servidor usa para concluir a codificação: antes de existir, o botão
+ *  prometia "Enviar respostas" a quem ainda não podia enviar, e o pesquisador só
+ *  descobria a pendência depois do clique (#519). O botão segue habilitado —
+ *  quem clica recebe o destaque e o rolamento até o primeiro campo em branco. */
+export function SubmitBar({ onClick, ...state }: SubmitBarProps) {
+  const { label, pending, spinner } = resolveSubmitBarState(state);
   return (
     <div className="border-t px-4 py-3 shrink-0">
       <Button
         onClick={onClick}
-        disabled={submitting || readOnly || outOfScopeBlocked}
-        className="w-full bg-brand hover:bg-brand/90 text-brand-foreground"
+        disabled={state.submitting || state.readOnly || state.outOfScopeBlocked}
+        variant={pending ? "outline" : "default"}
+        className={cn("w-full", !pending && "bg-brand hover:bg-brand/90 text-brand-foreground")}
       >
-        {outOfScopeBlocked ? (
-          "Aguardando revisão do coordenador"
-        ) : readOnly ? (
-          "Somente leitura"
-        ) : submitting ? (
-          <>
-            <Loader2 className="size-4 animate-spin" />
-            Salvando…
-          </>
-        ) : (
-          "Enviar respostas"
-        )}
+        {spinner && <Loader2 className="size-4 animate-spin" />}
+        {label}
       </Button>
     </div>
   );

--- a/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
+++ b/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
@@ -195,8 +195,10 @@ describe("QuestionsPanel — pergunta fora do escopo", () => {
       />,
     );
     expect(screen.getByRole("switch")).toBeTruthy();
-    // Formulário não bloqueado: botão de envio normal.
-    expect(screen.getByRole("button", { name: /Enviar respostas/ })).toBeTruthy();
+    // Formulário não bloqueado: o botão reporta as pendências do próprio
+    // formulário, não o bloqueio por sinalização de fora do escopo.
+    expect(screen.queryByRole("button", { name: /Aguardando revisão/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /Faltam 2 obrigatórias/ })).toBeTruthy();
   });
 
   it("pendente: perguntas inertes e envio substituído por aviso", () => {

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -6,6 +6,7 @@ import {
   autosaveDirtyDoc,
   saveCodingResponse,
 } from "@/lib/coding-autosave";
+import { notifySaved } from "@/lib/coding-save-feedback";
 import { clearHiddenConditionalAnswers } from "@/lib/conditional";
 import { toast } from "sonner";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
@@ -178,7 +179,7 @@ export function useAssignedCoding({
       });
       if (result.success) {
         markClean(currentDoc.id);
-        toast.success("Respostas salvas!");
+        notifySaved(result.missingRequired);
         if (docIndex < sortedDocuments.length - 1) {
           const nextIndex = docIndex + 1;
           dispatch({ type: "index", index: nextIndex });

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useBrowseDocuments } from "@/hooks/useBrowseDocuments";
 import { useDocumentForCoding } from "@/hooks/useDocumentForCoding";
 import { saveCodingResponse } from "@/lib/coding-autosave";
+import { notifySaved } from "@/lib/coding-save-feedback";
 import { type CodingDraft } from "./BrowseDocCoder";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
 import type { AssignedDoc } from "@/lib/types";
@@ -120,7 +121,7 @@ export function useBrowseCoding({
         });
         if (result.success) {
           markClean(browseDocId);
-          toast.success("Respostas salvas!");
+          notifySaved(result.missingRequired);
           markResponded(browseDocId);
           browseDraftRef.current = null;
           // Zera o ?doc= ANTES de invalidar: com browseDocId já null o hook não

--- a/frontend/src/components/coding/useQuestionValidation.ts
+++ b/frontend/src/components/coding/useQuestionValidation.ts
@@ -1,25 +1,23 @@
-import { useCallback, useState, type RefObject } from "react";
+import { useCallback, useMemo, useState, type RefObject } from "react";
 import { toast } from "sonner";
-import { isIncompleteOther } from "@/lib/other-option";
+import {
+  isAnsweredValue,
+  missingRequiredHumanFields,
+  requiredHumanFields,
+} from "@/lib/coding-completeness";
 import { getScrollBehavior } from "@/lib/scroll";
-import { resolveRequired, resolveTarget } from "@/lib/pydantic-field";
 import type { PydanticField } from "@/lib/types";
-
-const isAnsweredValue = (field: PydanticField, val: unknown): boolean => {
-  if (val === undefined || val === null || val === "") return false;
-  if (field.type === "single" && isIncompleteOther(val)) return false;
-  if (field.type === "multi" && Array.isArray(val)) {
-    if (val.length === 0) return false;
-    if (val.some(isIncompleteOther)) return false;
-  }
-  return true;
-};
 
 /**
  * Estado de destaque de obrigatórias faltantes + validação de envio. O
  * highlight de um campo some assim que ele recebe resposta (`handleAnswerWithClear`),
  * e a validação de envio bloqueia por `submitting`/`outOfScopeBlocked` além de
  * checar as obrigatórias visíveis.
+ *
+ * As obrigatórias faltantes saem da MESMA régua que o servidor usa para concluir
+ * a codificação (`missingRequiredHumanFields`, em coding-completeness) — enquanto
+ * a regra vivia duplicada aqui, "o que o botão exige" podia divergir de "o que o
+ * servidor considera concluído" sem nenhum gate reclamar (#519).
  */
 export function useQuestionValidation(
   visibleFields: PydanticField[],
@@ -36,13 +34,21 @@ export function useQuestionValidation(
   handleSubmitWithValidation: () => void;
   requiredFields: PydanticField[];
   answeredRequiredCount: number;
+  missingRequiredCount: number;
 } {
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
 
-  const requiredFields = visibleFields.filter((f) => resolveRequired(f.required));
-  const answeredRequiredCount = requiredFields.filter((f) =>
-    isAnsweredValue(f, answers[f.name]),
-  ).length;
+  // Régua do servidor, avaliada no cliente: o que falta aqui é exatamente o que
+  // impede `isCodingComplete` de promover a codificação a concluída.
+  const requiredFields = useMemo(
+    () => requiredHumanFields(visibleFields, answers),
+    [visibleFields, answers],
+  );
+  const missingRequired = useMemo(
+    () => missingRequiredHumanFields(visibleFields, answers),
+    [visibleFields, answers],
+  );
+  const answeredRequiredCount = requiredFields.length - missingRequired.length;
 
   const isAnswered = useCallback(
     (field: PydanticField) => isAnsweredValue(field, answers[field.name]),
@@ -65,27 +71,22 @@ export function useQuestionValidation(
   const handleSubmitWithValidation = useCallback(() => {
     if (submitting || outOfScopeBlocked) return;
 
-    const unanswered = visibleFields
-      .filter(
-        (f) =>
-          resolveTarget(f.target) !== "llm_only" &&
-          resolveRequired(f.required) &&
-          !isAnswered(f),
-      )
-      .map((f) => f.name);
-
-    if (unanswered.length > 0) {
+    if (missingRequired.length > 0) {
       // Um só `Set`: o mesmo conjunto destaca os campos e localiza o primeiro.
-      const unansweredSet = new Set(unanswered);
-      setHighlightedFields(unansweredSet);
-      const firstIdx = visibleFields.findIndex((f) => unansweredSet.has(f.name));
+      const unanswered = new Set(missingRequired.map((f) => f.name));
+      setHighlightedFields(unanswered);
+      const firstIdx = visibleFields.findIndex((f) => unanswered.has(f.name));
       questionRefs.current[firstIdx]?.scrollIntoView({ behavior: getScrollBehavior(), block: "center" });
-      toast.warning("Preencha todas as perguntas obrigatórias");
+      toast.warning(
+        missingRequired.length === 1
+          ? "Falta 1 pergunta obrigatória para enviar"
+          : `Faltam ${missingRequired.length} perguntas obrigatórias para enviar`,
+      );
       return;
     }
 
     onSubmit();
-  }, [visibleFields, isAnswered, onSubmit, submitting, outOfScopeBlocked, questionRefs]);
+  }, [visibleFields, missingRequired, onSubmit, submitting, outOfScopeBlocked, questionRefs]);
 
   return {
     highlightedFields,
@@ -94,5 +95,6 @@ export function useQuestionValidation(
     handleSubmitWithValidation,
     requiredFields,
     answeredRequiredCount,
+    missingRequiredCount: missingRequired.length,
   };
 }

--- a/frontend/src/lib/__tests__/coding-save-signal.test.ts
+++ b/frontend/src/lib/__tests__/coding-save-signal.test.ts
@@ -1,0 +1,55 @@
+// Régua única de completude compartilhada entre a UI de codificação e o
+// servidor: `missingRequiredHumanFields` decide tanto o que o botão "Enviar"
+// exige quanto o `is_partial` gravado. Enquanto a regra vivia duplicada, "o que
+// o botão exige" podia divergir de "o que o servidor considera concluído" sem
+// nenhum gate reclamar (#519). O carimbo de proveniência em si (o mapa
+// `answer_field_hashes`) é coberto por `response-snapshot.test.ts` (#520/#528);
+// aqui fixamos só a régua que se apoia nele.
+import { describe, it, expect } from "vitest";
+import { missingRequiredHumanFields } from "@/lib/coding-completeness";
+import type { PydanticField } from "@/lib/types";
+
+const field = (partial: Partial<PydanticField> & { name: string }): PydanticField =>
+  ({ type: "text", options: null, ...partial }) as PydanticField;
+
+// Schema de 2 campos contra o qual a codificação foi feita.
+const schemaAntigo = [
+  field({ name: "q1", type: "single", options: ["a", "b"], hash: "h-q1" }),
+  field({ name: "q2", hash: "h-q2" }),
+];
+// Campo obrigatório criado DEPOIS: o caso do `medicamento` no Zolgensma.
+const schemaAtual = [...schemaAntigo, field({ name: "q3_novo", hash: "h-q3" })];
+
+const codificacaoCompleta = { q1: "a", q2: "texto" };
+const carimboDaEpoca = { q1: "h-q1", q2: "h-q2" };
+
+describe("missingRequiredHumanFields — régua única de UI e servidor", () => {
+  it("conta apenas obrigatórias visíveis para humano", () => {
+    const fields = [
+      field({ name: "obrigatoria" }),
+      field({ name: "opcional", required: false }),
+      field({ name: "so_llm", target: "llm_only" }),
+      field({ name: "oculta", condition: { field: "obrigatoria", equals: "x" } }),
+    ];
+    expect(missingRequiredHumanFields(fields, {}).map((f) => f.name)).toEqual(["obrigatoria"]);
+  });
+
+  it("não cobra campo que ainda não existia quando a resposta foi codificada", () => {
+    expect(missingRequiredHumanFields(schemaAtual, codificacaoCompleta, carimboDaEpoca)).toEqual([]);
+    // Sem o carimbo (avaliação staleness-blind), o campo novo é cobrado.
+    expect(
+      missingRequiredHumanFields(schemaAtual, codificacaoCompleta).map((f) => f.name),
+    ).toEqual(["q3_novo"]);
+  });
+
+  it("'Outro:' pela metade e multi vazio contam como faltantes", () => {
+    const fields = [
+      field({ name: "single", type: "single", options: ["a"], allow_other: true }),
+      field({ name: "multi", type: "multi", options: ["a"] }),
+    ];
+    expect(
+      missingRequiredHumanFields(fields, { single: "Outro: ", multi: [] }).map((f) => f.name),
+    ).toEqual(["single", "multi"]);
+    expect(missingRequiredHumanFields(fields, { single: "Outro: x", multi: ["a"] })).toEqual([]);
+  });
+});

--- a/frontend/src/lib/__tests__/viewas-no-write.test.ts
+++ b/frontend/src/lib/__tests__/viewas-no-write.test.ts
@@ -114,7 +114,9 @@ describe("saveResponse — escrita persiste o ator real, nunca o viewAs", () => 
       "member-viewed",
     );
 
-    expect(result).toEqual({ success: true });
+    // `missingRequired` acompanha todo save bem-sucedido: é a contagem de
+    // obrigatórias em aberto no conjunto GRAVADO (0 = codificação completa).
+    expect(result).toEqual({ success: true, missingRequired: 0 });
     // A identidade veio do ator autenticado (por projectId), não de input do caller.
     expect(resolveMemberUserId).toHaveBeenCalledWith("project-1");
 

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -10,7 +10,7 @@ import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 // que já existiam no schema contra o qual a resposta foi codificada
 // (staleness-aware). Os defaults de `target` e `required` saem dos resolvedores
 // de pydantic-field, nunca de uma re-derivação local.
-function requiredHumanFields(
+export function requiredHumanFields(
   fields: PydanticField[],
   answers: Record<string, unknown>,
   answerFieldHashes?: AnswerFieldHashes,
@@ -22,6 +22,36 @@ function requiredHumanFields(
       resolveRequired(f.required) &&
       isFieldVisible(f, answers) &&
       fieldExistedWhenCoded(answerFieldHashes, f.name),
+  );
+}
+
+// Um campo conta como respondido quando tem valor e esse valor não é um
+// "Outro:" pela metade nem uma seleção múltipla vazia. Exportado porque a UI de
+// codificação marca pergunta a pergunta com a MESMA régua que decide completude
+// — duas cópias da regra é o que deixava "o que o botão exige" divergir de "o
+// que o servidor considera concluído" (#519).
+export function isAnsweredValue(field: PydanticField, value: unknown): boolean {
+  if (value === undefined || value === null || value === "") return false;
+  if (field.type === "single" && isIncompleteOther(value)) return false;
+  if (field.type === "multi" && Array.isArray(value)) {
+    if (value.length === 0) return false;
+    if (value.some(isIncompleteOther)) return false;
+  }
+  return true;
+}
+
+// Campos obrigatórios que ainda faltam — a régua de completude na forma que a UI
+// precisa (quantos e quais), com `isCodingComplete` derivado dela. A UI de
+// codificação consome esta primitiva em vez de reimplementar a regra: enquanto
+// existiam duas cópias, "o que o botão exige" e "o que o servidor considera
+// concluído" podiam divergir sem nenhum gate reclamar (ver #519).
+export function missingRequiredHumanFields(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+  answerFieldHashes?: AnswerFieldHashes,
+): PydanticField[] {
+  return requiredHumanFields(fields, answers, answerFieldHashes).filter(
+    (f) => !isAnsweredValue(f, answers[f.name]),
   );
 }
 
@@ -44,15 +74,5 @@ export function isCodingComplete(
   answers: Record<string, unknown>,
   answerFieldHashes?: AnswerFieldHashes,
 ): boolean {
-  const required = requiredHumanFields(fields, answers, answerFieldHashes);
-  return required.every((f) => {
-    const v = answers[f.name];
-    if (v === undefined || v === null || v === "") return false;
-    if (f.type === "single" && isIncompleteOther(v)) return false;
-    if (f.type === "multi" && Array.isArray(v)) {
-      if (v.length === 0) return false;
-      if (v.some(isIncompleteOther)) return false;
-    }
-    return true;
-  });
+  return missingRequiredHumanFields(fields, answers, answerFieldHashes).length === 0;
 }

--- a/frontend/src/lib/coding-save-feedback.ts
+++ b/frontend/src/lib/coding-save-feedback.ts
@@ -1,0 +1,24 @@
+import { toast } from "sonner";
+
+// Feedback de um save bem-sucedido de codificação. Salvar com sucesso e
+// concluir a codificação são coisas diferentes, e o toast precisa distingui-las:
+// enquanto os dois casos diziam "Respostas salvas!", um envio que deixou
+// obrigatórias em aberto — porque o schema mudou entre o carregamento do
+// formulário e o envio — devolvia ao pesquisador o mesmo sinal de conclusão, e o
+// documento reaparecia na fila depois. Quem lê isso conclui que a codificação
+// não salvou (#519).
+//
+// `missingRequired` vem do servidor e conta o conjunto GRAVADO, não o que a tela
+// mostrava; `undefined` é o caso legacy (resposta sem schema), tratado como
+// completo por não haver régua a aplicar.
+export function notifySaved(missingRequired: number | undefined): void {
+  if (!missingRequired) {
+    toast.success("Respostas salvas!");
+    return;
+  }
+  toast.warning(
+    missingRequired === 1
+      ? "Salvo — o documento segue pendente (falta 1 obrigatória)"
+      : `Salvo — o documento segue pendente (faltam ${missingRequired} obrigatórias)`,
+  );
+}


### PR DESCRIPTION
## O que é

Reconstrução limpa do #519 sobre a `origin/main` atual (pós-#528). **Substitui o #541**, que estava stale: nascido antes do merge do #528, o #541 arrastava uma cópia divergente do #520 (sem o hardening `keepsLegacyProvenance`/#548) e, como diff contra a main atual, revertia `response-snapshot.ts` e o bloco de proveniência de schema de `responses.ts`. Aqui o delta é só o do #519, cirúrgico, sem tocar em nada do #528.

## Problema

`is_partial` era função do **canal** da escrita (`isAutoSave && existing?.is_partial !== false`): um auto-save de navegação herdava o `false` de um submit anterior e carimbava "submetida" um conjunto que já não estava completo — o documento voltava à fila com aparência de concluído, e o pesquisador lia como "minha codificação não salvou" (#519).

## O que muda

1. **`is_partial` descreve o que foi gravado, não o canal.** `!isCodingComplete(fields, answersToPersist, answerFieldHashes) || (isAutoSave && !submittedBefore)`, staleness-aware contra o carimbo per-campo — não rebaixa codificação que estava completa quando um campo obrigatório foi criado depois. O auto-save continua sem promover por conta própria.
2. **Régua única cliente↔servidor.** `isAnsweredValue`/`missingRequiredHumanFields`/`requiredHumanFields` exportadas de `coding-completeness` e consumidas por `useQuestionValidation`; `isCodingComplete` derivada delas. Fim das duas cópias que deixavam "o que o botão exige" divergir de "o que o servidor considera concluído".
3. **Feedback que não mente.** `saveResponse` devolve `missingRequired` (contagem no conjunto **gravado**); `notifySaved` diferencia "Respostas salvas!" de "Salvo — o documento segue pendente (faltam N)". O `SubmitBar` anuncia a pendência **antes** do clique.

Mantido o bloqueio duro do envio incompleto.

## Contido intencionalmente (o que NÃO regride)

- `responses.ts`: mudança cirúrgica preserva **intacto** o bloco `keepsLegacyProvenance`/#548 do #528.
- **Zero alteração** em `response-snapshot.ts` (o #528 já faz a distinção nova/legacy) e em `coding-autosave.ts` (o adapter `saveCodingResponse`/#257 fica de pé).
- `SaveResponseResult` fica união discriminada (não interface achatada), mantendo irrepresentável o estado `{ success: true, error }`; `missingRequired` opcional na arm de sucesso porque só `saveResponse` a computa.
- Exclusão de `target` `llm_only`/`none` da contagem de obrigatórias: um campo só-LLM obrigatório deixa de bloquear o envio humano (mais correto).

## Verificação

- **Prova do vermelho por mutação**, guard a guard: removido o termo `!isCodingComplete(...)`, caem os testes de submit incompleto + encolhe; removido `(isAutoSave && !submittedBefore)`, caem os testes de "auto-save nunca submetido segue parcial".
- Vitest **178 arquivos / 1844 testes** verdes; typecheck, lint, `lint:types`, `fallow audit` (new-only), semgrep, react-doctor verdes.
- **e2e-smoke**: 7 specs passaram nas duas runs (`coding-save.smoke` inclusive); `config-guard.smoke` **não trava mais** (fix dos #522/#523 já em main). Push passou com todos os pre-push hooks, sem `SKIP`.

## Follow-up

Reparo dos registros históricos (as 95 respostas levantadas no #519) não entra aqui — decisão à parte, casos já levantados.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmEeTGy89Qh2AypTtAng29