### PR TITLE
fix(supabase): pagina as leituras usadas como universo de membros

### DIFF
--- a/frontend/src/actions/__tests__/arbitration-retry.test.ts
+++ b/frontend/src/actions/__tests__/arbitration-retry.test.ts
@@ -20,12 +20,16 @@ let tableData: Record<string, unknown>;
 const arbitrationCalls = () =>
   rpcCalls.filter((call) => call.fn === "assign_arbitration_cycles_if_eligible");
 
+// Teto do PostgREST por resposta; só o teste de paginação o reduz.
+let maxRows: number | undefined;
+
 function makeClient() {
   return makeSimpleSupabaseMock({
     tableData,
     writeCalls,
     rpcCalls,
     rpcResults,
+    maxRows,
   });
 }
 
@@ -56,6 +60,7 @@ beforeEach(() => {
   };
   hoisted.isCoord.mockResolvedValue(true);
   hoisted.adminFactory.mockClear();
+  maxRows = undefined;
 });
 
 async function loadRetry() {
@@ -225,6 +230,40 @@ describe("retryPendingArbitrations — exclui codificadores do documento", () =>
     expect(r.assigned).toBe(0);
     expect(r.stillNoPool).toBe(1);
     expect(arbitrationCalls()).toHaveLength(0);
+  });
+});
+
+describe("retryPendingArbitrations — pool além do teto do PostgREST", () => {
+  // O pool de can_arbitrate é um universo, como o de comparação: lido sem
+  // paginar, um projeto acima do teto do PostgREST não enxerga os árbitros que
+  // caem fora da primeira página. Aqui o único candidato ocioso está na 2ª —
+  // sem paginação a arbitragem recai sobre quem já está carregado, e a
+  // degradação do balanceamento não deixa rastro.
+  it("considera árbitro além da primeira página", async () => {
+    maxRows = 2;
+    tableData.field_reviews = [
+      { id: "fr1", document_id: "doc1", self_reviewer_id: "userA" },
+    ];
+    tableData.project_members = [
+      // O auto-revisor nunca arbitra a própria resposta: ocupa a 1ª página sem
+      // ser candidato.
+      { user_id: "userA", role: "pesquisador" },
+      { user_id: "ocupado", role: "pesquisador" },
+      { user_id: "userC", role: "pesquisador" },
+    ];
+    // Carga aberta só de quem está na 1ª página, para que o desempate por menor
+    // carga escolha userC de forma determinística assim que ele for visto.
+    tableData.assignments = [
+      { user_id: "ocupado" },
+      { user_id: "ocupado" },
+    ];
+
+    const retry = await loadRetry();
+    const r = await retry("p1");
+
+    expect(r.success).toBe(true);
+    expect(arbitrationCalls()).toHaveLength(1);
+    expect(arbitrationCalls()[0].args).toMatchObject({ p_user_id: "userC" });
   });
 });
 

--- a/frontend/src/actions/__tests__/assignments.test.ts
+++ b/frontend/src/actions/__tests__/assignments.test.ts
@@ -182,6 +182,33 @@ describe("previewLottery", () => {
     expect(fromCalls).toContain("lottery_doc_stats");
     expect(fromCalls).toContain("assignments");
   });
+
+  // `fetchAllPaged` devolve as páginas já lidas JUNTO com o erro. Ignorar esse
+  // erro faria o sorteio validar os participantes contra um universo de membros
+  // parcial — e recusar participante legítimo sob a mensagem genérica de
+  // "participante válido", que é o truncamento silencioso de volta por outra
+  // porta. O erro real tem que chegar ao coordenador.
+  it("reporta a falha ao ler os membros em vez de recusar o participante", async () => {
+    serverTableResults = {
+      project_members: { data: null, error: { message: "conexão caiu" } },
+      lottery_doc_stats: { data: [] },
+      assignment_batches: { data: [] },
+      projects: { data: { min_responses_for_comparison: 2, automation_mode: null } },
+      assignments: { data: [] },
+    };
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "codificacao",
+      mode: "append",
+      balancing: "round",
+      researchersPerDoc: 1,
+      participantIds: ["u1"],
+    });
+
+    expect(result.error).toContain("conexão caiu");
+    expect(result.error).not.toContain("participante válido");
+  });
 });
 
 // Regressão da issue #490: o sorteio de Comparação herdava o default 2 do

--- a/frontend/src/actions/__tests__/supabase-mock.ts
+++ b/frontend/src/actions/__tests__/supabase-mock.ts
@@ -97,13 +97,17 @@ export function makeSupabaseMock(opts?: {
     from: (table: string) => {
       const builder: Record<string, unknown> = {};
       let rangeFrom: number | null = null;
+      let rangeTo: number | null = null;
       for (const m of ["select", "single", "maybeSingle", "order", "limit"]) {
         builder[m] = () => builder;
       }
-      // range() precisa recortar de verdade: um mock que devolve o conjunto
-      // inteiro a cada página faz um leitor paginado nunca alcançar o fim.
-      builder.range = (from: number) => {
+      // range() precisa recortar de verdade, com os DOIS limites: um mock que
+      // devolve o conjunto inteiro a cada página faz um leitor paginado nunca
+      // alcançar o fim, e um que ignora o limite superior nunca deixa uma
+      // leitura truncada se distinguir de uma completa.
+      builder.range = (from: number, to: number) => {
         rangeFrom = from;
+        rangeTo = to;
         return builder;
       };
       for (const method of ["eq", "is", "in", "neq", "match"] as const) {
@@ -144,7 +148,7 @@ export function makeSupabaseMock(opts?: {
         // inteira: sem o recorte, um leitor paginado nunca veria o fim.
         const paginated =
           !queued && rangeFrom !== null && Array.isArray(data)
-            ? data.slice(rangeFrom)
+            ? data.slice(rangeFrom, rangeTo !== null ? rangeTo + 1 : undefined)
             : data;
         return resolve({
           data: paginated,

--- a/frontend/src/actions/__tests__/supabase-mock.ts
+++ b/frontend/src/actions/__tests__/supabase-mock.ts
@@ -96,9 +96,16 @@ export function makeSupabaseMock(opts?: {
     },
     from: (table: string) => {
       const builder: Record<string, unknown> = {};
-      for (const m of ["select", "single", "maybeSingle", "order", "limit", "range"]) {
+      let rangeFrom: number | null = null;
+      for (const m of ["select", "single", "maybeSingle", "order", "limit"]) {
         builder[m] = () => builder;
       }
+      // range() precisa recortar de verdade: um mock que devolve o conjunto
+      // inteiro a cada página faz um leitor paginado nunca alcançar o fim.
+      builder.range = (from: number) => {
+        rangeFrom = from;
+        return builder;
+      };
       for (const method of ["eq", "is", "in", "neq", "match"] as const) {
         builder[method] = (column: string, value: unknown) => {
           filterCalls?.push({ table, method, column, value });
@@ -128,10 +135,19 @@ export function makeSupabaseMock(opts?: {
       };
       builder.then = (resolve: (v: unknown) => unknown) => {
         const entry = tableResults?.[table];
-        const fixed = Array.isArray(entry) ? entry.shift() : entry;
+        const queued = Array.isArray(entry);
+        const fixed = queued ? entry.shift() : entry;
         const result = fixed ?? defaultResult;
+        const data = result?.data ?? null;
+        // Uma fila já entrega cada página pronta — recortá-la de novo cortaria
+        // duas vezes. Um resultado fixo, ao contrário, representa a tabela
+        // inteira: sem o recorte, um leitor paginado nunca veria o fim.
+        const paginated =
+          !queued && rangeFrom !== null && Array.isArray(data)
+            ? data.slice(rangeFrom)
+            : data;
         return resolve({
-          data: result?.data ?? null,
+          data: paginated,
           error: result?.error ?? null,
           count: result?.count ?? null,
         });

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createSupabaseServer } from "@/lib/supabase/server";
+import { fetchAllPaged } from "@/lib/supabase/paginate";
 import { getAuthUser } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import {
@@ -596,10 +597,14 @@ async function computeLottery(params: LotteryParams): Promise<{
   }
 
   const [{ data: members }, data] = await Promise.all([
-    supabase
-      .from("project_members")
-      .select("user_id")
-      .eq("project_id", params.projectId),
+    // Paginado: a lista valida os participantes escolhidos. Truncada, um
+    // participante legítimo seria recusado como se não fosse membro.
+    fetchAllPaged<{ user_id: string }>(() =>
+      supabase
+        .from("project_members")
+        .select("user_id")
+        .eq("project_id", params.projectId),
+    ),
     fetchLotteryData(params.projectId),
   ]);
 

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -596,21 +596,33 @@ async function computeLottery(params: LotteryParams): Promise<{
     throw new Error("Os filtros de lote são mutuamente exclusivos.");
   }
 
-  const [{ data: members }, data] = await Promise.all([
+  const [membersResult, data] = await Promise.all([
     // Paginado: a lista valida os participantes escolhidos. Truncada, um
     // participante legítimo seria recusado como se não fosse membro.
-    fetchAllPaged<{ user_id: string }>(() =>
-      supabase
-        .from("project_members")
-        .select("user_id")
-        .eq("project_id", params.projectId),
+    fetchAllPaged<{ user_id: string }>(
+      () =>
+        supabase
+          .from("project_members")
+          .select("user_id")
+          .eq("project_id", params.projectId),
+      "user_id",
     ),
     fetchLotteryData(params.projectId),
   ]);
 
+  // `fetchAllPaged` devolve as páginas que já leu JUNTO com o erro. Ignorar o
+  // erro aqui aceitaria esse universo parcial e recusaria participante legítimo
+  // sob a mensagem genérica de "participante válido" — o truncamento silencioso
+  // que a paginação existe para eliminar, de volta por outra porta.
+  if (membersResult.error) {
+    throw new Error(
+      `Falha ao carregar os membros do projeto: ${membersResult.error.message}`,
+    );
+  }
+
   // Pool de participantes: deduplicado e validado contra project_members
   // (qualquer role) — defesa em profundidade além do RLS (research D5)
-  const memberIds = new Set((members || []).map((m) => m.user_id));
+  const memberIds = new Set((membersResult.data || []).map((m) => m.user_id));
   const uniqueIds = [...new Set(params.participantIds)];
   const participantIds = uniqueIds.filter((id) => memberIds.has(id));
   if (!participantIds.length || participantIds.length !== uniqueIds.length) {

--- a/frontend/src/actions/export.ts
+++ b/frontend/src/actions/export.ts
@@ -51,25 +51,32 @@ export async function getExportDataset(
     // Base exportada: documentos não excluídos. Exclusão apenas pendente
     // (exclusion_pending_at) continua na base até ser confirmada. Paginado para
     // não truncar em projetos grandes (ver fetchAllPaged).
-    fetchAllPaged<ExportDocument>(() =>
-      supabase
-        .from("documents")
-        .select("id, external_id, title, created_at, metadata")
-        .eq("project_id", projectId)
-        .is("excluded_at", null)
+    fetchAllPaged<ExportDocument>(
+      () =>
+        supabase
+          .from("documents")
+          .select("id, external_id, title, created_at, metadata")
+          .eq("project_id", projectId)
+          .is("excluded_at", null),
+      "id"
     ),
-    fetchAllPaged<ExportResponse>(() =>
-      supabase
-        .from("responses")
-        .select("document_id, respondent_name, respondent_type, answers")
-        .eq("project_id", projectId)
-        .eq("is_latest", true)
+    fetchAllPaged<ExportResponse>(
+      () =>
+        supabase
+          .from("responses")
+          .select("document_id, respondent_name, respondent_type, answers")
+          .eq("project_id", projectId)
+          .eq("is_latest", true),
+      // A PK basta como ordem total; não precisa estar no select.
+      "id"
     ),
-    fetchAllPaged<ExportReview>(() =>
-      supabase
-        .from("reviews")
-        .select("document_id, field_name, verdict, comment")
-        .eq("project_id", projectId)
+    fetchAllPaged<ExportReview>(
+      () =>
+        supabase
+          .from("reviews")
+          .select("document_id, field_name, verdict, comment")
+          .eq("project_id", projectId),
+      "id"
     ),
   ]);
 

--- a/frontend/src/actions/export.ts
+++ b/frontend/src/actions/export.ts
@@ -4,6 +4,7 @@
 // export síncrono em módulo "use server" quebra o deploy silenciosamente e nenhum
 // gate local pega (lição do PR #412); a montagem pura mora em lib/export/assemble.
 import { createSupabaseServer } from "@/lib/supabase/server";
+import { fetchAllPaged } from "@/lib/supabase/paginate";
 import { requireCoordinator } from "@/lib/auth";
 import type { PydanticField } from "@/lib/types";
 import {
@@ -16,36 +17,10 @@ import {
 
 export type GetExportDatasetResult = ExportDataset | { error: string };
 
-// O PostgREST limita cada query a `max_rows` (1000 por padrão, hospedado e local).
-// Sem paginar, um projeto grande teria a exportação truncada SILENCIOSAMENTE —
-// contradizendo a FR-008 ("conjunto completo"). Buscamos por páginas com .range()
-// até uma página vir incompleta. `build()` recria a query a cada página porque um
-// builder do PostgREST é de uso único (o await o executa).
-const EXPORT_PAGE_SIZE = 1000;
-
-async function fetchAllPaged<T>(
-  build: () => {
-    range: (
-      from: number,
-      to: number
-    ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
-  }
-): Promise<{ data: T[]; error: { message: string } | null }> {
-  const all: T[] = [];
-  let from = 0;
-  for (;;) {
-    // await sequencial é da natureza da paginação: só dá para pedir a próxima
-    // página sabendo que a anterior veio cheia.
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop
-    const { data, error } = await build().range(from, from + EXPORT_PAGE_SIZE - 1);
-    if (error) return { data: all, error };
-    const batch = data ?? [];
-    all.push(...batch);
-    if (batch.length < EXPORT_PAGE_SIZE) break;
-    from += EXPORT_PAGE_SIZE;
-  }
-  return { data: all, error: null };
-}
+// Sem paginar, a exportação sairia truncada SILENCIOSAMENTE ao passar do teto do
+// PostgREST — contradizendo a FR-008 ("conjunto completo"). A mecânica vive em
+// lib/supabase/paginate porque o mesmo teto atinge toda leitura usada como
+// universo (ver os pools de membros em auto-comparison e auto-review-reconciler).
 
 // Retorna o conjunto completo do projeto (documentos + respostas + gabarito)
 // já montado como planilhas de strings. Gate coordinator-only (fail-closed);

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -2,6 +2,7 @@
 
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
+import { fetchAllPaged } from "@/lib/supabase/paginate";
 import {
   getProjectAccessContext,
   requireCoordinator,
@@ -242,11 +243,26 @@ async function assignArbitrator(
 
   // Elegíveis (can_arbitrate) menos o auto-revisor original — esse nunca
   // arbitra, sob nenhuma circunstância, porque julgaria a própria resposta.
-  const { data: eligibleMembers } = await admin
-    .from("project_members")
-    .select("user_id, role")
-    .eq("project_id", projectId)
-    .eq("can_arbitrate", true);
+  //
+  // Paginado porque este pool é um universo: truncado no teto do PostgREST, um
+  // árbitro apto simplesmente não existe para o sorteio. Diferente do sorteio de
+  // participantes em computeLottery, um erro aqui NÃO precisa lançar — o pool
+  // parcial ainda devolve árbitro válido (a RPC final revalida can_arbitrate sob
+  // lock), e uma leitura que falhe inteira cai em noPool=true, que já é sinal
+  // visível no banner de pendências. O que se perde é balanceamento, não
+  // correção.
+  const { data: eligibleMembers } = await fetchAllPaged<{
+    user_id: string;
+    role: string;
+  }>(
+    () =>
+      admin
+        .from("project_members")
+        .select("user_id, role")
+        .eq("project_id", projectId)
+        .eq("can_arbitrate", true),
+    "user_id",
+  );
   const eligible = (eligibleMembers ?? []).filter(
     (m) => m.user_id !== excludeUserId,
   );

--- a/frontend/src/lib/__tests__/auto-comparison.test.ts
+++ b/frontend/src/lib/__tests__/auto-comparison.test.ts
@@ -24,6 +24,8 @@ let rpcCalls: RpcCall[];
 let rpcResults: Record<string, RpcResult>;
 let tableData: Record<string, unknown[]>;
 let queryErrors: Record<string, QueryError | null>;
+// Teto do PostgREST por resposta; só os testes de paginação o reduzem.
+let maxRows: number | undefined;
 
 const assignmentCalls = () =>
   rpcCalls.filter((call) => call.fn === "assign_comparison_if_eligible");
@@ -35,6 +37,7 @@ function makeClient() {
     rpcCalls,
     rpcResults,
     queryErrors,
+    maxRows,
   });
 }
 
@@ -70,6 +73,7 @@ beforeEach(() => {
   };
   tableData = makeEmptyComparisonTableData();
   queryErrors = {};
+  maxRows = undefined;
 });
 
 async function loadLib() {
@@ -97,6 +101,29 @@ async function expectAutoComparisonOutcome(
 }
 
 describe("assignComparisonReviewer — pool e balanceamento", () => {
+  // O pool elegível é um universo: lido sem paginar, um projeto acima do teto do
+  // PostgREST perde os revisores que caem fora da primeira página — que ficariam
+  // permanentemente fora do sorteio, sem erro nem log.
+  it("considera revisor além da primeira página do PostgREST", async () => {
+    const { assignComparisonReviewer } = await loadLib();
+    maxRows = 2;
+    tableData.project_members = [
+      makeProjectMember("userA"),
+      makeProjectMember("userB"),
+      makeProjectMember("userC"),
+    ];
+
+    const r = await assignComparisonReviewer(
+      makeClient() as never,
+      "p1",
+      "doc1",
+      new Set(["userA", "userB"]),
+    );
+
+    expect(r.assigned).toBe(true);
+    expect(assignmentCalls()[0].args).toMatchObject({ p_user_id: "userC" });
+  });
+
   it("exclui TODOS os codificadores do pool", async () => {
     const { assignComparisonReviewer } = await loadLib();
     tableData.project_members = [

--- a/frontend/src/lib/__tests__/auto-review-reconciler.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-reconciler.test.ts
@@ -11,6 +11,10 @@ const state = vi.hoisted(() => ({
   rpcCalls: [] as Array<{ name: string; args: unknown }>,
   failures: [] as unknown[],
   deletes: [] as Array<Array<[string, unknown]>>,
+  projectMembers: [{ user_id: "user-1" }] as Array<{ user_id: string }>,
+  // Teto do PostgREST simulado: quanto o mock devolve por página, para provar
+  // que o reconciliador pagina em vez de tomar a primeira página como universo.
+  pageSize: 1000,
 }));
 
 vi.mock("server-only", () => ({}));
@@ -21,6 +25,7 @@ class Query {
   private filters: Array<[string, unknown]> = [];
   private operation: "select" | "delete" = "select";
   private head = false;
+  private rangeFrom: number | null = null;
 
   constructor(private table: string) {}
 
@@ -29,6 +34,7 @@ class Query {
     return this;
   }
   order() { return this; }
+  range(from: number, _to: number) { this.rangeFrom = from; return this; }
   limit() { return this; }
   lte() { return this; }
   single() { return this; }
@@ -95,10 +101,16 @@ class Query {
       field_reviews: [],
       field_review_cycle_history_entries: [{ self_reviewer_id: "user-1" }],
       member_email_links: [],
-      project_members: [{ user_id: "user-1" }],
+      project_members: state.projectMembers,
     };
     if (!(this.table in rowsByTable)) throw new Error(`Tabela inesperada: ${this.table}`);
-    return { data: rowsByTable[this.table], error: null };
+    const rows = rowsByTable[this.table];
+    if (!Array.isArray(rows)) return { data: rows, error: null };
+    // O teto do PostgREST vale mesmo sem .range(): quem não pagina recebe a
+    // primeira página como se fosse o conjunto inteiro. É isso que torna o
+    // truncamento silencioso — e o que faz este mock detectar a regressão.
+    const from = this.rangeFrom ?? 0;
+    return { data: rows.slice(from, from + state.pageSize), error: null };
   }
 
   private result() {
@@ -146,6 +158,8 @@ beforeEach(() => {
   state.rpcCalls = [];
   state.failures = [];
   state.deletes = [];
+  state.projectMembers = [{ user_id: "user-1" }];
+  state.pageSize = 1000;
   admin.rpc.mockClear();
   buildEquivalenceMap.mockClear();
   computeBacklogRows.mockReset();
@@ -183,6 +197,25 @@ describe("drainAutoReviewReconciliationRequests", () => {
       }] },
     }]);
     expect(state.deletes[0]).toContainEqual(["llm_response_id", "llm-1"]);
+  });
+
+  // O Set de membros é o universo que decide quem ainda pode gerar auto-revisão.
+  // Lido sem paginar, um projeto acima do teto do PostgREST devolveria só a
+  // primeira página e o autor da resposta seria descartado como ex-membro — sem
+  // erro, sem log, sem ciclo gerado.
+  it("não trata membro além da primeira página como ex-membro", async () => {
+    state.projectMembers = [
+      ...Array.from({ length: 1000 }, (_, i) => ({ user_id: `outro-${i}` })),
+      { user_id: "user-1" },
+    ];
+    const { drainAutoReviewReconciliationRequests } = await import("@/lib/auto-review-reconciler");
+
+    const result = await drainAutoReviewReconciliationRequests();
+
+    expect(result.processed).toBe(1);
+    expect(computeBacklogRows).toHaveBeenCalledOnce();
+    const humansConsidered = computeBacklogRows.mock.calls[0][1];
+    expect(humansConsidered).toHaveLength(1);
   });
 
   it("também reconcilia consenso para encerrar um ciclo anterior", async () => {

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -148,12 +148,14 @@ async function loadEligibleReviewerIds(
   const [membersResult, previousAssignmentsResult] = await Promise.all([
     // Paginado: o pool elegível é um universo. Truncado, um revisor apto ficaria
     // permanentemente fora do sorteio de comparação, sem erro.
-    fetchAllPaged<{ user_id: string }>(() =>
-      admin
-        .from("project_members")
-        .select("user_id")
-        .eq("project_id", projectId)
-        .eq("can_compare", true),
+    fetchAllPaged<{ user_id: string }>(
+      () =>
+        admin
+          .from("project_members")
+          .select("user_id")
+          .eq("project_id", projectId)
+          .eq("can_compare", true),
+      "user_id",
     ),
     admin
       .from("assignments")

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -1,4 +1,5 @@
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
+import { fetchAllPaged } from "@/lib/supabase/paginate";
 import { buildLoadMap } from "@/lib/load-balancing";
 import { computeDivergentFieldNames } from "@/lib/compare-divergence";
 import { isCodingComplete } from "@/lib/coding-completeness";
@@ -145,11 +146,15 @@ async function loadEligibleReviewerIds(
   coderIds: Set<string>,
 ): Promise<string[]> {
   const [membersResult, previousAssignmentsResult] = await Promise.all([
-    admin
-      .from("project_members")
-      .select("user_id")
-      .eq("project_id", projectId)
-      .eq("can_compare", true),
+    // Paginado: o pool elegível é um universo. Truncado, um revisor apto ficaria
+    // permanentemente fora do sorteio de comparação, sem erro.
+    fetchAllPaged<{ user_id: string }>(() =>
+      admin
+        .from("project_members")
+        .select("user_id")
+        .eq("project_id", projectId)
+        .eq("can_compare", true),
+    ),
     admin
       .from("assignments")
       .select("user_id")

--- a/frontend/src/lib/auto-review-reconciler.ts
+++ b/frontend/src/lib/auto-review-reconciler.ts
@@ -122,11 +122,13 @@ async function eligibleHumanResponses(
   // Paginado: este Set é o universo de quem ainda é membro. Truncado no teto do
   // PostgREST, um membro legítimo seria lido como ex-membro e sua resposta
   // sairia da reconciliação sem erro nenhum.
-  const membersResult = await fetchAllPaged<{ user_id: string }>(() =>
-    admin
-      .from("project_members")
-      .select("user_id")
-      .eq("project_id", request.project_id),
+  const membersResult = await fetchAllPaged<{ user_id: string }>(
+    () =>
+      admin
+        .from("project_members")
+        .select("user_id")
+        .eq("project_id", request.project_id),
+    "user_id",
   );
   if (membersResult.error) throw new Error(membersResult.error.message);
   const memberIds = new Set(

--- a/frontend/src/lib/auto-review-reconciler.ts
+++ b/frontend/src/lib/auto-review-reconciler.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { computeBacklogRows, type HumanResponseRow, type LlmResponseRow } from "@/lib/auto-review-backlog";
 import { buildEquivalenceMap, type EquivalenceRow } from "@/lib/compare-queue";
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
+import { fetchAllPaged } from "@/lib/supabase/paginate";
 import type { PydanticField } from "@/lib/types";
 
 interface ReconciliationRequest {
@@ -118,10 +119,15 @@ async function eligibleHumanResponses(
   request: ReconciliationRequest,
   humans: VersionedHumanResponse[],
 ): Promise<VersionedHumanResponse[]> {
-  const membersResult = await admin
-    .from("project_members")
-    .select("user_id")
-    .eq("project_id", request.project_id);
+  // Paginado: este Set é o universo de quem ainda é membro. Truncado no teto do
+  // PostgREST, um membro legítimo seria lido como ex-membro e sua resposta
+  // sairia da reconciliação sem erro nenhum.
+  const membersResult = await fetchAllPaged<{ user_id: string }>(() =>
+    admin
+      .from("project_members")
+      .select("user_id")
+      .eq("project_id", request.project_id),
+  );
   if (membersResult.error) throw new Error(membersResult.error.message);
   const memberIds = new Set(
     (membersResult.data ?? []).map((member) => member.user_id),

--- a/frontend/src/lib/supabase/__tests__/paginate.test.ts
+++ b/frontend/src/lib/supabase/__tests__/paginate.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { SUPABASE_PAGE_SIZE, fetchAllPaged } from "@/lib/supabase/paginate";
+
+function rows(count: number, offset = 0) {
+  return Array.from({ length: count }, (_, i) => ({ user_id: `u${offset + i}` }));
+}
+
+// Simula o teto do PostgREST: cada chamada devolve no máximo uma página do
+// conjunto total, recortada pelo range pedido.
+function fakeTable(total: number) {
+  const range = vi.fn((from: number, to: number) =>
+    Promise.resolve({
+      data: rows(Math.max(0, Math.min(to + 1, total) - from), from),
+      error: null,
+    }),
+  );
+  return { build: () => ({ range }), range };
+}
+
+describe("fetchAllPaged", () => {
+  it("lê tudo e encerra na página vazia quando cabe numa página", async () => {
+    const table = fakeTable(3);
+
+    const result = await fetchAllPaged(table.build);
+
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(3);
+    expect(table.range).toHaveBeenCalledWith(0, SUPABASE_PAGE_SIZE - 1);
+    expect(table.range).toHaveBeenLastCalledWith(3, 3 + SUPABASE_PAGE_SIZE - 1);
+  });
+
+  it("busca as páginas seguintes quando a primeira vem cheia", async () => {
+    const total = SUPABASE_PAGE_SIZE + 7;
+    const table = fakeTable(total);
+
+    const result = await fetchAllPaged(table.build);
+
+    expect(result.data).toHaveLength(total);
+    expect(new Set(result.data.map((r) => r.user_id)).size).toBe(total);
+    expect(table.range).toHaveBeenNthCalledWith(
+      2,
+      SUPABASE_PAGE_SIZE,
+      SUPABASE_PAGE_SIZE * 2 - 1,
+    );
+  });
+
+  // O caso que quebra a heurística "página curta = fim": um servidor cujo
+  // max_rows é menor que o nosso devolve a primeira página já incompleta.
+  // Avançar pelo tamanho recebido é o que mantém a leitura completa.
+  it("lê tudo mesmo quando o servidor devolve menos que a página pedida", async () => {
+    const serverMax = 2;
+    const total = 5;
+    const range = vi.fn((from: number) =>
+      Promise.resolve({
+        data: rows(Math.max(0, Math.min(from + serverMax, total) - from), from),
+        error: null,
+      }),
+    );
+
+    const result = await fetchAllPaged(() => ({ range }));
+
+    expect(result.data).toHaveLength(total);
+    expect(new Set(result.data.map((r) => r.user_id)).size).toBe(total);
+  });
+
+  it("interrompe no erro e devolve o que já tinha lido", async () => {
+    const range = vi
+      .fn()
+      .mockResolvedValueOnce({ data: rows(SUPABASE_PAGE_SIZE), error: null })
+      .mockResolvedValueOnce({ data: null, error: { message: "boom" } });
+
+    const result = await fetchAllPaged(() => ({ range }));
+
+    expect(result.error).toEqual({ message: "boom" });
+    expect(result.data).toHaveLength(SUPABASE_PAGE_SIZE);
+  });
+
+  it("recria o builder a cada página, porque o do PostgREST é de uso único", async () => {
+    const table = fakeTable(SUPABASE_PAGE_SIZE + 1);
+    const build = vi.fn(table.build);
+
+    await fetchAllPaged(build);
+
+    // 2 páginas com dados + a vazia que encerra.
+    expect(build).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend/src/lib/supabase/__tests__/paginate.test.ts
+++ b/frontend/src/lib/supabase/__tests__/paginate.test.ts
@@ -5,8 +5,11 @@ function rows(count: number, offset = 0) {
   return Array.from({ length: count }, (_, i) => ({ user_id: `u${offset + i}` }));
 }
 
+type OrderCall = [string, { ascending: boolean }];
+
 // Simula o teto do PostgREST: cada chamada devolve no máximo uma página do
-// conjunto total, recortada pelo range pedido.
+// conjunto total, recortada pelo range pedido. `order` fica registrado para que
+// os testes possam afirmar que a paginação pede ordem estável ao servidor.
 function fakeTable(total: number) {
   const range = vi.fn((from: number, to: number) =>
     Promise.resolve({
@@ -14,14 +17,22 @@ function fakeTable(total: number) {
       error: null,
     }),
   );
-  return { build: () => ({ range }), range };
+  const orderCalls: OrderCall[] = [];
+  const query = {
+    order: (column: string, options: { ascending: boolean }) => {
+      orderCalls.push([column, options]);
+      return query;
+    },
+    range,
+  };
+  return { build: () => query, range, orderCalls };
 }
 
 describe("fetchAllPaged", () => {
   it("lê tudo e encerra na página vazia quando cabe numa página", async () => {
     const table = fakeTable(3);
 
-    const result = await fetchAllPaged(table.build);
+    const result = await fetchAllPaged(table.build, "user_id");
 
     expect(result.error).toBeNull();
     expect(result.data).toHaveLength(3);
@@ -33,7 +44,7 @@ describe("fetchAllPaged", () => {
     const total = SUPABASE_PAGE_SIZE + 7;
     const table = fakeTable(total);
 
-    const result = await fetchAllPaged(table.build);
+    const result = await fetchAllPaged(table.build, "user_id");
 
     expect(result.data).toHaveLength(total);
     expect(new Set(result.data.map((r) => r.user_id)).size).toBe(total);
@@ -42,6 +53,30 @@ describe("fetchAllPaged", () => {
       SUPABASE_PAGE_SIZE,
       SUPABASE_PAGE_SIZE * 2 - 1,
     );
+  });
+
+  // Paginação por offset sem ORDER BY é ambígua na fronteira das páginas: o
+  // Postgres não promete a mesma ordem entre execuções, então a linha da divisa
+  // pode repetir ou — o caso grave — ser pulada, reproduzindo o truncamento
+  // silencioso. A ordem tem que ir em TODA página, não só na primeira.
+  it("pede ordem estável ao servidor em todas as páginas", async () => {
+    const table = fakeTable(SUPABASE_PAGE_SIZE + 1);
+
+    await fetchAllPaged(table.build, "user_id");
+
+    // 2 páginas com dados + a vazia que encerra.
+    expect(table.orderCalls).toHaveLength(3);
+    for (const call of table.orderCalls) {
+      expect(call).toEqual(["user_id", { ascending: true }]);
+    }
+  });
+
+  it("ordena pela coluna que o chamador declarou", async () => {
+    const table = fakeTable(1);
+
+    await fetchAllPaged(table.build, "id");
+
+    expect(table.orderCalls[0]).toEqual(["id", { ascending: true }]);
   });
 
   // O caso que quebra a heurística "página curta = fim": um servidor cujo
@@ -56,8 +91,9 @@ describe("fetchAllPaged", () => {
         error: null,
       }),
     );
+    const query = { order: () => query, range };
 
-    const result = await fetchAllPaged(() => ({ range }));
+    const result = await fetchAllPaged(() => query, "user_id");
 
     expect(result.data).toHaveLength(total);
     expect(new Set(result.data.map((r) => r.user_id)).size).toBe(total);
@@ -68,8 +104,9 @@ describe("fetchAllPaged", () => {
       .fn()
       .mockResolvedValueOnce({ data: rows(SUPABASE_PAGE_SIZE), error: null })
       .mockResolvedValueOnce({ data: null, error: { message: "boom" } });
+    const query = { order: () => query, range };
 
-    const result = await fetchAllPaged(() => ({ range }));
+    const result = await fetchAllPaged(() => query, "user_id");
 
     expect(result.error).toEqual({ message: "boom" });
     expect(result.data).toHaveLength(SUPABASE_PAGE_SIZE);
@@ -79,7 +116,7 @@ describe("fetchAllPaged", () => {
     const table = fakeTable(SUPABASE_PAGE_SIZE + 1);
     const build = vi.fn(table.build);
 
-    await fetchAllPaged(build);
+    await fetchAllPaged(build, "user_id");
 
     // 2 páginas com dados + a vazia que encerra.
     expect(build).toHaveBeenCalledTimes(3);

--- a/frontend/src/lib/supabase/paginate.ts
+++ b/frontend/src/lib/supabase/paginate.ts
@@ -12,6 +12,22 @@ export const SUPABASE_PAGE_SIZE = 1000;
 // isso em voz alta em vez de girar em silêncio.
 const MAX_PAGES = 10_000;
 
+// Duas vias de falha, de propósito: erro da query vira `{ error }` (falha de
+// runtime que o chamador reporta), estourar `MAX_PAGES` lança (defeito do
+// cliente, inalcançável em leitura legítima — não há o que reportar ao usuário).
+type PagedResult<T> = { data: T[]; error: { message: string } | null };
+
+// A query paginável: aceita `.order()` e `.range()` e resolve como uma resposta
+// do PostgREST. O `.order()` está no tipo porque `fetchAllPaged` é quem o
+// aplica — ver a nota sobre ordem estável abaixo.
+interface PagedQuery<T> {
+  order: (column: string, options: { ascending: boolean }) => PagedQuery<T>;
+  range: (
+    from: number,
+    to: number,
+  ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
+}
+
 // `build()` recria a query a cada página porque um builder do PostgREST é de
 // uso único: o await o executa e ele não pode ser reaproveitado.
 // O avanço usa o tamanho REALMENTE recebido, e o fim é a página vazia — não
@@ -21,14 +37,23 @@ const MAX_PAGES = 10_000;
 // silenciosamente — exatamente o defeito que esta função existe para impedir.
 // O custo é uma requisição a mais no fim, que também seria necessária quando o
 // total é múltiplo exato da página.
+//
+// `orderBy` é OBRIGATÓRIO porque ordem estável é pré-requisito da paginação por
+// offset, não refinamento: `.range()` vira LIMIT/OFFSET e, sem ORDER BY, o
+// Postgres não promete a mesma ordem entre duas execuções — `synchronize_seqscans`
+// vem `on`, um HOT update move a tupla, o planner pode trocar de plano entre
+// páginas. A linha da fronteira então repete (inócuo, o chamador deduplica) ou é
+// PULADA — que reproduz em silêncio o mesmo truncamento que esta função existe
+// para impedir, e só acima do teto, onde ninguém está olhando. Exigir na
+// assinatura é o que torna a leitura sem ordem impossível de escrever, em vez de
+// depender de cada call site lembrar.
+// A coluna precisa ser única DENTRO do recorte já filtrado — `user_id` sob um
+// `project_id` fixo, `id` em tabela com PK própria. Ordem apenas parcial (`role`,
+// `created_at` com repetição) deixa a fronteira ambígua de novo.
 export async function fetchAllPaged<T>(
-  build: () => {
-    range: (
-      from: number,
-      to: number,
-    ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
-  },
-): Promise<{ data: T[]; error: { message: string } | null }> {
+  build: () => PagedQuery<T>,
+  orderBy: string,
+): Promise<PagedResult<T>> {
   const all: T[] = [];
   let from = 0;
   for (let page = 0; ; page++) {
@@ -41,7 +66,9 @@ export async function fetchAllPaged<T>(
     // await sequencial é da natureza da paginação: só dá para pedir a próxima
     // página sabendo o que a anterior devolveu.
     // react-doctor-disable-next-line react-doctor/async-await-in-loop
-    const { data, error } = await build().range(from, from + SUPABASE_PAGE_SIZE - 1);
+    const { data, error } = await build()
+      .order(orderBy, { ascending: true })
+      .range(from, from + SUPABASE_PAGE_SIZE - 1);
     if (error) return { data: all, error };
     const batch = data ?? [];
     if (batch.length === 0) break;

--- a/frontend/src/lib/supabase/paginate.ts
+++ b/frontend/src/lib/supabase/paginate.ts
@@ -1,0 +1,52 @@
+// O PostgREST limita cada resposta a `max_rows` (1000 por padrão, hospedado e
+// local). Uma query sem paginação não falha ao ultrapassar o teto: ela devolve
+// as primeiras 1000 linhas como se fossem o conjunto inteiro. Quem usa o
+// resultado como universo — "estes são os membros do projeto" — passa a tratar
+// o que ficou de fora como inexistente, sem nenhum sinal de erro.
+export const SUPABASE_PAGE_SIZE = 1000;
+
+// Teto de páginas. Um cliente que ignore o `.range()` devolveria a mesma página
+// para sempre e o laço abaixo nunca terminaria — travando o request em vez de
+// falhar. Em 10 milhões de linhas nenhuma leitura legítima deste app chega
+// perto, então estourar o teto é sempre defeito de quem responde, e o erro diz
+// isso em voz alta em vez de girar em silêncio.
+const MAX_PAGES = 10_000;
+
+// `build()` recria a query a cada página porque um builder do PostgREST é de
+// uso único: o await o executa e ele não pode ser reaproveitado.
+// O avanço usa o tamanho REALMENTE recebido, e o fim é a página vazia — não
+// `batch.length < SUPABASE_PAGE_SIZE`. Comparar com o tamanho pedido presume que
+// o `max_rows` do servidor é igual ao nosso: onde ele for menor, a primeira
+// página já vem "incompleta", o laço encerra e a leitura volta a truncar
+// silenciosamente — exatamente o defeito que esta função existe para impedir.
+// O custo é uma requisição a mais no fim, que também seria necessária quando o
+// total é múltiplo exato da página.
+export async function fetchAllPaged<T>(
+  build: () => {
+    range: (
+      from: number,
+      to: number,
+    ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
+  },
+): Promise<{ data: T[]; error: { message: string } | null }> {
+  const all: T[] = [];
+  let from = 0;
+  for (let page = 0; ; page++) {
+    if (page >= MAX_PAGES) {
+      throw new Error(
+        `fetchAllPaged: ${MAX_PAGES} páginas sem fim à vista (${all.length} linhas). ` +
+          "O cliente provavelmente está ignorando .range().",
+      );
+    }
+    // await sequencial é da natureza da paginação: só dá para pedir a próxima
+    // página sabendo o que a anterior devolveu.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const { data, error } = await build().range(from, from + SUPABASE_PAGE_SIZE - 1);
+    if (error) return { data: all, error };
+    const batch = data ?? [];
+    if (batch.length === 0) break;
+    all.push(...batch);
+    from += batch.length;
+  }
+  return { data: all, error: null };
+}

--- a/frontend/src/test-utils/supabase-mock.ts
+++ b/frontend/src/test-utils/supabase-mock.ts
@@ -18,6 +18,22 @@ export type QueryError = {
   code?: string;
 };
 
+// Comparação estável por coluna. `localeCompare` não serve: os valores são ids
+// opacos e o que importa é uma ordem TOTAL e repetível entre páginas, igual à do
+// servidor — não uma ordem sensível a locale.
+function sortRows(
+  rows: Array<Record<string, unknown>>,
+  { column, ascending }: { column: string; ascending: boolean },
+) {
+  const direction = ascending ? 1 : -1;
+  return [...rows].sort((a, b) => {
+    const left = String(a[column] ?? "");
+    const right = String(b[column] ?? "");
+    if (left === right) return 0;
+    return left < right ? -direction : direction;
+  });
+}
+
 function makeRpc(state: {
   rpcCalls?: RpcCall[];
   rpcResults?: Record<string, RpcResult>;
@@ -118,6 +134,7 @@ export function makeFilterAwareSupabaseMock(state: {
       let limitN: number | null = null;
       let rangeFrom: number | null = null;
       let rangeTo: number | null = null;
+      let orderBy: { column: string; ascending: boolean } | null = null;
       const builder: Record<string, unknown> = {};
       builder.select = () => builder;
       builder.eq = (c: string, v: unknown) => {
@@ -145,6 +162,13 @@ export function makeFilterAwareSupabaseMock(state: {
         rangeTo = to;
         return builder;
       };
+      // Ordena de verdade, porque é a ordem que decide QUAIS linhas caem em cada
+      // página: um mock que aceitasse `.order()` sem aplicá-lo não distinguiria
+      // uma paginação estável de uma que pula linha na fronteira.
+      builder.order = (column: string, options?: { ascending?: boolean }) => {
+        orderBy = { column, ascending: options?.ascending !== false };
+        return builder;
+      };
       attachWriteOps(builder, table, state.writeCalls, opRef);
       const rows = () => {
         const data = (state.tableData[table] ?? []) as Array<
@@ -156,7 +180,10 @@ export function makeFilterAwareSupabaseMock(state: {
           for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
           return true;
         });
-        const limited = limitN != null ? filtered.slice(0, limitN) : filtered;
+        // A ordem é aplicada ANTES do recorte, como no servidor: ordenar depois
+        // de paginar reordenaria a página em vez de definir o seu conteúdo.
+        const ordered = orderBy ? sortRows(filtered, orderBy) : filtered;
+        const limited = limitN != null ? ordered.slice(0, limitN) : ordered;
         // `maxRows` reproduz o teto do PostgREST, que vale mesmo sem .range():
         // sem ele o mock devolveria o conjunto inteiro e nenhum teste
         // conseguiria distinguir uma leitura paginada de uma truncada. Default
@@ -187,22 +214,43 @@ export function makeSimpleSupabaseMock(state: {
   rpcCalls?: RpcCall[];
   rpcResults?: Record<string, RpcResult>;
   queryErrors?: Record<string, QueryError | null>;
+  // Teto de linhas por resposta (PostgREST `max_rows`). Default: sem teto.
+  maxRows?: number;
 }) {
   return {
     rpc: makeRpc(state),
     from: (table: string) => {
       const builder: Record<string, unknown> = {};
       const opRef: OpRef = { current: "select" };
-      for (const m of ["select", "eq", "is", "in", "neq", "limit"]) {
+      let rangeFrom: number | null = null;
+      let rangeTo: number | null = null;
+      // `order` é no-op aqui de propósito: esta variante resolve por chave de
+      // tabela e não modela ordenação. O que ela precisa modelar é o TETO, que
+      // é o que separa leitura completa de leitura truncada.
+      for (const m of ["select", "eq", "is", "in", "neq", "limit", "order"]) {
         builder[m] = () => builder;
       }
+      builder.range = (from: number, to: number) => {
+        rangeFrom = from;
+        rangeTo = to;
+        return builder;
+      };
       attachWriteOps(builder, table, state.writeCalls, opRef);
+      // O teto vale mesmo sem .range(): quem não pagina recebe a primeira
+      // página como se fosse o conjunto inteiro.
+      const paginate = (data: unknown) => {
+        if (!Array.isArray(data)) return data;
+        const from = rangeFrom ?? 0;
+        const to = rangeTo != null ? rangeTo + 1 : Infinity;
+        return data.slice(from, Math.min(to, from + (state.maxRows ?? Infinity)));
+      };
       builder.then = (resolve: (v: unknown) => unknown) =>
         resolve({
-          data:
+          data: paginate(
             state.tableData[`${table}:${opRef.current}`] ??
-            state.tableData[table] ??
-            null,
+              state.tableData[table] ??
+              null,
+          ),
           error: state.queryErrors?.[`${table}:${opRef.current}`] ?? null,
         });
       return builder;

--- a/frontend/src/test-utils/supabase-mock.ts
+++ b/frontend/src/test-utils/supabase-mock.ts
@@ -105,6 +105,8 @@ export function makeFilterAwareSupabaseMock(state: {
   rpcCalls?: RpcCall[];
   rpcResults?: Record<string, RpcResult>;
   queryErrors?: Record<string, QueryError | null>;
+  // Teto de linhas por resposta (PostgREST `max_rows`). Default: sem teto.
+  maxRows?: number;
 }) {
   return {
     rpc: makeRpc(state),
@@ -114,6 +116,8 @@ export function makeFilterAwareSupabaseMock(state: {
       const ins: Array<[string, unknown[]]> = [];
       const opRef: OpRef = { current: "select" };
       let limitN: number | null = null;
+      let rangeFrom: number | null = null;
+      let rangeTo: number | null = null;
       const builder: Record<string, unknown> = {};
       builder.select = () => builder;
       builder.eq = (c: string, v: unknown) => {
@@ -136,6 +140,11 @@ export function makeFilterAwareSupabaseMock(state: {
         limitN = n;
         return builder;
       };
+      builder.range = (from: number, to: number) => {
+        rangeFrom = from;
+        rangeTo = to;
+        return builder;
+      };
       attachWriteOps(builder, table, state.writeCalls, opRef);
       const rows = () => {
         const data = (state.tableData[table] ?? []) as Array<
@@ -147,7 +156,15 @@ export function makeFilterAwareSupabaseMock(state: {
           for (const [c, vals] of ins) if (!vals.includes(r[c])) return false;
           return true;
         });
-        return limitN != null ? filtered.slice(0, limitN) : filtered;
+        const limited = limitN != null ? filtered.slice(0, limitN) : filtered;
+        // `maxRows` reproduz o teto do PostgREST, que vale mesmo sem .range():
+        // sem ele o mock devolveria o conjunto inteiro e nenhum teste
+        // conseguiria distinguir uma leitura paginada de uma truncada. Default
+        // Infinity para não impor fixtures gigantes a quem não testa isso.
+        const maxRows = state.maxRows ?? Infinity;
+        const from = rangeFrom ?? 0;
+        const to = rangeTo != null ? rangeTo + 1 : Infinity;
+        return limited.slice(from, Math.min(to, from + maxRows));
       };
       const err = () => state.queryErrors?.[`${table}:${opRef.current}`] ?? null;
       builder.single = () =>


### PR DESCRIPTION
Bug latente descoberto ao reconstruir o #450. Independente da #177 — não toca o fluxo de remoção de membro.

## Problema

Três leituras de `project_members` tratam o resultado como o conjunto completo do projeto, sem paginar. O PostgREST **não falha** ao ultrapassar `max_rows` (1000): devolve a primeira página como se fosse tudo. Acima desse teto, cada uma degrada em silêncio:

| Local | Efeito acima de 1.000 membros |
|---|---|
| `auto-review-reconciler.ts` | o Set decide quem ainda é membro → membro legítimo lido como **ex-membro**, resposta sai da reconciliação sem erro nem log |
| `auto-comparison.ts` | revisor fora da 1ª página fica **permanentemente fora** do sorteio de comparação |
| `actions/assignments.ts` | participante legítimo **recusado** como se não fosse membro |

O primeiro é o mais grave: some trabalho de auto-revisão sem nenhum sinal.

## O que muda

A mecânica de paginação já existia dentro de `actions/export.ts`, mas presa a um arquivo `"use server"`. Movida para `lib/supabase/paginate` e reusada pelos quatro pontos, em vez de uma segunda cópia.

O algoritmo também mudou, e essa é a parte que merece revisão: o avanço passa a usar o tamanho **realmente recebido**, e o fim é a página vazia. A condição anterior (`batch.length < PAGE_SIZE`) presume que o `max_rows` do servidor é igual ao nosso — onde ele for menor, a primeira página já chega "incompleta", o laço encerra e a leitura volta a truncar, justamente o defeito que a função existe para impedir. Descobri isso porque o teste do pool com teto 2 falhou mesmo já usando `fetchAllPaged`.

O custo é uma requisição a mais no fim, que o caso "total múltiplo exato da página" já exigia. `MAX_PAGES` converte em erro explícito o cenário de um cliente que ignore `.range()` — que, com o novo critério de parada, travaria o request em vez de falhar.

## Mocks

Dois mocks aceitavam `.range()` **ignorando os argumentos**, devolvendo a tabela inteira a cada página — foi o que travou a suíte em laço infinito quando mudei o critério de parada. Agora recortam como o servidor. O mock filter-aware ganhou `maxRows` (default sem teto) para simular o `max_rows`: sem isso, nenhum teste consegue distinguir uma leitura paginada de uma truncada, que é exatamente por que esse bug passou despercebido até aqui.

## Verificação

- 5 testes do `fetchAllPaged`, incluindo o caso "servidor devolve menos que a página pedida";
- **prova do vermelho** nos dois pontos com efeito de negócio: revertendo a paginação, o teste do reconciliador acusa lista de humanos **vazia** (o membro virou ex-membro) e o do pool de comparação acusa `noPool`. Cada um foi mutado e restaurado;
- suíte completa: 1.891 testes, 182 arquivos, verde; typecheck, eslint (0 errors), react-doctor 100/100;
- pre-push integral verde. O smoke E2E falhou na 1ª execução e passou na 2ª — padrão conhecido de falha a frio do Turbopack, não regressão deste PR.

Não cobri com teste dedicado o terceiro ponto (`assignments`); ali o efeito é um erro visível ("participante válido"), não perda silenciosa, e os testes existentes já exercitam o caminho paginado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMmUAcmnYF9b9vwTJsjjzt