### PR TITLE
fix(schema): estado congelado da UI não sobrevive ao remoto que avança (#501)

### DIFF
--- a/frontend/src/actions/__tests__/suggestions.test.ts
+++ b/frontend/src/actions/__tests__/suggestions.test.ts
@@ -227,7 +227,10 @@ describe("approveSchemaSuggestionWithEdits", () => {
         [FIELD],
         EMPTY_BASELINE,
       );
-      expect(r.error).toMatch(/O schema mudou enquanto a sugestão era revisada/);
+      // O conflito volta tipado com o snapshot atual, para o EditFieldDialog
+      // re-mesclar e reenviar em vez de descartar a edição (#501).
+      expect(r.error).toBeUndefined();
+      expect(r.conflict).toMatchObject({ revision: 7, fields: [FIELD] });
     });
 
     it("sugestão já resolvida volta com a copy pt-BR da RPC", async () => {

--- a/frontend/src/actions/suggestions.ts
+++ b/frontend/src/actions/suggestions.ts
@@ -7,20 +7,12 @@ import { saveSchemaAndApproveSuggestion } from "./schema";
 import type {
   PydanticField,
   SchemaBaselineIdentity,
-  SchemaSaveResult,
+  SchemaSnapshot,
 } from "@/lib/types";
 import {
   schemaSuggestionChangesSchema,
   type SchemaSuggestionChanges,
 } from "@/lib/schema-suggestion";
-
-function schemaSaveError(result: SchemaSaveResult): string | null {
-  if (result.status === "saved") return null;
-  if (result.status === "conflict") {
-    return "O schema mudou enquanto a sugestão era revisada. Recarregue a página e reaplique a sugestão sobre a versão atual.";
-  }
-  return result.message;
-}
 
 export async function createSchemaSuggestion(
   projectId: string,
@@ -100,7 +92,7 @@ export async function approveSchemaSuggestionWithEdits(
   projectId: string,
   editedFields: PydanticField[],
   expectedBaseline: SchemaBaselineIdentity,
-): Promise<{ error?: string }> {
+): Promise<{ error?: string; conflict?: SchemaSnapshot }> {
   const gate = await requireCoordinator(
     projectId,
     "Apenas coordenadores podem aprovar sugestões de schema.",
@@ -112,8 +104,11 @@ export async function approveSchemaSuggestionWithEdits(
     editedFields,
     expectedBaseline,
   );
-  const saveError = schemaSaveError(saved);
-  if (saveError) return { error: saveError };
+  // O conflito de CAS volta tipado, com o snapshot atual: o EditFieldDialog
+  // re-mescla a edição sobre ele e reenvia, em vez de descartar o trabalho do
+  // coordenador com "recarregue a página" (#501).
+  if (saved.status === "conflict") return { conflict: saved.current };
+  if (saved.status === "error") return { error: saved.message };
   revalidatePath(`/projects/${projectId}/reviews/comments`);
   return {};
 }

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -210,18 +210,31 @@ function SchemaEditor({
     }
   }, [origin]);
 
-  // O anúncio de rebase chaveia também na revisão: `origin` fica em "rebased"
-  // após o primeiro merge automático, e um segundo rebase consecutivo trocava
-  // os campos no canvas sem aviso (#501). A guarda anti-retrocesso do
-  // useSchemaDraft garante que todo rebase avança `baseline.revision`, então a
-  // revisão é o token de "aconteceu de novo".
+  // Um rebase só é anunciável quando FECHOU, e os dois termos abaixo são o que
+  // distingue isso:
+  //
+  //  - `conflict === null` porque `stateAfterRemoteChange` preserva a
+  //    proveniência no ramo de conflito (de propósito: quem decide é o usuário
+  //    no diálogo) e a baseline de um estado em conflito já é o remoto novo.
+  //    Sem esse termo, uma revisão que colide anunciava "suas alterações foram
+  //    mescladas" enquanto o diálogo pedia a resolução. É o mesmo teste que o
+  //    `statusMessage` do rodapé faz: conflito primeiro, proveniência depois.
+  //  - `baseline.revision` nas deps porque `origin` fica em "rebased" após o
+  //    primeiro merge automático, e sem a revisão um segundo rebase consecutivo
+  //    trocava os campos no canvas sem aviso (#501). A guarda anti-retrocesso
+  //    do useSchemaDraft garante que todo rebase avança a revisão.
+  //
+  // O predicado ainda cobre o rebase que fecha por resolução manual, em que a
+  // revisão NÃO muda (a baseline já era o remoto) e só o conflito zera.
+  const mergeSettled = origin === "rebased" && conflict === null;
+
   useEffect(() => {
-    if (origin === "rebased") {
+    if (mergeSettled) {
       toast.info(
         "O schema mudou em outra sessão. Suas alterações foram mescladas com a versão mais recente.",
       );
     }
-  }, [origin, baseline.revision]);
+  }, [mergeSettled, baseline.revision]);
 
   // --- Troca de modo ---
   // O modo "código" é só visualização da fonte de verdade. Alternar não

--- a/frontend/src/components/schema/SchemaEditor.tsx
+++ b/frontend/src/components/schema/SchemaEditor.tsx
@@ -208,12 +208,20 @@ function SchemaEditor({
         "Rascunho local recuperado. Revise e salve para confirmar as alterações.",
       );
     }
+  }, [origin]);
+
+  // O anúncio de rebase chaveia também na revisão: `origin` fica em "rebased"
+  // após o primeiro merge automático, e um segundo rebase consecutivo trocava
+  // os campos no canvas sem aviso (#501). A guarda anti-retrocesso do
+  // useSchemaDraft garante que todo rebase avança `baseline.revision`, então a
+  // revisão é o token de "aconteceu de novo".
+  useEffect(() => {
     if (origin === "rebased") {
       toast.info(
         "O schema mudou em outra sessão. Suas alterações foram mescladas com a versão mais recente.",
       );
     }
-  }, [origin]);
+  }, [origin, baseline.revision]);
 
   // --- Troca de modo ---
   // O modo "código" é só visualização da fonte de verdade. Alternar não

--- a/frontend/src/components/schema/__tests__/SchemaEditor.draft.test.tsx
+++ b/frontend/src/components/schema/__tests__/SchemaEditor.draft.test.tsx
@@ -187,6 +187,36 @@ describe("SchemaEditor — ciclo do draft", () => {
     expect(screen.getByRole("button", { name: "Minha alteração" })).toBeTruthy();
     expect(screen.getByText("Versão 0.2.0")).toBeTruthy();
   });
+
+  // `origin` fica em "rebased" após o primeiro merge automático; o segundo
+  // rebase consecutivo substituía os campos no canvas sem anúncio (#501).
+  it("anuncia cada rebase automático, inclusive consecutivos", async () => {
+    const view = await renderEditor();
+    await userEvent.click(screen.getByRole("button", { name: "Editar campo" }));
+
+    const remoteRevision = (help_text: string, revision: number) =>
+      view.rerender(
+        <SchemaEditorSession
+          projectId="project-1"
+          userId="user-1"
+          initialCode={null}
+          initialFields={[{ ...BASE_FIELDS[0], help_text }]}
+          currentVersion={`0.1.${revision}`}
+          currentRevision={revision}
+        />,
+      );
+
+    remoteRevision("Ajuda remota", 1);
+    await waitFor(() =>
+      expect(hoisted.toast.info).toHaveBeenCalledTimes(1),
+    );
+
+    remoteRevision("Ajuda remota revista", 2);
+    await waitFor(() =>
+      expect(hoisted.toast.info).toHaveBeenCalledTimes(2),
+    );
+    expect(screen.getByText("Campo: Editada")).toBeTruthy();
+  });
 });
 
 // O segmento /config não tem `error.tsx`, então lançar aqui trocava uma condição

--- a/frontend/src/components/schema/__tests__/SchemaEditor.draft.test.tsx
+++ b/frontend/src/components/schema/__tests__/SchemaEditor.draft.test.tsx
@@ -217,6 +217,50 @@ describe("SchemaEditor — ciclo do draft", () => {
     );
     expect(screen.getByText("Campo: Editada")).toBeTruthy();
   });
+
+  // Um rebase anunciado é um rebase FECHADO. `stateAfterRemoteChange` preserva a
+  // proveniência no ramo de conflito (de propósito: quem decide é o usuário no
+  // diálogo), e a baseline de um estado em conflito já é o remoto novo — então a
+  // revisão sozinha anuncia "suas alterações foram mescladas" exatamente
+  // enquanto o diálogo pede que as colisões sejam resolvidas.
+  it("não anuncia rebase quando a revisão nova abre conflito", async () => {
+    const view = await renderEditor();
+    await userEvent.click(screen.getByRole("button", { name: "Editar campo" }));
+
+    const remoteRevision = (field: PydanticField, revision: number) =>
+      view.rerender(
+        <SchemaEditorSession
+          projectId="project-1"
+          userId="user-1"
+          initialCode={null}
+          initialFields={[field]}
+          currentVersion={`0.1.${revision}`}
+          currentRevision={revision}
+        />,
+      );
+
+    // Primeiro rebase fecha limpo (o remoto tocou outra propriedade).
+    remoteRevision({ ...BASE_FIELDS[0], help_text: "Ajuda remota" }, 1);
+    await waitFor(() => expect(hoisted.toast.info).toHaveBeenCalledTimes(1));
+
+    // O segundo colide na propriedade que o usuário editou.
+    remoteRevision(
+      { ...BASE_FIELDS[0], help_text: "Ajuda remota", description: "Remota" },
+      2,
+    );
+    expect(
+      await screen.findByRole("dialog", { name: "Resolver alterações concorrentes" }),
+    ).toBeTruthy();
+    expect(hoisted.toast.info).toHaveBeenCalledTimes(1);
+
+    // Fechar o merge pela resolução manual é o rebase que faltava anunciar: a
+    // revisão não muda (a baseline já era o remoto), só o conflito é que zera.
+    await userEvent.click(screen.getByRole("button", { name: "Minha alteração" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Aplicar merge para revisar" }),
+    );
+    await waitFor(() => expect(hoisted.toast.info).toHaveBeenCalledTimes(2));
+  });
 });
 
 // O segmento /config não tem `error.tsx`, então lançar aqui trocava uma condição

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -22,23 +22,17 @@ import { OptionsAllowOtherEditor } from "@/components/schema/OptionsAllowOtherEd
 import { DateSentinelEditor } from "@/components/schema/DateSentinelEditor";
 import { useOptionRemovalGuard } from "@/components/schema/useOptionRemovalGuard";
 import { TYPE_LABELS } from "@/lib/field-labels";
-import { stripOptionFromConditions } from "@/lib/schema-utils";
-import { propertyLabel } from "@/lib/schema-change-format";
-import {
-  mergeSchemas,
-  unresolvedSchemaConflicts,
-  type SchemaMergeConflict,
-} from "@/lib/schema-merge";
 import { saveSchemaFromGUI } from "@/actions/schema";
 import { approveSchemaSuggestionWithEdits } from "@/actions/suggestions";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { useEditFieldForm, type PendingSuggestion } from "./useEditFieldForm";
-import type {
-  PydanticField,
-  SchemaBaselineIdentity,
-  SchemaSnapshot,
-} from "@/lib/types";
+import {
+  applyFormEdits,
+  saveMergedEdit,
+  type SubmitOutcome,
+} from "./edit-field-save";
+import type { PydanticField, SchemaBaselineIdentity } from "@/lib/types";
 import { resolveTarget } from "@/lib/pydantic-field";
 
 export type { PendingSuggestion };
@@ -53,25 +47,77 @@ interface EditFieldDialogProps {
   schemaBaseline: SchemaBaselineIdentity;
 }
 
-// Um conflito aqui é colisão real: a mesma propriedade editada no diálogo e em
-// outra sessão. A UX mínima é bloquear sem perder a digitação — reconstruir o
-// diálogo de resoluções do SchemaEditor neste fluxo seria um segundo mecanismo
-// de conflito completo para um caso raro.
-function conflictBlockMessage(conflicts: SchemaMergeConflict[]): string {
-  const disputed = conflicts.map((conflict) => {
-    if (conflict.kind === "property") {
-      return `${propertyLabel(conflict.property)} de "${conflict.fieldName}"`;
-    }
-    if (conflict.kind === "field") return `o campo "${conflict.fieldName}"`;
-    return "a ordem dos campos";
-  });
-  return `Outra sessão editou ao mesmo tempo: ${[...new Set(disputed)].join(", ")}. Recarregue a página para rever a versão atual antes de salvar.`;
-}
+type EditFieldForm = ReturnType<typeof useEditFieldForm>;
 
-type SubmitOutcome =
-  | { status: "saved" }
-  | { status: "conflict"; current: SchemaSnapshot }
-  | { status: "error"; message: string };
+// Editores específicos do tipo do campo (e das propriedades que só alguns
+// tipos têm). Fora do componente principal para o shell do diálogo não
+// carregar os ramos por tipo junto do fluxo de save.
+function FieldTypeEditors({
+  form,
+  baseField,
+  fieldName,
+  allFields,
+  onBeforeRemoveOption,
+}: {
+  form: EditFieldForm;
+  baseField: PydanticField;
+  fieldName: string;
+  allFields: PydanticField[];
+  onBeforeRemoveOption: (opt: string) => Promise<boolean>;
+}) {
+  return (
+    <>
+      {(baseField.type === "single" || baseField.type === "multi") && (
+        <OptionsAllowOtherEditor
+          options={form.options}
+          onChange={form.setOptions}
+          onBeforeRemoveOption={onBeforeRemoveOption}
+          allowOther={form.allowOther}
+          onAllowOtherChange={form.setAllowOther}
+        />
+      )}
+
+      {baseField.type === "date" && (
+        <DateSentinelEditor
+          options={form.options}
+          onChange={form.setOptions}
+          onBeforeRemoveOption={onBeforeRemoveOption}
+        />
+      )}
+
+      {baseField.type === "text" && (
+        <SubfieldsEditor
+          subfields={form.subfields}
+          subfieldRule={form.subfieldRule}
+          options={form.options}
+          onChange={(patch) => {
+            form.setSubfields(patch.subfields);
+            form.setSubfieldRule(patch.subfield_rule ?? "all");
+            form.setOptions(patch.options ?? []);
+          }}
+          onBeforeRemoveOption={onBeforeRemoveOption}
+        />
+      )}
+
+      <ConditionEditor
+        fieldName={fieldName}
+        condition={form.condition}
+        candidateTriggers={candidateTriggersFor(allFields, fieldName)}
+        onChange={form.setCondition}
+      />
+
+      {/* Prompt de justificativa do LLM — só faz sentido quando o campo
+          é enviado ao LLM. Vazio = backend usa o default exigente. */}
+      {resolveTarget(baseField.target) !== "human_only" &&
+        resolveTarget(baseField.target) !== "none" && (
+          <JustificationPromptField
+            value={form.justificationPrompt}
+            onChange={form.setJustificationPrompt}
+          />
+        )}
+    </>
+  );
+}
 
 export function EditFieldDialog({
   projectId,
@@ -83,6 +129,7 @@ export function EditFieldDialog({
   schemaBaseline,
 }: EditFieldDialogProps) {
   const { refresh } = useRouter();
+  const form = useEditFieldForm(fieldName, allFields, pendingSuggestion);
   const {
     baseFields,
     baseField,
@@ -91,20 +138,14 @@ export function EditFieldDialog({
     helpText,
     setHelpText,
     options,
-    setOptions,
     allowOther,
-    setAllowOther,
     subfields,
-    setSubfields,
     subfieldRule,
-    setSubfieldRule,
     condition,
-    setCondition,
     justificationPrompt,
-    setJustificationPrompt,
     isSaving,
     startSave,
-  } = useEditFieldForm(fieldName, allFields, pendingSuggestion);
+  } = form;
 
   const { confirmRemoval, dialogProps } = useOptionRemovalGuard(
     allFields,
@@ -118,94 +159,47 @@ export function EditFieldDialog({
   if (!baseField) return null;
 
   const descriptionChanged = description !== baseField.description;
-  const hasSubfields = subfields && subfields.length > 0;
 
   const submit = async (
     fields: PydanticField[],
     baseline: SchemaBaselineIdentity,
   ): Promise<SubmitOutcome> => {
-    if (pendingSuggestion) {
-      const result = await approveSchemaSuggestionWithEdits(
-        pendingSuggestion.id,
-        projectId,
-        fields,
-        baseline,
-      );
-      if (result.conflict) {
-        return { status: "conflict", current: result.conflict };
-      }
-      if (result.error) return { status: "error", message: result.error };
-      return { status: "saved" };
-    }
-    return saveSchemaFromGUI(projectId, fields, baseline);
+    if (!pendingSuggestion) return saveSchemaFromGUI(projectId, fields, baseline);
+    const result = await approveSchemaSuggestionWithEdits(
+      pendingSuggestion.id,
+      projectId,
+      fields,
+      baseline,
+    );
+    if (result.conflict) return { status: "conflict", current: result.conflict };
+    if (result.error) return { status: "error", message: result.error };
+    return { status: "saved" };
   };
 
   const handleSave = () => {
     startSave(async () => {
-      // O diff local é form × BASE capturado na abertura — o que o usuário de
-      // fato mudou. Aplicá-lo direto sobre o `allFields` vivo reescreveria as
-      // propriedades geridas pelo form com valores congelados, revertendo em
-      // silêncio a edição concorrente que um refresh trouxe (#501).
-      const originalOpts = baseField.options ?? [];
-      const optionSet = new Set(options);
-      const removedOpts = originalOpts.filter((o) => !optionSet.has(o));
-      let localFields = baseFields.map((f) =>
-        f.name === fieldName
-          ? {
-              ...f,
-              description,
-              help_text: helpText.trim() || undefined,
-              options: hasSubfields ? null : (options.length > 0 ? options : null),
-              subfields: hasSubfields ? subfields : undefined,
-              subfield_rule: hasSubfields ? subfieldRule : undefined,
-              allow_other:
-                (f.type === "single" || f.type === "multi") && allowOther
-                  ? true
-                  : undefined,
-              condition,
-              justification_prompt: justificationPrompt.trim() || undefined,
-            }
-          : f,
-      );
-      for (const removed of removedOpts) {
-        localFields = stripOptionFromConditions(localFields, fieldName, removed);
-      }
       try {
-        // Merge de três vias: base capturado × edição do form × remoto vivo.
-        // Edições concorrentes em outras propriedades entram no payload;
-        // colisão na mesma propriedade bloqueia com a digitação intacta.
-        const merged = mergeSchemas(baseFields, localFields, allFields);
-        const blocked = unresolvedSchemaConflicts(merged);
-        if (blocked.length > 0) {
-          toast.error(conflictBlockMessage(blocked));
+        const localFields = applyFormEdits(baseFields, fieldName, {
+          description,
+          helpText,
+          options,
+          allowOther,
+          subfields,
+          subfieldRule,
+          condition,
+          justificationPrompt,
+        });
+        const saved = await saveMergedEdit(
+          baseFields,
+          localFields,
+          allFields,
+          schemaBaseline,
+          submit,
+        );
+        if (saved.status === "blocked") {
+          toast.error(saved.message);
           return;
         }
-
-        let result = await submit(merged.fields, schemaBaseline);
-        if (result.status === "conflict") {
-          // O CAS recusou porque o baseline da prop ficou atrás do banco. O
-          // `current` devolvido é o remoto real: re-mesclar e reenviar uma
-          // vez, em vez de descartar a edição com "recarregue a página".
-          const remerged = mergeSchemas(
-            baseFields,
-            localFields,
-            result.current.fields,
-          );
-          const reblocked = unresolvedSchemaConflicts(remerged);
-          if (reblocked.length > 0) {
-            toast.error(conflictBlockMessage(reblocked));
-            return;
-          }
-          result = await submit(remerged.fields, {
-            revision: result.current.revision,
-          });
-        }
-        if (result.status === "conflict") {
-          throw new Error(
-            "O schema mudou em outra sessão. Recarregue a página e reaplique esta edição sobre a versão atual.",
-          );
-        }
-        if (result.status === "error") throw new Error(result.message);
         toast.success(
           pendingSuggestion
             ? "Sugestão aprovada e campo atualizado"
@@ -282,54 +276,13 @@ export function EditFieldDialog({
             />
           </div>
 
-          {(baseField.type === "single" || baseField.type === "multi") && (
-            <OptionsAllowOtherEditor
-              options={options}
-              onChange={setOptions}
-              onBeforeRemoveOption={handleBeforeRemoveOption}
-              allowOther={allowOther}
-              onAllowOtherChange={setAllowOther}
-            />
-          )}
-
-          {baseField.type === "date" && (
-            <DateSentinelEditor
-              options={options}
-              onChange={setOptions}
-              onBeforeRemoveOption={handleBeforeRemoveOption}
-            />
-          )}
-
-          {baseField.type === "text" && (
-            <SubfieldsEditor
-              subfields={subfields}
-              subfieldRule={subfieldRule}
-              options={options}
-              onChange={(patch) => {
-                setSubfields(patch.subfields);
-                setSubfieldRule(patch.subfield_rule ?? "all");
-                setOptions(patch.options ?? []);
-              }}
-              onBeforeRemoveOption={handleBeforeRemoveOption}
-            />
-          )}
-
-          <ConditionEditor
+          <FieldTypeEditors
+            form={form}
+            baseField={baseField}
             fieldName={fieldName}
-            condition={condition}
-            candidateTriggers={candidateTriggersFor(allFields, fieldName)}
-            onChange={setCondition}
+            allFields={allFields}
+            onBeforeRemoveOption={handleBeforeRemoveOption}
           />
-
-          {/* Prompt de justificativa do LLM — só faz sentido quando o campo
-              é enviado ao LLM. Vazio = backend usa o default exigente. */}
-          {resolveTarget(baseField.target) !== "human_only" &&
-            resolveTarget(baseField.target) !== "none" && (
-              <JustificationPromptField
-                value={justificationPrompt}
-                onChange={setJustificationPrompt}
-              />
-            )}
         </div>
 
         <DialogFooter>

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -159,7 +159,7 @@ export function EditFieldDialog({
   // uma condição que só existe no remoto sobrevive apontando para a opção
   // removida. O save recusa isso (`validateConditionValues` em pydantic-field),
   // então é fail-closed e não schema inconsistente — mas a mensagem culpa o
-  // campo, não a concorrência. Ver issue de follow-up.
+  // campo, não a concorrência. Ver issue #599.
   const { confirmRemoval, dialogProps } = useOptionRemovalGuard(
     allFields,
     fieldName,

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -23,12 +23,22 @@ import { DateSentinelEditor } from "@/components/schema/DateSentinelEditor";
 import { useOptionRemovalGuard } from "@/components/schema/useOptionRemovalGuard";
 import { TYPE_LABELS } from "@/lib/field-labels";
 import { stripOptionFromConditions } from "@/lib/schema-utils";
+import { propertyLabel } from "@/lib/schema-change-format";
+import {
+  mergeSchemas,
+  unresolvedSchemaConflicts,
+  type SchemaMergeConflict,
+} from "@/lib/schema-merge";
 import { saveSchemaFromGUI } from "@/actions/schema";
 import { approveSchemaSuggestionWithEdits } from "@/actions/suggestions";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { useEditFieldForm, type PendingSuggestion } from "./useEditFieldForm";
-import type { PydanticField, SchemaBaselineIdentity } from "@/lib/types";
+import type {
+  PydanticField,
+  SchemaBaselineIdentity,
+  SchemaSnapshot,
+} from "@/lib/types";
 import { resolveTarget } from "@/lib/pydantic-field";
 
 export type { PendingSuggestion };
@@ -43,6 +53,26 @@ interface EditFieldDialogProps {
   schemaBaseline: SchemaBaselineIdentity;
 }
 
+// Um conflito aqui é colisão real: a mesma propriedade editada no diálogo e em
+// outra sessão. A UX mínima é bloquear sem perder a digitação — reconstruir o
+// diálogo de resoluções do SchemaEditor neste fluxo seria um segundo mecanismo
+// de conflito completo para um caso raro.
+function conflictBlockMessage(conflicts: SchemaMergeConflict[]): string {
+  const disputed = conflicts.map((conflict) => {
+    if (conflict.kind === "property") {
+      return `${propertyLabel(conflict.property)} de "${conflict.fieldName}"`;
+    }
+    if (conflict.kind === "field") return `o campo "${conflict.fieldName}"`;
+    return "a ordem dos campos";
+  });
+  return `Outra sessão editou ao mesmo tempo: ${[...new Set(disputed)].join(", ")}. Recarregue a página para rever a versão atual antes de salvar.`;
+}
+
+type SubmitOutcome =
+  | { status: "saved" }
+  | { status: "conflict"; current: SchemaSnapshot }
+  | { status: "error"; message: string };
+
 export function EditFieldDialog({
   projectId,
   fieldName,
@@ -53,8 +83,9 @@ export function EditFieldDialog({
   schemaBaseline,
 }: EditFieldDialogProps) {
   const { refresh } = useRouter();
-  const field = allFields.find((f) => f.name === fieldName);
   const {
+    baseFields,
+    baseField,
     description,
     setDescription,
     helpText,
@@ -73,7 +104,7 @@ export function EditFieldDialog({
     setJustificationPrompt,
     isSaving,
     startSave,
-  } = useEditFieldForm(field, fieldName, allFields, pendingSuggestion);
+  } = useEditFieldForm(fieldName, allFields, pendingSuggestion);
 
   const { confirmRemoval, dialogProps } = useOptionRemovalGuard(
     allFields,
@@ -82,17 +113,43 @@ export function EditFieldDialog({
   const handleBeforeRemoveOption = async (opt: string): Promise<boolean> =>
     (await confirmRemoval(opt)).confirmed;
 
-  if (!field) return null;
+  // O campo pode ter sido deletado remotamente com o diálogo aberto; o form
+  // segue ancorado no base capturado e o merge do save expõe o edit-delete.
+  if (!baseField) return null;
 
-  const descriptionChanged = description !== field.description;
+  const descriptionChanged = description !== baseField.description;
   const hasSubfields = subfields && subfields.length > 0;
+
+  const submit = async (
+    fields: PydanticField[],
+    baseline: SchemaBaselineIdentity,
+  ): Promise<SubmitOutcome> => {
+    if (pendingSuggestion) {
+      const result = await approveSchemaSuggestionWithEdits(
+        pendingSuggestion.id,
+        projectId,
+        fields,
+        baseline,
+      );
+      if (result.conflict) {
+        return { status: "conflict", current: result.conflict };
+      }
+      if (result.error) return { status: "error", message: result.error };
+      return { status: "saved" };
+    }
+    return saveSchemaFromGUI(projectId, fields, baseline);
+  };
 
   const handleSave = () => {
     startSave(async () => {
-      const originalOpts = field.options ?? [];
+      // O diff local é form × BASE capturado na abertura — o que o usuário de
+      // fato mudou. Aplicá-lo direto sobre o `allFields` vivo reescreveria as
+      // propriedades geridas pelo form com valores congelados, revertendo em
+      // silêncio a edição concorrente que um refresh trouxe (#501).
+      const originalOpts = baseField.options ?? [];
       const optionSet = new Set(options);
       const removedOpts = originalOpts.filter((o) => !optionSet.has(o));
-      let updatedFields = allFields.map((f) =>
+      let localFields = baseFields.map((f) =>
         f.name === fieldName
           ? {
               ...f,
@@ -111,32 +168,49 @@ export function EditFieldDialog({
           : f,
       );
       for (const removed of removedOpts) {
-        updatedFields = stripOptionFromConditions(updatedFields, fieldName, removed);
+        localFields = stripOptionFromConditions(localFields, fieldName, removed);
       }
       try {
-        if (pendingSuggestion) {
-          const result = await approveSchemaSuggestionWithEdits(
-            pendingSuggestion.id,
-            projectId,
-            updatedFields,
-            schemaBaseline,
-          );
-          if (result.error) throw new Error(result.error);
-          toast.success("Sugestão aprovada e campo atualizado");
-        } else {
-          const result = await saveSchemaFromGUI(
-            projectId,
-            updatedFields,
-            schemaBaseline,
-          );
-          if (result.status === "error") throw new Error(result.message);
-          if (result.status === "conflict") {
-            throw new Error(
-              "O schema mudou em outra sessão. Recarregue a página e reaplique esta edição sobre a versão atual.",
-            );
-          }
-          toast.success("Campo atualizado");
+        // Merge de três vias: base capturado × edição do form × remoto vivo.
+        // Edições concorrentes em outras propriedades entram no payload;
+        // colisão na mesma propriedade bloqueia com a digitação intacta.
+        const merged = mergeSchemas(baseFields, localFields, allFields);
+        const blocked = unresolvedSchemaConflicts(merged);
+        if (blocked.length > 0) {
+          toast.error(conflictBlockMessage(blocked));
+          return;
         }
+
+        let result = await submit(merged.fields, schemaBaseline);
+        if (result.status === "conflict") {
+          // O CAS recusou porque o baseline da prop ficou atrás do banco. O
+          // `current` devolvido é o remoto real: re-mesclar e reenviar uma
+          // vez, em vez de descartar a edição com "recarregue a página".
+          const remerged = mergeSchemas(
+            baseFields,
+            localFields,
+            result.current.fields,
+          );
+          const reblocked = unresolvedSchemaConflicts(remerged);
+          if (reblocked.length > 0) {
+            toast.error(conflictBlockMessage(reblocked));
+            return;
+          }
+          result = await submit(remerged.fields, {
+            revision: result.current.revision,
+          });
+        }
+        if (result.status === "conflict") {
+          throw new Error(
+            "O schema mudou em outra sessão. Recarregue a página e reaplique esta edição sobre a versão atual.",
+          );
+        }
+        if (result.status === "error") throw new Error(result.message);
+        toast.success(
+          pendingSuggestion
+            ? "Sugestão aprovada e campo atualizado"
+            : "Campo atualizado",
+        );
         onOpenChange(false);
         refresh();
       } catch (e) {
@@ -173,7 +247,7 @@ export function EditFieldDialog({
           <div className="flex items-center gap-2">
             <Label className="text-xs">Tipo</Label>
             <Badge variant="outline" className="text-xs">
-              {TYPE_LABELS[field.type]}
+              {TYPE_LABELS[baseField.type]}
             </Badge>
           </div>
 
@@ -208,7 +282,7 @@ export function EditFieldDialog({
             />
           </div>
 
-          {(field.type === "single" || field.type === "multi") && (
+          {(baseField.type === "single" || baseField.type === "multi") && (
             <OptionsAllowOtherEditor
               options={options}
               onChange={setOptions}
@@ -218,7 +292,7 @@ export function EditFieldDialog({
             />
           )}
 
-          {field.type === "date" && (
+          {baseField.type === "date" && (
             <DateSentinelEditor
               options={options}
               onChange={setOptions}
@@ -226,7 +300,7 @@ export function EditFieldDialog({
             />
           )}
 
-          {field.type === "text" && (
+          {baseField.type === "text" && (
             <SubfieldsEditor
               subfields={subfields}
               subfieldRule={subfieldRule}
@@ -249,8 +323,8 @@ export function EditFieldDialog({
 
           {/* Prompt de justificativa do LLM — só faz sentido quando o campo
               é enviado ao LLM. Vazio = backend usa o default exigente. */}
-          {resolveTarget(field.target) !== "human_only" &&
-            resolveTarget(field.target) !== "none" && (
+          {resolveTarget(baseField.target) !== "human_only" &&
+            resolveTarget(baseField.target) !== "none" && (
               <JustificationPromptField
                 value={justificationPrompt}
                 onChange={setJustificationPrompt}

--- a/frontend/src/components/stats/EditFieldDialog.tsx
+++ b/frontend/src/components/stats/EditFieldDialog.tsx
@@ -50,8 +50,10 @@ interface EditFieldDialogProps {
 type EditFieldForm = ReturnType<typeof useEditFieldForm>;
 
 // Editores específicos do tipo do campo (e das propriedades que só alguns
-// tipos têm). Fora do componente principal para o shell do diálogo não
-// carregar os ramos por tipo junto do fluxo de save.
+// tipos têm). Vive fora do componente principal porque os ramos por tipo são
+// puramente declarativos e, somados ao fluxo de save, punham o `EditFieldDialog`
+// acima do limiar de complexidade cognitiva do gate do fallow. Não há
+// code-splitting envolvido: é o mesmo módulo e a mesma árvore renderizada.
 function FieldTypeEditors({
   form,
   baseField,
@@ -147,6 +149,17 @@ export function EditFieldDialog({
     startSave,
   } = form;
 
+  // A guarda de remoção é a única coisa aqui que fica no `allFields` VIVO, e é
+  // intencional: ela pergunta "quais condições quebram se esta opção sair", e a
+  // resposta útil é sobre as condições que existem AGORA — inclusive uma criada
+  // em outra sessão depois que o diálogo abriu. Ancorá-la no base capturado
+  // esconderia exatamente a dependência que o usuário não tem como ver.
+  //
+  // A contrapartida é que o strip de `applyFormEdits` roda sobre o base, então
+  // uma condição que só existe no remoto sobrevive apontando para a opção
+  // removida. O save recusa isso (`validateConditionValues` em pydantic-field),
+  // então é fail-closed e não schema inconsistente — mas a mensagem culpa o
+  // campo, não a concorrência. Ver issue de follow-up.
   const { confirmRemoval, dialogProps } = useOptionRemovalGuard(
     allFields,
     fieldName,
@@ -196,7 +209,10 @@ export function EditFieldDialog({
           schemaBaseline,
           submit,
         );
-        if (saved.status === "blocked") {
+        // Bloqueio e erro chegam pelo mesmo canal e param o save do mesmo jeito:
+        // o diálogo fica aberto com a digitação intacta. O `catch` abaixo passa a
+        // cuidar só do inesperado (queda de rede, exceção de Server Action).
+        if (saved.status !== "saved") {
           toast.error(saved.message);
           return;
         }

--- a/frontend/src/components/stats/__tests__/EditFieldDialog.test.tsx
+++ b/frontend/src/components/stats/__tests__/EditFieldDialog.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EditFieldDialog } from "../EditFieldDialog";
+import type { PydanticField } from "@/lib/types";
+
+const hoisted = vi.hoisted(() => ({
+  saveSchemaFromGUI: vi.fn(),
+  approveSchemaSuggestionWithEdits: vi.fn(),
+  refresh: vi.fn(),
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock("@/actions/schema", () => ({
+  saveSchemaFromGUI: hoisted.saveSchemaFromGUI,
+}));
+vi.mock("@/actions/suggestions", () => ({
+  approveSchemaSuggestionWithEdits: hoisted.approveSchemaSuggestionWithEdits,
+}));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: hoisted.refresh }),
+}));
+vi.mock("sonner", () => ({ toast: hoisted.toast }));
+
+const fieldA: PydanticField = {
+  name: "a",
+  type: "text",
+  options: null,
+  description: "Descrição base",
+  help_text: "Ajuda base",
+};
+
+beforeEach(() => {
+  hoisted.saveSchemaFromGUI.mockReset();
+  hoisted.approveSchemaSuggestionWithEdits.mockReset();
+  Object.values(hoisted.toast).forEach((mock) => mock.mockClear());
+});
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function dialogAt(fields: PydanticField[], revision: number) {
+  return (
+    <EditFieldDialog
+      projectId="project-1"
+      fieldName="a"
+      allFields={fields}
+      open
+      onOpenChange={vi.fn()}
+      schemaBaseline={{ revision }}
+    />
+  );
+}
+
+function descriptionInput(): HTMLInputElement {
+  return screen.getByPlaceholderText(
+    "O que este campo representa?",
+  ) as HTMLInputElement;
+}
+
+async function typeDescription(text: string) {
+  const input = descriptionInput();
+  await userEvent.clear(input);
+  await userEvent.type(input, text);
+}
+
+function savedFieldsArg(call = 0): PydanticField[] {
+  return hoisted.saveSchemaFromGUI.mock.calls[call][1] as PydanticField[];
+}
+
+// O formulário congela na abertura (por design: um refresh RSC não pode apagar
+// a digitação), mas o save e a exibição precisam reconciliar com o remoto que
+// avançou sob o diálogo aberto — issue #501.
+describe("EditFieldDialog — remoto avança com o diálogo aberto", () => {
+  it("salvar não reverte edição concorrente de outra propriedade", async () => {
+    hoisted.saveSchemaFromGUI.mockResolvedValue({
+      status: "saved",
+      snapshot: { fields: [], version: "0.1.2", revision: 3 },
+    });
+    const view = render(dialogAt([fieldA], 1));
+    await typeDescription("Descrição editada");
+
+    // Refresh RSC aterrissa: outro coordenador mudou o help_text.
+    view.rerender(dialogAt([{ ...fieldA, help_text: "Ajuda remota" }], 2));
+    await userEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() => expect(hoisted.saveSchemaFromGUI).toHaveBeenCalled());
+    expect(hoisted.saveSchemaFromGUI).toHaveBeenCalledWith(
+      "project-1",
+      expect.anything(),
+      { revision: 2 },
+    );
+    expect(savedFieldsArg()[0]).toMatchObject({
+      description: "Descrição editada",
+      help_text: "Ajuda remota",
+    });
+    expect(hoisted.toast.error).not.toHaveBeenCalled();
+  });
+
+  it("o aviso de descrição compara com o base do form, não com o remoto vivo", async () => {
+    const view = render(dialogAt([fieldA], 1));
+    expect(screen.queryByText(/Alterar a descrição/)).toBeNull();
+
+    view.rerender(dialogAt([{ ...fieldA, description: "Descrição remota" }], 2));
+
+    // O input ainda mostra o valor com que o form foi semeado; o usuário não
+    // alterou nada, então não há aviso a dar.
+    expect(descriptionInput().value).toBe("Descrição base");
+    expect(screen.queryByText(/Alterar a descrição/)).toBeNull();
+  });
+
+  it("baseline stale re-mescla e reenvia uma vez em vez de descartar a edição", async () => {
+    hoisted.saveSchemaFromGUI
+      .mockResolvedValueOnce({
+        status: "conflict",
+        current: {
+          fields: [{ ...fieldA, help_text: "Ajuda remota" }],
+          version: "0.1.4",
+          revision: 5,
+        },
+      })
+      .mockResolvedValueOnce({
+        status: "saved",
+        snapshot: { fields: [], version: "0.1.5", revision: 6 },
+      });
+    render(dialogAt([fieldA], 1));
+    await typeDescription("Descrição editada");
+    await userEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() =>
+      expect(hoisted.saveSchemaFromGUI).toHaveBeenCalledTimes(2),
+    );
+    expect(hoisted.saveSchemaFromGUI).toHaveBeenLastCalledWith(
+      "project-1",
+      expect.anything(),
+      { revision: 5 },
+    );
+    expect(savedFieldsArg(1)[0]).toMatchObject({
+      description: "Descrição editada",
+      help_text: "Ajuda remota",
+    });
+    expect(hoisted.toast.success).toHaveBeenCalled();
+    expect(hoisted.toast.error).not.toHaveBeenCalled();
+  });
+
+  it("colisão na mesma propriedade bloqueia o save sem perder a digitação", async () => {
+    const view = render(dialogAt([fieldA], 1));
+    await typeDescription("Descrição editada");
+
+    view.rerender(
+      dialogAt([{ ...fieldA, description: "Descrição remota" }], 2),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() => expect(hoisted.toast.error).toHaveBeenCalled());
+    expect(hoisted.saveSchemaFromGUI).not.toHaveBeenCalled();
+    // O diálogo permanece aberto com o trabalho do usuário intacto.
+    expect(descriptionInput().value).toBe("Descrição editada");
+  });
+});

--- a/frontend/src/components/stats/__tests__/EditFieldDialog.test.tsx
+++ b/frontend/src/components/stats/__tests__/EditFieldDialog.test.tsx
@@ -150,6 +150,22 @@ describe("EditFieldDialog — remoto avança com o diálogo aberto", () => {
     expect(hoisted.toast.error).not.toHaveBeenCalled();
   });
 
+  it("erro do save mantém o diálogo aberto com a digitação", async () => {
+    hoisted.saveSchemaFromGUI.mockResolvedValue({
+      status: "error",
+      message: "Falha remota",
+    });
+    render(dialogAt([fieldA], 1));
+    await typeDescription("Descrição editada");
+    await userEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() =>
+      expect(hoisted.toast.error).toHaveBeenCalledWith("Falha remota"),
+    );
+    expect(hoisted.toast.success).not.toHaveBeenCalled();
+    expect(descriptionInput().value).toBe("Descrição editada");
+  });
+
   it("colisão na mesma propriedade bloqueia o save sem perder a digitação", async () => {
     const view = render(dialogAt([fieldA], 1));
     await typeDescription("Descrição editada");
@@ -163,5 +179,80 @@ describe("EditFieldDialog — remoto avança com o diálogo aberto", () => {
     expect(hoisted.saveSchemaFromGUI).not.toHaveBeenCalled();
     // O diálogo permanece aberto com o trabalho do usuário intacto.
     expect(descriptionInput().value).toBe("Descrição editada");
+  });
+});
+
+// A aprovação de sugestão é a via cujo contrato mais mudou: o conflito de CAS
+// deixou de sair achatado em `error` e passou a voltar tipado, com o snapshot
+// atual, para que o re-merge e o reenvio sejam possíveis (#501). Ela usa uma
+// Server Action distinta, então precisa do seu próprio par de testes.
+describe("EditFieldDialog — aprovação de sugestão", () => {
+  const SUGGESTION = {
+    id: "suggestion-1",
+    changes: { description: "Descrição sugerida" },
+  };
+
+  function suggestionDialogAt(fields: PydanticField[], revision: number) {
+    return (
+      <EditFieldDialog
+        projectId="project-1"
+        fieldName="a"
+        allFields={fields}
+        open
+        onOpenChange={vi.fn()}
+        schemaBaseline={{ revision }}
+        pendingSuggestion={SUGGESTION}
+      />
+    );
+  }
+
+  it("baseline stale re-mescla sobre o snapshot devolvido e reenvia uma vez", async () => {
+    hoisted.approveSchemaSuggestionWithEdits
+      .mockResolvedValueOnce({
+        conflict: {
+          fields: [{ ...fieldA, help_text: "Ajuda remota" }],
+          version: "0.1.4",
+          revision: 5,
+        },
+      })
+      .mockResolvedValueOnce({});
+    render(suggestionDialogAt([fieldA], 1));
+
+    // O form já vem semeado com a proposta; aprovar é salvar o que ela pede.
+    expect(descriptionInput().value).toBe("Descrição sugerida");
+    await userEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() =>
+      expect(hoisted.approveSchemaSuggestionWithEdits).toHaveBeenCalledTimes(2),
+    );
+    const [suggestionId, projectId, fields, baseline] =
+      hoisted.approveSchemaSuggestionWithEdits.mock.calls[1];
+    expect([suggestionId, projectId, baseline]).toEqual([
+      "suggestion-1",
+      "project-1",
+      { revision: 5 },
+    ]);
+    expect((fields as PydanticField[])[0]).toMatchObject({
+      description: "Descrição sugerida",
+      help_text: "Ajuda remota",
+    });
+    expect(hoisted.toast.success).toHaveBeenCalledWith(
+      "Sugestão aprovada e campo atualizado",
+    );
+  });
+
+  it("erro da action não é confundido com aprovação", async () => {
+    hoisted.approveSchemaSuggestionWithEdits.mockResolvedValue({
+      error: "Sugestão já resolvida por outro coordenador.",
+    });
+    render(suggestionDialogAt([fieldA], 1));
+    await userEvent.click(screen.getByRole("button", { name: "Salvar" }));
+
+    await waitFor(() =>
+      expect(hoisted.toast.error).toHaveBeenCalledWith(
+        "Sugestão já resolvida por outro coordenador.",
+      ),
+    );
+    expect(hoisted.toast.success).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/stats/__tests__/edit-field-save.test.ts
+++ b/frontend/src/components/stats/__tests__/edit-field-save.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyFormEdits,
+  saveMergedEdit,
+  type EditFieldFormValues,
+  type SubmitOutcome,
+} from "../edit-field-save";
+import type { PydanticField, SchemaBaselineIdentity } from "@/lib/types";
+
+const q1: PydanticField = {
+  name: "q1",
+  type: "single",
+  options: ["Sim", "Não"],
+  description: "Pergunta 1",
+};
+// Depende de uma opção de q1: é o campo que o strip precisa alcançar quando a
+// opção que dispara a condição é removida no diálogo.
+const q2: PydanticField = {
+  name: "q2",
+  type: "text",
+  options: null,
+  description: "Pergunta 2",
+  condition: { field: "q1", equals: "Não" },
+};
+
+// Os valores que o form devolve quando nada foi tocado, para cada teste mudar
+// só a propriedade que está em jogo.
+function formOf(overrides: Partial<EditFieldFormValues> = {}): EditFieldFormValues {
+  return {
+    description: q1.description,
+    helpText: "",
+    options: q1.options ?? [],
+    allowOther: false,
+    subfields: undefined,
+    subfieldRule: "all",
+    condition: undefined,
+    justificationPrompt: "",
+    ...overrides,
+  };
+}
+
+const BASELINE: SchemaBaselineIdentity = { revision: 3 };
+
+describe("applyFormEdits", () => {
+  it("aplica a edição sobre o base capturado e preserva os outros campos", () => {
+    const fields = applyFormEdits([q1, q2], "q1", formOf({
+      description: "Pergunta 1 revista",
+      helpText: "  Instruções  ",
+    }));
+
+    expect(fields[0]).toMatchObject({
+      name: "q1",
+      description: "Pergunta 1 revista",
+      help_text: "Instruções",
+    });
+    expect(fields[1]).toEqual(q2);
+  });
+
+  it("remover uma opção limpa as condições que dependiam dela", () => {
+    const fields = applyFormEdits([q1, q2], "q1", formOf({ options: ["Sim"] }));
+
+    expect(fields[0].options).toEqual(["Sim"]);
+    expect(fields[1].condition).toBeUndefined();
+  });
+
+  it("subcampos presentes zeram as opções próprias do campo", () => {
+    const fields = applyFormEdits([q1], "q1", formOf({
+      subfields: [{ key: "s1", label: "Subcampo 1" }],
+      subfieldRule: "at_least_one",
+    }));
+
+    expect(fields[0]).toMatchObject({
+      options: null,
+      subfields: [{ key: "s1", label: "Subcampo 1" }],
+      subfield_rule: "at_least_one",
+    });
+  });
+
+  // O EditFieldDialog não renderiza sem `baseField`, então isto é o contrato do
+  // módulo puro para um chamador futuro: sem o campo, não há edição a aplicar.
+  it("base sem o campo devolve os campos intactos", () => {
+    expect(applyFormEdits([q2], "q1", formOf())).toEqual([q2]);
+  });
+});
+
+describe("saveMergedEdit", () => {
+  const localEdit = applyFormEdits([q1], "q1", formOf({ description: "Local" }));
+
+  // Edição concorrente em OUTRA propriedade: o merge tem que carregá-la ao
+  // payload em vez de reescrevê-la com o valor congelado na abertura.
+  it("carrega a edição concorrente de outra propriedade ao payload", async () => {
+    const submit = vi.fn<(f: PydanticField[], b: SchemaBaselineIdentity) => Promise<SubmitOutcome>>()
+      .mockResolvedValue({ status: "saved" });
+
+    const result = await saveMergedEdit(
+      [q1],
+      localEdit,
+      [{ ...q1, help_text: "Ajuda remota" }],
+      BASELINE,
+      submit,
+    );
+
+    expect(result).toEqual({ status: "saved" });
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0][0][0]).toMatchObject({
+      description: "Local",
+      help_text: "Ajuda remota",
+    });
+    expect(submit.mock.calls[0][1]).toEqual(BASELINE);
+  });
+
+  it("colisão na mesma propriedade bloqueia sem chamar o submit", async () => {
+    const submit = vi.fn<(f: PydanticField[], b: SchemaBaselineIdentity) => Promise<SubmitOutcome>>();
+
+    const result = await saveMergedEdit(
+      [q1],
+      localEdit,
+      [{ ...q1, description: "Remota" }],
+      BASELINE,
+      submit,
+    );
+
+    expect(result.status).toBe("blocked");
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("conflito de CAS re-mescla sobre o snapshot devolvido e reenvia uma vez", async () => {
+    const submit = vi.fn<(f: PydanticField[], b: SchemaBaselineIdentity) => Promise<SubmitOutcome>>()
+      .mockResolvedValueOnce({
+        status: "conflict",
+        current: {
+          fields: [{ ...q1, help_text: "Ajuda remota" }],
+          version: "0.1.4",
+          revision: 9,
+        },
+      })
+      .mockResolvedValueOnce({ status: "saved" });
+
+    const result = await saveMergedEdit([q1], localEdit, [q1], BASELINE, submit);
+
+    expect(result).toEqual({ status: "saved" });
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(submit.mock.calls[1][0][0]).toMatchObject({
+      description: "Local",
+      help_text: "Ajuda remota",
+    });
+    // A revisão do reenvio é a devolvida pelo servidor, não a que já falhou.
+    expect(submit.mock.calls[1][1]).toEqual({ revision: 9 });
+  });
+
+  it("re-merge que colide bloqueia sem um segundo submit", async () => {
+    const submit = vi.fn<(f: PydanticField[], b: SchemaBaselineIdentity) => Promise<SubmitOutcome>>()
+      .mockResolvedValueOnce({
+        status: "conflict",
+        current: {
+          fields: [{ ...q1, description: "Remota" }],
+          version: "0.1.4",
+          revision: 9,
+        },
+      });
+
+    const result = await saveMergedEdit([q1], localEdit, [q1], BASELINE, submit);
+
+    expect(result.status).toBe("blocked");
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("segundo conflito consecutivo vira falha, não um terceiro reenvio", async () => {
+    const conflict: SubmitOutcome = {
+      status: "conflict",
+      current: { fields: [q1], version: "0.1.4", revision: 9 },
+    };
+    const submit = vi.fn<(f: PydanticField[], b: SchemaBaselineIdentity) => Promise<SubmitOutcome>>()
+      .mockResolvedValue(conflict);
+
+    const result = await saveMergedEdit([q1], localEdit, [q1], BASELINE, submit);
+
+    expect(result).toMatchObject({ status: "error" });
+    expect(submit).toHaveBeenCalledTimes(2);
+  });
+
+  it("erro do save volta pelo mesmo canal do bloqueio", async () => {
+    const submit = vi.fn<(f: PydanticField[], b: SchemaBaselineIdentity) => Promise<SubmitOutcome>>()
+      .mockResolvedValue({ status: "error", message: "Falha remota" });
+
+    const result = await saveMergedEdit([q1], localEdit, [q1], BASELINE, submit);
+
+    expect(result).toEqual({ status: "error", message: "Falha remota" });
+  });
+});
+
+// A mensagem de bloqueio é o que resta ao usuário quando o save para: precisa
+// nomear a disputa nos três `kind` que o merge produz, e não o id opaco.
+describe("saveMergedEdit — a mensagem nomeia a disputa", () => {
+  async function blockedMessage(
+    base: PydanticField[],
+    local: PydanticField[],
+    remote: PydanticField[],
+  ): Promise<string> {
+    const result = await saveMergedEdit(base, local, remote, BASELINE, async () => ({
+      status: "saved",
+    }));
+    if (result.status !== "blocked") throw new Error(`esperava blocked, veio ${result.status}`);
+    return result.message;
+  }
+
+  it("colisão de propriedade nomeia o rótulo pt-BR e o campo", async () => {
+    const message = await blockedMessage(
+      [q1],
+      [{ ...q1, description: "Local" }],
+      [{ ...q1, description: "Remota" }],
+    );
+    expect(message).toContain('descrição de "q1"');
+  });
+
+  it("edit-delete nomeia o campo", async () => {
+    const message = await blockedMessage(
+      [q1, q2],
+      [q1, { ...q2, description: "Local" }],
+      [q1],
+    );
+    expect(message).toContain('o campo "q2"');
+  });
+
+  it("ordem incompatível nomeia a ordem", async () => {
+    const q3: PydanticField = { ...q2, name: "q3", condition: undefined };
+    const message = await blockedMessage(
+      [q1, q2, q3],
+      [q2, q1, q3],
+      [q1, q3, q2],
+    );
+    expect(message).toContain("a ordem dos campos");
+  });
+});

--- a/frontend/src/components/stats/edit-field-save.ts
+++ b/frontend/src/components/stats/edit-field-save.ts
@@ -1,0 +1,152 @@
+import {
+  mergeSchemas,
+  unresolvedSchemaConflicts,
+  type SchemaMergeConflict,
+} from "@/lib/schema-merge";
+import { stripOptionFromConditions } from "@/lib/schema-utils";
+import { propertyLabel } from "@/lib/schema-change-format";
+import type {
+  FieldCondition,
+  PydanticField,
+  SchemaBaselineIdentity,
+  SchemaSnapshot,
+  SubfieldDef,
+} from "@/lib/types";
+
+export interface EditFieldFormValues {
+  description: string;
+  helpText: string;
+  options: string[];
+  allowOther: boolean;
+  subfields?: SubfieldDef[];
+  subfieldRule: PydanticField["subfield_rule"];
+  condition?: FieldCondition;
+  justificationPrompt: string;
+}
+
+// Subcampos e opções são mutuamente exclusivos no form: com subcampos
+// presentes, as opções gravadas são as deles (via SubfieldsEditor), não uma
+// lista própria do campo.
+function optionShapeFromForm(
+  form: EditFieldFormValues,
+): Pick<PydanticField, "options" | "subfields" | "subfield_rule"> {
+  const hasSubfields = (form.subfields?.length ?? 0) > 0;
+  if (hasSubfields) {
+    return {
+      options: null,
+      subfields: form.subfields,
+      subfield_rule: form.subfieldRule,
+    };
+  }
+  return {
+    options: form.options.length > 0 ? form.options : null,
+    subfields: undefined,
+    subfield_rule: undefined,
+  };
+}
+
+function editedFieldFromForm(
+  baseField: PydanticField,
+  form: EditFieldFormValues,
+): PydanticField {
+  const allowsOther =
+    (baseField.type === "single" || baseField.type === "multi") &&
+    form.allowOther;
+  return {
+    ...baseField,
+    description: form.description,
+    help_text: form.helpText.trim() || undefined,
+    ...optionShapeFromForm(form),
+    allow_other: allowsOther ? true : undefined,
+    condition: form.condition,
+    justification_prompt: form.justificationPrompt.trim() || undefined,
+  };
+}
+
+// O diff local é form × BASE capturado na abertura do diálogo — o que o
+// usuário de fato mudou. Aplicá-lo direto sobre o `allFields` vivo
+// reescreveria as propriedades geridas pelo form com valores congelados,
+// revertendo em silêncio a edição concorrente que um refresh trouxe (#501).
+export function applyFormEdits(
+  baseFields: PydanticField[],
+  fieldName: string,
+  form: EditFieldFormValues,
+): PydanticField[] {
+  const baseField = baseFields.find((f) => f.name === fieldName);
+  if (!baseField) return baseFields;
+  const edited = editedFieldFromForm(baseField, form);
+  let fields = baseFields.map((f) => (f.name === fieldName ? edited : f));
+  const kept = new Set(form.options);
+  const removedOpts = (baseField.options ?? []).filter((o) => !kept.has(o));
+  for (const removed of removedOpts) {
+    fields = stripOptionFromConditions(fields, fieldName, removed);
+  }
+  return fields;
+}
+
+// Um conflito aqui é colisão real: a mesma propriedade editada no diálogo e em
+// outra sessão. A UX mínima é bloquear sem perder a digitação — reconstruir o
+// diálogo de resoluções do SchemaEditor neste fluxo seria um segundo mecanismo
+// de conflito completo para um caso raro.
+function conflictBlockMessage(conflicts: SchemaMergeConflict[]): string {
+  const disputed = conflicts.map((conflict) => {
+    if (conflict.kind === "property") {
+      return `${propertyLabel(conflict.property)} de "${conflict.fieldName}"`;
+    }
+    if (conflict.kind === "field") return `o campo "${conflict.fieldName}"`;
+    return "a ordem dos campos";
+  });
+  return `Outra sessão editou ao mesmo tempo: ${[...new Set(disputed)].join(", ")}. Recarregue a página para rever a versão atual antes de salvar.`;
+}
+
+export type SubmitOutcome =
+  | { status: "saved" }
+  | { status: "conflict"; current: SchemaSnapshot }
+  | { status: "error"; message: string };
+
+export type SaveMergedEditResult =
+  | { status: "saved" }
+  | { status: "blocked"; message: string };
+
+const STALE_RETRY_FAILED_MESSAGE =
+  "O schema mudou em outra sessão. Recarregue a página e reaplique esta edição sobre a versão atual.";
+
+// Merge de três vias (base capturado × edição do form × remoto vivo) antes de
+// submeter: edições concorrentes em outras propriedades entram no payload;
+// colisão na mesma propriedade bloqueia com a digitação intacta. Um conflito
+// de CAS re-mescla sobre o snapshot devolvido e reenvia UMA vez, em vez de
+// descartar a edição com "recarregue a página". Erros de save continuam
+// lançados — o chamador já os trata.
+export async function saveMergedEdit(
+  baseFields: PydanticField[],
+  localFields: PydanticField[],
+  allFields: PydanticField[],
+  baseline: SchemaBaselineIdentity,
+  submit: (
+    fields: PydanticField[],
+    baseline: SchemaBaselineIdentity,
+  ) => Promise<SubmitOutcome>,
+): Promise<SaveMergedEditResult> {
+  const merged = mergeSchemas(baseFields, localFields, allFields);
+  const blocked = unresolvedSchemaConflicts(merged);
+  if (blocked.length > 0) {
+    return { status: "blocked", message: conflictBlockMessage(blocked) };
+  }
+
+  let result = await submit(merged.fields, baseline);
+  if (result.status === "conflict") {
+    const remerged = mergeSchemas(baseFields, localFields, result.current.fields);
+    const reblocked = unresolvedSchemaConflicts(remerged);
+    if (reblocked.length > 0) {
+      return { status: "blocked", message: conflictBlockMessage(reblocked) };
+    }
+    result = await submit(remerged.fields, {
+      revision: result.current.revision,
+    });
+  }
+  if (result.status === "conflict") {
+    throw new Error(STALE_RETRY_FAILED_MESSAGE);
+  }
+  if (result.status === "error") throw new Error(result.message);
+  return { status: "saved" };
+}

--- a/frontend/src/components/stats/edit-field-save.ts
+++ b/frontend/src/components/stats/edit-field-save.ts
@@ -104,9 +104,15 @@ export type SubmitOutcome =
   | { status: "conflict"; current: SchemaSnapshot }
   | { status: "error"; message: string };
 
+// Toda parada tem uma mensagem e sai pelo mesmo canal. `blocked` e `error` são
+// distintos porque só o primeiro preserva a digitação por design (a colisão é
+// resolúvel recarregando), mas nenhum dos dois é exceção: fazer a falha de save
+// sair por `throw` obrigava o `try/catch` do chamador a servir a erro de domínio
+// e a queda de rede ao mesmo tempo.
 export type SaveMergedEditResult =
   | { status: "saved" }
-  | { status: "blocked"; message: string };
+  | { status: "blocked"; message: string }
+  | { status: "error"; message: string };
 
 const STALE_RETRY_FAILED_MESSAGE =
   "O schema mudou em outra sessão. Recarregue a página e reaplique esta edição sobre a versão atual.";
@@ -115,8 +121,7 @@ const STALE_RETRY_FAILED_MESSAGE =
 // submeter: edições concorrentes em outras propriedades entram no payload;
 // colisão na mesma propriedade bloqueia com a digitação intacta. Um conflito
 // de CAS re-mescla sobre o snapshot devolvido e reenvia UMA vez, em vez de
-// descartar a edição com "recarregue a página". Erros de save continuam
-// lançados — o chamador já os trata.
+// descartar a edição com "recarregue a página".
 export async function saveMergedEdit(
   baseFields: PydanticField[],
   localFields: PydanticField[],
@@ -145,8 +150,10 @@ export async function saveMergedEdit(
     });
   }
   if (result.status === "conflict") {
-    throw new Error(STALE_RETRY_FAILED_MESSAGE);
+    return { status: "error", message: STALE_RETRY_FAILED_MESSAGE };
   }
-  if (result.status === "error") throw new Error(result.message);
+  if (result.status === "error") {
+    return { status: "error", message: result.message };
+  }
   return { status: "saved" };
 }

--- a/frontend/src/components/stats/useEditFieldForm.ts
+++ b/frontend/src/components/stats/useEditFieldForm.ts
@@ -14,25 +14,40 @@ export interface PendingSuggestion {
   };
 }
 
+interface FormSeed {
+  description: string;
+  helpText: string;
+  options: string[];
+}
+
+function seedFromField(field: PydanticField | undefined): FormSeed {
+  return {
+    description: field?.description ?? "",
+    helpText: field?.help_text ?? "",
+    options: field?.options ?? [],
+  };
+}
+
+// Distinguish "no change" (undefined) from "clear" (null) in suggestions:
+// null in suggested_changes means the suggestion explicitly wants to empty
+// the field, so ?? against the current field value would mask that intent.
+function seedWithSuggestion(
+  seed: FormSeed,
+  ch: PendingSuggestion["changes"],
+): FormSeed {
+  return {
+    description: ch.description ?? seed.description,
+    helpText: ch.help_text !== undefined ? (ch.help_text ?? "") : seed.helpText,
+    options: ch.options !== undefined ? (ch.options ?? []) : seed.options,
+  };
+}
+
 function initialFromField(
   field: PydanticField | undefined,
   suggestion?: PendingSuggestion | null,
-) {
-  const ch = suggestion?.changes ?? {};
-  // Distinguish "no change" (undefined) from "clear" (null) in suggestions:
-  // null in suggested_changes means the suggestion explicitly wants to empty
-  // the field, so ?? against the current field value would mask that intent.
-  return {
-    description: ch.description ?? field?.description ?? "",
-    helpText:
-      ch.help_text !== undefined
-        ? (ch.help_text ?? "")
-        : (field?.help_text ?? ""),
-    options:
-      ch.options !== undefined
-        ? (ch.options ?? [])
-        : (field?.options ?? []),
-  };
+): FormSeed {
+  const seed = seedFromField(field);
+  return suggestion ? seedWithSuggestion(seed, suggestion.changes) : seed;
 }
 
 export function useEditFieldForm(

--- a/frontend/src/components/stats/useEditFieldForm.ts
+++ b/frontend/src/components/stats/useEditFieldForm.ts
@@ -36,31 +36,44 @@ function initialFromField(
 }
 
 export function useEditFieldForm(
-  field: PydanticField | undefined,
   fieldName: string,
   allFields: PydanticField[],
   pendingSuggestion?: PendingSuggestion | null,
 ) {
-  const initial = initialFromField(field, pendingSuggestion);
+  // O form congela na abertura por design (um refresh RSC não pode apagar a
+  // digitação), então o schema-base do qual ele foi semeado precisa congelar
+  // JUNTO: é ele o "base" do merge de três vias no save e a referência de
+  // exibição (descriptionChanged, opções removidas). Comparar o state do form
+  // com o `allFields` vivo mistura dois instantes e foi o que deixou o save
+  // sobrescrever edição concorrente em silêncio (#501).
+  const [baseFields, setBaseFields] = useState(allFields);
+  const baseField = baseFields.find((f) => f.name === fieldName);
+
+  const initial = initialFromField(baseField, pendingSuggestion);
   const [description, setDescription] = useState(initial.description);
   const [helpText, setHelpText] = useState(initial.helpText);
   const [options, setOptions] = useState<string[]>(initial.options);
   const [allowOther, setAllowOther] = useState<boolean>(() =>
-    resolveAllowOther(field?.allow_other),
+    resolveAllowOther(baseField?.allow_other),
   );
-  const [subfields, setSubfields] = useState<SubfieldDef[] | undefined>(field?.subfields);
+  const [subfields, setSubfields] = useState<SubfieldDef[] | undefined>(
+    baseField?.subfields,
+  );
   const [subfieldRule, setSubfieldRule] = useState(() =>
-    resolveSubfieldRule(field?.subfield_rule),
+    resolveSubfieldRule(baseField?.subfield_rule),
   );
-  const [condition, setCondition] = useState<FieldCondition | undefined>(field?.condition);
+  const [condition, setCondition] = useState<FieldCondition | undefined>(
+    baseField?.condition,
+  );
   const [justificationPrompt, setJustificationPrompt] = useState<string>(
-    field?.justification_prompt ?? "",
+    baseField?.justification_prompt ?? "",
   );
   const [isSaving, startSave] = useTransition();
 
   // Reset state when dialog opens with a different field or suggestion
   const resetKey = `${fieldName}::${pendingSuggestion?.id ?? ""}`;
   useResetOnKeyChange(resetKey, () => {
+    setBaseFields(allFields);
     const f = allFields.find((ff) => ff.name === fieldName);
     const init = initialFromField(f, pendingSuggestion);
     setDescription(init.description);
@@ -74,6 +87,8 @@ export function useEditFieldForm(
   });
 
   return {
+    baseFields,
+    baseField,
     description,
     setDescription,
     helpText,

--- a/frontend/src/hooks/__tests__/useSchemaDraft.test.ts
+++ b/frontend/src/hooks/__tests__/useSchemaDraft.test.ts
@@ -612,6 +612,38 @@ describe("useSchemaDraft", () => {
     }]);
   });
 
+  // A resolução responde a uma disputa concreta. Se o remoto avança para um
+  // TERCEIRO valor na mesma propriedade com o diálogo aberto, reaplicar a
+  // escolha antiga adotaria um valor que o usuário nunca revisou (#501) — o
+  // conflito precisa ser reapresentado sem resolução.
+  it("revisão nova na mesma propriedade invalida a resolução pendente", () => {
+    const view = renderDraft();
+    act(() => view.result.current.setFields(EDITED_FIELDS));
+    act(() =>
+      view.result.current.registerRemoteConflict(
+        snapshot([{ ...BASE_FIELDS[0], description: "Pergunta remota" }], "0.1.1", 2),
+      ),
+    );
+
+    const [conflict] = unresolvedSchemaConflicts(
+      view.result.current.conflict!.merge,
+    );
+    act(() => view.result.current.resolveConflict(conflict.id, "remote"));
+    expect(unresolvedSchemaConflicts(view.result.current.conflict!.merge)).toEqual([]);
+
+    // Antes de aplicar, chega outra revisão com um 3º valor na MESMA propriedade.
+    act(() =>
+      view.result.current.registerRemoteConflict(
+        snapshot([{ ...BASE_FIELDS[0], description: "Terceira versão" }], "0.1.2", 3),
+      ),
+    );
+
+    expect(view.result.current.conflict).not.toBeNull();
+    expect(
+      unresolvedSchemaConflicts(view.result.current.conflict!.merge),
+    ).toHaveLength(1);
+  });
+
   it("ignora snapshot atrasado com revisão menor", () => {
     const view = renderDraft();
     const revision3 = [{ ...BASE_FIELDS[0], help_text: "Revisão 3" }];

--- a/frontend/src/lib/__tests__/schema-merge.test.ts
+++ b/frontend/src/lib/__tests__/schema-merge.test.ts
@@ -164,7 +164,7 @@ describe("mergeSchemas", () => {
   it("expõe reorder incompatível e permite escolher a ordem local", () => {
     const initial = mergeSchemas([q1, q2, q3], [q2, q1, q3], [q1, q3, q2]);
     expect(initial.conflicts).toContainEqual(
-      expect.objectContaining({ id: "order", kind: "order", resolution: null }),
+      expect.objectContaining({ kind: "order", resolution: null }),
     );
     expect(initial.fields.map(({ name }) => name)).toEqual(["q1", "q3", "q2"]);
 
@@ -172,7 +172,7 @@ describe("mergeSchemas", () => {
       [q1, q2, q3],
       [q2, q1, q3],
       [q1, q3, q2],
-      { order: "local" },
+      { [initial.conflicts[0].id]: "local" },
     );
     expect(resolved.fields.map(({ name }) => name)).toEqual(["q2", "q1", "q3"]);
   });
@@ -326,5 +326,62 @@ describe("mergeSchemas — default implícito não é edição", () => {
       [{ ...semTarget, target: "llm_only" }],
     );
     expect(unresolvedSchemaConflicts(merge)).toHaveLength(1);
+  });
+});
+
+// Uma resolução é a resposta a UMA disputa concreta ("Local" × "Remota"), não ao
+// endereço campo+propriedade. Se o remoto avança para um terceiro valor com o
+// diálogo de conflito aberto, reaplicar a escolha antiga adota um valor que o
+// usuário nunca viu — o id precisa carregar os valores em disputa para que o
+// re-merge deixe a resolução antiga órfã e reapresente o conflito (#501).
+describe("mergeSchemas — resolução pertence à disputa, não ao endereço", () => {
+  const local = [{ ...q1, description: "Local" }];
+  const remote = [{ ...q1, description: "Remota" }];
+
+  it("resolução de propriedade não se reaplica quando o valor remoto mudou", () => {
+    const id = mergeSchemas([q1], local, remote).conflicts[0].id;
+    const remerge = mergeSchemas(
+      [q1],
+      local,
+      [{ ...q1, description: "Remota v2" }],
+      { [id]: "remote" },
+    );
+    expect(unresolvedSchemaConflicts(remerge)).toHaveLength(1);
+  });
+
+  it("resolução de propriedade continua valendo enquanto a disputa é a mesma", () => {
+    const id = mergeSchemas([q1], local, remote).conflicts[0].id;
+    const remerge = mergeSchemas([q1], local, remote, { [id]: "local" });
+    expect(unresolvedSchemaConflicts(remerge)).toEqual([]);
+    expect(remerge.fields[0].description).toBe("Local");
+  });
+
+  it("resolução de add-add não se reaplica quando o campo remoto mudou", () => {
+    const localAdd = [q1, { ...q2, description: "Local" }];
+    const id = mergeSchemas(
+      [q1],
+      localAdd,
+      [q1, { ...q2, description: "Remota" }],
+    ).conflicts[0].id;
+    const remerge = mergeSchemas(
+      [q1],
+      localAdd,
+      [q1, { ...q2, description: "Remota v2" }],
+      { [id]: "local" },
+    );
+    expect(unresolvedSchemaConflicts(remerge)).toHaveLength(1);
+  });
+
+  it("resolução de ordem não se reaplica quando a ordem remota mudou", () => {
+    // Ambas as ordens remotas ciclam contra o local (q1<q3<q2<q1 e
+    // q1<q4<q2<q1), mas são disputas diferentes — a resolução da primeira não
+    // pode fechar a segunda.
+    const base = [q1, q2, q3, q4];
+    const local = [q2, q1, q3, q4];
+    const id = mergeSchemas(base, local, [q1, q3, q2, q4]).conflicts[0].id;
+    const remerge = mergeSchemas(base, local, [q1, q4, q2, q3], {
+      [id]: "local",
+    });
+    expect(unresolvedSchemaConflicts(remerge)).toHaveLength(1);
   });
 });

--- a/frontend/src/lib/schema-merge.ts
+++ b/frontend/src/lib/schema-merge.ts
@@ -93,8 +93,19 @@ function fieldMap(fields: PydanticField[], source: string): Map<string, Pydantic
   return result;
 }
 
+// O id identifica a DISPUTA (endereço + valores em jogo), não só o endereço.
+// Uma resolução é a resposta do usuário a "Local × Remota"; se um re-merge
+// chega com outro valor remoto, o id muda e a resolução antiga vira órfã —
+// `resolutionFor` devolve null e o conflito é reapresentado, em vez de adotar
+// em silêncio um valor que o usuário nunca revisou (#501). Os valores entram
+// via `stableStringify` do snapshot, a mesma serialização canônica que decide
+// igualdade no merge — a disputa "muda" exatamente quando o merge a vê mudar.
 function conflictId(...parts: string[]): string {
   return parts.map(encodeURIComponent).join(":");
+}
+
+function fieldSnapshotKey(field: PydanticField): string {
+  return stableStringify(snapshotOf(field));
 }
 
 function resolutionFor(
@@ -130,7 +141,13 @@ function mergeAddedField(
     return { field: clone(remoteField ?? localField), conflicts: [] };
   }
 
-  const id = conflictId("field", name, "add-add");
+  const id = conflictId(
+    "field",
+    name,
+    "add-add",
+    fieldSnapshotKey(localField),
+    fieldSnapshotKey(remoteField),
+  );
   const resolution = resolutionFor(id, resolutions);
   return {
     field: clone(resolution === "local" ? localField : remoteField),
@@ -184,7 +201,13 @@ function mergeFieldProperties(
       continue;
     }
 
-    const id = conflictId("property", name, String(property));
+    const id = conflictId(
+      "property",
+      name,
+      String(property),
+      stableStringify(local),
+      stableStringify(remote),
+    );
     const resolution = resolutionFor(id, resolutions);
     conflicts.push({
       id,
@@ -208,7 +231,12 @@ function mergeLocalDeletion(
   resolutions: SchemaMergeResolutions,
 ): FieldMergeOutcome {
   if (sameFieldContent(remoteField, baseField)) return { field: null, conflicts: [] };
-  const id = conflictId("field", name, "delete-edit");
+  const id = conflictId(
+    "field",
+    name,
+    "delete-edit",
+    fieldSnapshotKey(remoteField),
+  );
   const resolution = resolutionFor(id, resolutions);
   return {
     field: resolution === "local" ? null : clone(remoteField),
@@ -232,7 +260,12 @@ function mergeRemoteDeletion(
   resolutions: SchemaMergeResolutions,
 ): FieldMergeOutcome {
   if (sameFieldContent(localField, baseField)) return { field: null, conflicts: [] };
-  const id = conflictId("field", name, "edit-delete");
+  const id = conflictId(
+    "field",
+    name,
+    "edit-delete",
+    fieldSnapshotKey(localField),
+  );
   const resolution = resolutionFor(id, resolutions);
   return {
     field: resolution === "local" ? clone(localField) : null,
@@ -468,7 +501,11 @@ export function mergeSchemas(
 
   let selectedOrder = mergedOrder ?? remoteOrder;
   if (!mergedOrder) {
-    const id = "order";
+    const id = conflictId(
+      "order",
+      stableStringify(localOrder),
+      stableStringify(remoteOrder),
+    );
     const resolution = resolutionFor(id, resolutions);
     conflicts.push({
       id,


### PR DESCRIPTION
Corrige os três defeitos da issue, todos com a mesma raiz — estado de UI congelado num instante continuando válido depois que o remoto avançou.

## O que muda

**1. EditFieldDialog salva por merge de três vias (base capturado × form × remoto vivo).** O form continua congelando na abertura (por design: um refresh RSC não pode apagar a digitação), mas `useEditFieldForm` agora captura o schema-base junto, e o save reconcilia via `mergeSchemas` — a mesma máquina do `SchemaEditor`, sem lógica duplicada. Em consequência: edição concorrente em outra propriedade entra no payload em vez de ser sobrescrita em silêncio; colisão na mesma propriedade bloqueia o save com toast nomeando a disputa e a digitação intacta; CAS recusado re-mescla sobre o snapshot devolvido e reenvia uma vez, em vez de descartar a edição com "recarregue a página". A exibição (aviso de descrição, tipo, opções removidas) deriva do base capturado, eliminando a incoerência interna da UI. `approveSchemaSuggestionWithEdits` passa a devolver o conflito de CAS tipado (com o snapshot atual) em vez de achatá-lo em string.

**2. `conflictId` identifica a disputa, não o endereço.** O id passa a incluir os valores em jogo (serialização canônica via `snapshotOf`/`stableStringify`, a mesma que decide igualdade no merge). Um re-merge com remoto mais novo deixa a resolução antiga órfã e o diálogo de conflito reapresenta a decisão — em vez de adotar um valor que o usuário nunca revisou. Zero mudança em `useSchemaDraft`: o comportamento certo emerge da máquina existente.

**3. Toast de rebase chaveia também em `baseline.revision`.** Rebases automáticos consecutivos (`rebased`→`rebased`) voltam a ser anunciados — a guarda anti-retrocesso do hook garante que todo rebase avança a revisão, então ela é o token de "aconteceu de novo".

Um refactor acompanha: a lógica de save do diálogo vive em `edit-field-save.ts` (funções puras), exigido pelo gate de complexidade do fallow.

## Verificação

- **Prova do vermelho**: os 9 testes novos falharam antes de cada correção correspondente (4 em `EditFieldDialog.test.tsx` — arquivo novo, o componente não tinha nenhum teste; 3 em `schema-merge.test.ts`; 1 em `useSchemaDraft.test.ts`; 1 em `SchemaEditor.draft.test.tsx`).
- **Mutação**: reverter o `conflictId` por valor e as deps do effect re-vermelha exatamente os testes novos (o caso de ordem foi provado apenas no vermelho pré-fix — a mutação por `slice(0,3)` preserva as 3 partes do id de ordem).
- Suíte completa 1873/1873, typecheck, lint:types, react-doctor, fallow audit e e2e smoke verdes no pre-push.

Revisão sugerida: **integral** (write path de schema + mudança de identidade de conflito).

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYTbYinqPW1iYdAjqhohbj

---

## Correções da revisão (2ª rodada)

**Regressão do próprio PR, corrigida.** O anúncio de rebase passou a disparar também no ramo em que o merge NÃO fechou: `stateAfterRemoteChange` preserva a proveniência quando há conflito (de propósito) e a baseline de um estado em conflito já é o remoto novo, então `baseline.revision` avança e o effect roda — o toast "suas alterações foram mescladas" aparecia junto com o diálogo que pede a resolução, exatamente o que o comentário em `useSchemaDraft.ts:460` existe para impedir. O predicado agora exige `conflict === null`, o mesmo teste que o `statusMessage` do rodapé já fazia. De quebra, o rebase que fecha por resolução manual (revisão inalterada, conflito zerado) passa a ser anunciado — antes era silencioso.

**Um canal só para falha de save.** `saveMergedEdit` sinalizava bloqueio por retorno e erro por `throw`, o que fazia o `try/catch` do diálogo servir a erro de domínio e a queda de rede ao mesmo tempo. Agora os dois voltam pelo mesmo union e o `catch` cuida só do inesperado.

**Cobertura.** `edit-field-save.ts` — o único lugar do merge de três vias — ganhou teste próprio (13 casos: diff sobre o base, strip de opções, retry de CAS, mensagem de disputa nos três `kind`). A via de aprovação de sugestão, que **nenhum** teste exercitava apesar de ser a de contrato mais alterado, ganhou os dois casos que faltavam.

**Comentários passam a dizer a mecânica real.** A extração de `FieldTypeEditors` é pelo limiar do fallow (não há code-splitting, como o comentário afirmava); e a guarda de remoção fica no `allFields` vivo de propósito, com a contrapartida registrada.

### Verificação desta rodada

- **Prova do vermelho** antes de cada correção: o cenário rebase→conflito falhava com 2 toasts; os dois casos de `error` falhavam contra o canal por `throw`.
- **Mutação, lendo quais testes re-vermelham**: sem `conflict === null` cai só o teste novo; sem `origin === "rebased"` caem os dois; sem `baseline.revision` cai o teste original do #501 — nenhum termo do predicado é morto. Reverter o canal para `throw` derruba os 2 casos novos; usar a baseline velha no reenvio derruba 3, incluindo o da via de sugestão (prova de que ele não é redundante).
- Suíte completa 1890/1890, typecheck, lint:types, react-doctor 100/100, fallow audit e o pre-push inteiro (com e2e smoke) verdes.

### Follow-ups abertos

- #599 — remover opção não limpa condição criada em outra sessão (fail-closed, anterior a este PR; a assimetria está documentada no código).
- #600 — `server-action-exports.test.ts` estoura timeout sob a suíte completa (flakiness de gate, sem relação com este diff; medido isolado em 884ms).
