### PR TITLE
fix(membros): impede autoexclusão e move liberação de pendências para a membership

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "test:db:llm-rate-limit": "npm run test:db:psql -- supabase/tests/llm_rate_limit.test.sql",
     "test:db:member-permissions": "npm run test:db:psql -- supabase/tests/member_permission_rpcs.test.sql",
     "test:db:column-guard": "npm run test:db:psql -- supabase/tests/project_members_column_guard.test.sql",
+    "test:db:remove-member": "npm run test:db:psql -- supabase/tests/remove_project_member_self_identity.test.sql",
     "test:db:unmark-equivalence": "npm run test:db:psql -- supabase/tests/unmark_equivalence_atomic.test.sql",
     "test:db:arbitration-reopen": "npm run test:db:psql -- supabase/tests/arbitration_reopen.test.sql",
     "test:db:rls-audit": "npm run test:db:psql -- supabase/tests/rls_audit.test.sql",

--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -56,6 +56,7 @@ GATE_SUITES=(
   auto_review_reconciliation_outbox
   arbitration_reopen
   rls_audit
+  remove_project_member_self_identity
 )
 
 # Órfãs quebradas pela era da migration 20260717120000 (índice único one-latest

--- a/frontend/supabase/migrations/20260725120000_remove_project_member_self_identity.sql
+++ b/frontend/supabase/migrations/20260725120000_remove_project_member_self_identity.sql
@@ -1,0 +1,240 @@
+-- Autoidentidade e liberação de pendências na remoção de membros (issue #177).
+--
+-- Duas lacunas distintas na `main`:
+--
+--   1. `enforce_project_members_column_guard` impede que alguém mude o PRÓPRIO
+--      papel, mas nada impede que se REMOVA a própria membership. A policy
+--      "Coordinators manage members" é FOR ALL por projeto, não por linha, então
+--      um coordenador pode se autoexcluir por DELETE direto no PostgREST —
+--      possivelmente deixando o projeto sem coordenador.
+--
+--   2. `remove_project_member` limpa as pendências do membro, mas essa limpeza
+--      vive na RPC. Qualquer outro caminho de DELETE (PostgREST direto, script
+--      administrativo) deixa assignments pendentes apontando para quem não é
+--      mais membro.
+--
+-- Escolha de mecanismo para (1): policy RESTRICTIVE, não trigger. É a primeira
+-- restritiva do repositório, e a razão é o CASCADE: `project_members.project_id`
+-- referencia `projects` com ON DELETE CASCADE, então apagar um projeto remove a
+-- membership do próprio dono. RLS não se aplica a DELETE disparado por cascade
+-- referencial, de modo que a policy protege o caminho do usuário sem bloquear a
+-- exclusão do projeto. Um trigger que levantasse exceção quebraria justamente
+-- esse caso — a armadilha que a 20260724100000 teve de desfazer para os
+-- triggers de arquivamento.
+
+-- ---------------------------------------------------------------------------
+-- Saneamento: pendências que já perderam a membership pelos caminhos antigos.
+-- Reparo medido, não abort: a contagem vai para o log do deploy.
+-- Aliases órfãos não entram aqui — a FK composta criada em 20260716155000
+-- (member_email_links_project_member_fkey, ON DELETE CASCADE) já os elimina.
+--
+-- Não conflita com a nota da 20260716160300 ("pendência real sem membro atual
+-- não é órfã e fica intacta"): lá a regra governa o RECONCILIADOR, que não faz
+-- coleta de lixo por conta própria. O caminho de REMOÇÃO sempre limpou as
+-- pendências do removido — a RPC anterior já fazia isso, sem filtro de tipo. O
+-- que este DELETE alcança é o resíduo dos caminhos que não passaram pela RPC.
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_orphan_pending integer;
+BEGIN
+  DELETE FROM public.assignments AS a
+  WHERE a.status = 'pendente'
+    AND a.user_id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.project_members AS pm
+      WHERE pm.project_id = a.project_id
+        AND pm.user_id = a.user_id
+    )
+    -- Conta-alias legada exerce a membership por VÍNCULO, não por linha
+    -- própria em project_members: o NOT EXISTS acima não a enxerga. Antes da
+    -- 20260716155000 as filas resolviam a identidade canônica enquanto outras
+    -- escritas gravavam o uid CRU da sessão — a mesma assimetria que aquela
+    -- migration teve de reescrever em response_equivalences,
+    -- verdict_acknowledgments e researcher_field_orders. Uma pendência assim é
+    -- trabalho vivo de quem continua no projeto, não resíduo.
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.member_email_links AS mel
+      WHERE mel.project_id = a.project_id
+        AND mel.linked_user_id = a.user_id
+    );
+  GET DIAGNOSTICS v_orphan_pending = ROW_COUNT;
+
+  RAISE NOTICE
+    'Saneamento #177: % assignment(s) pendente(s) sem membership devolvido(s) ao pool.',
+    v_orphan_pending;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- (2) A liberação passa a viver na membership, e não só na RPC.
+--
+-- Mesmo movimento que a 20260716155000 fez com os aliases: declarou o ciclo de
+-- vida na FK e removeu o DELETE explícito da RPC, para não ter duas fontes da
+-- mesma regra. Aqui o trigger assume as pendências e o CTE correspondente sai
+-- da RPC (mais abaixo).
+--
+-- Histórico é preservado por construção: só `status = 'pendente'` é apagado.
+-- Trabalho iniciado ou concluído continua sendo o registro do que aconteceu.
+--
+-- SECURITY DEFINER, e não INVOKER como a RPC de onde a limpeza saiu: a
+-- liberação precisa acontecer para TODO caminho de DELETE, inclusive um cujo
+-- chamador não tenha RLS de DELETE em `assignments`. Sob INVOKER esse caso
+-- produziria remoção silenciosamente PARCIAL — a membership sai, as pendências
+-- ficam —, que é exatamente o estado que este trigger existe para tornar
+-- irrepresentável. O escopo compensa a elevação: só (project_id, user_id) da
+-- linha removida, e só `pendente`.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.release_pending_assignments_on_member_delete()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  -- Quando o DELETE vem do cascade de `projects`, a âncora já saiu e os
+  -- assignments serão cascateados pela mesma remoção: varrer aqui seria
+  -- trabalho puro. Mesmo cuidado da 20260724100000.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.projects WHERE id = OLD.project_id
+  ) THEN
+    RETURN OLD;
+  END IF;
+
+  DELETE FROM public.assignments AS a
+  WHERE a.project_id = OLD.project_id
+    AND a.user_id = OLD.user_id
+    AND a.status = 'pendente';
+
+  RETURN OLD;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.release_pending_assignments_on_member_delete()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS release_pending_assignments_on_member_delete_trigger
+  ON public.project_members;
+CREATE TRIGGER release_pending_assignments_on_member_delete_trigger
+  BEFORE DELETE ON public.project_members
+  FOR EACH ROW
+  EXECUTE FUNCTION public.release_pending_assignments_on_member_delete();
+
+-- ---------------------------------------------------------------------------
+-- (1) Autoidentidade: nem por DELETE direto.
+--
+-- RESTRICTIVE porque a proibição precisa valer junto de TODA policy permissiva,
+-- atual ou futura, de administração de membros — uma permissiva nova não pode
+-- reabrir o buraco por engano. Sem cláusula TO, pelo mesmo motivo: restritiva
+-- com TO explícito só restringe os roles listados, e um role novo entraria
+-- livre. `service_role` segue passando por BYPASSRLS, como em toda a RLS daqui.
+--
+-- Master é isento, como em enforce_project_members_column_guard
+-- (20260715095741), que já o isenta para a alteração do próprio papel. O alvo
+-- desta regra é o coordenador/criador que se autoexcluiria e possivelmente
+-- deixaria o projeto sem coordenador; master é o break-glass da plataforma e
+-- não perde a própria linha de membership como efeito colateral disso.
+--
+-- NOTA DE FORMA (não "corrigir" para a tupla): o predicado é um NOT EXISTS
+-- CORRELACIONADO de propósito, e não a forma `(project_id, user_id) NOT IN
+-- (SELECT ...)` que a 20260716155000:1362 registra como preferida. O motivo é
+-- que `project_members.user_id` é NULLABLE (001_initial_schema.sql): para uma
+-- linha de user_id nulo, a tupla-NOT IN avalia NULL — não true —, e a
+-- restritiva tornaria essa linha INDELETÁVEL por qualquer caminho de usuário.
+-- A regressão de ~9× que aquela migration mediu era com o helper
+-- PARAMETRIZADO (auth_user_member_identity_ids(project_id)), reexecutado por
+-- linha; aqui o helper não recebe argumento, então o function scan mantém o
+-- tuplestore entre os rescans do SubPlan. A tabela também é minúscula.
+--
+-- O helper cobre também a conta-alias: quem entra por e-mail vinculado exerce a
+-- identidade canônica e igualmente não pode removê-la.
+-- ---------------------------------------------------------------------------
+DROP POLICY IF EXISTS "Members cannot remove their own identity"
+  ON public.project_members;
+CREATE POLICY "Members cannot remove their own identity"
+  ON public.project_members
+  AS RESTRICTIVE
+  FOR DELETE
+  USING (
+    (SELECT public.is_master())
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.auth_user_project_memberships() AS membership
+      WHERE membership.project_id = project_members.project_id
+        AND membership.user_id = project_members.user_id
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- A RPC ganha o guard explícito e perde a limpeza de pendências (agora no
+-- trigger acima).
+--
+-- Guard e policy cobrem a MESMA invariante, de propósito, e cada um vale numa
+-- situação diferente:
+--   - a policy é a garantia real, e a única que alcança o DELETE direto no
+--     PostgREST;
+--   - o guard existe pela mensagem: barrado só pela policy, o DELETE remove
+--     zero linhas e a action traduz isso como "Membro não encontrado ou sem
+--     permissão", indistinguível de um id inexistente. O RAISE devolve 42501 e
+--     diz ao coordenador o que de fato aconteceu.
+-- Remover o guard não abre falha de segurança; degrada a mensagem. Remover a
+-- policy abre.
+--
+-- O braço de master repete o da policy porque os dois lados decidem a MESMA
+-- coisa: sem ele, master seria liberado pela policy e levaria 42501 da RPC —
+-- barrado justamente pelo mecanismo que existe só para explicar o bloqueio.
+--
+-- CREATE OR REPLACE preservando assinatura e tipo de retorno: um DROP+CREATE
+-- descartaria o `GRANT EXECUTE ... TO authenticated` emitido na
+-- 20260715160000 e a RPC passaria a falhar em produção para todo mundo.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.remove_project_member(
+  p_member_id uuid
+) RETURNS TABLE(project_id uuid)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_project_id uuid;
+  v_user_id uuid;
+BEGIN
+  -- FOR UPDATE trava a linha alvo: sem isso, a checagem de autoidentidade e o
+  -- DELETE poderiam observar estados diferentes se um alias fosse vinculado no
+  -- meio do caminho. A RLS continua valendo (SECURITY INVOKER), então este
+  -- SELECT só enxerga o que o chamador poderia enxergar.
+  SELECT pm.project_id, pm.user_id
+  INTO v_project_id, v_user_id
+  FROM public.project_members AS pm
+  WHERE pm.id = p_member_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  IF NOT (SELECT public.is_master()) AND EXISTS (
+    SELECT 1
+    FROM public.auth_user_project_memberships() AS membership
+    WHERE membership.project_id = v_project_id
+      AND membership.user_id = v_user_id
+  ) THEN
+    RAISE EXCEPTION 'Você não pode remover sua própria associação ao projeto.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- As pendências saem pelo trigger BEFORE DELETE e os aliases pela FK
+  -- composta. Repetir qualquer um dos dois aqui criaria uma segunda fonte da
+  -- mesma regra.
+  DELETE FROM public.project_members AS pm
+  WHERE pm.id = p_member_id;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY SELECT v_project_id;
+END;
+$$;

--- a/frontend/supabase/tests/canonical_project_identity_rls.test.sql
+++ b/frontend/supabase/tests/canonical_project_identity_rls.test.sql
@@ -2386,6 +2386,14 @@ BEGIN
       AND status = 'concluido'
       AND completed_at = '2001-01-01T00:00:00Z'::timestamptz
   ) OR NOT EXISTS (
+    -- Desde a 20260725120000 (issue #177) esta asserção também é o que segura a
+    -- ORDEM interna do unify contra o trigger BEFORE DELETE de project_members:
+    -- o 012 entra na fixture como 'pendente' do SOURCE, então, se a membership
+    -- do source saísse antes do UPDATE que repontou os assignments, o trigger o
+    -- apagaria como pendência de ex-membro e o NOT EXISTS abaixo cairia. Não há
+    -- asserção separada para isso de propósito — reforço de ordem
+    -- intra-transação é comentário, não uma segunda asserção que envelhece.
+    --
     -- 012 (auto_revisao no doc 002) migra para o target e fica 'concluido'. O
     -- status de auto_revisao é DERIVADO dos field_reviews pelo trigger
     -- archive_review_dependencies_on_response_change (migration 20260717120000),
@@ -2825,15 +2833,32 @@ BEGIN
       'FALHOU contrato: guard não usa exclusivamente a identidade canônica';
   END IF;
 
+  -- Cada efeito da remoção mora em exatamente um lugar. Aliases saem pela FK
+  -- composta (ON DELETE CASCADE) desde esta migration; pendências saíram da RPC
+  -- para o trigger BEFORE DELETE na 20260725120000 (issue #177), de modo que
+  -- também sejam liberadas por DELETE direto, e não só pela RPC. A RPC, então,
+  -- não pode conter nenhum dos dois DELETEs.
   SELECT pg_get_functiondef(
     'public.remove_project_member(uuid)'::regprocedure
   ) INTO definition;
   IF definition NOT ILIKE '%delete from public.project_members%'
-     OR definition NOT ILIKE '%delete from public.assignments%'
+     OR definition ILIKE '%delete from public.assignments%'
      OR definition ILIKE '%delete from public.member_email_links%'
   THEN
     RAISE EXCEPTION
       'FALHOU contrato: remoção duplica ou omite responsabilidades da FK';
+  END IF;
+
+  -- O lado positivo do mesmo contrato: a liberação existe, está no trigger e
+  -- alcança só o que é pendente — histórico iniciado/concluído sobrevive.
+  SELECT pg_get_functiondef(
+    'public.release_pending_assignments_on_member_delete()'::regprocedure
+  ) INTO definition;
+  IF definition NOT ILIKE '%delete from public.assignments%'
+     OR definition NOT ILIKE '%pendente%'
+  THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: liberação de pendências não vive no trigger da membership';
   END IF;
 
   SELECT pg_get_functiondef(

--- a/frontend/supabase/tests/remove_project_member_self_identity.test.sql
+++ b/frontend/supabase/tests/remove_project_member_self_identity.test.sql
@@ -1,0 +1,335 @@
+-- Contrato da remoção de membros (issue #177).
+--
+-- Como rodar:
+--   npm run test:db:remove-member
+--
+-- O runner conecta como `postgres`, que é OWNER das tabelas e portanto BYPASSA
+-- RLS. Todo bloco que exercita a policy troca para o role `authenticated` com
+-- um JWT forjado — sem isso o teste passaria por engano, medindo o owner em vez
+-- da policy.
+
+BEGIN;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('17710000-0000-0000-0000-000000000001', 'issue177-coordinator@example.test'),
+  ('17710000-0000-0000-0000-000000000002', 'issue177-alias@example.test'),
+  ('17710000-0000-0000-0000-000000000003', 'issue177-target@example.test'),
+  ('17710000-0000-0000-0000-000000000004', 'issue177-creator@example.test'),
+  ('17710000-0000-0000-0000-000000000005', 'issue177-creator-target@example.test'),
+  ('17710000-0000-0000-0000-000000000006', 'issue177-master@example.test');
+
+-- clerk_uid() resolve pelo par (sub, supabase_uid) em clerk_user_mapping: sem
+-- esta linha o helper devolve NULL e todo bloco abaixo mediria "sem identidade"
+-- em vez da regra sob teste.
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+SELECT id::text, id, 1
+FROM auth.users
+WHERE id::text LIKE '17710000-0000-0000-0000-%';
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('17700000-0000-0000-0000-000000000001', 'Issue 177 - coordenador',
+   '17710000-0000-0000-0000-000000000001'),
+  ('17700000-0000-0000-0000-000000000002', 'Issue 177 - criador',
+   '17710000-0000-0000-0000-000000000004');
+
+INSERT INTO public.project_members (id, project_id, user_id, role) VALUES
+  ('17730000-0000-0000-0000-000000000001',
+   '17700000-0000-0000-0000-000000000001',
+   '17710000-0000-0000-0000-000000000001', 'coordenador'),
+  ('17730000-0000-0000-0000-000000000003',
+   '17700000-0000-0000-0000-000000000001',
+   '17710000-0000-0000-0000-000000000003', 'pesquisador'),
+  ('17730000-0000-0000-0000-000000000004',
+   '17700000-0000-0000-0000-000000000002',
+   '17710000-0000-0000-0000-000000000004', 'coordenador'),
+  ('17730000-0000-0000-0000-000000000005',
+   '17700000-0000-0000-0000-000000000002',
+   '17710000-0000-0000-0000-000000000005', 'pesquisador'),
+  ('17730000-0000-0000-0000-000000000006',
+   '17700000-0000-0000-0000-000000000001',
+   '17710000-0000-0000-0000-000000000006', 'coordenador');
+
+-- Master é isento da proibição, como já é do guard de mudança do próprio papel
+-- (enforce_project_members_column_guard). Precisa ser MEMBRO para o caso ter
+-- conteúdo: um master de fora do projeto nunca casaria o predicado.
+INSERT INTO public.master_users (user_id) VALUES
+  ('17710000-0000-0000-0000-000000000006');
+
+-- A conta-alias exerce a identidade canônica do coordenador.
+INSERT INTO public.member_email_links (
+  project_id, member_user_id, email, linked_user_id, created_by
+) VALUES (
+  '17700000-0000-0000-0000-000000000001',
+  '17710000-0000-0000-0000-000000000001',
+  'issue177-alias@example.test',
+  '17710000-0000-0000-0000-000000000002',
+  '17710000-0000-0000-0000-000000000001'
+);
+
+INSERT INTO public.documents (id, project_id, external_id, title, text) VALUES
+  ('17740000-0000-0000-0000-000000000001',
+   '17700000-0000-0000-0000-000000000001', '177-D1', 'Doc 1', 'texto'),
+  ('17740000-0000-0000-0000-000000000002',
+   '17700000-0000-0000-0000-000000000001', '177-D2', 'Doc 2', 'texto'),
+  ('17740000-0000-0000-0000-000000000003',
+   '17700000-0000-0000-0000-000000000002', '177-D3', 'Doc 3', 'texto');
+
+-- Do alvo: uma pendência (deve sumir) e um histórico concluído (deve ficar).
+INSERT INTO public.assignments (id, project_id, document_id, user_id, status, type) VALUES
+  ('17750000-0000-0000-0000-000000000001',
+   '17700000-0000-0000-0000-000000000001',
+   '17740000-0000-0000-0000-000000000001',
+   '17710000-0000-0000-0000-000000000003', 'pendente', 'codificacao'),
+  ('17750000-0000-0000-0000-000000000002',
+   '17700000-0000-0000-0000-000000000001',
+   '17740000-0000-0000-0000-000000000002',
+   '17710000-0000-0000-0000-000000000003', 'concluido', 'codificacao'),
+  ('17750000-0000-0000-0000-000000000003',
+   '17700000-0000-0000-0000-000000000002',
+   '17740000-0000-0000-0000-000000000003',
+   '17710000-0000-0000-0000-000000000005', 'pendente', 'codificacao'),
+  -- Pendência gravada sob o uid CRU da conta-alias (legado anterior à
+  -- 20260716155000, quando as filas já resolviam a identidade canônica mas
+  -- nem toda escrita resolvia). Não há membership com esse user_id, então ela
+  -- é o caso que separa "varrer o que é do removido" de "varrer tudo que não
+  -- tem membership": tem de sobreviver à remoção de qualquer outro membro.
+  ('17750000-0000-0000-0000-000000000004',
+   '17700000-0000-0000-0000-000000000001',
+   '17740000-0000-0000-0000-000000000001',
+   '17710000-0000-0000-0000-000000000002', 'pendente', 'codificacao');
+
+GRANT SELECT, UPDATE, DELETE ON public.project_members TO authenticated;
+
+-- ----- Contrato declarado no catálogo -----
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc AS p
+    WHERE p.oid = 'public.remove_project_member(uuid)'::regprocedure
+      AND p.prosecdef
+  ) THEN
+    RAISE EXCEPTION 'FALHOU contrato: remove_project_member deve ser SECURITY INVOKER';
+  END IF;
+
+  -- SECURITY DEFINER + service_role bypassaria a RLS e zeraria clerk_uid().
+  IF NOT has_function_privilege('authenticated',
+        'public.remove_project_member(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'FALHOU contrato: authenticated perdeu EXECUTE na RPC';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_policy AS p
+    JOIN pg_class AS c ON c.oid = p.polrelid
+    JOIN pg_namespace AS n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'project_members'
+      AND p.polname = 'Members cannot remove their own identity'
+      AND p.polcmd = 'd'
+      AND NOT p.polpermissive
+      -- polroles = {0} é PUBLIC, isto é, a policy foi criada SEM cláusula TO.
+      -- Numa RESTRICTIVE isso não é detalhe: com TO explícito ela só restringe
+      -- os roles listados, e um role novo — ou um caminho que autentique por
+      -- outro role — entraria livre justamente onde a restritiva deveria valer
+      -- sempre. `service_role` continua passando por BYPASSRLS.
+      AND p.polroles = '{0}'::oid[]
+  ) THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: policy DELETE deve ser restritiva e sem cláusula TO';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.project_members'::regclass
+      AND tgname = 'release_pending_assignments_on_member_delete_trigger'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'FALHOU contrato: trigger de liberação de pendências ausente';
+  END IF;
+
+  RAISE NOTICE 'OK contrato: RPC INVOKER + policy restritiva + trigger presentes';
+END;
+$$;
+
+-- ----- Coordenador não remove a própria membership (RPC nem DELETE direto) ---
+SELECT set_config('request.jwt.claims',
+  '{"sub":"17710000-0000-0000-0000-000000000001","supabase_uid":"17710000-0000-0000-0000-000000000001"}', true);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.remove_project_member(
+      '17730000-0000-0000-0000-000000000001');
+    RAISE EXCEPTION 'FALHOU: coordenador removeu a própria membership pela RPC';
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;
+  END;
+END;
+$$;
+DELETE FROM public.project_members
+WHERE id = '17730000-0000-0000-0000-000000000001';
+
+-- Terceiro continua removível — e é a RPC quem devolve o projeto.
+SELECT * FROM public.remove_project_member(
+  '17730000-0000-0000-0000-000000000003');
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.project_members
+    WHERE id = '17730000-0000-0000-0000-000000000001'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: DELETE direto removeu a própria membership';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.project_members
+    WHERE id = '17730000-0000-0000-0000-000000000003'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: remoção autorizada de terceiro não ocorreu';
+  END IF;
+
+  -- A pendência do removido volta ao pool; o histórico permanece.
+  IF EXISTS (
+    SELECT 1 FROM public.assignments
+    WHERE id = '17750000-0000-0000-0000-000000000001'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: pendência do ex-membro sobreviveu à remoção';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.assignments
+    WHERE id = '17750000-0000-0000-0000-000000000002' AND status = 'concluido'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: histórico concluído foi apagado com a membership';
+  END IF;
+
+  -- O trigger varre por (project_id, user_id) DA LINHA REMOVIDA, não "toda
+  -- pendência sem membership": a do uid cru da conta-alias fica de pé, embora
+  -- não tenha membership própria. Trocar o filtro por uma varredura ampla
+  -- apagaria trabalho de quem continua no projeto.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.assignments
+    WHERE id = '17750000-0000-0000-0000-000000000004' AND status = 'pendente'
+  ) THEN
+    RAISE EXCEPTION
+      'FALHOU: pendência de conta-alias caiu junto com a remoção de outro membro';
+  END IF;
+
+  -- A FK composta cuida dos aliases do membro removido; o do coordenador fica.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.member_email_links
+    WHERE member_user_id = '17710000-0000-0000-0000-000000000001'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: alias do coordenador sumiu sem remoção';
+  END IF;
+
+  RAISE NOTICE 'OK: autoidentidade preservada, terceiro removido, pendência liberada';
+END;
+$$;
+
+-- ----- A conta-alias também não remove a identidade que exerce -----
+SELECT set_config('request.jwt.claims',
+  '{"sub":"17710000-0000-0000-0000-000000000002","supabase_uid":"17710000-0000-0000-0000-000000000002"}', true);
+SET LOCAL ROLE authenticated;
+DELETE FROM public.project_members
+WHERE id = '17730000-0000-0000-0000-000000000001';
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.project_members
+    WHERE id = '17730000-0000-0000-0000-000000000001'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: alias removeu a identidade canônica que exerce';
+  END IF;
+  RAISE NOTICE 'OK: alias não remove a identidade canônica';
+END;
+$$;
+
+-- ----- Criador tampouco se autoexclui, mas remove terceiro -----
+SELECT set_config('request.jwt.claims',
+  '{"sub":"17710000-0000-0000-0000-000000000004","supabase_uid":"17710000-0000-0000-0000-000000000004"}', true);
+SET LOCAL ROLE authenticated;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.remove_project_member(
+      '17730000-0000-0000-0000-000000000004');
+    RAISE EXCEPTION 'FALHOU: criador removeu a própria membership';
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;
+  END;
+END;
+$$;
+SELECT * FROM public.remove_project_member(
+  '17730000-0000-0000-0000-000000000005');
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.project_members
+    WHERE id = '17730000-0000-0000-0000-000000000004'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: criador conseguiu se autoexcluir';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.assignments
+    WHERE id = '17750000-0000-0000-0000-000000000003'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: pendência não liberada na remoção pelo criador';
+  END IF;
+
+  RAISE NOTICE 'OK: criador não se autoexclui e a remoção de terceiro libera pendência';
+END;
+$$;
+
+-- ----- Master é o break-glass: remove a própria membership -------------------
+-- Isenção deliberada, alinhada com enforce_project_members_column_guard, que já
+-- permite ao master mudar o próprio papel. Os DOIS lados precisam concordar: a
+-- policy libera o DELETE e o guard da RPC não pode levantar 42501 em cima
+-- disso, senão o mecanismo que existe para EXPLICAR o bloqueio vira o bloqueio.
+-- Por isso o caso exercita a RPC (que devolve o project_id) e não só o DELETE.
+SELECT set_config('request.jwt.claims',
+  '{"sub":"17710000-0000-0000-0000-000000000006","supabase_uid":"17710000-0000-0000-0000-000000000006"}', true);
+SET LOCAL ROLE authenticated;
+SELECT * FROM public.remove_project_member(
+  '17730000-0000-0000-0000-000000000006');
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.project_members
+    WHERE id = '17730000-0000-0000-0000-000000000006'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: master foi barrado ao remover a própria membership';
+  END IF;
+  RAISE NOTICE 'OK: master remove a própria membership (policy e guard concordam)';
+END;
+$$;
+
+-- ----- Excluir o projeto continua possível: o cascade não passa pela RLS -----
+-- Um trigger que levantasse exceção na autoidentidade quebraria este caminho,
+-- que remove a membership do próprio dono por cascade.
+DELETE FROM public.projects
+WHERE id = '17700000-0000-0000-0000-000000000002';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.project_members
+    WHERE project_id = '17700000-0000-0000-0000-000000000002'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: cascade do projeto não removeu as memberships';
+  END IF;
+  RAISE NOTICE 'OK: exclusão de projeto cascateia sem esbarrar na autoidentidade';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
Parte de banco da reconstrução do #450, sobre a `main` atual. A parte de UI está no #589 e não depende deste PR.

> [!IMPORTANT]
> **A migration precisa ser aplicada no remoto ANTES do merge** (regra do projeto para RPC fail-closed). Validada apenas no Supabase local; nada foi aplicado ao remoto.

## Duas lacunas distintas

**1. Autoexclusão.** `enforce_project_members_column_guard` impede mudar o *próprio papel*, mas nada impedia **remover a própria membership**: `"Coordinators manage members"` é `FOR ALL` por projeto, não por linha. Um coordenador podia se autoexcluir por `DELETE` direto no PostgREST — possivelmente deixando o projeto sem coordenador.

**2. Liberação de pendências presa à RPC.** `remove_project_member` limpava os assignments pendentes, mas só ela. Qualquer outro caminho de DELETE deixava pendências apontando para quem não é mais membro.

## Decisões que merecem revisão

**Policy RESTRICTIVE, não trigger** — será a primeira restritiva do repositório. O motivo é o CASCADE: `project_members.project_id` referencia `projects` com `ON DELETE CASCADE`, então apagar um projeto remove a membership do próprio dono. RLS **não se aplica** a DELETE por cascade referencial, então a policy protege o caminho do usuário sem bloquear a exclusão do projeto. Um trigger que levantasse exceção quebraria exatamente esse caso — a armadilha que a `20260724100000` teve de desfazer para os triggers de arquivamento. Há teste cobrindo a exclusão de projeto.

O predicado usa a forma de tupla contra `auth_user_project_memberships()`; a forma correlacionada com `auth_user_member_identity_ids(project_id)` reexecuta o helper por linha (~9× de regressão medida e registrada na `20260716155000`).

**A limpeza sai da RPC e vai para um trigger `BEFORE DELETE`** — mesmo movimento que a `20260716155000` fez com os aliases, quando declarou o ciclo de vida na FK e removeu o DELETE explícito da RPC. Manter os dois seria uma segunda fonte da mesma regra. O trigger ignora o cascade de `projects` (a âncora já saiu e os assignments vêm junto), seguindo o padrão da `20260724100000`.

**O guard na RPC é redundante com a policy, de propósito.** Barrado só pela policy, o DELETE afeta zero linhas e a action traduz como "Membro não encontrado ou sem permissão" — indistinguível de um id inexistente. O `RAISE` devolve `42501` e diz o que houve. A migration registra a condição de ativação de cada um: remover o guard degrada a mensagem, remover a policy abre a falha.

`CREATE OR REPLACE` preservando assinatura e retorno — um `DROP`+`CREATE` descartaria o `GRANT EXECUTE ... TO authenticated` emitido na `20260715160000` e a RPC passaria a falhar para todos.

## Contrato reescrito (não afrouxado)

`canonical_project_identity_rls` exigia o `DELETE FROM assignments` **dentro** da RPC. Com a responsabilidade movida, a asserção passa a exigir o oposto — e ganhou o lado positivo: a liberação precisa existir **no trigger** e alcançar apenas `'pendente'`, para que histórico iniciado/concluído sobreviva. O contrato continua afirmando "cada efeito em exatamente um lugar".

## Fora de escopo, por decisão

O #450 propunha um trigger proibindo assignment pendente sem membership. **Não entra**: a `20260716160300` documenta que pendência de ex-membro não é órfã e fica intacta, e o trigger quebraria três writers em lote (`replace_and_add_documents`, `apply_lottery_assignments` com `ON CONFLICT DO NOTHING` sem target, e o reconciliador). Vou abrir issue para decidir esse contrato separadamente.

## Verificação

- suíte SQL nova (`npm run test:db:remove-member`), registrada em `GATE_SUITES` — sem isso a guarda 1 do runner derrubaria o gate;
- **prova do vermelho por mutação**, cada uma isolada: derrubada a policy → "DELETE direto removeu a própria membership"; derrubado o trigger → "pendência do ex-membro sobreviveu"; RPC redefinida sem o guard → "coordenador removeu a própria membership pela RPC" (confirmando que o guard é o que produz a mensagem). As mutações foram inseridas **depois** do bloco de contrato, senão a asserção de catálogo abortaria antes e não provaria as asserções comportamentais;
- os blocos que exercitam a policy trocam para `authenticated` com JWT forjado — o runner conecta como `postgres`, que é owner e bypassa RLS, então sem isso o teste passaria por engano. A fixture precisou de linha em `clerk_user_mapping` e do claim `sub`: `clerk_uid()` resolve pelo par, e sem ela o helper devolve NULL (foi o que fez o teste falhar na primeira execução);
- `npx supabase db reset` + **suíte SQL inteira**: 12 PASS, 0 FAIL. As 2 RED* (`schema_revision_rpcs` #571, `schema_revision_serialization` #572) são pré-existentes e rastreadas;
- pre-push integral verde, incluindo o gate `test:db`.

O saneamento inicial (pendências órfãs legadas) rodou no reset com zero linhas, já que o banco local estava limpo — não tem teste dedicado com dados legados. É um `DELETE` de uma condição simples, mas vale conferir na aplicação ao remoto, onde o `RAISE NOTICE` reporta a contagem.

Ref #177 — o auto-close fica no #589, que entrega o pedido literal da issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMmUAcmnYF9b9vwTJsjjzt


---

## Revisão aplicada (2026-07-24)

Seis achados da revisão entraram neste mesmo PR, sem migration de follow-up (nada havia sido aplicado ao remoto quando foram escritos).

**1. O comentário do predicado descrevia o código errado.** A migration afirmava usar "a forma de tupla"; usa `NOT EXISTS` correlacionado — e essa é a forma **certa**, porque `project_members.user_id` é nullable (`001_initial_schema.sql`): sob tupla-`NOT IN`, uma linha de `user_id` nulo avaliaria `NULL`, não `true`, e a restritiva a tornaria **indeletável**. A nota agora diz isso e registra que a regressão de ~9× da `20260716155000` era com o helper *parametrizado*, não com este, que não recebe argumento e mantém o tuplestore entre rescans.

**2. Master passa a ser isento** — nos dois lados. O guard irmão (`enforce_project_members_column_guard`) já isenta master para a mudança do próprio papel; a policy e o guard da RPC agora concordam com ele. Sem o braço na RPC, master seria liberado pela policy e levaria `42501` do mecanismo que existe só para *explicar* o bloqueio.

**3. A policy perdeu o `TO authenticated`.** Restritiva com `TO` explícito só restringe os roles listados — um role novo entraria livre justamente onde a proibição deveria valer sempre. `service_role` segue passando por `BYPASSRLS`. Fixado no catálogo: a asserção agora exige `polroles = '{0}'`.

**4. O saneamento ficou alias-aware.** Uma conta-alias legada exerce a membership por *vínculo* (`member_email_links`), não por linha própria, então a pendência gravada sob o uid cru dela não tem membership e seria apagada como resíduo — sendo trabalho vivo. O comentário também reconcilia com a nota da `20260716160300`: aquela regra governa o reconciliador, não o caminho de remoção.

**5. O trigger registra por que é `SECURITY DEFINER`** — sob `INVOKER`, um chamador sem RLS de `DELETE` em `assignments` produziria remoção silenciosamente *parcial*, que é o estado que o trigger existe para tornar irrepresentável.

**6. A ordem interna do `unify_project_members` virou load-bearing** e isso está registrado onde já era coberto. O assignment `41…012` entra na fixture como `'pendente'` do source; se a membership saísse antes do `UPDATE` que reponta os assignments, o trigger novo o apagaria e a asserção existente cairia. Entrou comentário, não asserção nova — reforço de ordem intra-transação envelhece pior como segunda asserção (#577).

### Medição do saneamento no remoto (antes de aplicar)

| | |
|---|---|
| assignments pendentes com `user_id` | 290 |
| sem membership própria | **0** |
| destas, com vínculo de conta-alias | **0** |
| alcançadas pelo `DELETE` | **0** |

A medição se autovalida: se o anti-join estivesse errado, as 290 apareceriam como órfãs. O `RAISE NOTICE` na aplicação confirmou `0 assignment(s)`.

### Verificação

- **Prova do vermelho por mutação**, quatro guardas, cada uma isolada e restaurada: policy sem o braço de master → `FALHOU: master foi barrado`; guard da RPC sem o braço → `42501` na remoção legítima; `TO authenticated` reintroduzido → `FALHOU contrato: policy deve ser restritiva e sem cláusula TO`; trigger varrendo além de `OLD.user_id` → `FALHOU: pendência de conta-alias caiu junto`.
- `npm run test:db` completo: **14 PASS, 0 FAIL de gate**, as 2 RED* pré-existentes (#571, #572).
- Pre-push integral verde numa passagem só.
- Migration aplicada ao remoto antes do merge; `npm run invariants` depois: **12/12**.

Rebaseado duas vezes durante a sessão — a `main` recebeu #586, #590, #598, #588 e #601 no intervalo. Uma execução da suíte acusou 3 falhas que eram estado alheio no container local compartilhado (tinha migrations de outra branch e não a deste PR), não regressão: confirmado por dump do catálogo antes de qualquer conclusão.
