### PR TITLE
test(invariants): versão carimbada exige hash da própria época (#579)

### DIFF
--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -20,6 +20,13 @@
 
 import { createClient } from "@supabase/supabase-js";
 import { isCodingComplete } from "@/lib/coding-completeness";
+import {
+  reconstructSnapshotsByVersion,
+  computeHashesFromSnapshot,
+  type EnrichedEntry,
+  type Version,
+} from "@/lib/schema-backfill";
+import { bumpVersion, fieldDiffIsStructural, type ChangeType } from "@/lib/schema-utils";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import { loadEnv } from "../comentarios-relatorio/load-env";
 
@@ -300,6 +307,129 @@ const invariants: Invariant[] = [
           key: a.id,
           detail: `assignment concluído cuja response is_latest é rascunho, nunca submetida (doc ${a.document_id}, user ${a.user_id})`,
         }));
+    },
+  },
+  {
+    name: "versao-carimbada-tem-hash-da-propria-epoca",
+    motivation:
+      "família #529/#573 (medição #574/#579): antes do #573, o auto-save promovia schema_version_* sem revisão. Sob o critério do #573, carimbar a versão V exige revisão real sob V — que grava ao menos um hash de V em answer_field_hashes. Uma response cujo carimbo não é sustentado por NENHUM hash da própria época foi promovida por canal que pulou essa regra (ou o log de versões foi reescrito sob os pés dela — também vale investigação)",
+    run: async () => {
+      // Timeline de hashes por versão na ESCALA PERSISTIDA: usa as colunas
+      // version_* gravadas no schema_change_log — NÃO classifyLogEntries, que
+      // re-deriva o semver (reclassifica patch→minor e bumpa por entry em vez
+      // de por lote de save) e produz uma escala incomparável com a que as
+      // responses e o piso da fila carregam (medido no Zolgensma em
+      // 2026-07-24: 0.38.0 re-derivado contra 0.20.0 persistido). O prefixo
+      // pré-versionamento (entries com version_major NULL, anteriores à
+      // migration 20260420) é sintetizado replicando os bumps a partir de
+      // 0.1.0; entries com versão gravada reancoram a síntese.
+      const buildHashesByVersion = (
+        log: Array<{
+          id: string;
+          field_name: string;
+          before_value: Record<string, unknown> | null;
+          after_value: Record<string, unknown> | null;
+          created_at: string;
+          change_type: string | null;
+          version_major: number | null;
+          version_minor: number | null;
+          version_patch: number | null;
+        }>,
+        fields: PydanticField[],
+      ): Map<string, Record<string, string>> => {
+        let synth: Version = { major: 0, minor: 1, patch: 0 };
+        const enriched: EnrichedEntry[] = log.map((entry) => {
+          const before = entry.before_value ?? {};
+          const after = entry.after_value ?? {};
+          const changeType: ChangeType =
+            entry.change_type === "major" || entry.change_type === "minor" || entry.change_type === "patch"
+              ? entry.change_type
+              : fieldDiffIsStructural(before, after)
+                ? "minor"
+                : "patch";
+          let version: Version;
+          if (entry.version_major !== null) {
+            version = {
+              major: entry.version_major,
+              minor: entry.version_minor ?? 0,
+              patch: entry.version_patch ?? 0,
+            };
+            synth = version;
+          } else {
+            synth = bumpVersion(synth, changeType);
+            version = synth;
+          }
+          return {
+            id: entry.id,
+            field_name: entry.field_name,
+            before,
+            after,
+            createdAt: new Date(entry.created_at).getTime(),
+            changeType,
+            version,
+          };
+        });
+        const snapshots = reconstructSnapshotsByVersion(fields, enriched, enriched.at(-1)!.version);
+        const out = new Map<string, Record<string, string>>();
+        for (const [key, snap] of snapshots) out.set(key, computeHashesFromSnapshot(snap));
+        return out;
+      };
+
+      const projects = await fetchAll<{ id: string; pydantic_fields: PydanticField[] | null }>(
+        "projects",
+        "id, pydantic_fields",
+      );
+      const violations: Violation[] = [];
+      for (const p of projects) {
+        const fields = p.pydantic_fields ?? [];
+        if (fields.length === 0) continue;
+        const log = await fetchAll<Parameters<typeof buildHashesByVersion>[0][number]>(
+          "schema_change_log",
+          "id, field_name, before_value, after_value, created_at, change_type, version_major, version_minor, version_patch",
+          (q) => q.eq("project_id", p.id),
+        );
+        // fetchAll pagina por id; a síntese do prefixo exige ordem (created_at, id).
+        log.sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id));
+        if (log.length === 0) continue;
+        const hashesByVersion = buildHashesByVersion(log, fields);
+
+        const rows = await fetchAll<{
+          id: string;
+          answer_field_hashes: AnswerFieldHashes | null;
+          schema_version_major: number;
+          schema_version_minor: number | null;
+          schema_version_patch: number | null;
+          version_inferred_from: string | null;
+        }>(
+          "responses",
+          "id, answer_field_hashes, schema_version_major, schema_version_minor, schema_version_patch, version_inferred_from",
+          (q) => q.eq("project_id", p.id).eq("is_latest", true).not("schema_version_major", "is", null),
+        );
+
+        for (const r of rows) {
+          // Sem hash não-nulo não há evidência de época — o sentinela {} das
+          // linhas legadas (#528) e mapas só-null ficam fora, não são violação.
+          const nonNull = Object.entries(r.answer_field_hashes ?? {}).filter(([, h]) => h !== null);
+          if (nonNull.length === 0) continue;
+          const stampedKey = `${r.schema_version_major}.${r.schema_version_minor ?? 0}.${r.schema_version_patch ?? 0}`;
+          const snap = hashesByVersion.get(stampedKey);
+          if (!snap) {
+            violations.push({
+              key: r.id,
+              detail: `carimbo ${stampedKey} [${r.version_inferred_from}] não existe na timeline do schema_change_log`,
+            });
+            continue;
+          }
+          const epochHashes = nonNull.filter(([name, h]) => snap[name] === h).length;
+          if (epochHashes === 0) {
+            violations.push({
+              key: r.id,
+              detail: `carimbo ${stampedKey} [${r.version_inferred_from}] sem nenhum hash da própria época (0/${nonNull.length})`,
+            });
+          }
+        }
+      }
+      return violations;
     },
   },
   {

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -21,12 +21,9 @@
 import { createClient } from "@supabase/supabase-js";
 import { isCodingComplete } from "@/lib/coding-completeness";
 import {
-  reconstructSnapshotsByVersion,
-  computeHashesFromSnapshot,
-  type EnrichedEntry,
-  type Version,
+  buildTimelineFromPersistedVersions,
+  type PersistedLogEntryRow,
 } from "@/lib/schema-backfill";
-import { bumpVersion, fieldDiffIsStructural, type ChangeType } from "@/lib/schema-utils";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import { loadEnv } from "../comentarios-relatorio/load-env";
 
@@ -312,101 +309,82 @@ const invariants: Invariant[] = [
   {
     name: "versao-carimbada-tem-hash-da-propria-epoca",
     motivation:
-      "família #529/#573 (medição #574/#579): antes do #573, o auto-save promovia schema_version_* sem revisão. Sob o critério do #573, carimbar a versão V exige revisão real sob V — que grava ao menos um hash de V em answer_field_hashes. Uma response cujo carimbo não é sustentado por NENHUM hash da própria época foi promovida por canal que pulou essa regra (ou o log de versões foi reescrito sob os pés dela — também vale investigação)",
+      "família #529/#573 (medição #574/#579): antes do #573, o auto-save promovia schema_version_* sem revisão. Sob o critério do #573, carimbar a versão V no save ao vivo exige revisão real sob V — que grava ao menos um hash de V em answer_field_hashes. Uma response live_save cujo carimbo não é sustentado por NENHUM hash da própria época foi promovida por canal que pulou essa regra (ou o log de versões foi reescrito sob os pés dela — também vale investigação)",
     run: async () => {
-      // Timeline de hashes por versão na ESCALA PERSISTIDA: usa as colunas
-      // version_* gravadas no schema_change_log — NÃO classifyLogEntries, que
-      // re-deriva o semver (reclassifica patch→minor e bumpa por entry em vez
-      // de por lote de save) e produz uma escala incomparável com a que as
-      // responses e o piso da fila carregam (medido no Zolgensma em
-      // 2026-07-24: 0.38.0 re-derivado contra 0.20.0 persistido). O prefixo
-      // pré-versionamento (entries com version_major NULL, anteriores à
-      // migration 20260420) é sintetizado replicando os bumps a partir de
-      // 0.1.0; entries com versão gravada reancoram a síntese.
-      const buildHashesByVersion = (
-        log: Array<{
-          id: string;
-          field_name: string;
-          before_value: Record<string, unknown> | null;
-          after_value: Record<string, unknown> | null;
-          created_at: string;
-          change_type: string | null;
-          version_major: number | null;
-          version_minor: number | null;
-          version_patch: number | null;
-        }>,
-        fields: PydanticField[],
-      ): Map<string, Record<string, string>> => {
-        let synth: Version = { major: 0, minor: 1, patch: 0 };
-        const enriched: EnrichedEntry[] = log.map((entry) => {
-          const before = entry.before_value ?? {};
-          const after = entry.after_value ?? {};
-          const changeType: ChangeType =
-            entry.change_type === "major" || entry.change_type === "minor" || entry.change_type === "patch"
-              ? entry.change_type
-              : fieldDiffIsStructural(before, after)
-                ? "minor"
-                : "patch";
-          let version: Version;
-          if (entry.version_major !== null) {
-            version = {
-              major: entry.version_major,
-              minor: entry.version_minor ?? 0,
-              patch: entry.version_patch ?? 0,
-            };
-            synth = version;
-          } else {
-            synth = bumpVersion(synth, changeType);
-            version = synth;
-          }
-          return {
-            id: entry.id,
-            field_name: entry.field_name,
-            before,
-            after,
-            createdAt: new Date(entry.created_at).getTime(),
-            changeType,
-            version,
-          };
-        });
-        const snapshots = reconstructSnapshotsByVersion(fields, enriched, enriched.at(-1)!.version);
-        const out = new Map<string, Record<string, string>>();
-        for (const [key, snap] of snapshots) out.set(key, computeHashesFromSnapshot(snap));
-        return out;
-      };
-
-      const projects = await fetchAll<{ id: string; pydantic_fields: PydanticField[] | null }>(
+      const activeDocs = await activeDocIds();
+      const projects = await fetchAll<{
+        id: string;
+        pydantic_fields: PydanticField[] | null;
+        schema_version_major: number | null;
+        schema_version_minor: number | null;
+        schema_version_patch: number | null;
+      }>(
         "projects",
-        "id, pydantic_fields",
+        "id, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch",
       );
       const violations: Violation[] = [];
       for (const p of projects) {
         const fields = p.pydantic_fields ?? [];
         if (fields.length === 0) continue;
-        const log = await fetchAll<Parameters<typeof buildHashesByVersion>[0][number]>(
+        const log = await fetchAll<PersistedLogEntryRow>(
           "schema_change_log",
           "id, field_name, before_value, after_value, created_at, change_type, version_major, version_minor, version_patch",
           (q) => q.eq("project_id", p.id),
         );
-        // fetchAll pagina por id; a síntese do prefixo exige ordem (created_at, id).
+        // fetchAll pagina por id; a auditoria de ordem e a síntese do prefixo
+        // em buildTimelineFromPersistedVersions exigem ordem (created_at, id).
         log.sort((a, b) => a.created_at.localeCompare(b.created_at) || a.id.localeCompare(b.id));
         if (log.length === 0) continue;
-        const hashesByVersion = buildHashesByVersion(log, fields);
+        const timeline = buildTimelineFromPersistedVersions(log, fields, {
+          major: p.schema_version_major ?? 0,
+          minor: p.schema_version_minor ?? 0,
+          patch: p.schema_version_patch ?? 0,
+        });
+        // A timeline inconsistente é achado do projeto, não das responses:
+        // reconstruir por cima dela produziria snapshots errados e marcaria em
+        // massa linhas honestas — falso positivo, que aqui é o pior resultado.
+        if (timeline.status !== "ok") {
+          violations.push({ key: p.id, detail: `${timeline.status}: ${timeline.detail}` });
+          continue;
+        }
+        const { hashesByVersion } = timeline;
 
+        // Só `live_save` (actions/responses.ts) carimba a versão como
+        // afirmação de revisão real sob ela — é o carimbo que o critério do
+        // #573 governa e o único sobre o qual esta invariante tem o que dizer.
+        // Os outros três valores de version_inferred_from são inferência
+        // retroativa do backfill, e dois deles tornariam a asserção degenerada:
+        // `hashes` escolhe a versão MAXIMIZANDO hashes que batem
+        // (findBestHashMatch exige score > 0), então nunca pode violar; e
+        // `fallback_created_at` é o ramo alcançado justamente porque NENHUMA
+        // versão compatível pontuou, então violaria por construção — a
+        // condição que ativaria esse falso positivo é rodar o Backfill pela UI
+        // num projeto com hashes legados que não batem com versão alguma.
+        // `created_at` foi atribuído em bloco pela migration 20260421 a tudo
+        // que era NULL, e também não afirma revisão.
         const rows = await fetchAll<{
           id: string;
+          document_id: string;
           answer_field_hashes: AnswerFieldHashes | null;
           schema_version_major: number;
           schema_version_minor: number | null;
           schema_version_patch: number | null;
-          version_inferred_from: string | null;
         }>(
           "responses",
-          "id, answer_field_hashes, schema_version_major, schema_version_minor, schema_version_patch, version_inferred_from",
-          (q) => q.eq("project_id", p.id).eq("is_latest", true).not("schema_version_major", "is", null),
+          "id, document_id, answer_field_hashes, schema_version_major, schema_version_minor, schema_version_patch",
+          (q) =>
+            q
+              .eq("project_id", p.id)
+              .eq("is_latest", true)
+              .eq("version_inferred_from", "live_save")
+              .not("schema_version_major", "is", null),
         );
 
         for (const r of rows) {
+          // Mesma exclusão de documento soft-deletado das invariantes de
+          // fila/status: a cópia excluída do dedup de 2026-06 carrega carimbo e
+          // hashes da época e é inerte.
+          if (!activeDocs.has(r.document_id)) continue;
           // Sem hash não-nulo não há evidência de época — o sentinela {} das
           // linhas legadas (#528) e mapas só-null ficam fora, não são violação.
           const nonNull = Object.entries(r.answer_field_hashes ?? {}).filter(([, h]) => h !== null);
@@ -416,7 +394,7 @@ const invariants: Invariant[] = [
           if (!snap) {
             violations.push({
               key: r.id,
-              detail: `carimbo ${stampedKey} [${r.version_inferred_from}] não existe na timeline do schema_change_log`,
+              detail: `carimbo ${stampedKey} não existe na timeline do schema_change_log`,
             });
             continue;
           }
@@ -424,7 +402,7 @@ const invariants: Invariant[] = [
           if (epochHashes === 0) {
             violations.push({
               key: r.id,
-              detail: `carimbo ${stampedKey} [${r.version_inferred_from}] sem nenhum hash da própria época (0/${nonNull.length})`,
+              detail: `carimbo ${stampedKey} sem nenhum hash da própria época (0/${nonNull.length})`,
             });
           }
         }

--- a/frontend/src/lib/__tests__/schema-backfill.test.ts
+++ b/frontend/src/lib/__tests__/schema-backfill.test.ts
@@ -213,6 +213,63 @@ describe("buildTimelineFromPersistedVersions", () => {
     expect(timeline.hashesByVersion.get("0.11.1")?.campo1).toBe(hashV2);
   });
 
+  // Duas propriedades da síntese que um prefixo de uma só entry não distingue:
+  // ela ACUMULA ao longo do prefixo (não recomeça de 0.1.0 a cada entry) e
+  // REANCORA na última versão vista, de modo que uma entry NULL depois de uma
+  // gravada continua de lá. Sem isso a síntese voltaria para a casa dos 0.2.x
+  // depois de uma persistida 0.11.0 e a própria auditoria de ordem acusaria
+  // retrocesso — a timeline inteira do projeto viraria achado.
+  it("a síntese acumula ao longo do prefixo e reancora na última versão gravada", () => {
+    const rows: PersistedLogEntryRow[] = [
+      persistedRow({
+        id: "a",
+        before_value: {},
+        after_value: { type: "text", description: "v0" },
+        created_at: "2026-01-01T00:00:00.000Z",
+        change_type: "minor",
+      }),
+      persistedRow({
+        id: "b",
+        before_value: { description: "v0" },
+        after_value: { description: "v1" },
+        created_at: "2026-01-02T00:00:00.000Z",
+        change_type: "patch",
+      }),
+      persistedRow({
+        id: "c",
+        before_value: { description: "v1" },
+        after_value: { description: "v2" },
+        created_at: "2026-05-01T00:00:00.000Z",
+        change_type: "patch",
+        version_major: 0,
+        version_minor: 11,
+        version_patch: 0,
+      }),
+      persistedRow({
+        id: "d",
+        field_name: "campo2",
+        before_value: { description: "x" },
+        after_value: { description: "y" },
+        created_at: "2026-05-02T00:00:00.000Z",
+        change_type: "patch",
+      }),
+    ];
+    const timeline = buildTimelineFromPersistedVersions(rows, currentFields, {
+      major: 0,
+      minor: 11,
+      patch: 1,
+    });
+    expect(timeline.status).toBe("ok");
+    if (timeline.status !== "ok") return;
+    // Prefixo acumulado: minor → 0.2.0, patch → 0.2.1.
+    expect([...timeline.hashesByVersion.keys()]).toEqual(
+      expect.arrayContaining(["0.2.0", "0.2.1", "0.11.0"]),
+    );
+    // A entry NULL após a gravada continua de 0.11.0, não de 0.2.1.
+    expect(timeline.hashesByVersion.has("0.11.1")).toBe(true);
+    expect(timeline.hashesByVersion.has("0.2.2")).toBe(false);
+  });
+
   it("acusa versão que retrocede em (created_at, id) em vez de reconstruir", () => {
     const retrocede = persistedRow({
       id: "e3",

--- a/frontend/src/lib/__tests__/schema-backfill.test.ts
+++ b/frontend/src/lib/__tests__/schema-backfill.test.ts
@@ -3,10 +3,13 @@ import {
   classifyLogEntries,
   reconstructSnapshotsByVersion,
   matchResponsesToVersions,
+  buildTimelineFromPersistedVersions,
   type LogEntryRow,
   type EnrichedEntry,
+  type PersistedLogEntryRow,
   type ResponseRow,
 } from "@/lib/schema-backfill";
+import { computeFieldHash } from "@/lib/schema-utils";
 import type { PydanticField } from "@/lib/types";
 
 // Testes das funções puras extraídas de runBackfill (issue #392) — sem
@@ -129,6 +132,148 @@ describe("reconstructSnapshotsByVersion", () => {
     });
     expect(snapByVersion.size).toBe(1);
     expect(snapByVersion.get("0.1.0")?.get("campo1")?.description).toBe("v1");
+  });
+});
+
+describe("buildTimelineFromPersistedVersions", () => {
+  // Campo em dois estados: "v1" foi adicionado numa versão e virou "v2" na
+  // seguinte. Os hashes por versão distinguem as duas épocas.
+  const currentFields: PydanticField[] = [
+    { name: "campo1", type: "text", options: null, description: "v2" },
+  ];
+  const hashV1 = computeFieldHash("campo1", "text", null, "v1");
+  const hashV2 = computeFieldHash("campo1", "text", null, "v2");
+
+  function persistedRow(overrides: Partial<PersistedLogEntryRow>): PersistedLogEntryRow {
+    return {
+      ...logRow({}),
+      version_major: null,
+      version_minor: null,
+      version_patch: null,
+      ...overrides,
+    };
+  }
+
+  const addV1 = persistedRow({
+    id: "e1",
+    before_value: {},
+    after_value: { type: "text", description: "v1" },
+    created_at: "2026-05-01T00:00:00.000Z",
+    change_type: "minor",
+    version_major: 0,
+    version_minor: 11,
+    version_patch: 0,
+  });
+  const patchV2 = persistedRow({
+    id: "e2",
+    before_value: { description: "v1" },
+    after_value: { description: "v2" },
+    created_at: "2026-05-02T00:00:00.000Z",
+    change_type: "patch",
+    version_major: 0,
+    version_minor: 11,
+    version_patch: 1,
+  });
+
+  it("usa a escala PERSISTIDA, não a re-derivada por classifyLogEntries", () => {
+    const timeline = buildTimelineFromPersistedVersions([addV1, patchV2], currentFields, {
+      major: 0,
+      minor: 11,
+      patch: 1,
+    });
+    expect(timeline.status).toBe("ok");
+    if (timeline.status !== "ok") return;
+    expect(timeline.hashesByVersion.get("0.11.1")?.campo1).toBe(hashV2);
+    expect(timeline.hashesByVersion.get("0.11.0")?.campo1).toBe(hashV1);
+    // A régua re-derivada daria 0.2.0/0.2.1 para as MESMAS entries: é o
+    // descasamento que faria o carimbo de uma response nunca encontrar época.
+    const rederived = classifyLogEntries([addV1, patchV2]);
+    expect(rederived.finalVersion).toEqual({ major: 0, minor: 2, patch: 1 });
+    expect(timeline.hashesByVersion.has("0.2.1")).toBe(false);
+  });
+
+  it("sintetiza o prefixo pré-versionamento e reancora na primeira versão gravada", () => {
+    const legacyAdd = persistedRow({
+      id: "e0",
+      before_value: {},
+      after_value: { type: "text", description: "v0" },
+      created_at: "2026-01-01T00:00:00.000Z",
+      change_type: null,
+    });
+    const timeline = buildTimelineFromPersistedVersions(
+      [legacyAdd, addV1, patchV2],
+      currentFields,
+      { major: 0, minor: 11, patch: 1 },
+    );
+    expect(timeline.status).toBe("ok");
+    if (timeline.status !== "ok") return;
+    // Entry NULL sintetiza 0.2.0 (bump minor sobre 0.1.0); as gravadas mandam.
+    expect(timeline.hashesByVersion.has("0.2.0")).toBe(true);
+    expect(timeline.hashesByVersion.get("0.11.0")?.campo1).toBe(hashV1);
+    expect(timeline.hashesByVersion.get("0.11.1")?.campo1).toBe(hashV2);
+  });
+
+  it("acusa versão que retrocede em (created_at, id) em vez de reconstruir", () => {
+    const retrocede = persistedRow({
+      id: "e3",
+      before_value: { description: "v2" },
+      after_value: { description: "v3" },
+      created_at: "2026-05-03T00:00:00.000Z",
+      version_major: 0,
+      version_minor: 10,
+      version_patch: 0,
+    });
+    const timeline = buildTimelineFromPersistedVersions(
+      [addV1, patchV2, retrocede],
+      currentFields,
+      { major: 0, minor: 11, patch: 1 },
+    );
+    expect(timeline.status).toBe("non_monotonic");
+  });
+
+  // O critério é não-decrescente, não estritamente crescente: um lote de save
+  // grava várias entries na MESMA versão e isso é o caso normal. Sem este
+  // teste, endurecer a guarda para "estritamente crescente" passaria batido e
+  // reprovaria todo projeto que salva mais de um campo por vez.
+  it("aceita várias entries na mesma versão (lote de um save)", () => {
+    const mesmoLote = persistedRow({
+      id: "e2b",
+      field_name: "campo2",
+      before_value: {},
+      after_value: { type: "text", description: "outro" },
+      created_at: "2026-05-02T00:00:00.000Z",
+      change_type: "patch",
+      version_major: 0,
+      version_minor: 11,
+      version_patch: 1,
+    });
+    const timeline = buildTimelineFromPersistedVersions(
+      [addV1, patchV2, mesmoLote],
+      currentFields,
+      { major: 0, minor: 11, patch: 1 },
+    );
+    expect(timeline.status).toBe("ok");
+  });
+
+  it("acusa projeto cuja versão corrente está atrás da última entry do log", () => {
+    const timeline = buildTimelineFromPersistedVersions([addV1, patchV2], currentFields, {
+      major: 0,
+      minor: 10,
+      patch: 0,
+    });
+    expect(timeline.status).toBe("current_behind_log");
+  });
+
+  it("ancora o snapshot atual na versão do projeto quando ela está à frente do log", () => {
+    const timeline = buildTimelineFromPersistedVersions([addV1, patchV2], currentFields, {
+      major: 1,
+      minor: 0,
+      patch: 0,
+    });
+    expect(timeline.status).toBe("ok");
+    if (timeline.status !== "ok") return;
+    expect(timeline.hashesByVersion.get("1.0.0")?.campo1).toBe(hashV2);
+    expect(timeline.hashesByVersion.get("0.11.0")?.campo1).toBe(hashV1);
   });
 });
 

--- a/frontend/src/lib/schema-backfill.ts
+++ b/frontend/src/lib/schema-backfill.ts
@@ -11,7 +11,7 @@ import {
   isProjectScopedLogEntry,
   type ChangeType,
 } from "@/lib/schema-utils";
-import type { SchemaVersion } from "@/lib/compare-version";
+import { formatVersion, versionGte, type SchemaVersion } from "@/lib/compare-version";
 
 export type FieldSnapshot = Partial<PydanticField> & { name: string };
 
@@ -127,6 +127,150 @@ export function classifyLogEntries(log: LogEntryRow[]): {
   }
 
   return { enriched, finalVersion: current };
+}
+
+export type PersistedLogEntryRow = LogEntryRow & {
+  version_major: number | null;
+  version_minor: number | null;
+  version_patch: number | null;
+};
+
+// `non_monotonic` e `current_behind_log` não são erros de leitura: são estados
+// do banco que quebram a premissa da reconstrução (ver
+// buildTimelineFromPersistedVersions). Voltam como resultado nomeado em vez de
+// exceção ou de um Map incompleto porque quem chama precisa poder reportá-los
+// como achado próprio — reconstruir por cima deles produz snapshot errado, que
+// vira falso positivo silencioso.
+export type PersistedTimeline =
+  | { status: "ok"; hashesByVersion: Map<string, Record<string, string>> }
+  | { status: "non_monotonic"; detail: string }
+  | { status: "current_behind_log"; detail: string };
+
+type TimelineCursor = { key: string; version: Version };
+
+function asChangeType(value: string | null): ChangeType | null {
+  return value === "major" || value === "minor" || value === "patch" ? value : null;
+}
+
+// Devolve a descrição da quebra de ordem, ou null se a entry pode entrar na
+// timeline. Versões iguais em sequência são o normal — um lote de save grava
+// várias entries na mesma versão — então o critério é não-decrescente, não
+// estritamente crescente.
+//
+// Uma única comparação basta para as DUAS quebras que a reconstrução não
+// tolera. O reaparecimento de uma versão já vista (que fundiria num grupo só
+// entries de épocas distintas) não precisa de checagem própria: como a
+// sequência é não-decrescente até aqui, a última versão é também a maior vista,
+// logo qualquer chave já vista e diferente dela é menor — isto é, reaparecer
+// implica retroceder. Uma segunda guarda com um Set de chaves vistas seria
+// inalcançável; medido por mutação em 2026-07-24 (desativá-la mantinha a suíte
+// verde).
+function timelineOrderViolation(
+  entryId: string,
+  key: string,
+  version: Version,
+  prev: TimelineCursor | null,
+): string | null {
+  if (!prev) return null;
+  if (!versionGte(version, prev.version)) {
+    return `entry ${entryId} carrega versão ${key}, anterior à ${prev.key} da entry precedente em (created_at, id)`;
+  }
+  return null;
+}
+
+// Timeline de hashes por versão na ESCALA PERSISTIDA: usa as colunas version_*
+// gravadas no schema_change_log, e não a reclassificação de
+// `classifyLogEntries`.
+//
+// A distinção importa porque as duas são réguas diferentes. `classifyLogEntries`
+// re-deriva o semver do zero (reclassifica patch→minor por fieldDiffIsStructural
+// e bumpa por entry, não por lote de save), então recalcular hoje um log que
+// cresceu desde o último backfill dá uma escala inflada — medido no Zolgensma em
+// 2026-07-24: 0.38.0 re-derivado contra 0.20.0 persistido. Já o valor
+// persistido é o mesmo que `runBackfill` gravou no log e no carimbo das
+// responses dentro da MESMA transação (ver apply_schema_backfill): comparar
+// response contra coluna persistida compara dois lados congelados juntos.
+//
+// O prefixo pré-versionamento (entries com version_major NULL, anteriores à
+// migration 20260420) é sintetizado replicando os bumps a partir de 0.1.0, e
+// cada entry com versão gravada reancora a síntese.
+//
+// PREMISSA VERIFICADA, NÃO ASSUMIDA: `reconstructSnapshotsByVersion` agrupa por
+// versão e reverte os grupos em ordem numérica decrescente, ou seja, trata
+// ordem numérica como ordem cronológica. A síntese por entry pode inflar acima
+// da primeira versão persistida e furar isso de dois modos — interleaving (os
+// grupos revertem fora de ordem e TODOS os snapshots saem errados) e colisão de
+// chave (uma chave sintetizada igual a uma persistida funde grupos
+// cronologicamente distantes). Por isso o log é auditado antes de reconstruir:
+// não-decrescente em (created_at, id) e cada versão contígua. O `log` precisa
+// chegar ordenado por (created_at, id).
+export function buildTimelineFromPersistedVersions(
+  log: PersistedLogEntryRow[],
+  fields: PydanticField[],
+  currentVersion: Version,
+): PersistedTimeline {
+  let synth: Version = { major: 0, minor: 1, patch: 0 };
+  const enriched: EnrichedEntry[] = [];
+  let previous: TimelineCursor | null = null;
+
+  for (const entry of log) {
+    const before = entry.before_value ?? {};
+    const after = entry.after_value ?? {};
+    // `changeType` só governa a síntese do prefixo — `reconstructSnapshotsByVersion`
+    // não o lê. Para entries que já trazem versão gravada ele registra o que o
+    // log diz, sem re-derivar por fieldDiffIsStructural.
+    let changeType: ChangeType;
+    let version: Version;
+    if (entry.version_major !== null) {
+      version = {
+        major: entry.version_major,
+        minor: entry.version_minor ?? 0,
+        patch: entry.version_patch ?? 0,
+      };
+      synth = version;
+      changeType = asChangeType(entry.change_type) ?? "patch";
+    } else {
+      changeType =
+        asChangeType(entry.change_type) ?? (fieldDiffIsStructural(before, after) ? "minor" : "patch");
+      synth = bumpVersion(synth, changeType);
+      version = synth;
+    }
+
+    const key = formatVersion(version);
+    const orderProblem = timelineOrderViolation(entry.id, key, version, previous);
+    if (orderProblem) return { status: "non_monotonic", detail: orderProblem };
+    previous = { key, version };
+
+    enriched.push({
+      id: entry.id,
+      field_name: entry.field_name,
+      before,
+      after,
+      createdAt: new Date(entry.created_at).getTime(),
+      changeType,
+      version,
+    });
+  }
+
+  // A âncora da reconstrução é a versão CORRENTE do projeto, não a da última
+  // entry: `fields` é o estado de agora, então é sob a versão de agora que ele
+  // deve ser registrado. Quando as duas coincidem o resultado é o mesmo; quando
+  // o projeto está à frente (versão avançada sem diff de campo), ancorar na
+  // última entry atribuiria o snapshot atual à chave errada e as responses da
+  // versão corrente cairiam em "não existe na timeline". O projeto atrás do log
+  // é estado impossível — o commit grava os dois na mesma transação — e por
+  // isso volta como achado em vez de ser acomodado.
+  if (previous && !versionGte(currentVersion, previous.version)) {
+    return {
+      status: "current_behind_log",
+      detail: `versão corrente do projeto ${formatVersion(currentVersion)} é anterior à ${previous.key} da última entry do schema_change_log`,
+    };
+  }
+
+  const snapshots = reconstructSnapshotsByVersion(fields, enriched, currentVersion);
+  const hashesByVersion = new Map<string, Record<string, string>>();
+  for (const [key, snap] of snapshots) hashesByVersion.set(key, computeHashesFromSnapshot(snap));
+  return { status: "ok", hashesByVersion };
 }
 
 // Reconstrói o snapshot de campos em cada versão, andando o log de trás para

--- a/frontend/src/lib/schema-backfill.ts
+++ b/frontend/src/lib/schema-backfill.ts
@@ -204,38 +204,45 @@ function timelineOrderViolation(
 // cronologicamente distantes). Por isso o log é auditado antes de reconstruir:
 // não-decrescente em (created_at, id) e cada versão contígua. O `log` precisa
 // chegar ordenado por (created_at, id).
-export function buildTimelineFromPersistedVersions(
+// Resolve a versão de uma entry: a gravada, quando existe, ou a síntese
+// acumulada do prefixo pré-versionamento. `changeType` só governa essa síntese
+// — `reconstructSnapshotsByVersion` não o lê — então para entries que já trazem
+// versão gravada ele apenas registra o que o log diz, sem re-derivar por
+// fieldDiffIsStructural.
+function resolveEntryVersion(
+  entry: PersistedLogEntryRow,
+  synth: Version,
+): { version: Version; changeType: ChangeType } {
+  if (entry.version_major !== null) {
+    return {
+      version: {
+        major: entry.version_major,
+        minor: entry.version_minor ?? 0,
+        patch: entry.version_patch ?? 0,
+      },
+      changeType: asChangeType(entry.change_type) ?? "patch",
+    };
+  }
+  const changeType =
+    asChangeType(entry.change_type) ??
+    (fieldDiffIsStructural(entry.before_value ?? {}, entry.after_value ?? {}) ? "minor" : "patch");
+  return { version: bumpVersion(synth, changeType), changeType };
+}
+
+function enrichWithPersistedVersions(
   log: PersistedLogEntryRow[],
-  fields: PydanticField[],
-  currentVersion: Version,
-): PersistedTimeline {
-  let synth: Version = { major: 0, minor: 1, patch: 0 };
+):
+  | { status: "ok"; enriched: EnrichedEntry[]; last: TimelineCursor | null }
+  | { status: "non_monotonic"; detail: string } {
   const enriched: EnrichedEntry[] = [];
   let previous: TimelineCursor | null = null;
 
   for (const entry of log) {
-    const before = entry.before_value ?? {};
-    const after = entry.after_value ?? {};
-    // `changeType` só governa a síntese do prefixo — `reconstructSnapshotsByVersion`
-    // não o lê. Para entries que já trazem versão gravada ele registra o que o
-    // log diz, sem re-derivar por fieldDiffIsStructural.
-    let changeType: ChangeType;
-    let version: Version;
-    if (entry.version_major !== null) {
-      version = {
-        major: entry.version_major,
-        minor: entry.version_minor ?? 0,
-        patch: entry.version_patch ?? 0,
-      };
-      synth = version;
-      changeType = asChangeType(entry.change_type) ?? "patch";
-    } else {
-      changeType =
-        asChangeType(entry.change_type) ?? (fieldDiffIsStructural(before, after) ? "minor" : "patch");
-      synth = bumpVersion(synth, changeType);
-      version = synth;
-    }
-
+    const { version, changeType } = resolveEntryVersion(entry, previous?.version ?? {
+      major: 0,
+      minor: 1,
+      patch: 0,
+    });
     const key = formatVersion(version);
     const orderProblem = timelineOrderViolation(entry.id, key, version, previous);
     if (orderProblem) return { status: "non_monotonic", detail: orderProblem };
@@ -244,13 +251,24 @@ export function buildTimelineFromPersistedVersions(
     enriched.push({
       id: entry.id,
       field_name: entry.field_name,
-      before,
-      after,
+      before: entry.before_value ?? {},
+      after: entry.after_value ?? {},
       createdAt: new Date(entry.created_at).getTime(),
       changeType,
       version,
     });
   }
+
+  return { status: "ok", enriched, last: previous };
+}
+
+export function buildTimelineFromPersistedVersions(
+  log: PersistedLogEntryRow[],
+  fields: PydanticField[],
+  currentVersion: Version,
+): PersistedTimeline {
+  const audited = enrichWithPersistedVersions(log);
+  if (audited.status !== "ok") return audited;
 
   // A âncora da reconstrução é a versão CORRENTE do projeto, não a da última
   // entry: `fields` é o estado de agora, então é sob a versão de agora que ele
@@ -260,14 +278,15 @@ export function buildTimelineFromPersistedVersions(
   // versão corrente cairiam em "não existe na timeline". O projeto atrás do log
   // é estado impossível — o commit grava os dois na mesma transação — e por
   // isso volta como achado em vez de ser acomodado.
-  if (previous && !versionGte(currentVersion, previous.version)) {
+  const last = audited.last;
+  if (last && !versionGte(currentVersion, last.version)) {
     return {
       status: "current_behind_log",
-      detail: `versão corrente do projeto ${formatVersion(currentVersion)} é anterior à ${previous.key} da última entry do schema_change_log`,
+      detail: `versão corrente do projeto ${formatVersion(currentVersion)} é anterior à ${last.key} da última entry do schema_change_log`,
     };
   }
 
-  const snapshots = reconstructSnapshotsByVersion(fields, enriched, currentVersion);
+  const snapshots = reconstructSnapshotsByVersion(fields, audited.enriched, currentVersion);
   const hashesByVersion = new Map<string, Record<string, string>>();
   for (const [key, snap] of snapshots) hashesByVersion.set(key, computeHashesFromSnapshot(snap));
   return { status: "ok", hashesByVersion };


### PR DESCRIPTION
## O que muda

Adiciona a invariante `versao-carimbada-tem-hash-da-propria-epoca` ao `npm run invariants` — o critério de aceite explícito da #579.

Regra: toda response `is_latest` com `schema_version_*` preenchido e ao menos um hash não-nulo em `answer_field_hashes` precisa ter **ao menos um hash que bata com o snapshot da versão carimbada**. Esse é o rastro que uma revisão real sob aquela versão deixa — é justamente o que o critério do #573 (`hasRevision`) garante daqui pra frente. Zero hashes da própria época significa que o carimbo veio de um canal que pulou essa regra. Carimbo apontando para versão inexistente na timeline também acusa.

Fora do escopo por definição, não por conveniência: mapas vazios (o sentinela `{}` das linhas legadas do #528) e mapas só-null não carregam evidência de época — nada a afirmar sobre eles.

### Detalhe que custou uma volta: escala de versão

A timeline de hashes é construída a partir das **colunas `version_*` gravadas no `schema_change_log`**, não de `classifyLogEntries`. Aquela função re-deriva o semver do zero (reclassifica `patch`→`minor` por `fieldDiffIsStructural` e bumpa por *entry*, não por lote de save) e chega numa escala inflada — medido no Zolgensma em 2026-07-24: **0.38.0 re-derivado contra 0.20.0 persistido**. Comparar o carimbo de uma response contra a escala re-derivada compara duas réguas diferentes. O prefixo pré-versionamento (entries com `version_major` NULL, anteriores à migration de 2026-04-20) é sintetizado replicando os bumps a partir de 0.1.0, e cada entry com versão gravada reancora a síntese; no Zolgensma a síntese chega a 0.10.0 e conecta na primeira armazenada, 0.11.0.

## Escopo: só o carimbo do save ao vivo

A invariante roda sobre responses `version_inferred_from = 'live_save'` — o único carimbo que afirma revisão real sob a versão, que é o que o critério do #573 governa. Os outros três valores são inferência retroativa do backfill, e dois deles tornariam a asserção degenerada: `hashes` escolhe a versão MAXIMIZANDO hashes que batem (`findBestHashMatch` exige score > 0), então nunca poderia violar; `fallback_created_at` é o ramo alcançado justamente porque nenhuma versão compatível pontuou, então violaria por construção. A condição que ativaria esse falso positivo é nomeável: rodar o Backfill pela UI num projeto com hashes legados sem correspondência.

## A premissa da reconstrução é verificada, não assumida

`reconstructSnapshotsByVersion` agrupa por versão e reverte em ordem numérica decrescente, isto é, trata ordem numérica como ordem cronológica. A síntese do prefixo bumpa por entry e pode inflar acima da primeira versão persistida, o que faria os grupos reverterem fora de ordem e marcaria em massa linhas honestas. Por isso a timeline é auditada antes de reconstruir; inconsistência volta como achado nomeado do projeto (`non_monotonic` / `current_behind_log`), não como snapshot errado.

A âncora da reconstrução é a versão corrente do projeto, não a da última entry do log: `pydantic_fields` é o estado de agora.

## Prova do vermelho

Invariante contra o banco: mutação da condição de violação (`epochHashes === 0` → `> 0`) dá **FAIL com 607 violações**, provando que o filtro `live_save` não esvaziou o universo. Restaurada: **8/8 PASS**.

Lógica pura (`buildTimelineFromPersistedVersions`, em `schema-backfill.ts` com 7 testes): 6 mutações, cada uma pega por um teste nomeado — retrocesso de versão; projeto atrás do log; âncora na última entry; endurecer para estritamente crescente; escala re-derivada em vez da persistida; síntese sem reancoragem.

Duas guardas caíram ou nasceram por medição, não por leitura. A guarda de contiguidade que eu havia escrito era **inalcançável**: como a sequência é não-decrescente, reaparecer implica retroceder e a primeira comparação já pega — desativá-la mantinha a suíte verde, então foi removida. E a mutação que remove a reancoragem da síntese passava 21/21 até um fixture com prefixo de duas entries NULL e uma NULL depois de uma gravada fechar o buraco.

Suíte 1870/1870; typecheck, lint, fallow, semgrep e e2e smoke verdes.

## Contexto: as #574/#579 não têm reparo a fazer

Este PR nasceu como a peça de repo de um reparo de dados que, medido, se mostrou sem alvo. Resumo da apuração (detalhes no comentário da #574):

- O discriminador das issues reproduz: 617 responses `live_save`, das quais 34 "assimétricas" no Zolgensma.
- Mas as 34 carimbam 0.14.0 / 0.16.4 / 0.18.0 — **nunca** a versão corrente 0.20.0 — com `updated_at` entre março e maio. Com piso `latest_major` = 0.20.0, nenhuma está na fila da Comparação.
- **34/34** têm todo hash não-nulo idêntico ao snapshot da própria versão carimbada: é staleness normal (o schema evoluiu depois do save), não promoção espúria. O `pydantic_hash` delas também é o da época.
- Varredura de todos os projetos: **0** responses com carimbo sem hash da própria época, **0** fora da timeline.

O discriminador de 2026-07-23 comparava os hashes com o schema **atual**, o que marca qualquer linha honestamente codificada sob versão antiga assim que o schema avança. O discriminador correto — comparar com o snapshot da versão carimbada **na própria linha** — é o que esta invariante codifica. Nenhum dado foi escrito.

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Da81JVsscovZD95X52pPp

