### PR TITLE
fix(membros): confirma antes de remover e conserta o fechamento do ConfirmActionDialog

### DIFF
--- a/frontend/src/components/documents/__tests__/exclude-documents-flow.test.tsx
+++ b/frontend/src/components/documents/__tests__/exclude-documents-flow.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { DocumentSummary } from "@/components/documents/DocumentList";
+
+const mocks = vi.hoisted(() => ({
+  excludeDocuments: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+// useDocumentActions importa as três actions; declarar só a exercida aqui
+// quebraria o import do módulo.
+vi.mock("@/actions/documents", () => ({
+  excludeDocuments: mocks.excludeDocuments,
+  restoreDocuments: vi.fn(),
+  hardDeleteDocuments: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess },
+}));
+
+import { ExcludeDocumentsDialog } from "@/components/documents/ExcludeDocumentsDialog";
+import { useDocumentActions } from "@/components/documents/useDocumentActions";
+
+const doc: DocumentSummary = {
+  id: "doc-1",
+  external_id: "0001",
+  title: "Parecer 0001",
+  responseCount: 2,
+};
+
+// Exercita o fluxo real do DocumentsPageClient — o hook de verdade ligado ao
+// diálogo de verdade — em vez de reimplementar o estado no teste. É o que faz
+// esta suíte responder pelo comportamento que o preventDefault mudou.
+function Harness() {
+  const {
+    excludeTarget,
+    excludeReason,
+    setExcludeReason,
+    isPending,
+    requestExcludeSingle,
+    closeExclude,
+    confirmExclude,
+  } = useDocumentActions("project-1", [doc]);
+
+  return (
+    <>
+      <button onClick={() => requestExcludeSingle(doc)}>Excluir documento</button>
+      <ExcludeDocumentsDialog
+        target={excludeTarget}
+        reason={excludeReason}
+        onReasonChange={setExcludeReason}
+        isPending={isPending}
+        onConfirm={confirmExclude}
+        onClose={closeExclude}
+      />
+    </>
+  );
+}
+
+// O gatilho e o botão de confirmação não compartilham rótulo, mas escopar ao
+// diálogo deixa explícito qual dos dois está sendo acionado.
+function confirmButton() {
+  return within(screen.getByRole("alertdialog")).getByRole("button", {
+    name: "Excluir",
+  });
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.excludeDocuments.mockResolvedValue(undefined);
+});
+
+describe("ExcludeDocumentsDialog — fechamento sob controle do pai", () => {
+  it("preserva o motivo digitado quando a exclusão falha e conclui no retry", async () => {
+    mocks.excludeDocuments
+      .mockResolvedValueOnce({ error: "Falha ao excluir" })
+      .mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "Excluir documento" }));
+    await user.type(
+      await screen.findByLabelText(/Motivo da exclusão/),
+      "fora do escopo",
+    );
+    await user.click(confirmButton());
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith("Falha ao excluir"),
+    );
+    // O diálogo permanece em cena com o texto intacto: fechar aqui obrigaria o
+    // coordenador a reabrir e redigitar o motivo que a action exige.
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+    expect(
+      screen.getByLabelText<HTMLTextAreaElement>(/Motivo da exclusão/).value,
+    ).toBe("fora do escopo");
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+
+    await user.click(confirmButton());
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.excludeDocuments).toHaveBeenCalledTimes(2);
+    expect(mocks.excludeDocuments).toHaveBeenLastCalledWith(
+      "project-1",
+      ["doc-1"],
+      "fora do escopo",
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("não deixa confirmar sem motivo, mantendo o diálogo utilizável", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole("button", { name: "Excluir documento" }));
+
+    // O gate do motivo vive no `disabled` do botão, não no corpo do onConfirm:
+    // a validação de confirmExclude é defesa em profundidade e não é alcançada
+    // por esta via enquanto o botão estiver desabilitado.
+    await waitFor(() =>
+      expect(confirmButton().hasAttribute("disabled")).toBe(true),
+    );
+    expect(mocks.excludeDocuments).not.toHaveBeenCalled();
+
+    await user.type(
+      screen.getByLabelText(/Motivo da exclusão/),
+      "duplicado",
+    );
+
+    expect(confirmButton().hasAttribute("disabled")).toBe(false);
+  });
+});

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -17,6 +17,7 @@ import { useMemberListDialogs } from "@/hooks/useMemberListDialogs";
 import { MemberRow } from "./MemberRow";
 import {
   memberDisplayName,
+  memberSecondaryEmail,
   groupLinksByMember,
   type MemberEmailLinkView,
   type MemberRow as MemberRowData,
@@ -151,6 +152,11 @@ export function MemberList({
     startTransition,
   );
 
+  const removalName = removingMember ? memberDisplayName(removingMember) : null;
+  const removalEmail = removingMember
+    ? memberSecondaryEmail(removingMember)
+    : null;
+
   return (
     <div className="space-y-2">
       {optimisticMembers.map((m) => (
@@ -181,16 +187,12 @@ export function MemberList({
         onClose={() => setRemovingMember(null)}
         title="Remover membro?"
         description={
-          removingMember ? (
+          removalName ? (
             <>
-              Remover <strong>{memberDisplayName(removingMember)}</strong>
-              {removingMember.profiles?.email &&
-              removingMember.profiles.email !==
-                memberDisplayName(removingMember) ? (
-                <> ({removingMember.profiles.email})</>
-              ) : null}{" "}
-              deste projeto? As atribuições ainda não iniciadas voltam ao
-              conjunto disponível; o trabalho já feito permanece como histórico.
+              Remover <strong>{removalName}</strong>
+              {removalEmail ? <> ({removalEmail})</> : null} deste projeto? As
+              atribuições ainda não iniciadas voltam ao conjunto disponível; o
+              trabalho já feito permanece como histórico.
             </>
           ) : null
         }

--- a/frontend/src/components/members/MemberList.tsx
+++ b/frontend/src/components/members/MemberList.tsx
@@ -9,6 +9,7 @@ import {
   setCanCompare,
   unlinkMemberEmail,
 } from "@/actions/members";
+import { ConfirmActionDialog } from "@/components/ui/confirm-action-dialog";
 import { LinkEmailDialog } from "@/components/members/LinkEmailDialog";
 import { UnifyMembersDialog } from "@/components/members/UnifyMembersDialog";
 import { toast } from "sonner";
@@ -30,15 +31,6 @@ interface MemberListProps {
   members: MemberRowData[];
   emailLinks: MemberEmailLinkView[];
   currentUserId: string;
-}
-
-async function removeMemberWithToast(memberId: string) {
-  const result = await removeMember(memberId);
-  if (result?.error) {
-    toast.error(result.error);
-  } else {
-    toast.success("Membro removido");
-  }
 }
 
 async function changeRoleWithToast(
@@ -66,8 +58,11 @@ export function MemberList({
     setLinkingMember,
     unify,
     setUnify,
+    removingMember,
+    setRemovingMember,
   } = useMemberListDialogs();
   const [, startTransition] = useTransition();
+  const [isRemoving, startRemoving] = useTransition();
 
   const linksByMember = groupLinksByMember(emailLinks);
 
@@ -80,6 +75,28 @@ export function MemberList({
         "E-mail desvinculado. Acessos futuros por ele cessam; o histórico permanece.",
       );
     }
+  };
+
+  // A remoção é irreversível para o trabalho pendente do membro, então só o
+  // sucesso fecha o diálogo: erro e falha de rede mantêm a confirmação em cena
+  // para o coordenador tentar de novo sem reabrir e reencontrar a linha.
+  const confirmRemove = () => {
+    if (!removingMember) return;
+    const memberId = removingMember.id;
+    startRemoving(async () => {
+      try {
+        const result = await removeMember(memberId);
+        if (result?.error) {
+          toast.error(result.error);
+          return;
+        }
+        toast.success("Membro removido");
+        setRemovingMember(null);
+      } catch (error) {
+        console.error("[MemberList] erro ao remover membro", error);
+        toast.error("Não foi possível remover o membro. Tente novamente.");
+      }
+    });
   };
 
   // useOptimistic: o Switch reflete imediatamente o valor escolhido enquanto o
@@ -156,9 +173,33 @@ export function MemberList({
           onChangeRole={(memberId, newRole) =>
             void changeRoleWithToast(memberId, newRole)
           }
-          onRemove={(memberId) => void removeMemberWithToast(memberId)}
+          onRequestRemove={setRemovingMember}
         />
       ))}
+      <ConfirmActionDialog
+        open={!!removingMember}
+        onClose={() => setRemovingMember(null)}
+        title="Remover membro?"
+        description={
+          removingMember ? (
+            <>
+              Remover <strong>{memberDisplayName(removingMember)}</strong>
+              {removingMember.profiles?.email &&
+              removingMember.profiles.email !==
+                memberDisplayName(removingMember) ? (
+                <> ({removingMember.profiles.email})</>
+              ) : null}{" "}
+              deste projeto? As atribuições ainda não iniciadas voltam ao
+              conjunto disponível; o trabalho já feito permanece como histórico.
+            </>
+          ) : null
+        }
+        confirmLabel="Remover"
+        pendingLabel="Removendo…"
+        destructive
+        isPending={isRemoving}
+        onConfirm={confirmRemove}
+      />
       {linkingMember && (
         <LinkEmailDialog
           projectId={projectId}

--- a/frontend/src/components/members/MemberRoleControls.tsx
+++ b/frontend/src/components/members/MemberRoleControls.tsx
@@ -14,14 +14,14 @@ interface MemberRoleControlsProps {
   member: MemberRow;
   currentUserId: string;
   onChangeRole: (memberId: string, newRole: "coordenador" | "pesquisador") => void;
-  onRemove: (memberId: string) => void;
+  onRequestRemove: (member: MemberRow) => void;
 }
 
 export function MemberRoleControls({
   member,
   currentUserId,
   onChangeRole,
-  onRemove,
+  onRequestRemove,
 }: MemberRoleControlsProps) {
   return (
     <>
@@ -42,7 +42,7 @@ export function MemberRoleControls({
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => onRemove(member.id)}
+          onClick={() => onRequestRemove(member)}
           className="text-destructive"
         >
           Remover

--- a/frontend/src/components/members/MemberRow.tsx
+++ b/frontend/src/components/members/MemberRow.tsx
@@ -31,7 +31,7 @@ interface MemberRowProps {
     memberId: string,
     newRole: "coordenador" | "pesquisador",
   ) => void;
-  onRemove: (memberId: string) => void;
+  onRequestRemove: (member: MemberRowData) => void;
 }
 
 export function MemberRow({
@@ -50,7 +50,7 @@ export function MemberRow({
   onToggleResolve,
   onToggleCompare,
   onChangeRole,
-  onRemove,
+  onRequestRemove,
 }: MemberRowProps) {
   const isProjectPending = member.accessState === "pending";
   const isAccessUnavailable = member.accessState === "unavailable";
@@ -118,7 +118,7 @@ export function MemberRow({
           member={member}
           currentUserId={currentUserId}
           onChangeRole={onChangeRole}
-          onRemove={onRemove}
+          onRequestRemove={onRequestRemove}
         />
       </div>
     </div>

--- a/frontend/src/components/members/__tests__/MemberList.test.tsx
+++ b/frontend/src/components/members/__tests__/MemberList.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { MemberRow } from "../member-list-utils";
+
+const mocks = vi.hoisted(() => ({
+  removeMember: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+// O módulo importa seis actions; declarar só a testada quebraria o import.
+vi.mock("@/actions/members", () => ({
+  removeMember: mocks.removeMember,
+  changeRole: vi.fn(),
+  setCanArbitrate: vi.fn(),
+  setCanResolve: vi.fn(),
+  setCanCompare: vi.fn(),
+  unlinkMemberEmail: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess },
+}));
+
+import { MemberList } from "../MemberList";
+
+const targetMember: MemberRow = {
+  id: "member-target",
+  project_id: "project-1",
+  user_id: "user-target",
+  role: "pesquisador",
+  can_arbitrate: false,
+  can_resolve: false,
+  can_compare: false,
+  accessState: "ready",
+  isClaimable: false,
+  profiles: {
+    id: "user-target",
+    email: "ana@example.com",
+    first_name: "Ana",
+    last_name: "Silva",
+    created_at: "2026-01-01T00:00:00Z",
+    activated_at: "2026-01-02T00:00:00Z",
+  },
+};
+
+function renderList({
+  member = targetMember,
+  currentUserId = "coordinator-user",
+}: { member?: MemberRow; currentUserId?: string } = {}) {
+  return render(
+    <MemberList
+      projectId="project-1"
+      members={[member]}
+      emailLinks={[]}
+      currentUserId={currentUserId}
+    />,
+  );
+}
+
+// O gatilho e o botão de confirmação compartilham o rótulo "Remover"; dentro do
+// diálogo a busca é escopada para não casar com o gatilho que segue montado.
+function confirmButton() {
+  return within(screen.getByRole("alertdialog")).getByRole("button", {
+    name: "Remover",
+  });
+}
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.removeMember.mockResolvedValue(undefined);
+});
+
+describe("MemberList — confirmação de remoção (#177)", () => {
+  it("abre um alertdialog identificado e não chama a action no clique inicial", async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+    expect(dialog.getAttribute("aria-describedby")).toBeTruthy();
+    expect(dialog.textContent).toContain("Ana");
+    expect(dialog.textContent).toContain("ana@example.com");
+    expect(screen.getByRole("button", { name: "Cancelar" })).toBe(
+      document.activeElement,
+    );
+    expect(mocks.removeMember).not.toHaveBeenCalled();
+  });
+
+  it("cancela sem remover o membro", async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    await user.click(await screen.findByRole("button", { name: "Cancelar" }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.removeMember).not.toHaveBeenCalled();
+  });
+
+  it("confirma uma única vez com o membro e sinaliza o progresso", async () => {
+    let finishRemoval: ((value: undefined) => void) | undefined;
+    mocks.removeMember.mockReturnValue(
+      new Promise<undefined>((resolve) => {
+        finishRemoval = resolve;
+      }),
+    );
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    await user.click(confirmButton());
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Removendo…" }).hasAttribute("disabled"),
+      ).toBe(true),
+    );
+    expect(mocks.removeMember).toHaveBeenCalledTimes(1);
+    expect(mocks.removeMember).toHaveBeenCalledWith("member-target");
+
+    finishRemoval?.(undefined);
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Membro removido");
+  });
+
+  it("mantém o diálogo aberto após erro e permite tentar novamente", async () => {
+    mocks.removeMember
+      .mockResolvedValueOnce({ error: "Falha ao remover" })
+      .mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    await user.click(confirmButton());
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith("Falha ao remover"),
+    );
+    expect(mocks.toastSuccess).not.toHaveBeenCalled();
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+
+    await user.click(confirmButton());
+
+    await waitFor(() => expect(mocks.removeMember).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("mantém o diálogo aberto quando a action rejeita e permite tentar novamente", async () => {
+    mocks.removeMember
+      .mockRejectedValueOnce(new Error("rede indisponível"))
+      .mockResolvedValueOnce(undefined);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const user = userEvent.setup();
+    renderList();
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+    await user.click(confirmButton());
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Não foi possível remover o membro. Tente novamente.",
+      ),
+    );
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+
+    await user.click(confirmButton());
+
+    await waitFor(() => expect(mocks.removeMember).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+    expect(mocks.toastSuccess).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it("não oferece remoção para a identidade canônica exercida pela conta atual", () => {
+    renderList({ currentUserId: targetMember.user_id });
+
+    expect(screen.queryByRole("button", { name: "Remover" })).toBeNull();
+    expect(screen.queryByRole("alertdialog")).toBeNull();
+  });
+
+  it("nomeia o membro sem perfil pelo fallback, sem quebrar a descrição", async () => {
+    const user = userEvent.setup();
+    renderList({ member: { ...targetMember, profiles: null } });
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+
+    const dialog = await screen.findByRole("alertdialog");
+    expect(dialog.textContent).toContain("Sem perfil");
+  });
+});

--- a/frontend/src/components/members/__tests__/member-list-utils.test.ts
+++ b/frontend/src/components/members/__tests__/member-list-utils.test.ts
@@ -4,7 +4,10 @@ import {
   activeAliasMemberIds,
   canEditPendingMemberEmail,
   isMemberEmailLinkAccessReady,
+  memberDisplayName,
+  memberSecondaryEmail,
   projectMemberAccessState,
+  type MemberRow,
 } from "@/components/members/member-list-utils";
 
 describe("project member activation", () => {
@@ -108,5 +111,52 @@ describe("project member activation", () => {
       }),
     ).toBe(false);
     expect(isMemberEmailLinkAccessReady(null, activeAt, undefined)).toBe(false);
+  });
+});
+
+describe("identificação do membro na confirmação de remoção", () => {
+  function memberWithProfile(profile: MemberRow["profiles"]): MemberRow {
+    return {
+      id: "member-1",
+      project_id: "project-1",
+      user_id: "user-1",
+      role: "pesquisador",
+      can_arbitrate: false,
+      can_resolve: false,
+      can_compare: false,
+      accessState: "ready",
+      isClaimable: false,
+      profiles: profile,
+    };
+  }
+
+  const baseProfile = {
+    id: "user-1",
+    email: "ana@example.com",
+    first_name: null,
+    last_name: null,
+    created_at: "2026-01-01T00:00:00Z",
+    activated_at: "2026-01-02T00:00:00Z",
+  };
+
+  it("omite o e-mail quando ele já é o nome exibido", () => {
+    const member = memberWithProfile(baseProfile);
+
+    expect(memberDisplayName(member)).toBe("ana@example.com");
+    expect(memberSecondaryEmail(member)).toBeNull();
+  });
+
+  it("mantém o e-mail quando ele desambigua o primeiro nome", () => {
+    const member = memberWithProfile({ ...baseProfile, first_name: "Ana" });
+
+    expect(memberDisplayName(member)).toBe("Ana");
+    expect(memberSecondaryEmail(member)).toBe("ana@example.com");
+  });
+
+  it("não inventa e-mail para membro sem perfil", () => {
+    const member = memberWithProfile(null);
+
+    expect(memberDisplayName(member)).toBe("Sem perfil");
+    expect(memberSecondaryEmail(member)).toBeNull();
   });
 });

--- a/frontend/src/components/members/member-list-utils.ts
+++ b/frontend/src/components/members/member-list-utils.ts
@@ -1,6 +1,11 @@
 import type { MemberEmailLink, ProjectMember, Profile } from "@/lib/types";
 
-export type MemberRow = ProjectMember & {
+// `Omit` antes da interseção: ProjectMember declara `profiles?: Profile`, e
+// `Profile | undefined` interseccionado com `Profile | null` colapsa para
+// `Profile`. Sem o Omit o tipo afirmaria que o perfil sempre existe, enquanto o
+// join da página devolve null para membro sem profile — o caso que
+// memberDisplayName cobre com "Sem perfil".
+export type MemberRow = Omit<ProjectMember, "profiles"> & {
   profiles: Profile | null;
   accessState: MemberAccessState;
   isClaimable: boolean;

--- a/frontend/src/components/members/member-list-utils.ts
+++ b/frontend/src/components/members/member-list-utils.ts
@@ -107,6 +107,15 @@ export function memberDisplayName(m: MemberRow): string {
   return m.profiles?.first_name || m.profiles?.email || "Sem perfil";
 }
 
+// E-mail que desambigua o nome exibido, quando acrescenta informação.
+// memberDisplayName já cai no e-mail quando não há first_name, então repeti-lo
+// entre parênteses duplicaria o mesmo texto na mesma frase.
+export function memberSecondaryEmail(m: MemberRow): string | null {
+  const email = m.profiles?.email;
+  if (!email || email === memberDisplayName(m)) return null;
+  return email;
+}
+
 export function groupLinksByMember(
   emailLinks: MemberEmailLinkView[],
 ): Map<string, MemberEmailLinkView[]> {

--- a/frontend/src/components/ui/__tests__/confirm-action-dialog.test.tsx
+++ b/frontend/src/components/ui/__tests__/confirm-action-dialog.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { ConfirmActionDialog } from "@/components/ui/confirm-action-dialog";
+
+afterEach(cleanup);
+
+// O fechamento é do pai: quem chama decide se a confirmação encerrou o fluxo.
+// Sem isso, `isPending`/`pendingLabel` seriam inalcançáveis e a validação que
+// recusa confirmar (ExcludeDocumentsDialog sem motivo) descartaria o que o
+// usuário já tinha digitado.
+function Harness({
+  onConfirm,
+  isPending = false,
+}: {
+  onConfirm: () => void;
+  isPending?: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+  return (
+    <ConfirmActionDialog
+      open={open}
+      onClose={() => setOpen(false)}
+      title="Remover?"
+      description="Descrição da ação."
+      confirmLabel="Remover"
+      pendingLabel="Removendo…"
+      destructive
+      isPending={isPending}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+describe("ConfirmActionDialog", () => {
+  it("mantém o diálogo aberto quando o pai não fecha na confirmação", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(<Harness onConfirm={onConfirm} />);
+
+    await user.click(screen.getByRole("button", { name: "Remover" }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+
+  it("fecha quando o pai fecha, e o cancelar sempre encerra", async () => {
+    const user = userEvent.setup();
+    render(<Harness onConfirm={() => {}} />);
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+  });
+
+  it("exibe o estado pendente e desabilita as duas saídas", () => {
+    render(<Harness onConfirm={() => {}} isPending />);
+
+    const confirm = screen.getByRole("button", { name: "Removendo…" });
+    expect(confirm.hasAttribute("disabled")).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Cancelar" }).hasAttribute("disabled"),
+    ).toBe(true);
+  });
+});

--- a/frontend/src/components/ui/__tests__/confirm-action-dialog.test.tsx
+++ b/frontend/src/components/ui/__tests__/confirm-action-dialog.test.tsx
@@ -64,4 +64,25 @@ describe("ConfirmActionDialog", () => {
       screen.getByRole("button", { name: "Cancelar" }).hasAttribute("disabled"),
     ).toBe(true);
   });
+
+  // Este par fixa a guarda dos dois lados: o primeiro caso prova que a ação em
+  // voo não é descartável pelo teclado; o segundo prova que a guarda é
+  // condicional, e não um diálogo que deixou de fechar no Esc.
+  it("ignora Esc enquanto a ação está em curso", async () => {
+    const user = userEvent.setup();
+    render(<Harness onConfirm={() => {}} isPending />);
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("alertdialog")).toBeTruthy();
+  });
+
+  it("fecha no Esc quando não há ação em curso", async () => {
+    const user = userEvent.setup();
+    render(<Harness onConfirm={() => {}} />);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByRole("alertdialog")).toBeNull());
+  });
 });

--- a/frontend/src/components/ui/confirm-action-dialog.tsx
+++ b/frontend/src/components/ui/confirm-action-dialog.tsx
@@ -61,7 +61,15 @@ export function ConfirmActionDialog({
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
           <AlertDialogAction
-            onClick={onConfirm}
+            // AlertDialogAction fecha o diálogo por padrão. Quem confirma é que
+            // decide se o fluxo terminou: sem o preventDefault o diálogo sai de
+            // cena antes de `isPending` renderizar, e uma confirmação recusada
+            // (ExcludeDocumentsDialog sem motivo) descartaria o que já foi
+            // digitado em vez de deixar o usuário corrigir.
+            onClick={(event) => {
+              event.preventDefault();
+              onConfirm();
+            }}
             disabled={isPending || disabled}
             className={cn(
               destructive &&

--- a/frontend/src/components/ui/confirm-action-dialog.tsx
+++ b/frontend/src/components/ui/confirm-action-dialog.tsx
@@ -47,7 +47,12 @@ export function ConfirmActionDialog({
     <AlertDialog
       open={open}
       onOpenChange={(nextOpen) => {
-        if (!nextOpen) onClose();
+        // Enquanto a ação corre, o fechamento é do pai — mesma razão do
+        // Cancelar desabilitado. Radix fecha no Esc e no clique fora sem
+        // consultar o estado do footer; sem o !isPending, essas duas saídas
+        // descartariam a confirmação em voo e o erro que chegasse depois
+        // viraria só um toast, sem a confirmação em cena para tentar de novo.
+        if (!nextOpen && !isPending) onClose();
       }}
     >
       <AlertDialogContent>

--- a/frontend/src/hooks/useMemberListDialogs.ts
+++ b/frontend/src/hooks/useMemberListDialogs.ts
@@ -15,6 +15,9 @@ export function useMemberListDialogs() {
     preview: UnificationPreview;
     targetName: string;
   } | null>(null);
+  // Confirmação de remoção (#177): guarda o membro inteiro, não o id, porque a
+  // pergunta precisa nomeá-lo e a linha some da lista assim que a action volta.
+  const [removingMember, setRemovingMember] = useState<MemberRow | null>(null);
 
   return {
     editingEmailMemberId,
@@ -23,5 +26,7 @@ export function useMemberListDialogs() {
     setLinkingMember,
     unify,
     setUnify,
+    removingMember,
+    setRemovingMember,
   };
 }


### PR DESCRIPTION
Reconstrução da parte de UI do #450 sobre a `main` atual. Sem migration — o endurecimento do banco vai em PR próprio.

## Problema

Remover membro disparava a Server Action direto no clique, sem confirmação. A ação devolve as atribuições pendentes ao pool e encerra o acesso do pesquisador, mas não tinha ponto de arrependimento.

## O que muda

Passa a usar o `ConfirmActionDialog` já existente no repo, com a pergunta nomeando o membro — em vez do AlertDialog escrito à mão que o #450 propunha.

Ao consumir o wrapper, apareceu um defeito nele que impedia justamente o contrato que os chamadores já expressavam: `AlertDialogAction` fecha o diálogo por padrão e o `onClick` não fazia `preventDefault`. Consequências:

- o diálogo saía de cena antes de `isPending` renderizar, então **spinner e `pendingLabel` eram inalcançáveis** em todos os consumidores — confirmado por teste;
- o "fecha só no sucesso" de `useDocumentActions` não tinha efeito — o Radix já havia fechado. Também confirmado por teste: o `ExcludeDocumentsDialog` descartava o motivo digitado quando a action falhava, obrigando a redigitar o que ela própria exige;
- há ainda um terceiro caminho, hoje **latente**: `confirmExclude` recusa confirmar quando falta o motivo e retorna sem fechar, mas o diálogo já teria fechado, descartando o texto. Não morde hoje porque o `ExcludeDocumentsDialog` valida via `disabled={!reason.trim()}` e o botão nem chega a ser clicável — passa a morder no dia em que um consumidor validar dentro do `onConfirm` em vez de no `disabled`.

O `preventDefault` devolve a decisão de fechar a quem confirma. Os três diálogos de documentos já chamam `onClose` no sucesso, então o comportamento deles passa a ser o que o código sempre aparentou.

O `preventDefault` sozinho, porém, só neutraliza uma das três saídas que o Radix controla pelo mesmo funil. `Esc` e clique no overlay continuavam chamando `onOpenChange` sem consultar o footer — o `AlertDialogCancel` já tinha `disabled={isPending}`, então a saída visível estava travada e a saída por teclado não. A guarda `!isPending` no `onOpenChange` fecha as duas, tornando o "só o sucesso fecha" verdadeiro por construção, e não apenas pelos caminhos testados.

Além disso:

- `MemberRow`/`MemberRoleControls` recebem `onRequestRemove(member)` no lugar de `onRemove(memberId)` — a pergunta precisa nomear o membro, e a linha some da lista assim que a action retorna;
- a chamada ganha `try/catch`: antes rodava com `void` e sem catch, e uma rejeição de rede virava unhandled rejection sem nenhum feedback;
- `MemberRow.profiles` afirmava ser nulável sem ser (`ProjectMember` declara `profiles?: Profile`, e a interseção colapsava `Profile | undefined` com `Profile | null` em `Profile`), contradizendo o join da página e o fallback `"Sem perfil"` de `memberDisplayName`. Corrigido com `Omit`, sem cascata no typecheck;
- a decisão de exibir o e-mail entre parênteses saiu do JSX para `memberSecondaryEmail` em `member-list-utils` — estava inline, chamando `memberDisplayName` três vezes, e o caso em que o e-mail *é* o nome exibido não tinha cobertura.

Mantive `currentUserId`: a página já resolve a identidade canônica (alias incluído) via `access.memberUserId`. O rename para `effectiveUserId` que o #450 fazia é ruído.

## Verificação

- 15 testes novos (7 de `MemberList`, 5 de `ConfirmActionDialog`, 3 de `member-list-utils`) mais uma suíte nova de fluxo em `documents/__tests__/exclude-documents-flow.test.tsx`, que exercita o `useDocumentActions` real ligado ao `ExcludeDocumentsDialog` real — `MemberList` e `ConfirmActionDialog` não tinham cobertura nenhuma antes;
- **prova do vermelho por mutação**, cada guarda mutada uma a uma e restaurada:
  - remover o `preventDefault` → caem cinco testes de diálogo persistente, incluindo o de motivo preservado no fluxo de documentos;
  - remover o `!isPending` do `onOpenChange` → cai só o teste de `Esc` sob pending, e o de `Esc` sem pending segue verde (a guarda é condicional, não um diálogo que deixou de fechar);
  - remover o `return` no erro → caem os dois testes de retry;
  - remover o `try/catch` → cai o teste de rejeição;
  - trocar `memberSecondaryEmail` por `email ?? null` → cai o teste do e-mail redundante;
- suíte completa: 1.880 testes, 181 arquivos, verde;
- typecheck, eslint (0 errors), react-doctor 100/100;
- pre-push integral verde, incluindo smoke E2E.

Não validei em navegador — o fluxo está coberto pelos testes de componente, incluindo foco inicial no Cancelar, os `aria-*` do diálogo e as saídas por teclado.

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMmUAcmnYF9b9vwTJsjjzt
