### PR TITLE
fix(arbitragem): reabre assignment concluído quando surge nova contestação

### DIFF
--- a/frontend/supabase/migrations/20260724120000_arbitration_reopen_concluded_assignment.sql
+++ b/frontend/supabase/migrations/20260724120000_arbitration_reopen_concluded_assignment.sql
@@ -1,0 +1,84 @@
+-- Reabre o assignment de arbitragem quando surge nova contestacao sobre um
+-- documento cuja arbitragem anterior ja foi concluida.
+--
+-- Regressao do #510: ate a 20260716160100_prevent_self_arbitration.sql, a
+-- funcao assign_arbitration_if_eligible fazia
+--   ON CONFLICT (document_id, user_id, type) DO UPDATE
+--     SET status = 'pendente', completed_at = NULL
+--     WHERE assignments.status = 'concluido';
+-- ou seja, reabria um assignment ja concluido quando havia trabalho novo. A
+-- 20260717120000_auto_review_reconciliation_outbox.sql refatorou a arbitragem
+-- para assign_arbitration_cycles_if_eligible e, no processo, trocou esse
+-- DO UPDATE por DO NOTHING -- perdendo a reabertura. Efeito em producao: apos
+-- uma arbitragem concluida, uma nova contestacao (self_verdict volta a
+-- 'contesta_llm', arbitrator_id NULL) re-atribui o arbitro no field_review
+-- (v_assigned = 1), mas o assignment fica preso em 'concluido' e o arbitro
+-- nunca reve a fila. Mesma classe de bug do #440 (ON CONFLICT DO NOTHING nunca
+-- reabre linha concluida).
+--
+-- Correcao: restaurar o DO UPDATE de reabertura, identico ao padrao canonico ja
+-- usado por assign_auto_reviews_if_eligible (20260716160300) e pelo fechamento
+-- da auto-revisao (20260717120000). O guard WHERE assignments.status =
+-- 'concluido' garante idempotencia e nao rebaixa um assignment 'em_andamento'.
+--
+-- So o ON CONFLICT muda; o resto do corpo e identico ao de 20260717120000.
+
+CREATE OR REPLACE FUNCTION public.assign_arbitration_cycles_if_eligible(
+  p_project_id UUID,
+  p_document_id UUID,
+  p_user_id UUID,
+  p_field_review_ids UUID[]
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_assigned INTEGER := 0;
+BEGIN
+  PERFORM 1
+  FROM public.project_members AS member
+  WHERE member.project_id = p_project_id
+    AND member.user_id = p_user_id
+    AND member.can_arbitrate = true
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN 0;
+  END IF;
+
+  WITH assigned_reviews AS (
+    UPDATE public.field_reviews AS review
+    SET arbitrator_id = p_user_id
+    WHERE review.project_id = p_project_id
+      AND review.document_id = p_document_id
+      AND review.id = ANY(p_field_review_ids)
+      AND review.superseded_at IS NULL
+      AND review.self_verdict = 'contesta_llm'
+      AND review.arbitrator_id IS NULL
+    RETURNING review.id
+  )
+  SELECT count(*)::INTEGER INTO v_assigned FROM assigned_reviews;
+
+  IF v_assigned > 0 THEN
+    INSERT INTO public.assignments (
+      project_id, document_id, user_id, type, status
+    ) VALUES (
+      p_project_id, p_document_id, p_user_id, 'arbitragem', 'pendente'
+    )
+    ON CONFLICT (document_id, user_id, type) DO UPDATE
+    SET status = 'pendente',
+        completed_at = NULL
+    WHERE assignments.status = 'concluido';
+  END IF;
+
+  RETURN v_assigned;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.assign_arbitration_cycles_if_eligible(
+  UUID, UUID, UUID, UUID[]
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.assign_arbitration_cycles_if_eligible(
+  UUID, UUID, UUID, UUID[]
+) TO service_role;


### PR DESCRIPTION
## Contexto

Bug de produto **independente do #524**, mas descoberto ao corrigi-lo. A suíte `test:db:identity` está vermelha na `main`; a issue #524 aponta a FK de arquivamento (`canonical_project_identity_rls.test.sql:~1596`) como a falha. Ao remover essa barreira, o teste avança e revela uma **segunda falha latente do mesmo PR #510**, na linha 1977: `FALHOU RPC: nova arbitragem não reabriu assignment`.

## Causa raiz — regressão do #510

Até a `20260716160100_prevent_self_arbitration.sql`, a RPC de arbitragem fechava o INSERT do assignment com:

```sql
ON CONFLICT (document_id, user_id, type) DO UPDATE
  SET status = 'pendente', completed_at = NULL
  WHERE assignments.status = 'concluido';
```

— reabria um assignment já concluído quando havia trabalho novo. A `20260717120000_auto_review_reconciliation_outbox.sql` (PR #510) refatorou a arbitragem para `assign_arbitration_cycles_if_eligible` e, no processo, trocou esse `DO UPDATE` por `DO NOTHING`, **perdendo a reabertura**.

**Efeito em produção:** depois de uma arbitragem concluída, uma nova contestação (`self_verdict` volta a `contesta_llm`, `arbitrator_id` NULL) re-atribui o árbitro no `field_review` — a RPC retorna 1 —, mas o assignment fica preso em `concluido` e o árbitro nunca revê a fila. Mesma classe de bug do #440 (`ON CONFLICT DO NOTHING` nunca reabre linha concluída).

## Correção

Restaurar o `DO UPDATE` de reabertura, **idêntico ao padrão canônico** já usado por `assign_auto_reviews_if_eligible` (`20260716160300`) e pelo fechamento da auto-revisão (`20260717120000`). O guard `WHERE assignments.status = 'concluido'` garante idempotência e não rebaixa um assignment `em_andamento`. Só o `ON CONFLICT` muda; o resto do corpo é idêntico ao de `20260717120000`. Migration forward via `CREATE OR REPLACE` (a `20260717120000` já está aplicada no remoto).

## Verificação

A/B test em transações isoladas sobre fixtures idênticas (versão da função controlada em cada `BEGIN...ROLLBACK`, imune ao container compartilhado):

- **`DO NOTHING`** (bug): `assigned=1`, assignment permanece `status=concluido` — **não reabre**.
- **`DO UPDATE ... WHERE concluido`** (fix): `assigned=1`, assignment vira `status=pendente` com `completed_at NULL` — **reabre**.

Bate exatamente com a asserção da linha 1977.

## Dependência com o #524

Sozinho, este PR **não** deixa `test:db:identity` verde: sem a correção do #524 (PR #568 ou equivalente), a suíte ainda aborta antes, na FK de arquivamento (~linha 1596). Os dois PRs se desbloqueiam mutuamente — **#524 + este** deixam a suíte verde. Aplicar a migration no remoto antes do merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)