### PR TITLE
fix(schema): preserva required de subcampo no round-trip com at_least_one

### DIFF
--- a/backend/services/pydantic_compiler.py
+++ b/backend/services/pydantic_compiler.py
@@ -715,11 +715,16 @@ def _extract_subfields(annotation: type) -> list[dict] | None:
         if sf_origin is typing.Union:
             sf_args = get_args(sf_ann)
             is_optional = type(None) in sf_args
+        # Sob subfield_rule="at_least_one" a anotação é sempre Optional, então
+        # ela não consegue carregar o `required` individual — o gerador o
+        # transporta em json_schema_extra e o extra prevalece sobre a anotação
+        # (issue #491; mesmo padrão do `required` de campo, PR #454).
+        sf_extra = extract_json_schema_extra(sf_info)
         subfields.append(
             {
                 "key": sf_name,
                 "label": sf_info.description or sf_name,
-                "required": not is_optional,
+                "required": bool(sf_extra.get("required", not is_optional)),
             }
         )
     return subfields if subfields else None

--- a/backend/services/pydantic_compiler.py
+++ b/backend/services/pydantic_compiler.py
@@ -719,12 +719,18 @@ def _extract_subfields(annotation: type) -> list[dict] | None:
         # ela não consegue carregar o `required` individual — o gerador o
         # transporta em json_schema_extra e o extra prevalece sobre a anotação
         # (issue #491; mesmo padrão do `required` de campo, PR #454).
+        #
+        # A chave é `subfield_required` porque `_flatten_nested_basemodels`
+        # (services/llm_runner.py) reaproveita este FieldInfo inteiro ao achatar
+        # o modelo para o LLM: o extra vira uma *property* do JSON Schema
+        # mandado ao provider, e `required` ali é palavra reservada com outra
+        # semântica (array no nível do objeto). Ver generatePydanticCode.
         sf_extra = extract_json_schema_extra(sf_info)
         subfields.append(
             {
                 "key": sf_name,
                 "label": sf_info.description or sf_name,
-                "required": bool(sf_extra.get("required", not is_optional)),
+                "required": bool(sf_extra.get("subfield_required", not is_optional)),
             }
         )
     return subfields if subfields else None

--- a/backend/tests/test_llm_flatten_nested.py
+++ b/backend/tests/test_llm_flatten_nested.py
@@ -60,6 +60,34 @@ def test_flatten_preserves_subfield_descriptions():
     assert doenca_field.description == "Nome da doença"
 
 
+class _SubFieldsRequired(BaseModel):
+    doenca: Optional[str] = Field(
+        default=None,
+        description="Nome da doença",
+        json_schema_extra={"subfield_required": True},
+    )
+
+
+class _RootWithRequiredSubfield(BaseModel):
+    q5: _SubFieldsRequired = Field(description="campo aninhado")
+
+
+def test_flatten_does_not_leak_reserved_json_schema_keyword():
+    """O extra do subcampo sobe para property do schema mandado ao provider.
+
+    `_flatten_nested_basemodels` reaproveita o FieldInfo do subcampo inteiro,
+    então qualquer chave de `json_schema_extra` vira chave da property no JSON
+    Schema. `required` é palavra reservada ali (vale no nível do objeto, e como
+    array de strings), por isso o gerador emite `subfield_required` — ver
+    generatePydanticCode e _extract_subfields (issue #491).
+    """
+    flat, _ = _flatten_nested_basemodels(_RootWithRequiredSubfield)
+    prop = flat.model_json_schema()["properties"][f"q5{_NESTED_FLATTEN_SEP}doenca"]
+
+    assert "required" not in prop
+    assert prop["subfield_required"] is True
+
+
 def _reconstruct_nested(answers: dict, justifications: dict, field_map: dict):
     """Mirror da reconstrução em services.llm_runner.run_llm para permitir
     testar sem montar uma run completa. Manter em sincronia com o runner."""

--- a/backend/tests/test_pydantic_compiler.py
+++ b/backend/tests/test_pydantic_compiler.py
@@ -117,6 +117,30 @@ class Analysis(BaseModel):
     assert f["subfield_rule"] == "at_least_one"
 
 
+def test_subfield_required_round_trips_under_at_least_one():
+    # Sob at_least_one a anotação é sempre Optional[str], então o `required`
+    # individual do subcampo só sobrevive via json_schema_extra (issue #491).
+    code = """from pydantic import BaseModel, Field
+from typing import Literal, Optional
+
+class _doc_fields(BaseModel):
+    part_a: Optional[str] = Field(default=None, description="Part A", json_schema_extra={"required": True})
+    part_b: Optional[str] = Field(default=None, description="Part B")
+
+class Analysis(BaseModel):
+    doc: _doc_fields = Field(
+        description="Doc",
+        json_schema_extra={"subfield_rule": "at_least_one"},
+    )
+"""
+    result = compile_pydantic(code)
+    f = _field(result, "doc")
+    assert f["subfields"] == [
+        {"key": "part_a", "label": "Part A", "required": True},
+        {"key": "part_b", "label": "Part B", "required": False},
+    ]
+
+
 def test_allow_other_preserved_for_single():
     code = """from pydantic import BaseModel, Field
 from typing import Literal, Optional

--- a/backend/tests/test_pydantic_compiler.py
+++ b/backend/tests/test_pydantic_compiler.py
@@ -120,11 +120,13 @@ class Analysis(BaseModel):
 def test_subfield_required_round_trips_under_at_least_one():
     # Sob at_least_one a anotação é sempre Optional[str], então o `required`
     # individual do subcampo só sobrevive via json_schema_extra (issue #491).
+    # A chave é `subfield_required`: o subcampo é achatado para property do
+    # JSON Schema do provider, onde `required` é palavra reservada.
     code = """from pydantic import BaseModel, Field
 from typing import Literal, Optional
 
 class _doc_fields(BaseModel):
-    part_a: Optional[str] = Field(default=None, description="Part A", json_schema_extra={"required": True})
+    part_a: Optional[str] = Field(default=None, description="Part A", json_schema_extra={"subfield_required": True})
     part_b: Optional[str] = Field(default=None, description="Part B")
 
 class Analysis(BaseModel):

--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -23,6 +23,7 @@ import {
   padDatePart,
   parseDatePartsForUI,
 } from "@/lib/date-parts";
+import { resolveSubfieldRequired } from "@/lib/pydantic-field";
 
 interface FieldRendererProps {
   field: PydanticField;
@@ -447,7 +448,8 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
                   className="w-32 shrink-0 text-right text-xs text-muted-foreground"
                 >
                   {sf.label}
-                  {sf.required && field.subfield_rule !== "at_least_one" && (
+                  {resolveSubfieldRequired(sf.required) &&
+                    field.subfield_rule !== "at_least_one" && (
                     <span className="text-destructive ml-0.5">*</span>
                   )}
                 </label>

--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -23,7 +23,10 @@ import {
   padDatePart,
   parseDatePartsForUI,
 } from "@/lib/date-parts";
-import { resolveSubfieldRequired } from "@/lib/pydantic-field";
+import {
+  resolveSubfieldRequired,
+  resolveSubfieldRule,
+} from "@/lib/pydantic-field";
 
 interface FieldRendererProps {
   field: PydanticField;
@@ -449,9 +452,10 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
                 >
                   {sf.label}
                   {resolveSubfieldRequired(sf.required) &&
-                    field.subfield_rule !== "at_least_one" && (
-                    <span className="text-destructive ml-0.5">*</span>
-                  )}
+                    resolveSubfieldRule(field.subfield_rule) !==
+                      "at_least_one" && (
+                      <span className="text-destructive ml-0.5">*</span>
+                    )}
                 </label>
                 <Input
                   id={`${subfieldIdPrefix}-${sf.key}`}

--- a/frontend/src/components/schema/FieldChangeDiff.tsx
+++ b/frontend/src/components/schema/FieldChangeDiff.tsx
@@ -17,6 +17,7 @@ import {
   propertyLabel,
 } from "@/lib/schema-change-format";
 import { isProjectScopedLogEntry } from "@/lib/schema-utils";
+import { resolveSubfieldRequired } from "@/lib/pydantic-field";
 import type { SchemaChangeEntry, FieldCondition, SubfieldDef } from "@/lib/types";
 
 interface FieldChangeDiffProps {
@@ -412,6 +413,16 @@ function OptionsListDiff({
   );
 }
 
+// Asterisco pelo mesmo criterio do `FieldRenderer`, resolvido pelo canonico —
+// `sf.required` ausente e opcional, o oposto do default de campo.
+function subfieldText(s: SubfieldDef): string {
+  return `${s.label || s.key}${resolveSubfieldRequired(s.required) ? " *" : ""}`;
+}
+
+function subfieldRequiredLabel(required: boolean | undefined): string {
+  return resolveSubfieldRequired(required) ? "obrigatório" : "opcional";
+}
+
 function SubfieldsDiff({
   before,
   after,
@@ -425,19 +436,45 @@ function SubfieldsDiff({
   const beforeMap = new Map(beforeArr.map((s) => [s.key, s]));
   const removed = beforeArr.filter((s) => !afterMap.has(s.key));
   const added = afterArr.filter((s) => !beforeMap.has(s.key));
-  const kept = beforeArr.filter((s) => afterMap.has(s.key));
+  // Um subcampo que continua existindo mas mudou de obrigatoriedade e a unica
+  // alteracao que o particionamento kept/removed/added nao enxerga: sem esta
+  // separacao o log gravava a mudanca, o versionamento bumpava minor e o
+  // historico renderizava um badge identico ao de antes (issue #491).
+  const kept = beforeArr
+    .filter((s) => afterMap.has(s.key))
+    .map((s) => ({ before: s, after: afterMap.get(s.key)! }))
+    .map((pair) => ({
+      ...pair,
+      requiredChanged:
+        resolveSubfieldRequired(pair.before.required) !==
+        resolveSubfieldRequired(pair.after.required),
+    }));
 
   return (
     <div className="flex flex-wrap items-center gap-1">
-      {kept.map((s) => (
-        <Badge
-          key={`kept-${s.key}`}
-          variant="outline"
-          className="text-[10px] px-1.5 py-0 font-normal break-words"
-        >
-          {s.label || s.key}
-        </Badge>
-      ))}
+      {kept.map(({ before: b, after: a, requiredChanged }) =>
+        requiredChanged ? (
+          <Badge
+            key={`kept-${b.key}`}
+            className={cn(
+              "text-[10px] px-1.5 py-0 font-normal break-words gap-0.5",
+              "bg-amber-500/10 text-amber-700 hover:bg-amber-500/10",
+            )}
+          >
+            {b.label || b.key}: {subfieldRequiredLabel(b.required)}
+            <ArrowRight className="h-2.5 w-2.5 shrink-0" />
+            {subfieldRequiredLabel(a.required)}
+          </Badge>
+        ) : (
+          <Badge
+            key={`kept-${b.key}`}
+            variant="outline"
+            className="text-[10px] px-1.5 py-0 font-normal break-words"
+          >
+            {subfieldText(b)}
+          </Badge>
+        ),
+      )}
       {removed.map((s) => (
         <Badge
           key={`rem-${s.key}`}
@@ -446,7 +483,7 @@ function SubfieldsDiff({
             "bg-red-500/10 text-red-700 hover:bg-red-500/10",
           )}
         >
-          <del className="no-underline">− {s.label || s.key}</del>
+          <del className="no-underline">− {subfieldText(s)}</del>
         </Badge>
       ))}
       {added.map((s) => (
@@ -457,7 +494,7 @@ function SubfieldsDiff({
             "bg-green-500/10 text-green-700 hover:bg-green-500/10",
           )}
         >
-          <ins className="no-underline">+ {s.label || s.key}</ins>
+          <ins className="no-underline">+ {subfieldText(s)}</ins>
         </Badge>
       ))}
     </div>

--- a/frontend/src/components/schema/SubfieldsEditor.tsx
+++ b/frontend/src/components/schema/SubfieldsEditor.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { OptionsEditor } from "./OptionsEditor";
 import { useStableListIds } from "@/hooks/useStableListIds";
 import type { SubfieldDef } from "@/lib/types";
+import { resolveSubfieldRequired } from "@/lib/pydantic-field";
 
 // Estado completo (não um patch parcial): toda emissão inclui os 3 campos,
 // com os que não mudaram preenchidos com o valor atual. O FieldCard repassa
@@ -131,7 +132,7 @@ export function SubfieldsEditor({
               {subfieldRule !== "at_least_one" && (
                 <div className="flex items-center gap-1">
                   <Switch
-                    checked={sf.required !== false}
+                    checked={resolveSubfieldRequired(sf.required)}
                     onCheckedChange={(checked) => {
                       const sfs = [...subfields];
                       sfs[si] = { ...sfs[si], required: checked };

--- a/frontend/src/components/schema/__tests__/FieldChangeDiff.test.tsx
+++ b/frontend/src/components/schema/__tests__/FieldChangeDiff.test.tsx
@@ -63,3 +63,86 @@ describe("FieldChangeDiff — entradas de escopo de projeto", () => {
     expect(screen.getByText("Nova versão MAJOR publicada: 1.0.0")).toBeTruthy();
   });
 });
+
+// Mudar só a obrigatoriedade de um subcampo existente é a única alteração que o
+// particionamento kept/removed/added do SubfieldsDiff não enxergava: os dois
+// lados têm a mesma chave e o mesmo rótulo, então o badge saía idêntico ao de
+// antes. A entrada era gravada, o versionamento bumpava minor, e o histórico
+// não mostrava nada (issue #491, mesmo sintoma do `Boolean(null)` no `required`
+// de campo).
+describe("FieldChangeDiff — obrigatoriedade de subcampo", () => {
+  const comSubcampos = (subfields: unknown) => ({
+    name: "q1",
+    type: "text",
+    description: "Campo",
+    subfields,
+  });
+
+  it("mostra a transição quando o subcampo vira obrigatório", () => {
+    render(
+      <FieldChangeDiff
+        entry={entry({
+          changeSummary: "subcampos",
+          beforeValue: comSubcampos([{ key: "cid", label: "CID" }]),
+          afterValue: comSubcampos([
+            { key: "cid", label: "CID", required: true },
+          ]),
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/CID: opcional/)).toBeTruthy();
+    expect(screen.getByText(/obrigatório/)).toBeTruthy();
+  });
+
+  it("mostra a transição inversa quando deixa de ser obrigatório", () => {
+    render(
+      <FieldChangeDiff
+        entry={entry({
+          changeSummary: "subcampos",
+          beforeValue: comSubcampos([
+            { key: "cid", label: "CID", required: true },
+          ]),
+          afterValue: comSubcampos([{ key: "cid", label: "CID" }]),
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/CID: obrigatório/)).toBeTruthy();
+  });
+
+  // O par da invariante: promover o default a explícito NÃO é transição — sem
+  // isso, o teste acima passaria mesmo com a normalização desligada.
+  it("não trata `required` ausente e `false` como mudança", () => {
+    render(
+      <FieldChangeDiff
+        entry={entry({
+          changeSummary: "descrição alterada",
+          beforeValue: comSubcampos([{ key: "cid", label: "CID" }]),
+          afterValue: comSubcampos([
+            { key: "cid", label: "CID", required: false },
+          ]),
+        })}
+      />,
+    );
+
+    expect(screen.queryByText(/CID: /)).toBeNull();
+  });
+
+  it("marca subcampo obrigatório com asterisco nos adicionados", () => {
+    render(
+      <FieldChangeDiff
+        entry={entry({
+          changeSummary: "subcampos",
+          beforeValue: comSubcampos([{ key: "cid", label: "CID" }]),
+          afterValue: comSubcampos([
+            { key: "cid", label: "CID" },
+            { key: "doenca", label: "Doença", required: true },
+          ]),
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/\+ Doença \*/)).toBeTruthy();
+  });
+});

--- a/frontend/src/lib/__tests__/schema-merge.test.ts
+++ b/frontend/src/lib/__tests__/schema-merge.test.ts
@@ -327,4 +327,58 @@ describe("mergeSchemas — default implícito não é edição", () => {
     );
     expect(unresolvedSchemaConflicts(merge)).toHaveLength(1);
   });
+
+  // A quinta, um nível abaixo das outras: o default implícito vive DENTRO de
+  // `subfields`, e o produtor do explícito é `_extract_subfields`, que sempre
+  // grava `required` no subcampo. Um campo legado com `{key,label}` e o mesmo
+  // campo recuperado por `compile_pydantic` descrevem o mesmo grupo (#491).
+  const semRequired: PydanticField = {
+    ...q1,
+    subfields: [{ key: "a", label: "A" }],
+    subfield_rule: "at_least_one",
+  };
+  const comRequiredFalse: PydanticField = {
+    ...semRequired,
+    subfields: [{ key: "a", label: "A", required: false }],
+  };
+
+  it("required de subcampo implícito não conflita com o explícito", () => {
+    expect(
+      mergeSchemas([], [semRequired], [comRequiredFalse]).conflicts,
+    ).toEqual([]);
+  });
+
+  it("edição local do subcampo não conflita com remoto que só explicitou o default", () => {
+    const merge = mergeSchemas(
+      [semRequired],
+      [
+        {
+          ...semRequired,
+          subfields: [{ key: "a", label: "A", required: true }],
+        },
+      ],
+      [comRequiredFalse],
+    );
+    expect(unresolvedSchemaConflicts(merge)).toEqual([]);
+    expect(merge.fields[0].subfields?.[0].required).toBe(true);
+  });
+
+  it("tornar um subcampo obrigatório de verdade continua conflitando", () => {
+    const merge = mergeSchemas(
+      [semRequired],
+      [
+        {
+          ...semRequired,
+          subfields: [{ key: "a", label: "A", required: true }],
+        },
+      ],
+      [
+        {
+          ...semRequired,
+          subfields: [{ key: "a", label: "Rótulo remoto" }],
+        },
+      ],
+    );
+    expect(unresolvedSchemaConflicts(merge)).toHaveLength(1);
+  });
 });

--- a/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
+++ b/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
@@ -501,4 +501,64 @@ describe("generatePydanticCode round-trip surface", () => {
     expect(explicito).not.toContain('"required"');
     expect(explicito).toBe(implicito);
   });
+
+  // Issue #491: sob at_least_one a anotação é sempre Optional[str] e não
+  // consegue carregar o `required` individual do subcampo — ele viaja em
+  // json_schema_extra, só no caso não-default (o default de subcampo é
+  // `false`, o oposto do required de campo).
+  const subfieldGroup = (
+    subfields: PydanticField["subfields"],
+    subfield_rule?: "all" | "at_least_one",
+  ) =>
+    baseField({
+      name: "doc",
+      type: "text",
+      options: null,
+      subfields,
+      subfield_rule,
+    });
+
+  it("emits subfield required in json_schema_extra under at_least_one", () => {
+    const code = generatePydanticCode([
+      subfieldGroup(
+        [
+          { key: "a", label: "A", required: true },
+          { key: "b", label: "B", required: false },
+        ],
+        "at_least_one",
+      ),
+    ]);
+    expect(code).toContain(
+      '    a: Optional[str] = Field(default=None, description="A", json_schema_extra={"required": True})',
+    );
+    expect(code).toContain(
+      '    b: Optional[str] = Field(default=None, description="B")',
+    );
+  });
+
+  it("keeps subfield text byte-identical when required is default", () => {
+    // Sob "all" a anotação já carrega o required (str vs Optional[str]);
+    // sob at_least_one sem subcampo obrigatório não há o que emitir. Nos
+    // dois casos o texto — e portanto o pydantic_hash — não pode mudar.
+    const all = generatePydanticCode([
+      subfieldGroup([
+        { key: "a", label: "A", required: true },
+        { key: "b", label: "B", required: false },
+      ]),
+    ]);
+    expect(all).toContain('    a: str = Field(description="A")');
+    expect(all).toContain(
+      '    b: Optional[str] = Field(default=None, description="B")',
+    );
+    expect(all).not.toContain('"required"');
+
+    const explicito = generatePydanticCode([
+      subfieldGroup([{ key: "a", label: "A", required: false }], "at_least_one"),
+    ]);
+    const legado = generatePydanticCode([
+      subfieldGroup([{ key: "a", label: "A" }], "at_least_one"),
+    ]);
+    expect(explicito).not.toContain('"required"');
+    expect(legado).toBe(explicito);
+  });
 });

--- a/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
+++ b/frontend/src/lib/__tests__/schema-utils-versioning.test.ts
@@ -148,6 +148,29 @@ describe("classifyChange", () => {
     const mudada = [withSubfields({ subfield_rule: "at_least_one" })];
     expect(classifyChange(legado, mudada)).toBe("minor");
   });
+
+  // Um nível abaixo: o default implícito dentro do próprio subcampo. Quem
+  // produz o explícito é `_extract_subfields`, que sempre grava `required`
+  // (issue #491) — sem normalizar, recuperar um projeto legado pelo endpoint
+  // de recover bumpava minor e gravava auditoria de uma mudança que ninguém
+  // fez.
+  it("promover o default de required do subcampo a explícito não é mudança", () => {
+    const legado = [withSubfields()];
+    const recuperado = [
+      withSubfields({ subfields: [{ key: "a", label: "A", required: false }] }),
+    ];
+    expect(classifyChange(legado, recuperado)).toBeNull();
+    expect(diffFields(legado, recuperado)).toEqual([]);
+  });
+
+  it("tornar o subcampo obrigatório de verdade continua sendo minor", () => {
+    const legado = [withSubfields()];
+    const mudada = [
+      withSubfields({ subfields: [{ key: "a", label: "A", required: true }] }),
+    ];
+    expect(classifyChange(legado, mudada)).toBe("minor");
+    expect(diffFields(legado, mudada)).toHaveLength(1);
+  });
 });
 
 // O jsonb do Postgres normaliza a ordem das chaves; condition/subfields lidos
@@ -505,7 +528,9 @@ describe("generatePydanticCode round-trip surface", () => {
   // Issue #491: sob at_least_one a anotação é sempre Optional[str] e não
   // consegue carregar o `required` individual do subcampo — ele viaja em
   // json_schema_extra, só no caso não-default (o default de subcampo é
-  // `false`, o oposto do required de campo).
+  // `false`, o oposto do required de campo). A chave é `subfield_required`
+  // porque o backend achata o subcampo em property do JSON Schema do provider,
+  // onde `required` é palavra reservada — ver comentário em generatePydanticCode.
   const subfieldGroup = (
     subfields: PydanticField["subfields"],
     subfield_rule?: "all" | "at_least_one",
@@ -529,11 +554,14 @@ describe("generatePydanticCode round-trip surface", () => {
       ),
     ]);
     expect(code).toContain(
-      '    a: Optional[str] = Field(default=None, description="A", json_schema_extra={"required": True})',
+      '    a: Optional[str] = Field(default=None, description="A", json_schema_extra={"subfield_required": True})',
     );
     expect(code).toContain(
       '    b: Optional[str] = Field(default=None, description="B")',
     );
+    // `required` cru colidiria com a palavra reservada do JSON Schema quando o
+    // backend achata o subcampo para mandar ao provider.
+    expect(code).not.toContain('{"required"');
   });
 
   it("keeps subfield text byte-identical when required is default", () => {

--- a/frontend/src/lib/pydantic-field.ts
+++ b/frontend/src/lib/pydantic-field.ts
@@ -302,6 +302,15 @@ export function resolveSubfieldRule(
   return value ?? "all";
 }
 
+// Default de subcampo é `false` — o OPOSTO do `required` de campo
+// (`resolveRequired`, acima, resolve para `true`). O gerador e o
+// `FieldRenderer` sempre trataram ausente como opcional; o `SubfieldsEditor`
+// cria subcampos com `required: true` explícito, então `undefined` só existe
+// em dado legado (issue #491).
+export function resolveSubfieldRequired(value: boolean | null | undefined): boolean {
+  return value === true;
+}
+
 export const PYDANTIC_FIELD_PROPERTY_KEYS = Object.freeze(
   Object.keys(pydanticFieldSchema.shape).sort(),
 );

--- a/frontend/src/lib/pydantic-field.ts
+++ b/frontend/src/lib/pydantic-field.ts
@@ -307,8 +307,40 @@ export function resolveSubfieldRule(
 // `FieldRenderer` sempre trataram ausente como opcional; o `SubfieldsEditor`
 // cria subcampos com `required: true` explícito, então `undefined` só existe
 // em dado legado (issue #491).
-export function resolveSubfieldRequired(value: boolean | null | undefined): boolean {
+//
+// Diferente dos resolvedores de campo acima, este NÃO aceita `null`:
+// `subfieldDefSchema` declara `required` como `z.boolean().optional()`, então
+// um `null` vindo do jsonb já falha o parse fail-closed. Aceitá-lo aqui
+// resolveria em silêncio um payload que na verdade está corrompido.
+export function resolveSubfieldRequired(value: boolean | undefined): boolean {
   return value === true;
+}
+
+// Normalizacao canonica do array de subcampos, aplicada dentro de `snapshotOf`
+// (schema-utils.ts) e de `subfieldsEqual` (schema-change-diff.ts) — os dois
+// pontos que decidem se dois campos sao "o mesmo campo".
+//
+// Sem ela, `subfields` era a unica propriedade estrutural comparada crua,
+// enquanto `_extract_subfields` no backend SEMPRE grava a chave `required`:
+// um subcampo legado `{key,label}` no banco e o mesmo recuperado por
+// `compile_pydantic` (`{key,label,required:false}`) serializavam diferente,
+// gerando bump minor sem mudanca nenhuma e conflito de merge fabricado em
+// `mergeFieldProperties`, que indexa por `snapshotOf`. Mesma classe que
+// `hash`, `target` e `subfield_rule` ja causaram — a quarta rodada.
+// Spread em vez de projetar `{key,label,required}`: as comparacoes que chamam
+// isto rodam sobre payload cru de `schema_change_log`, onde uma propriedade que
+// o SubfieldDef ganhe no futuro ja aparece antes de existir aqui. Enumerar as
+// chaves conhecidas descartaria essa propriedade em silencio e a mudanca dela
+// sumiria do diff — e o teste "futureproof" de schema-change-diff.test.ts
+// existe exatamente para barrar isso. So o default implicito e resolvido.
+export function normalizeSubfields(
+  subfields: SubfieldDef[] | null | undefined,
+): SubfieldDef[] | null {
+  if (!subfields) return null;
+  return subfields.map((sf) => ({
+    ...sf,
+    required: resolveSubfieldRequired(sf.required),
+  }));
 }
 
 export const PYDANTIC_FIELD_PROPERTY_KEYS = Object.freeze(

--- a/frontend/src/lib/schema-change-diff.ts
+++ b/frontend/src/lib/schema-change-diff.ts
@@ -1,5 +1,6 @@
 import { stableStringify } from "./schema-utils";
 import {
+  normalizeSubfields,
   resolveAllowOther,
   resolveRequired,
   resolveSubfieldRule,
@@ -61,13 +62,20 @@ function arraysEqual<T>(a: T[] | null | undefined, b: T[] | null | undefined): b
 // cliente. Mesma correção de schema-utils.ts (classifyChange/diffFields),
 // aplicada aqui para o diff de histórico ficar em sincronia — ver CLAUDE.md
 // regra (d) e PR #352.
+// `normalizeSubfields` antes do stringify pela mesma razao que `snapshotOf` o
+// usa: o backend sempre grava `required` no subcampo e o dado legado pode nao
+// ter a chave, entao comparar cru acusaria mudanca onde so ha default
+// explicitado (issue #491).
 function subfieldsEqual(
   a: SubfieldDef[] | null | undefined,
   b: SubfieldDef[] | null | undefined,
 ): boolean {
   if (!a && !b) return true;
   if (!a || !b) return false;
-  return stableStringify(a) === stableStringify(b);
+  return (
+    stableStringify(normalizeSubfields(a)) ===
+    stableStringify(normalizeSubfields(b))
+  );
 }
 
 function conditionEqual(

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -6,6 +6,7 @@ import type {
 import {
   resolveAllowOther,
   resolveRequired,
+  resolveSubfieldRequired,
   resolveSubfieldRule,
   resolveTarget,
 } from "@/lib/pydantic-field";
@@ -144,12 +145,22 @@ export function generatePydanticCode(
     if (field.subfields && field.subfields.length > 0) {
       lines.push("");
       lines.push(`class ${subfieldClassName(field.name)}(BaseModel):`);
+      const rule = resolveSubfieldRule(field.subfield_rule);
       for (const sf of field.subfields) {
-        const ann = sf.required && field.subfield_rule !== "at_least_one"
-          ? "str"
-          : "Optional[str]";
+        const required = resolveSubfieldRequired(sf.required);
+        const ann = required && rule !== "at_least_one" ? "str" : "Optional[str]";
+        // Sob at_least_one a anotação é sempre Optional e não consegue carregar
+        // o `required` individual — ele viaja em json_schema_extra, só no caso
+        // não-default (`True`; o default de subcampo é `false`), para manter o
+        // texto — e portanto o pydantic_hash — byte-idêntico para quem não usa
+        // a propriedade (issue #491; mesmo racional do `required` de campo em
+        // `fieldExtra`).
+        const extra =
+          rule === "at_least_one" && required
+            ? `, json_schema_extra={"required": True}`
+            : "";
         lines.push(
-          `    ${sf.key}: ${ann} = Field(${ann === "Optional[str]" ? "default=None, " : ""}description="${escapeString(sf.label)}")`
+          `    ${sf.key}: ${ann} = Field(${ann === "Optional[str]" ? "default=None, " : ""}description="${escapeString(sf.label)}"${extra})`
         );
       }
     }

--- a/frontend/src/lib/schema-utils.ts
+++ b/frontend/src/lib/schema-utils.ts
@@ -2,8 +2,10 @@ import type {
   ConditionScalar,
   FieldCondition,
   PydanticField,
+  SubfieldDef,
 } from "@/lib/types";
 import {
+  normalizeSubfields,
   resolveAllowOther,
   resolveRequired,
   resolveSubfieldRequired,
@@ -155,9 +157,18 @@ export function generatePydanticCode(
         // texto — e portanto o pydantic_hash — byte-idêntico para quem não usa
         // a propriedade (issue #491; mesmo racional do `required` de campo em
         // `fieldExtra`).
+        //
+        // A chave é `subfield_required`, e não `required`, porque
+        // `_flatten_nested_basemodels` (backend/services/llm_runner.py)
+        // reaproveita o FieldInfo do subcampo inteiro ao achatar o modelo: o
+        // extra sobe para uma *property* do JSON Schema enviado ao provider, e
+        // `required` ali é palavra reservada (posição válida é no nível do
+        // objeto, valor é array de strings). Nome inerte evita depender de o
+        // conversor do provider descartar a chave — o do google_genai descarta,
+        // um provider em strict mode recusaria.
         const extra =
           rule === "at_least_one" && required
-            ? `, json_schema_extra={"required": True}`
+            ? `, json_schema_extra={"subfield_required": True}`
             : "";
         lines.push(
           `    ${sf.key}: ${ann} = Field(${ann === "Optional[str]" ? "default=None, " : ""}description="${escapeString(sf.label)}"${extra})`
@@ -502,13 +513,18 @@ export function bumpVersion(
 // Serializa um PydanticField para gravar em
 // schema_change_log.before_value / after_value.
 //
-// As quatro propriedades com default implicito passam pelos resolvedores
-// canonicos em vez de `?? null`: `snapshotOf` e a serializacao que `classifyChange`
+// As propriedades com default implicito passam pelos resolvedores canonicos em
+// vez de `?? null`: `snapshotOf` e a serializacao que `classifyChange`
 // classifica, que a deteccao de dirty compara e que `mergeSchemas` le propriedade
 // a propriedade, entao normalizar diferente em qualquer um deles fabrica conflito
 // de merge sem edicao nenhuma — foi o que `hash`, `target` e `subfield_rule` ja
 // causaram, um por rodada de revisao. Payloads gravados antes desta mudanca tem
 // `null` nessas chaves; o diff de historico resolve os dois para o mesmo default.
+//
+// `subfields` era a excecao — comparado cru, com o default de `required` de
+// cada subcampo por resolver — e por isso repetia o mesmo sintoma um nivel
+// abaixo (issue #491). `normalizeSubfields` fecha isso; a normalizacao mora
+// dentro do resolvedor, nao numa tabela paralela propriedade→default.
 export function snapshotOf(field: PydanticField): Record<string, unknown> {
   return {
     name: field.name,
@@ -518,7 +534,7 @@ export function snapshotOf(field: PydanticField): Record<string, unknown> {
     options: field.options ?? null,
     target: resolveTarget(field.target),
     required: resolveRequired(field.required),
-    subfields: field.subfields ?? null,
+    subfields: normalizeSubfields(field.subfields),
     subfield_rule: resolveSubfieldRule(field.subfield_rule),
     allow_other: resolveAllowOther(field.allow_other),
     condition: field.condition ?? null,
@@ -547,7 +563,12 @@ export function fieldDiffIsStructural(
   }
 
   if (before.subfields !== undefined || after.subfields !== undefined) {
-    if (stableStringify(before.subfields ?? null) !== stableStringify(after.subfields ?? null)) {
+    // Normalizado como em `snapshotOf`/`diffFields`: payloads gravados antes
+    // do #491 tem subcampo sem a chave `required`, e o backfill nao pode
+    // reclassificar como estrutural um default que so virou explicito.
+    const b = normalizeSubfields(before.subfields as SubfieldDef[] | null);
+    const a = normalizeSubfields(after.subfields as SubfieldDef[] | null);
+    if (stableStringify(b) !== stableStringify(a)) {
       return true;
     }
   }
@@ -698,12 +719,12 @@ export function diffFields(
       before.allow_other = resolveAllowOther(old.allow_other);
       after.allow_other = resolveAllowOther(f.allow_other);
     }
-    const oldSubs = stableStringify(old.subfields ?? null);
-    const newSubs = stableStringify(f.subfields ?? null);
-    if (oldSubs !== newSubs) {
+    const oldSubs = normalizeSubfields(old.subfields);
+    const newSubs = normalizeSubfields(f.subfields);
+    if (stableStringify(oldSubs) !== stableStringify(newSubs)) {
       diffs.push("subcampos");
-      before.subfields = old.subfields ?? null;
-      after.subfields = f.subfields ?? null;
+      before.subfields = oldSubs;
+      after.subfields = newSubs;
     }
     const oldCond = stableStringify(old.condition ?? null);
     const newCond = stableStringify(f.condition ?? null);


### PR DESCRIPTION
## Problema

Um subcampo marcado como obrigatório dentro de um grupo com `subfield_rule: "at_least_one"` voltava como opcional após o round-trip `UI → pydantic_code → compile_pydantic → UI`. Sob essa regra, `generatePydanticCode` emite todo subcampo como `Optional[str]` (correto para o Pydantic — "pelo menos um" não se expressa por obrigatoriedade individual), mas `_extract_subfields` inferia `required` só da anotação (`not is_optional`) e devolvia `False` para todos, descartando a intenção do usuário em silêncio. Mesma família do #454, um nível abaixo.

## Correção

- **Gerador** (`frontend/src/lib/schema-utils.ts`): sob `at_least_one`, o `required` do subcampo viaja em `json_schema_extra={"subfield_required": True}` — **só no caso não-default** (o default de subcampo é `false`, o oposto do `required` de campo). Como `pydantic_hash` é sha256 do texto do código, o texto fica byte-idêntico para grupos com regra `all` e para grupos `at_least_one` sem subcampo obrigatório.
- **Compilador** (`backend/services/pydantic_compiler.py`): `_extract_subfields` consulta `extract_json_schema_extra(sf_info)` e o extra prevalece sobre a inferência da anotação, espelhando o precedente do `required` de campo (#454).
- **Resolvedor** (`frontend/src/lib/pydantic-field.ts`): o default implícito vira `resolveSubfieldRequired` (regra c2 do CLAUDE.md), usado pelo gerador, `FieldRenderer` e `SubfieldsEditor`. Fecha o drift em que o editor mostrava marcado (`sf.required !== false`) um subcampo legado sem `required` que o gerador emitia como opcional. (Hoje isso não é observável em produção: os 2 subcampos legados sem a chave estão sob `at_least_one`, onde o Switch não é renderizado — a correção fecha a classe.)

## Segundo commit — achados da revisão

1. **Chave inerte no extra.** `_flatten_nested_basemodels` (`llm_runner.py`) reaproveita o `FieldInfo` do subcampo inteiro ao achatar o modelo, então o extra sobe para uma *property* do JSON Schema mandado ao provider — e `required` ali é palavra reservada (posição válida é no nível do objeto, valor é array de strings). Por isso a chave é `subfield_required`. Verificado que hoje seria inócuo (o conversor do `langchain_google_genai` copia só chaves de uma allowlist e descarta o resto; todos os projetos usam `google_genai`), mas um provider em strict mode recusaria. Teste novo em `test_llm_flatten_nested.py` fixa a ausência da colisão.
2. **Resolvedores crus.** `FieldRenderer` passa a resolver `subfield_rule` pelo canônico; `resolveSubfieldRequired` deixa de aceitar `null`, casando com o `subfieldDefSchema` (`z.boolean().optional()`) — um `null` já falha o parse fail-closed, e resolvê-lo aqui esconderia payload corrompido.
3. **`normalizeSubfields` na serialização canônica.** `subfields` era a única propriedade estrutural comparada crua (`snapshotOf`, `diffFields`, `fieldDiffIsStructural`, `subfieldsEqual`), enquanto `_extract_subfields` **sempre** grava a chave `required`: um campo legado `{key,label}` e o mesmo recuperado por `compile_pydantic` (`{key,label,required:false}`) fabricavam bump minor sem edição e conflito de merge em `mergeFieldProperties`. Quarta rodada da classe de `hash`/`target`/`subfield_rule`. Normaliza por spread, não projetando as chaves conhecidas — projetar descartaria propriedade futura do `SubfieldDef`, regressão que o teste "futureproof" de `schema-change-diff` pegou.
4. **Histórico renderiza obrigatoriedade.** `SubfieldsDiff` particionava em kept/removed/added e mostrava só o rótulo: mudar apenas o `required` bumpava minor, gravava o log e não exibia nada. Agora há asterisco nos badges e a transição obrigatório↔opcional nos mantidos.

## Verificação

- **Prova do vermelho**: o teste backend (`test_subfield_required_round_trips_under_at_least_one`) falhou contra o código atual com `required: False` antes do fix. Nos achados novos, cada braço foi mutado: desligar a normalização no `snapshotOf` derruba os 2 testes novos de merge (e **não** o de conflito real, provando que não são vácuos); forçar `requiredChanged: false` derruba os 2 de transição no histórico.
- **Blast radius do `pydantic_hash`, medido**: dos 8 projetos, só o Zolgensma tem `at_least_one` com subcampo `required: true` (4 subcampos), então só o texto dele muda no próximo save. Respostas que ficariam órfãs: **zero** — as 4 sem `answer_field_hashes` no Zolgensma têm `pydantic_hash NULL` e semver 0.1 (vínculo por semver), e as únicas 4 ligadas por hash sem `answer_field_hashes` no banco inteiro estão no fixture E2E `1d8afb23`, que não tem grupo `at_least_one`.
- Suítes completas verdes: vitest 1874, pytest 279, typecheck, ruff, eslint, e os 8 gates de pre-push (lint:types, fallow, semgrep, mypy, e2e-smoke).

Fica de fora, com issue própria: a régua de completude não consome `required` de subcampo nem `subfield_rule` (`isFieldAnswered` aceita qualquer objeto não-vazio). É write path e vai num PR separado.

Revisão sugerida: amostragem.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)