### PR TITLE
fix(codificação): sinal de submissão derivado do que foi gravado (#519)

### DIFF
--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -270,6 +270,60 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(state.assignmentUpdatePayload?.status).toBe("concluido");
   });
 
+  it("submit explicito com obrigatoria em branco grava is_partial=true e devolve a contagem", async () => {
+    // O sinal descreve o conjunto GRAVADO, nao o canal da escrita: sem isso, um
+    // envio incompleto ficava indistinguivel de uma conclusao — o documento
+    // voltava a fila e o pesquisador lia como "nao salvou" (#519).
+    state.pydanticFields = [
+      { name: "q1", type: "text", required: true, hash: "h-q1" },
+      { name: "q2", type: "text", required: true, hash: "h-q2" },
+    ];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+    expect(state.responseInsertPayload?.is_partial).toBe(true);
+    // E o cliente recebe a contagem para diferenciar o feedback.
+    expect(r.success && r.missingRequired).toBe(1);
+  });
+
+  it("auto-save que ENCOLHE uma response submetida devolve is_partial=true", async () => {
+    // A heranca do sinal ("ja foi submetida uma vez") sobrevivia a uma escrita
+    // posterior com menos respostas, carimbando de submetido um conjunto
+    // incompleto. Distinto do caso vizinho, onde o conjunto continua completo.
+    state.pydanticFields = [
+      { name: "q1", type: "text", required: true, hash: "h-q1" },
+      { name: "q2", type: "text", required: true, hash: "h-q2" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a", q2: "b" },
+      answer_field_hashes: { q1: "h-q1", q2: "h-q2" },
+    };
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    expect(state.responseUpdatePayload?.answers).toEqual({ q1: "a" });
+    expect(state.responseUpdatePayload?.is_partial).toBe(true);
+  });
+
+  it("campo obrigatorio criado depois NAO rebaixa codificacao antiga em auto-save", async () => {
+    // Espelho do caso real: a codificacao estava completa contra o schema da
+    // epoca; o campo novo so entra na regua se o carimbo provar que ele existia.
+    state.pydanticFields = [
+      { name: "q1", type: "text", required: true, hash: "h-q1" },
+      { name: "q_novo", type: "text", required: true, hash: "h-novo" },
+    ];
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: { q1: "h-q1" },
+    };
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    expect(state.responseUpdatePayload?.is_partial).toBe(false);
+    expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({ q1: "h-q1" });
+  });
+
   it("preserva resposta stale e seu hash sem usá-la para concluir a codificação", async () => {
     state.pydanticFields = [
       {

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -4,7 +4,7 @@ import { createSupabaseServer, type SupabaseServerClient } from "@/lib/supabase/
 import { resolveProjectMemberActor } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
-import { isCodingComplete, missingRequiredHumanFields } from "@/lib/coding-completeness";
+import { missingRequiredHumanFields } from "@/lib/coding-completeness";
 import { syncCodingAssignmentStatus } from "@/lib/coding-sync";
 import { deriveProjectVersionContext } from "@/lib/compare-version";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
@@ -88,7 +88,8 @@ interface SaveResponseProjectFields {
 }
 
 interface BuildResponsePayloadParams {
-  fields: PydanticField[];
+  /** Régua de completude já aplicada ao conjunto a gravar — ver `saveResponse`. */
+  codingIsComplete: boolean;
   answersToPersist: Record<string, unknown>;
   answerFieldHashes: Exclude<AnswerFieldHashes, null>;
   stampsCurrentSchema: boolean;
@@ -155,7 +156,7 @@ function resolveSchemaProvenance({
 }
 
 function buildResponsePayload({
-  fields,
+  codingIsComplete,
   answersToPersist,
   answerFieldHashes,
   stampsCurrentSchema,
@@ -178,19 +179,22 @@ function buildResponsePayload({
   // já não estava completo — o estado que fazia o documento voltar à fila com
   // aparência de concluído (#519).
   //
-  // Staleness-aware de propósito: avaliar contra o carimbo per-campo da própria
-  // resposta (`answerFieldHashes`) impede que um campo obrigatório criado depois
-  // rebaixe uma codificação que estava completa quando foi feita. O auto-save
-  // continua sem promover nada por conta própria — quem nunca enviou segue
-  // parcial mesmo com tudo preenchido; combinado com o guard que preserva
+  // `codingIsComplete` chega pronto de `saveResponse`, do MESMO cálculo que
+  // produz o `missingRequired` devolvido ao cliente: o sinal gravado no banco e o
+  // que o pesquisador lê no toast não podem discordar, e derivá-los de uma
+  // avaliação só torna isso verdade por construção, não por acordo entre dois
+  // call sites. A régua (staleness-aware contra o carimbo per-campo, para que um
+  // campo obrigatório criado depois não rebaixe codificação completa à época)
+  // vive em coding-completeness, onde está documentada.
+  //
+  // O auto-save continua sem promover nada por conta própria — quem nunca enviou
+  // segue parcial mesmo com tudo preenchido; combinado com o guard que preserva
   // assignment.status = "concluido" em coding-sync, um auto-save posterior a um
   // submit também não rebaixa um doc já concluído (salvo se o conjunto encolheu e
   // deixou de estar completo). A imutabilidade descrita na migration
   // 20260425000000 vale so para o fluxo LLM.
   const submittedBefore = existing?.is_partial === false;
-  const isPartialToWrite =
-    !isCodingComplete(fields, answersToPersist, answerFieldHashes) ||
-    (isAutoSave && !submittedBefore);
+  const isPartialToWrite = !codingIsComplete || (isAutoSave && !submittedBefore);
 
   const payload = {
     answers: answersToPersist,
@@ -311,8 +315,20 @@ export async function saveResponse(
       promoteLegacyIfComplete: !isAutoSave,
     });
 
-    const payload = buildResponsePayload({
+    // Régua de completude aplicada UMA vez, ao conjunto que vai ser gravado
+    // (`snapshot.persistedAnswers`) e com o carimbo per-campo da própria escrita —
+    // não ao que a tela mostrava. Dela saem os dois consumidores: o `is_partial`
+    // gravado e o `missingRequired` devolvido ao cliente. Se o schema mudou desde
+    // o carregamento do formulário, é esta contagem que impede o feedback de
+    // sucesso de anunciar uma conclusão que não houve (#519).
+    const missingRequired = missingRequiredHumanFields(
       fields,
+      snapshot.persistedAnswers,
+      snapshot.answerFieldHashes,
+    ).length;
+
+    const payload = buildResponsePayload({
+      codingIsComplete: missingRequired === 0,
       answersToPersist: snapshot.persistedAnswers,
       answerFieldHashes: snapshot.answerFieldHashes,
       stampsCurrentSchema: snapshot.stampsCurrentSchema,
@@ -348,18 +364,7 @@ export async function saveResponse(
     }
 
     revalidateAfterSave(projectId, isAutoSave);
-    // Contagem no conjunto GRAVADO (`snapshot.persistedAnswers`), com o mesmo
-    // carimbo staleness-aware que decidiu `is_partial` — não no que a tela
-    // mostrava. Se o schema mudou desde o carregamento do formulário, é ela que
-    // impede o feedback de sucesso de anunciar uma conclusão que não houve (#519).
-    return {
-      success: true,
-      missingRequired: missingRequiredHumanFields(
-        fields,
-        snapshot.persistedAnswers,
-        snapshot.answerFieldHashes,
-      ).length,
-    };
+    return { success: true, missingRequired };
   } catch (e) {
     return {
       success: false,

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -4,6 +4,7 @@ import { createSupabaseServer, type SupabaseServerClient } from "@/lib/supabase/
 import { resolveProjectMemberActor } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
+import { isCodingComplete, missingRequiredHumanFields } from "@/lib/coding-completeness";
 import { syncCodingAssignmentStatus } from "@/lib/coding-sync";
 import { deriveProjectVersionContext } from "@/lib/compare-version";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
@@ -14,7 +15,14 @@ export interface SaveResponseOpts {
 }
 
 export type SaveResponseResult =
-  | { success: true }
+  // `missingRequired`: obrigatórias ainda em branco no conjunto GRAVADO (0 =
+  // codificação completa). É a mesma contagem que decide `is_partial`, e vai ao
+  // cliente para o feedback distinguir "salvo" de "concluído" (#519). Opcional
+  // porque só `saveResponse` a computa — o adapter `saveCodingResponse` a repassa
+  // mas seu ramo de erro de transporte não a tem, e `notifySaved` lê `undefined`
+  // como "completo". União (não interface achatada) para manter irrepresentável
+  // o estado `{ success: true, error }`.
+  | { success: true; missingRequired?: number }
   | { success: false; error: string };
 
 // Response já existente do mesmo respondente para o mesmo documento. `answers`
@@ -80,6 +88,7 @@ interface SaveResponseProjectFields {
 }
 
 interface BuildResponsePayloadParams {
+  fields: PydanticField[];
   answersToPersist: Record<string, unknown>;
   answerFieldHashes: Exclude<AnswerFieldHashes, null>;
   stampsCurrentSchema: boolean;
@@ -146,6 +155,7 @@ function resolveSchemaProvenance({
 }
 
 function buildResponsePayload({
+  fields,
   answersToPersist,
   answerFieldHashes,
   stampsCurrentSchema,
@@ -159,14 +169,28 @@ function buildResponsePayload({
   const roundIdToPersist =
     project?.round_strategy === "manual" ? (project?.current_round_id ?? null) : null;
 
-  // Para humanos is_partial e mutavel: auto-save grava true (segue como
-  // current_pending em classifyDocStatus) e submit explicito grava false.
-  // Excecao: auto-save em response ja submetida (is_partial=false) NAO
-  // rebaixa o sinal — combinado com o guard que preserva assignment.status
-  // = "concluido", esse rebaixamento faria um doc ja concluido reaparecer
-  // como pendente em classifyDocStatus. A imutabilidade descrita na migration
+  // Para humanos is_partial descreve O QUE FOI GRAVADO, não por qual canal a
+  // escrita chegou: uma resposta só deixa de ser parcial quando o conjunto
+  // gravado satisfaz a régua de completude E o pesquisador já enviou (submit
+  // explícito). Enquanto o sinal era função apenas do canal
+  // (`isAutoSave && existing?.is_partial !== false`), um auto-save herdava o
+  // `false` de um submit anterior e podia carimbar "submetida" um conjunto que
+  // já não estava completo — o estado que fazia o documento voltar à fila com
+  // aparência de concluído (#519).
+  //
+  // Staleness-aware de propósito: avaliar contra o carimbo per-campo da própria
+  // resposta (`answerFieldHashes`) impede que um campo obrigatório criado depois
+  // rebaixe uma codificação que estava completa quando foi feita. O auto-save
+  // continua sem promover nada por conta própria — quem nunca enviou segue
+  // parcial mesmo com tudo preenchido; combinado com o guard que preserva
+  // assignment.status = "concluido" em coding-sync, um auto-save posterior a um
+  // submit também não rebaixa um doc já concluído (salvo se o conjunto encolheu e
+  // deixou de estar completo). A imutabilidade descrita na migration
   // 20260425000000 vale so para o fluxo LLM.
-  const isPartialToWrite = isAutoSave && existing?.is_partial !== false;
+  const submittedBefore = existing?.is_partial === false;
+  const isPartialToWrite =
+    !isCodingComplete(fields, answersToPersist, answerFieldHashes) ||
+    (isAutoSave && !submittedBefore);
 
   const payload = {
     answers: answersToPersist,
@@ -288,6 +312,7 @@ export async function saveResponse(
     });
 
     const payload = buildResponsePayload({
+      fields,
       answersToPersist: snapshot.persistedAnswers,
       answerFieldHashes: snapshot.answerFieldHashes,
       stampsCurrentSchema: snapshot.stampsCurrentSchema,
@@ -323,7 +348,18 @@ export async function saveResponse(
     }
 
     revalidateAfterSave(projectId, isAutoSave);
-    return { success: true };
+    // Contagem no conjunto GRAVADO (`snapshot.persistedAnswers`), com o mesmo
+    // carimbo staleness-aware que decidiu `is_partial` — não no que a tela
+    // mostrava. Se o schema mudou desde o carregamento do formulário, é ela que
+    // impede o feedback de sucesso de anunciar uma conclusão que não houve (#519).
+    return {
+      success: true,
+      missingRequired: missingRequiredHumanFields(
+        fields,
+        snapshot.persistedAnswers,
+        snapshot.answerFieldHashes,
+      ).length,
+    };
   } catch (e) {
     return {
       success: false,

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -66,6 +66,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
     handleSubmitWithValidation,
     requiredFields,
     answeredRequiredCount,
+    missingRequiredCount,
   } = useQuestionValidation(
     visibleFields,
     answers,
@@ -185,6 +186,7 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
         outOfScopeBlocked={outOfScopeBlocked}
         readOnly={readOnly}
         submitting={submitting}
+        missingRequiredCount={missingRequiredCount}
         onClick={handleSubmitWithValidation}
       />
     </div>

--- a/frontend/src/components/coding/SubmitBar.tsx
+++ b/frontend/src/components/coding/SubmitBar.tsx
@@ -1,37 +1,68 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
 
 interface SubmitBarProps {
   outOfScopeBlocked: boolean;
   readOnly: boolean;
   submitting: boolean;
+  /** Obrigatórias visíveis ainda em branco, pela régua de `isCodingComplete`. */
+  missingRequiredCount: number;
   onClick: () => void;
 }
 
-/** Rodapé do painel de perguntas: botão de envio, com texto/estado derivados
- *  de sinalização "fora do escopo" > somente leitura > salvando > normal. */
-export function SubmitBar({ outOfScopeBlocked, readOnly, submitting, onClick }: SubmitBarProps) {
+interface SubmitBarState {
+  label: string;
+  /** Pendência do formulário: neutra, para o botão não convidar ao clique. */
+  pending: boolean;
+  spinner: boolean;
+}
+
+// Estado do botão em ordem de precedência: sinalização "fora do escopo" >
+// somente leitura > salvando > pendências > normal.
+function resolveSubmitBarState({
+  outOfScopeBlocked,
+  readOnly,
+  submitting,
+  missingRequiredCount,
+}: Omit<SubmitBarProps, "onClick">): SubmitBarState {
+  if (outOfScopeBlocked) {
+    return { label: "Aguardando revisão do coordenador", pending: false, spinner: false };
+  }
+  if (readOnly) return { label: "Somente leitura", pending: false, spinner: false };
+  if (submitting) return { label: "Salvando…", pending: false, spinner: true };
+  if (missingRequiredCount > 0) {
+    return {
+      label:
+        missingRequiredCount === 1
+          ? "Falta 1 obrigatória"
+          : `Faltam ${missingRequiredCount} obrigatórias`,
+      pending: true,
+      spinner: false,
+    };
+  }
+  return { label: "Enviar respostas", pending: false, spinner: false };
+}
+
+/** Rodapé do painel de perguntas. A contagem de pendências sai da mesma régua
+ *  que o servidor usa para concluir a codificação: antes de existir, o botão
+ *  prometia "Enviar respostas" a quem ainda não podia enviar, e o pesquisador só
+ *  descobria a pendência depois do clique (#519). O botão segue habilitado —
+ *  quem clica recebe o destaque e o rolamento até o primeiro campo em branco. */
+export function SubmitBar({ onClick, ...state }: SubmitBarProps) {
+  const { label, pending, spinner } = resolveSubmitBarState(state);
   return (
     <div className="border-t px-4 py-3 shrink-0">
       <Button
         onClick={onClick}
-        disabled={submitting || readOnly || outOfScopeBlocked}
-        className="w-full bg-brand hover:bg-brand/90 text-brand-foreground"
+        disabled={state.submitting || state.readOnly || state.outOfScopeBlocked}
+        variant={pending ? "outline" : "default"}
+        className={cn("w-full", !pending && "bg-brand hover:bg-brand/90 text-brand-foreground")}
       >
-        {outOfScopeBlocked ? (
-          "Aguardando revisão do coordenador"
-        ) : readOnly ? (
-          "Somente leitura"
-        ) : submitting ? (
-          <>
-            <Loader2 className="size-4 animate-spin" />
-            Salvando…
-          </>
-        ) : (
-          "Enviar respostas"
-        )}
+        {spinner && <Loader2 className="size-4 animate-spin" />}
+        {label}
       </Button>
     </div>
   );

--- a/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
+++ b/frontend/src/components/coding/__tests__/QuestionsPanel.test.tsx
@@ -195,8 +195,10 @@ describe("QuestionsPanel — pergunta fora do escopo", () => {
       />,
     );
     expect(screen.getByRole("switch")).toBeTruthy();
-    // Formulário não bloqueado: botão de envio normal.
-    expect(screen.getByRole("button", { name: /Enviar respostas/ })).toBeTruthy();
+    // Formulário não bloqueado: o botão reporta as pendências do próprio
+    // formulário, não o bloqueio por sinalização de fora do escopo.
+    expect(screen.queryByRole("button", { name: /Aguardando revisão/ })).toBeNull();
+    expect(screen.getByRole("button", { name: /Faltam 2 obrigatórias/ })).toBeTruthy();
   });
 
   it("pendente: perguntas inertes e envio substituído por aviso", () => {

--- a/frontend/src/components/coding/__tests__/SubmitBar.test.tsx
+++ b/frontend/src/components/coding/__tests__/SubmitBar.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import { SubmitBar } from "@/components/coding/SubmitBar";
+
+afterEach(cleanup);
+
+// Estado default do rodapé: nada bloqueando e sem pendências. Cada teste vira
+// só o eixo que exercita, para que a PRECEDÊNCIA fique explícita — a mesma
+// ordem que o pesquisador enxerga: fora do escopo > leitura > salvando >
+// pendências > normal.
+const base = {
+  outOfScopeBlocked: false,
+  readOnly: false,
+  submitting: false,
+  missingRequiredCount: 0,
+  onClick: () => {},
+};
+
+describe("SubmitBar — precedência de estados", () => {
+  it("normal: envia respostas, habilitado", () => {
+    render(<SubmitBar {...base} />);
+    const btn = screen.getByRole("button", { name: /Enviar respostas/ });
+    expect(btn).toBeTruthy();
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("pendência (plural): reporta a contagem e mantém o botão habilitado", () => {
+    // O botão segue clicável de propósito: quem clica recebe o destaque e o
+    // scroll até o primeiro campo em branco (a validação vive em
+    // useQuestionValidation, não no disabled do botão).
+    render(<SubmitBar {...base} missingRequiredCount={3} />);
+    const btn = screen.getByRole("button", { name: /Faltam 3 obrigatórias/ });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("pendência (singular): 1 obrigatória", () => {
+    render(<SubmitBar {...base} missingRequiredCount={1} />);
+    expect(screen.getByRole("button", { name: /Falta 1 obrigatória/ })).toBeTruthy();
+  });
+
+  it("salvando vence pendência: mostra o estado de salvamento e desabilita", () => {
+    render(<SubmitBar {...base} submitting missingRequiredCount={2} />);
+    const btn = screen.getByRole("button", { name: /Salvando/ });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.queryByRole("button", { name: /Faltam/ })).toBeNull();
+  });
+
+  it("somente leitura vence salvando e pendência", () => {
+    render(<SubmitBar {...base} readOnly submitting missingRequiredCount={2} />);
+    const btn = screen.getByRole("button", { name: /Somente leitura/ });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("fora do escopo vence tudo, inclusive pendência", () => {
+    render(
+      <SubmitBar
+        {...base}
+        outOfScopeBlocked
+        readOnly
+        submitting
+        missingRequiredCount={2}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /Aguardando revisão do coordenador/ });
+    expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("clique com pendência dispara onClick (validação é do caller, não do disabled)", () => {
+    const onClick = vi.fn();
+    render(<SubmitBar {...base} missingRequiredCount={2} onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button", { name: /Faltam 2 obrigatórias/ }));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
@@ -8,7 +8,7 @@ import { useAssignedCoding } from "../useAssignedCoding";
 import type { Document, Assignment, PydanticField } from "@/lib/types";
 
 vi.mock("@/actions/responses", () => ({ saveResponse: vi.fn() }));
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } }));
 // sortByRecent é testado em outro lugar; aqui usamos a ordem como vem.
 vi.mock("@/lib/coding-sort", () => ({
   sortByRecent: (docs: unknown[]) => docs,
@@ -94,6 +94,48 @@ describe("useAssignedCoding", () => {
     expect(params.markClean).toHaveBeenCalledWith("d1");
     expect(view.result.current.currentDoc?.id).toBe("d2");
     expect(params.updateDocParam).toHaveBeenCalledWith("d2");
+  });
+
+  it("save com obrigatórias em aberto NÃO avança de documento", async () => {
+    // Avançar tiraria a tela de baixo do aviso que acabou de pedir para
+    // completar o documento — e ele reapareceria na fila depois, o sintoma
+    // relatado como "minha codificação não salvou" (#519). O save em si teve
+    // sucesso: markClean roda, só a navegação é que fica retida.
+    mockSave.mockResolvedValue({ success: true, missingRequired: 2 });
+    const { view, params } = setup();
+    act(() => view.result.current.handleAnswer("q1", "sim"));
+    await act(async () => {
+      await view.result.current.handleSubmit();
+    });
+    expect(params.markClean).toHaveBeenCalledWith("d1");
+    expect(view.result.current.currentDoc?.id).toBe("d1");
+    expect(params.updateDocParam).not.toHaveBeenCalled();
+    expect(view.result.current.allDone).toBe(false);
+  });
+
+  it("save sem pendência (missingRequired 0) avança normalmente", async () => {
+    // Boundary com o teste acima: é 0 — e não a mera presença da chave — que
+    // libera a navegação.
+    mockSave.mockResolvedValue({ success: true, missingRequired: 0 });
+    const { view, params } = setup();
+    act(() => view.result.current.handleAnswer("q1", "sim"));
+    await act(async () => {
+      await view.result.current.handleSubmit();
+    });
+    expect(view.result.current.currentDoc?.id).toBe("d2");
+    expect(params.updateDocParam).toHaveBeenCalledWith("d2");
+  });
+
+  it("pendência no último documento não marca allDone", async () => {
+    mockSave.mockResolvedValue({ success: true, missingRequired: 1 });
+    const { view } = setup();
+    act(() => view.result.current.handleDocNavigate(2)); // vai para d3 (último)
+    act(() => view.result.current.handleAnswer("q1", "sim"));
+    await act(async () => {
+      await view.result.current.handleSubmit();
+    });
+    expect(view.result.current.allDone).toBe(false);
+    expect(view.result.current.currentDoc?.id).toBe("d3");
   });
 
   it("mantém respostas e documento atual, e permite retry após rejeição de transporte", async () => {

--- a/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
@@ -14,7 +14,7 @@ import { useBrowseCoding } from "../useBrowseCoding";
 vi.mock("@/hooks/useBrowseDocuments", () => ({ useBrowseDocuments: vi.fn() }));
 vi.mock("@/hooks/useDocumentForCoding", () => ({ useDocumentForCoding: vi.fn() }));
 vi.mock("@/actions/responses", () => ({ saveResponse: vi.fn() }));
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() } }));
 
 const mockUseBrowseDocuments = vi.mocked(useBrowseDocuments);
 const mockUseDocumentForCoding = vi.mocked(useDocumentForCoding);
@@ -107,6 +107,25 @@ describe("useBrowseCoding", () => {
     expect(markResponded).toHaveBeenCalledWith("b1");
     expect(invalidate).toHaveBeenCalledWith("b1");
     expect(params.updateDocParam).toHaveBeenCalledWith(null);
+  });
+
+  it("submit com obrigatórias em aberto mantém o documento ABERTO e invalida", async () => {
+    // Espelha o modo Atribuídos: o save teve sucesso (markClean/markResponded
+    // rodam), mas fechar o doc tiraria a tela de baixo do aviso que pediu para
+    // completá-lo (#519). A invalidação vem SEM o `updateDocParam(null)` que a
+    // precede no caminho normal — aqui o refetch é desejado, para reassentar o
+    // formulário no que acabou de ser gravado.
+    mockSave.mockResolvedValue({ success: true, missingRequired: 2 });
+    const { view, params } = setup("b1");
+
+    await act(async () => {
+      await view.result.current.handleBrowseSubmit({ answers: { q: "sim" }, notes: "n" });
+    });
+
+    expect(params.markClean).toHaveBeenCalledWith("b1");
+    expect(markResponded).toHaveBeenCalledWith("b1");
+    expect(invalidate).toHaveBeenCalledWith("b1");
+    expect(params.updateDocParam).not.toHaveBeenCalled();
   });
 
   it("submit mantém rascunho e seleção, e permite retry após rejeição de transporte", async () => {

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -7,6 +7,7 @@ import {
   saveCodingResponse,
 } from "@/lib/coding-autosave";
 import { clearHiddenConditionalAnswers } from "@/lib/conditional";
+import { notifySaved } from "@/lib/coding-save-feedback";
 import { toast } from "sonner";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
 import type { CodingSortMode } from "./CodingPage";
@@ -178,7 +179,7 @@ export function useAssignedCoding({
       });
       if (result.success) {
         markClean(currentDoc.id);
-        toast.success("Respostas salvas!");
+        notifySaved(result.missingRequired);
         if (docIndex < sortedDocuments.length - 1) {
           const nextIndex = docIndex + 1;
           dispatch({ type: "index", index: nextIndex });

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -177,21 +177,28 @@ export function useAssignedCoding({
       const result = await saveCodingResponse(projectId, currentDoc.id, docAnswers, {
         notes: docNotes,
       });
-      if (result.success) {
-        markClean(currentDoc.id);
-        notifySaved(result.missingRequired);
-        if (docIndex < sortedDocuments.length - 1) {
-          const nextIndex = docIndex + 1;
-          dispatch({ type: "index", index: nextIndex });
-          // Mantem a URL em sincronia com o doc exibido — sem isso, um refresh
-          // apos enviar cai no doc recem-enviado (que no modo "recent" pula para
-          // o topo da lista), nao no proximo.
-          updateDocParam(sortedDocuments[nextIndex]?.id ?? null);
-        } else {
-          dispatch({ type: "allDone", value: true });
-        }
-      } else {
+      if (!result.success) {
         toast.error(result.error);
+        return;
+      }
+      markClean(currentDoc.id);
+      notifySaved(result.missingRequired);
+      // Save com obrigatórias em aberto mantém o pesquisador NO documento:
+      // avançar tiraria a tela de baixo do aviso que acabou de pedir para
+      // completá-lo, e o doc reapareceria na fila depois — o sintoma que o #519
+      // descreve. Só alcançável quando o schema cresceu entre o carregamento do
+      // formulário e o envio; fora disso o SubmitBar já cobra a pendência antes
+      // do clique, pela mesma régua.
+      if (result.missingRequired) return;
+      if (docIndex < sortedDocuments.length - 1) {
+        const nextIndex = docIndex + 1;
+        dispatch({ type: "index", index: nextIndex });
+        // Mantem a URL em sincronia com o doc exibido — sem isso, um refresh
+        // apos enviar cai no doc recem-enviado (que no modo "recent" pula para
+        // o topo da lista), nao no proximo.
+        updateDocParam(sortedDocuments[nextIndex]?.id ?? null);
+      } else {
+        dispatch({ type: "allDone", value: true });
       }
     } finally {
       // O `finally` garante que `submitting`/o ref não fiquem presos `true` se

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useBrowseDocuments } from "@/hooks/useBrowseDocuments";
 import { useDocumentForCoding } from "@/hooks/useDocumentForCoding";
 import { saveCodingResponse } from "@/lib/coding-autosave";
+import { notifySaved } from "@/lib/coding-save-feedback";
 import { type CodingDraft } from "./BrowseDocCoder";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
 import type { AssignedDoc } from "@/lib/types";
@@ -120,7 +121,7 @@ export function useBrowseCoding({
         });
         if (result.success) {
           markClean(browseDocId);
-          toast.success("Respostas salvas!");
+          notifySaved(result.missingRequired);
           markResponded(browseDocId);
           browseDraftRef.current = null;
           // Zera o ?doc= ANTES de invalidar: com browseDocId já null o hook não

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -124,6 +124,16 @@ export function useBrowseCoding({
           notifySaved(result.missingRequired);
           markResponded(browseDocId);
           browseDraftRef.current = null;
+          // Save com obrigatórias em aberto mantém o doc ABERTO, pelo mesmo
+          // motivo do modo Atribuídos (ver useAssignedCoding): fechá-lo tiraria a
+          // tela de baixo do aviso que acabou de pedir para completá-lo. Aqui a
+          // invalidação vem sem o `updateDocParam(null)` que a precede no caminho
+          // normal — o refetch é desejado, porque reassenta o formulário no que
+          // acabou de ser gravado em vez de num seed stale.
+          if (result.missingRequired) {
+            invalidateBrowseDoc(browseDocId);
+            return;
+          }
           // Zera o ?doc= ANTES de invalidar: com browseDocId já null o hook não
           // refetcha o doc que estamos deixando (evita refetch/flicker). A
           // invalidação garante que reabri-lo na sessão reflita o que foi salvo

--- a/frontend/src/components/coding/useQuestionValidation.ts
+++ b/frontend/src/components/coding/useQuestionValidation.ts
@@ -25,6 +25,7 @@ export function useQuestionValidation(
   handleSubmitWithValidation: () => void;
   requiredFields: PydanticField[];
   answeredRequiredCount: number;
+  missingRequiredCount: number;
 } {
   const [highlightedFields, setHighlightedFields] = useState<Set<string>>(new Set());
 
@@ -36,6 +37,12 @@ export function useQuestionValidation(
   // header mostrar "N-1/N" para sempre com o submit liberado.
   // Memoizado para estabilizar a identidade de `requiredFields` (dep de
   // `handleSubmitWithValidation`) entre renders sem mudança de campos/respostas.
+  //
+  // O cliente ser staleness-blind é de propósito: opera sempre contra o schema
+  // atual carregado no formulário, não contra o carimbo de uma escrita anterior.
+  // A assimetria com o gate de `is_partial` (staleness-aware, ver
+  // coding-completeness) é intencional — ao reeditar um doc cujo schema cresceu, o
+  // botão cobra o campo novo, o comportamento correto para uma re-submissão.
   const requiredFields = useMemo(
     () => requiredHumanFields(visibleFields, answers),
     [visibleFields, answers],
@@ -44,6 +51,7 @@ export function useQuestionValidation(
     () => requiredFields.filter((f) => isFieldAnswered(f, answers[f.name])).length,
     [requiredFields, answers],
   );
+  const missingRequiredCount = requiredFields.length - answeredRequiredCount;
 
   const isAnswered = useCallback(
     (field: PydanticField) => isFieldAnswered(field, answers[field.name]),
@@ -103,5 +111,6 @@ export function useQuestionValidation(
     handleSubmitWithValidation,
     requiredFields,
     answeredRequiredCount,
+    missingRequiredCount,
   };
 }

--- a/frontend/src/lib/__tests__/coding-save-feedback.test.ts
+++ b/frontend/src/lib/__tests__/coding-save-feedback.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
+import { notifySaved } from "@/lib/coding-save-feedback";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), warning: vi.fn() },
+}));
+
+beforeEach(() => {
+  vi.mocked(toast.success).mockClear();
+  vi.mocked(toast.warning).mockClear();
+});
+
+// A distinção "salvo" vs "concluído" é a metade cliente do #519: um envio que
+// deixou obrigatórias em aberto não pode devolver o mesmo sinal de conclusão. Uma
+// troca warning→success ou um erro de plural aqui passaria por todos os gates —
+// por isso as strings exatas são fixadas.
+describe("notifySaved — feedback de save distingue salvo × pendente", () => {
+  it("undefined (legacy, sem régua) → sucesso", () => {
+    notifySaved(undefined);
+    expect(toast.success).toHaveBeenCalledWith("Respostas salvas!");
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("0 obrigatória em aberto → sucesso (boundary com o ramo de pendência)", () => {
+    notifySaved(0);
+    expect(toast.success).toHaveBeenCalledWith("Respostas salvas!");
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it("1 obrigatória em aberto → aviso no singular", () => {
+    notifySaved(1);
+    expect(toast.warning).toHaveBeenCalledWith(
+      "Salvo — o documento segue pendente (falta 1 obrigatória)",
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("N obrigatórias em aberto → aviso no plural com a contagem", () => {
+    notifySaved(3);
+    expect(toast.warning).toHaveBeenCalledWith(
+      "Salvo — o documento segue pendente (faltam 3 obrigatórias)",
+    );
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/__tests__/coding-save-signal.test.ts
+++ b/frontend/src/lib/__tests__/coding-save-signal.test.ts
@@ -1,0 +1,55 @@
+// Régua única de completude compartilhada entre a UI de codificação e o
+// servidor: `missingRequiredHumanFields` decide tanto o que o botão "Enviar"
+// exige quanto o `is_partial` gravado. Enquanto a regra vivia duplicada, "o que
+// o botão exige" podia divergir de "o que o servidor considera concluído" sem
+// nenhum gate reclamar (#519). O carimbo de proveniência em si (o mapa
+// `answer_field_hashes`) é coberto por `response-snapshot.test.ts` (#520/#528);
+// aqui fixamos só a régua que se apoia nele.
+import { describe, it, expect } from "vitest";
+import { missingRequiredHumanFields } from "@/lib/coding-completeness";
+import type { PydanticField } from "@/lib/types";
+
+const field = (partial: Partial<PydanticField> & { name: string }): PydanticField =>
+  ({ type: "text", options: null, ...partial }) as PydanticField;
+
+// Schema de 2 campos contra o qual a codificação foi feita.
+const schemaAntigo = [
+  field({ name: "q1", type: "single", options: ["a", "b"], hash: "h-q1" }),
+  field({ name: "q2", hash: "h-q2" }),
+];
+// Campo obrigatório criado DEPOIS: o caso do `medicamento` no Zolgensma.
+const schemaAtual = [...schemaAntigo, field({ name: "q3_novo", hash: "h-q3" })];
+
+const codificacaoCompleta = { q1: "a", q2: "texto" };
+const carimboDaEpoca = { q1: "h-q1", q2: "h-q2" };
+
+describe("missingRequiredHumanFields — régua única de UI e servidor", () => {
+  it("conta apenas obrigatórias visíveis para humano", () => {
+    const fields = [
+      field({ name: "obrigatoria" }),
+      field({ name: "opcional", required: false }),
+      field({ name: "so_llm", target: "llm_only" }),
+      field({ name: "oculta", condition: { field: "obrigatoria", equals: "x" } }),
+    ];
+    expect(missingRequiredHumanFields(fields, {}).map((f) => f.name)).toEqual(["obrigatoria"]);
+  });
+
+  it("não cobra campo que ainda não existia quando a resposta foi codificada", () => {
+    expect(missingRequiredHumanFields(schemaAtual, codificacaoCompleta, carimboDaEpoca)).toEqual([]);
+    // Sem o carimbo (avaliação staleness-blind), o campo novo é cobrado.
+    expect(
+      missingRequiredHumanFields(schemaAtual, codificacaoCompleta).map((f) => f.name),
+    ).toEqual(["q3_novo"]);
+  });
+
+  it("'Outro:' pela metade e multi vazio contam como faltantes", () => {
+    const fields = [
+      field({ name: "single", type: "single", options: ["a"], allow_other: true }),
+      field({ name: "multi", type: "multi", options: ["a"] }),
+    ];
+    expect(
+      missingRequiredHumanFields(fields, { single: "Outro: ", multi: [] }).map((f) => f.name),
+    ).toEqual(["single", "multi"]);
+    expect(missingRequiredHumanFields(fields, { single: "Outro: x", multi: ["a"] })).toEqual([]);
+  });
+});

--- a/frontend/src/lib/__tests__/viewas-no-write.test.ts
+++ b/frontend/src/lib/__tests__/viewas-no-write.test.ts
@@ -114,7 +114,9 @@ describe("saveResponse — escrita persiste o ator real, nunca o viewAs", () => 
       "member-viewed",
     );
 
-    expect(result).toEqual({ success: true });
+    // `missingRequired` acompanha todo save bem-sucedido: é a contagem de
+    // obrigatórias em aberto no conjunto GRAVADO (0 = codificação completa).
+    expect(result).toEqual({ success: true, missingRequired: 0 });
     // A identidade veio do ator autenticado (por projectId), não de input do caller.
     expect(resolveMemberUserId).toHaveBeenCalledWith("project-1");
 

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -42,6 +42,21 @@ export function isFieldAnswered(field: PydanticField, value: unknown): boolean {
   return true;
 }
 
+// Campos obrigatórios que ainda faltam — a régua de completude na forma que a UI
+// precisa (quantos e quais), com `isCodingComplete` derivado dela. A UI de
+// codificação e o feedback de save consomem esta primitiva em vez de reimplementar
+// a regra: uma cópia paralela é o que deixava "o que o botão exige" divergir de "o
+// que o servidor considera concluído" sem nenhum gate reclamar (#519).
+export function missingRequiredHumanFields(
+  fields: PydanticField[],
+  answers: Record<string, unknown>,
+  answerFieldHashes?: AnswerFieldHashes,
+): PydanticField[] {
+  return requiredHumanFields(fields, answers, answerFieldHashes).filter(
+    (f) => !isFieldAnswered(f, answers[f.name]),
+  );
+}
+
 // True quando todos os campos obrigatórios e visíveis para o humano estão
 // respondidos. Fonte única da regra de "codificação completa", espelhada pelo
 // gate inline de saveResponse (promoção a "concluido") e pelo backlog de
@@ -50,17 +65,27 @@ export function isFieldAnswered(field: PydanticField, value: unknown): boolean {
 // apareciam como "(vazio)" em diversos campos. Puro/client-safe — usado tanto
 // em server actions quanto em testes Vitest.
 //
-// `answerFieldHashes` (opcional): quando avaliado RETROATIVAMENTE (backlog,
-// reconciliação da auto-revisão) contra o schema atual, passar o snapshot per-campo
-// da resposta evita que um campo obrigatório recém-adicionado torne codificações
-// antigas — completas à época — falsamente "incompletas". O gate inline de
-// saveResponse roda em save-time (schema = schema da codificação), então não
-// precisa passar e mantém o comportamento staleness-blind.
+// `answerFieldHashes` (opcional): passar o snapshot per-campo da resposta torna a
+// avaliação staleness-aware — um campo obrigatório recém-adicionado ao schema não
+// rebaixa uma codificação que estava completa à época, porque o carimbo prova
+// quais campos existiam (ver fieldExistedWhenCoded). Dois consumidores passam o
+// snapshot:
+//   • a avaliação RETROATIVA (backlog de auto-revisão, reconciliação) contra o
+//     schema atual, que sem isso marcaria toda codificação anterior a um bump de
+//     schema como falsamente incompleta;
+//   • o gate de `is_partial` em saveResponse, que avalia contra o snapshot da
+//     própria escrita (buildPersistedResponseSnapshot). Para uma codificação NOVA
+//     esse snapshot estampa o schema inteiro como chaves, então aware ≡ blind e
+//     nenhum obrigatório em branco é perdoado; a distinção só morde no auto-save de
+//     uma resposta JÁ submetida sob schema que cresceu — exatamente o caso que não
+//     deve rebaixar um doc concluído (#519/#520).
+// Quem permanece staleness-BLIND de propósito é a promoção a `concluido` em
+// syncCodingAssignmentStatus (coding-sync): lá é o guard de não-rebaixar um
+// assignment já concluído que sustenta a invariante, não o carimbo per-campo.
 export function isCodingComplete(
   fields: PydanticField[],
   answers: Record<string, unknown>,
   answerFieldHashes?: AnswerFieldHashes,
 ): boolean {
-  const required = requiredHumanFields(fields, answers, answerFieldHashes);
-  return required.every((f) => isFieldAnswered(f, answers[f.name]));
+  return missingRequiredHumanFields(fields, answers, answerFieldHashes).length === 0;
 }

--- a/frontend/src/lib/coding-save-feedback.ts
+++ b/frontend/src/lib/coding-save-feedback.ts
@@ -1,0 +1,24 @@
+import { toast } from "sonner";
+
+// Feedback de um save bem-sucedido de codificação. Salvar com sucesso e
+// concluir a codificação são coisas diferentes, e o toast precisa distingui-las:
+// enquanto os dois casos diziam "Respostas salvas!", um envio que deixou
+// obrigatórias em aberto — porque o schema mudou entre o carregamento do
+// formulário e o envio — devolvia ao pesquisador o mesmo sinal de conclusão, e o
+// documento reaparecia na fila depois. Quem lê isso conclui que a codificação
+// não salvou (#519).
+//
+// `missingRequired` vem do servidor e conta o conjunto GRAVADO, não o que a tela
+// mostrava; `undefined` é o caso legacy (resposta sem schema), tratado como
+// completo por não haver régua a aplicar.
+export function notifySaved(missingRequired: number | undefined): void {
+  if (!missingRequired) {
+    toast.success("Respostas salvas!");
+    return;
+  }
+  toast.warning(
+    missingRequired === 1
+      ? "Salvo — o documento segue pendente (falta 1 obrigatória)"
+      : `Salvo — o documento segue pendente (faltam ${missingRequired} obrigatórias)`,
+  );
+}


### PR DESCRIPTION
## O que é

Reconstrução **enxuta** do #519 a partir da `origin/main` atual. **Substitui o #576**, que estava stale: nascido antes do merge do #569 (que unificou a régua de validação UI×servidor) e de #524/#548/#566/#573, o #576 — como diff contra a main atual — revertia esses PRs (deletava `response-snapshot.test.ts`, `useQuestionValidation.test.ts`, a migration `guard_archive_triggers` do #524/#568). Aqui o delta parte da main atual e **aproveita** a régua já unificada pelo #569, sem tocar em nada do que já mergeou.

## Problema

O #569 unificou a régua de validação no submit, mas o **cerne do #519 seguia aberto na main**: `is_partial` era função do **canal** da escrita (`isAutoSave && existing?.is_partial !== false`). Um auto-save de navegação herdava o `false` de um submit anterior e carimbava "submetida" um conjunto que já não estava completo — o documento voltava à fila com aparência de concluído, e o pesquisador lia como "minha codificação não salvou".

## O que muda

1. **`is_partial` descreve o que foi gravado, não o canal.** `!isCodingComplete(fields, answersToPersist, answerFieldHashes) || (isAutoSave && !submittedBefore)`, staleness-aware contra o carimbo per-campo — não rebaixa codificação que estava completa quando um campo obrigatório foi criado depois. O auto-save continua sem promover por conta própria.
2. **Feedback que não mente.** `saveResponse` devolve `missingRequired` (contagem no conjunto **gravado**); `notifySaved` (novo, `coding-save-feedback.ts`) diferencia "Respostas salvas!" de "Salvo — o documento segue pendente (faltam N)". O `SubmitBar` anuncia a pendência **antes** do clique, com o botão habilitado (destaque + scroll ao clicar).
3. **Régua única reaproveitada.** `missingRequiredHumanFields` em `coding-completeness` dá a contagem e passa a ser a fonte de `isCodingComplete`; `useQuestionValidation` expõe `missingRequiredCount` da mesma régua que o #569 já unificou.

Mantido o bloqueio duro do envio incompleto.

## Contido intencionalmente

- **Zero reversão** da main: parte de `origin/main` atual, preserva #524/#548/#566/#569/#573 intactos.
- `is_partial` staleness-aware no save-time; a promoção a `concluido` em `syncCodingAssignmentStatus` segue staleness-blind (guard de não-rebaixar sustenta a invariante). Comentário de `isCodingComplete` atualizado para nomear a assimetria.
- Cliente staleness-blind de propósito (opera contra o schema atual do formulário); documentado em `useQuestionValidation`.

## Verificação

- **Prova do vermelho por mutação**, guard a guard: removido `!isCodingComplete(...)`, caem os testes de submit incompleto + encolhe; removido `(isAutoSave && !submittedBefore)`, caem os testes de "auto-save nunca submetido segue parcial".
- Vitest **180 arquivos / 1876 testes** verdes; typecheck, eslint, `lint:types`, `e2e-smoke`, `fallow audit` (new-only), semgrep verdes. Push passou com todos os pre-push hooks, sem `SKIP`.

## Follow-up

Reparo dos registros históricos (as 95 respostas levantadas no #519) não entra aqui — decisão à parte.

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XmEeTGy89Qh2AypTtAng29