### PR TITLE
fix(security): fecha gaps medidos de RLS e superfície de execução (#134)

### DIFF
--- a/docs/security/rls-audit-2026-07.md
+++ b/docs/security/rls-audit-2026-07.md
@@ -1,0 +1,57 @@
+# Auditoria de RLS e da superfície de execução — julho de 2026
+
+Documento de resultado da issue #134. Registra o inventário medido do catálogo, os gaps encontrados, o que foi corrigido nesta passagem e o que ficou deliberadamente de fora, com a razão.
+
+## Metodologia
+
+Todas as contagens abaixo foram medidas contra o banco reconstruído do zero por `npx supabase db reset` em 24/07/2026, sobre as 106 migrations versionadas — não estimadas nem herdadas de auditoria anterior. As invariantes viraram a suíte executável `frontend/supabase/tests/rls_audit.test.sql`, registrada como gate em `scripts/run-db-tests.sh`, de modo que o inventário não é uma fotografia num documento: é um teste que roda a cada `npm run test:db`.
+
+Optei por invariantes **estruturais** em vez de listas de nomes. A asserção não diz "estas 28 tabelas têm RLS"; diz "nenhuma tabela de `public` pode estar sem RLS". A diferença importa: uma tabela nova nasce coberta pelo gate sem ninguém precisar lembrar de adicioná-la a uma lista, que é exatamente o modo de falha que a issue #557 expôs em outra camada.
+
+## Inventário medido
+
+| Objeto | Contagem |
+|---|---|
+| Migrations versionadas e aplicadas | 106 |
+| Tabelas em `public` | 28 |
+| Tabelas com RLS habilitada | 28 (100%) |
+| Views em `public` | 4 |
+| Policies | 64 |
+| Funções em `public` | 79 |
+| Funções `SECURITY DEFINER` | 64 |
+| Foreign keys | 78 |
+| Suítes de contrato SQL | 14 |
+
+## Gaps encontrados e corrigidos
+
+A auditoria partiu de sete invariantes. Cinco já estavam limpas: RLS habilitada em toda tabela, nenhuma tabela com RLS e sem policy exposta a papel de cliente, nenhuma policy literalmente permissiva (`USING (true)`), todas as views com `security_invoker=true` e `anon` sem SELECT em view. As outras duas acusaram quatro gaps, corrigidos pela migration `20260724120000_rls_audit_hardening.sql`.
+
+Em primeiro lugar, **`handle_new_user()` era `SECURITY DEFINER` sem `search_path` fixado**. Numa função DEFINER, `search_path` mutável permite que o chamador escolha em que schema os nomes não qualificados resolvem, e a função grava lá com os privilégios do owner. O corpo já qualificava `public.profiles`, então fixar o path não alterou comportamento algum — apenas fechou o vetor.
+
+Em segundo lugar, **sete funções de trigger eram executáveis por papel de cliente**, isto é, chamáveis como RPC pelo PostgREST: `handle_new_user`, `enforce_project_schema_revision`, `enforce_projects_column_guard`, `enforce_resolver_column_guard`, `enforce_schema_change_log_column_guard`, `recompute_exclusion_pending` e `resolve_exclusion_requests_on_exclude`. Uma função de trigger invocada fora do seu trigger recebe `NEW`/`OLD` nulos e um `TG_OP` inexistente; com DEFINER, grava com os privilégios do owner. O cruzamento com o gap anterior é o achado mais grave desta auditoria: `handle_new_user` aparecia nas duas listas. A correção revoga de `PUBLIC`, não apenas dos papéis nomeados — toda função em `public` nasce com EXECUTE para PUBLIC, e revogar só de `anon` e `authenticated` deixaria a herança intacta, com `has_function_privilege` continuando verdadeiro.
+
+Em terceiro lugar, **`replace_and_add_documents` e `apply_lottery_assignments` eram executáveis por `anon`**, também por herança de PUBLIC. Confirmei por varredura que as duas são chamadas exclusivamente pelo client de sessão (`createSupabaseServer()` em `actions/documents.ts` e `actions/assignments.ts`), nunca pelo admin client nem pelo backend Python. `authenticated` é, portanto, o único papel que precisa de EXECUTE. Manter `anon` significaria aceitar que uma requisição sem sessão chegasse ao corpo da RPC e dependesse apenas do que ela própria valida — defesa em uma camada só.
+
+Por fim, **`remove_answer_key(uuid,text)` sobrevivia sem nenhum call site** em `frontend/src` ou `backend`. RPC alcançável que ninguém chama é superfície de ataque sem contrapartida; foi removida.
+
+## Contrato de autoria para contas-alias (issue #474)
+
+A #474 relatava que uma conta-alias marcando um campo como ambíguo recebia erro enquanto o veredito ficava gravado. **Medi o caso e a premissa não se sustenta mais.** O `author_id` do comentário automático passou a ser a conta autenticada em 11/06/2026, e o #440 tornou `auth_user_project_memberships()` alias-aware — juntos, os dois resolveram o sintoma antes de a issue ser aberta, em 16/07.
+
+O que a medição mostra hoje, com uma conta-alias autenticada: ela herda o acesso ao projeto do membro canônico, **consegue** criar a pendência de ambiguidade sob a própria conta e **consegue** removê-la; e **não consegue** atribuir a autoria ao membro canônico, porque a policy de INSERT exige `author_id = clerk_uid()`.
+
+Esse último ponto é o critério de aceite nº 3 da issue, e ele contradiz a decisão de desenho registrada em `20260716155000`, segundo a qual a conta bruta permanece a fonte de autoria global. Implementá-lo exigiria afrouxar a policy de INSERT sem nenhum bug por trás, então não o tratei como correção. Os três comportamentos ficaram travados como invariantes **pareadas** na suíte: sozinha, cada metade passaria por vácuo.
+
+## Fora de escopo, com razão
+
+O PR #456 original propunha muito mais. Reconstruí apenas o que medi como aplicável; o restante não entrou pelos motivos abaixo, e as medições já feitas estão anexadas às issues de continuação.
+
+As **RPCs atômicas de comparação, auto-revisão e arbitragem** foram construídas pela `main` por outro caminho depois que aquele PR foi escrito — `record_response_equivalences`, `assign_arbitration_cycles_if_eligible`, o outbox de reconciliação. Portar a versão do #456 substituiria trabalho recente e regrediria #416, #490 e #521.
+
+Os **guards de coluna por trigger** carregam um defeito sistemático: o padrão `to_jsonb(NEW) - ARRAY[...]` nunca resulta em `{}` depois que a tabela ganha qualquer coluna, porque `to_jsonb` materializa colunas nulas. Existe reescrita correta (comparar apenas colunas com valor não-nulo), mas é camada fail-closed nova no write path e um dos guards valida `response_snapshot` contra o estado corrente de `responses` — uma resposta que mude entre montar a tela e gravar a review derrubaria o INSERT. Isso exige o tier de verificação com replay antes de entrar.
+
+O **DDL estrutural** (nove `SET NOT NULL` e vinte FKs compostas project-scoped) foi verificado em parte: medi produção e há **zero nulos** nas nove colunas, e confirmei que os embeds `documents!inner` do PostgREST continuam resolvendo após a troca das FKs de coluna única por compostas — a sonda foi validada com um controle, que acusou `PGRST200` num embed inválido. O que não consegui medir foi a divergência cross-project que o `VALIDATE CONSTRAINT` exige; se houver, o comando aborta o deploy. Falta essa medição para o conjunto entrar com segurança.
+
+## Limites desta auditoria
+
+O inventário cobre o schema `public`. Não auditei `auth`, `storage` nem `realtime`, que são geridos pela plataforma. As duas suítes `schema_revision_*` seguem vermelhas e rastreadas nas issues #571 e #572; não fazem parte do gate. As contagens valem para 24/07/2026 — a suíte executável é que as mantém verdadeiras dali em diante.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "test:db:member-permissions": "npm run test:db:psql -- supabase/tests/member_permission_rpcs.test.sql",
     "test:db:column-guard": "npm run test:db:psql -- supabase/tests/project_members_column_guard.test.sql",
     "test:db:unmark-equivalence": "npm run test:db:psql -- supabase/tests/unmark_equivalence_atomic.test.sql",
+    "test:db:rls-audit": "npm run test:db:psql -- supabase/tests/rls_audit.test.sql",
     "test:db:psql": "bash scripts/run-sql-test.sh",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -54,6 +54,7 @@ GATE_SUITES=(
   auto_review_assignment_concurrency
   unmark_equivalence_atomic
   auto_review_reconciliation_outbox
+  rls_audit
 )
 
 # Órfãs quebradas pela era da migration 20260717120000 (índice único one-latest

--- a/frontend/supabase/migrations/20260724120000_rls_audit_hardening.sql
+++ b/frontend/supabase/migrations/20260724120000_rls_audit_hardening.sql
@@ -1,0 +1,96 @@
+-- Endurecimento da superfície de RLS e de execução (issue #134).
+--
+-- Reconstruído sobre a main de 2026-07-24. O PR #456 original foi escrito
+-- contra o modelo de identidade anterior ao #440 e não é aplicável: ele
+-- redefiniria os helpers canônicos, derrubaria policies de escrita que a
+-- arbitragem por ciclos usa hoje (`assign_arbitration_cycles_if_eligible` é
+-- SECURITY INVOKER e passa pela RLS) e colidiria em tipo de retorno com
+-- `remove_response_equivalence`. Esta migration entrega apenas o que foi
+-- MEDIDO como gap real contra o catálogo vigente.
+--
+-- Os quatro achados, medidos em 2026-07-24 com a suíte nova
+-- `supabase/tests/rls_audit.test.sql` rodando contra a main:
+--   1. `handle_new_user()` é SECURITY DEFINER sem `search_path` fixado;
+--   2. sete funções de trigger são executáveis por papel de cliente, isto é,
+--      chamáveis como RPC pelo PostgREST;
+--   3. duas RPCs de domínio são executáveis por `anon`;
+--   4. `remove_answer_key(uuid,text)` sobrevive sem nenhum call site.
+--
+-- O cruzamento de (1) e (2) é o mais grave: `handle_new_user` aparece nas duas
+-- listas, então um cliente não autenticado podia invocar uma função DEFINER de
+-- `search_path` mutável.
+
+-- ========== 1. DEFINER com search_path fixado ==========
+-- `search_path` mutável numa função SECURITY DEFINER é vetor de escalação: o
+-- chamador escolhe o schema onde `profiles` será resolvido e a função grava na
+-- tabela dele com os privilégios do owner. O corpo já qualifica `public.`, então
+-- fixar o path é inócuo para o comportamento e fecha o vetor.
+--
+-- O trigger em auth.users continua disparando independentemente dos grants
+-- abaixo: o Postgres não consulta EXECUTE do usuário sobre a função de trigger.
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email)
+  VALUES (NEW.id, NEW.email);
+  RETURN NEW;
+END;
+$$;
+
+-- ========== 2. Funções de trigger fora da superfície RPC ==========
+-- Toda função em `public` nasce com EXECUTE para PUBLIC, e o PostgREST expõe
+-- como RPC tudo que o papel da requisição pode executar. Uma função de trigger
+-- chamada fora do seu trigger recebe `NEW`/`OLD` nulos ou um TG_OP inexistente
+-- — na melhor hipótese erra, na pior grava com os privilégios do owner.
+--
+-- Revogar de PUBLIC é o que de fato fecha: revogar só de `anon` e
+-- `authenticated` deixaria o grant herdado de PUBLIC intacto e
+-- `has_function_privilege` continuaria verdadeiro.
+--
+-- Nenhuma das sete tem call site em `frontend/src` ou `backend` (medido por
+-- grep em 2026-07-24); todas são acionadas exclusivamente por trigger.
+REVOKE ALL ON FUNCTION public.handle_new_user()
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.enforce_project_schema_revision()
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.enforce_projects_column_guard()
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.enforce_resolver_column_guard()
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.enforce_schema_change_log_column_guard()
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.recompute_exclusion_pending()
+  FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON FUNCTION public.resolve_exclusion_requests_on_exclude()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+-- ========== 3. RPCs de domínio fechadas a anon e service_role ==========
+-- As duas são chamadas exclusivamente pelo client de sessão
+-- (`createSupabaseServer()` em `actions/documents.ts` e `actions/assignments.ts`),
+-- nunca pelo admin client nem pelo backend — medido por grep em 2026-07-24.
+-- Logo `authenticated` é o único papel que precisa de EXECUTE, e a autorização
+-- de fato acontece dentro delas e nas policies das tabelas que tocam.
+--
+-- `anon` tinha EXECUTE por herança de PUBLIC. Manter isso significaria aceitar
+-- que uma requisição sem sessão chegasse ao corpo da RPC e dependesse apenas do
+-- que ela mesma valida — defesa em uma só camada.
+REVOKE ALL ON FUNCTION public.replace_and_add_documents(uuid, uuid[], boolean, jsonb, jsonb)
+  FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.replace_and_add_documents(uuid, uuid[], boolean, jsonb, jsonb)
+  TO authenticated;
+
+REVOKE ALL ON FUNCTION public.apply_lottery_assignments(uuid, text, uuid, jsonb, boolean)
+  FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.apply_lottery_assignments(uuid, text, uuid, jsonb, boolean)
+  TO authenticated;
+
+-- ========== 4. Superfície morta ==========
+-- `remove_answer_key(uuid,text)` não tem call site em `frontend/src` nem em
+-- `backend` (medido em 2026-07-24). Uma RPC alcançável que ninguém chama é
+-- superfície de ataque sem contrapartida — o caminho vivo de remoção de gabarito
+-- passa pelas RPCs de resolução.
+DROP FUNCTION IF EXISTS public.remove_answer_key(uuid, text);

--- a/frontend/supabase/tests/rls_audit.test.sql
+++ b/frontend/supabase/tests/rls_audit.test.sql
@@ -1,0 +1,329 @@
+-- Auditoria de catálogo da superfície de RLS e de execução (issue #134).
+--
+-- Como rodar após `npx supabase db reset`:
+--   docker exec -i supabase_db_frontend psql -U postgres -d postgres \
+--     -X -v ON_ERROR_STOP=1 < supabase/tests/rls_audit.test.sql
+--
+-- As invariantes de catálogo são estruturais: valem para qualquer tabela,
+-- view ou função que exista, sem enumerar nomes. É isso que as torna um
+-- detector — uma tabela nova sem RLS, ou uma função de trigger nova deixada
+-- executável por cliente, derruba o gate sem ninguém precisar lembrar de
+-- adicioná-la a uma lista. O preço é que elas ficam vermelhas quando alguém
+-- introduz o gap, que é exatamente o comportamento desejado.
+--
+-- A segunda metade fixa o contrato de autoria da pendência de ambiguidade para
+-- contas-alias (issue #474), em invariantes PAREADAS: o que a conta-alias
+-- consegue fazer e o que ela não consegue. Uma sozinha passaria por vácuo.
+
+BEGIN;
+
+-- ========== Invariantes de catálogo ==========
+
+DO $$
+DECLARE
+  achado text;
+BEGIN
+  -- Toda tabela de `public` carrega dado de projeto e precisa de RLS. A ausência
+  -- não é degradação parcial: sem RLS a tabela fica legível por qualquer sessão
+  -- autenticada, independentemente das policies das tabelas vizinhas.
+  SELECT relation.relname INTO achado
+  FROM pg_class AS relation
+  WHERE relation.relnamespace = 'public'::regnamespace
+    AND relation.relkind = 'r'
+    AND NOT relation.relrowsecurity
+  ORDER BY 1
+  LIMIT 1;
+  IF achado IS NOT NULL THEN
+    RAISE EXCEPTION 'FALHOU contrato: tabela public sem RLS: %', achado;
+  END IF;
+
+  -- RLS habilitada sem nenhuma policy nega tudo — o que é seguro, mas indica
+  -- tabela exposta a papel de cliente por engano. O par com a invariante acima
+  -- é o que fecha o deny-by-default: uma cobre "sem RLS", a outra "com RLS e
+  -- sem regra".
+  SELECT relation.relname INTO achado
+  FROM pg_class AS relation
+  WHERE relation.relnamespace = 'public'::regnamespace
+    AND relation.relkind = 'r'
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_policy AS policy WHERE policy.polrelid = relation.oid
+    )
+    AND (
+      has_table_privilege(
+        'anon', relation.oid,
+        'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+      )
+      OR has_table_privilege(
+        'authenticated', relation.oid,
+        'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+      )
+    )
+  ORDER BY 1
+  LIMIT 1;
+  IF achado IS NOT NULL THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: tabela sem policy exposta a papel de cliente: %', achado;
+  END IF;
+
+  -- `USING (true)` / `WITH CHECK (true)` numa tabela de projeto anula a RLS sem
+  -- desabilitá-la, o que é pior que não ter policy: o catálogo parece protegido.
+  SELECT policy.tablename || '.' || policy.policyname INTO achado
+  FROM pg_policies AS policy
+  WHERE policy.schemaname = 'public'
+    AND (
+      btrim(lower(coalesce(policy.qual, '')), '() ') = 'true'
+      OR btrim(lower(coalesce(policy.with_check, '')), '() ') = 'true'
+    )
+  ORDER BY 1
+  LIMIT 1;
+  IF achado IS NOT NULL THEN
+    RAISE EXCEPTION 'FALHOU contrato: policy literalmente permissiva: %', achado;
+  END IF;
+
+  -- View sem `security_invoker=true` no PG15 executa com os direitos do dono e
+  -- ignora a RLS das tabelas de base — o furo que motivou a correção de
+  -- final_answers e lottery_doc_stats.
+  SELECT relation.relname INTO achado
+  FROM pg_class AS relation
+  WHERE relation.relnamespace = 'public'::regnamespace
+    AND relation.relkind = 'v'
+    AND NOT (
+      coalesce(relation.reloptions, ARRAY[]::text[])
+      @> ARRAY['security_invoker=true']
+    )
+  ORDER BY 1
+  LIMIT 1;
+  IF achado IS NOT NULL THEN
+    RAISE EXCEPTION 'FALHOU contrato: view sem security_invoker: %', achado;
+  END IF;
+
+  -- SECURITY DEFINER sem `search_path` fixado deixa o chamador escolher em que
+  -- schema os nomes não qualificados resolvem, com os privilégios do owner.
+  SELECT procedure.oid::regprocedure::text INTO achado
+  FROM pg_proc AS procedure
+  WHERE procedure.pronamespace = 'public'::regnamespace
+    AND procedure.prosecdef
+    AND NOT (
+      coalesce(procedure.proconfig, ARRAY[]::text[])
+      @> ARRAY['search_path=""']
+    )
+  ORDER BY 1
+  LIMIT 1;
+  IF achado IS NOT NULL THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: SECURITY DEFINER sem search_path vazio: %', achado;
+  END IF;
+
+  RAISE NOTICE 'OK catálogo: RLS, deny-by-default, policies, views e definers';
+END;
+$$;
+
+DO $$
+DECLARE
+  achado text;
+BEGIN
+  -- O PostgREST expõe como RPC toda função que o papel da requisição pode
+  -- executar. Função de trigger chamada fora do trigger recebe NEW/OLD nulos e
+  -- um TG_OP inexistente; com DEFINER, grava com os privilégios do owner.
+  -- Toda função em `public` nasce com EXECUTE para PUBLIC, então o fechamento
+  -- exige revogar de PUBLIC — revogar só dos papéis nomeados deixa a herança.
+  SELECT procedure.oid::regprocedure::text INTO achado
+  FROM pg_proc AS procedure
+  JOIN pg_trigger AS trigger ON trigger.tgfoid = procedure.oid
+  WHERE procedure.pronamespace = 'public'::regnamespace
+    AND NOT trigger.tgisinternal
+    AND (
+      has_function_privilege('anon', procedure.oid, 'EXECUTE')
+      OR has_function_privilege('authenticated', procedure.oid, 'EXECUTE')
+      OR has_function_privilege('service_role', procedure.oid, 'EXECUTE')
+    )
+  ORDER BY 1
+  LIMIT 1;
+  IF achado IS NOT NULL THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: função de trigger executável por cliente: %', achado;
+  END IF;
+
+  -- As duas RPCs de domínio são chamadas só pelo client de sessão. O par de
+  -- asserções é deliberado: exigir que `authenticated` TENHA execute impede que
+  -- alguém "conserte" a primeira metade revogando de todo mundo e quebrando o
+  -- caminho de produção.
+  IF has_function_privilege(
+       'anon',
+       'public.replace_and_add_documents(uuid,uuid[],boolean,jsonb,jsonb)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'service_role',
+       'public.replace_and_add_documents(uuid,uuid[],boolean,jsonb,jsonb)',
+       'EXECUTE'
+     )
+     OR NOT has_function_privilege(
+       'authenticated',
+       'public.replace_and_add_documents(uuid,uuid[],boolean,jsonb,jsonb)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION 'FALHOU contrato: grants de replace_and_add_documents';
+  END IF;
+
+  IF has_function_privilege(
+       'anon',
+       'public.apply_lottery_assignments(uuid,text,uuid,jsonb,boolean)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'service_role',
+       'public.apply_lottery_assignments(uuid,text,uuid,jsonb,boolean)',
+       'EXECUTE'
+     )
+     OR NOT has_function_privilege(
+       'authenticated',
+       'public.apply_lottery_assignments(uuid,text,uuid,jsonb,boolean)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION 'FALHOU contrato: grants de apply_lottery_assignments';
+  END IF;
+
+  IF has_table_privilege('anon', 'public.final_answers', 'SELECT')
+     OR has_table_privilege('anon', 'public.lottery_doc_stats', 'SELECT') THEN
+    RAISE EXCEPTION 'FALHOU contrato: anon tem SELECT em view de public';
+  END IF;
+
+  -- RPC alcançável sem call site é superfície sem contrapartida.
+  IF to_regprocedure('public.remove_answer_key(uuid,text)') IS NOT NULL THEN
+    RAISE EXCEPTION 'FALHOU contrato: RPC órfã remove_answer_key ainda existe';
+  END IF;
+
+  RAISE NOTICE 'OK superfície: funções de trigger fechadas e RPCs explícitas';
+END;
+$$;
+
+-- ========== Autoria da pendência de ambiguidade para conta-alias (#474) ==========
+-- Fixture mínimo: a conta-alias NÃO é membro; quem é membro é a identidade
+-- canônica. `addMember` impede ativamente que a conta vinculada seja membro
+-- própria, então essa assimetria é o estado normal, não uma borda.
+
+INSERT INTO auth.users (id, email) VALUES
+  ('30000000-0000-0000-0000-000000000001', 'audit-owner@example.test'),
+  ('30000000-0000-0000-0000-000000000002', 'audit-canonical@example.test'),
+  ('30000000-0000-0000-0000-000000000003', 'audit-alias@example.test');
+
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+SELECT id::text, id, 1
+FROM auth.users
+WHERE id::text LIKE '30000000-0000-0000-0000-%';
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('40000000-0000-0000-0000-000000000001', 'Projeto da auditoria',
+   '30000000-0000-0000-0000-000000000001');
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('40000000-0000-0000-0000-000000000001',
+   '30000000-0000-0000-0000-000000000001', 'coordenador'),
+  ('40000000-0000-0000-0000-000000000001',
+   '30000000-0000-0000-0000-000000000002', 'pesquisador');
+
+INSERT INTO public.member_email_links
+  (project_id, member_user_id, email, linked_user_id, created_by)
+VALUES
+  ('40000000-0000-0000-0000-000000000001',
+   '30000000-0000-0000-0000-000000000002',
+   'audit-alias@example.test',
+   '30000000-0000-0000-0000-000000000003',
+   '30000000-0000-0000-0000-000000000001');
+
+INSERT INTO public.documents (id, project_id, text) VALUES
+  ('50000000-0000-0000-0000-000000000001',
+   '40000000-0000-0000-0000-000000000001',
+   'texto da auditoria');
+
+-- O ambiente local não concede DML de `public` por default; o remoto concede.
+-- Os grants abaixo somem no ROLLBACK e mantêm a decisão de visibilidade na RLS.
+GRANT SELECT ON public.profiles, public.projects, public.project_members,
+  public.member_email_links, public.documents, public.reviews,
+  public.project_comments
+  TO authenticated;
+GRANT INSERT, UPDATE, DELETE ON public.project_comments TO authenticated;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"30000000-0000-0000-0000-000000000003","supabase_uid":"30000000-0000-0000-0000-000000000003"}',
+  true
+);
+SET LOCAL ROLE authenticated;
+
+DO $$
+DECLARE
+  removidas integer;
+BEGIN
+  -- Pré-condição: a conta-alias herda o acesso do membro canônico (#440). Sem
+  -- isso as duas asserções seguintes passariam por vácuo, porque a policy
+  -- recusaria tudo por falta de acesso ao projeto, não por autoria.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.auth_user_accessible_project_ids() AS acessivel(project_id)
+    WHERE acessivel.project_id = '40000000-0000-0000-0000-000000000001'
+  ) THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: conta-alias não herda acesso ao projeto do membro canônico';
+  END IF;
+
+  -- Metade 1: a conta-alias CONSEGUE criar a pendência sob a própria conta
+  -- autenticada. É o caminho que `submitVerdict` usa (`author_id = user.id`), e
+  -- foi o que resolveu o sintoma relatado na #474.
+  BEGIN
+    INSERT INTO public.project_comments
+      (project_id, document_id, field_name, author_id, body, kind)
+    VALUES
+      ('40000000-0000-0000-0000-000000000001',
+       '50000000-0000-0000-0000-000000000001',
+       'campo_ambiguo',
+       '30000000-0000-0000-0000-000000000003',
+       'Campo marcado como ambíguo na revisão (aba Comparar).',
+       'ambiguity');
+  EXCEPTION WHEN OTHERS THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: conta-alias não cria a pendência de ambiguidade (% / %)',
+      SQLSTATE, SQLERRM;
+  END;
+
+  -- Metade 2: a mesma conta NÃO consegue atribuir a autoria ao membro canônico.
+  -- A policy de INSERT exige `author_id = clerk_uid()`, e a decisão registrada
+  -- na 20260716155000 é que a conta bruta permanece a fonte de autoria. Trocar
+  -- isso exige afrouxar a policy — mudança de produto, não correção de bug.
+  BEGIN
+    INSERT INTO public.project_comments
+      (project_id, document_id, field_name, author_id, body, kind)
+    VALUES
+      ('40000000-0000-0000-0000-000000000001',
+       '50000000-0000-0000-0000-000000000001',
+       'outro_campo',
+       '30000000-0000-0000-0000-000000000002',
+       'Autoria canônica.',
+       'ambiguity');
+    RAISE EXCEPTION
+      'FALHOU contrato: autoria pelo membro canônico foi aceita sem afrouxar a policy';
+  EXCEPTION
+    WHEN insufficient_privilege THEN
+      NULL;
+  END;
+
+  -- Metade 3: a conta-alias remove a pendência que criou. O alinhamento da
+  -- remoção já existia (20260612090200); a asserção impede que ele regrida.
+  DELETE FROM public.project_comments
+  WHERE project_id = '40000000-0000-0000-0000-000000000001'
+    AND kind = 'ambiguity';
+  GET DIAGNOSTICS removidas = ROW_COUNT;
+  IF removidas <> 1 THEN
+    RAISE EXCEPTION
+      'FALHOU contrato: conta-alias removeu % pendência(s) de ambiguidade, esperado 1',
+      removidas;
+  END IF;
+
+  RAISE NOTICE 'OK conta-alias: cria e remove a pendência, autoria canônica recusada';
+END;
+$$;
+
+RESET ROLE;
+
+ROLLBACK;


### PR DESCRIPTION
Reconstrução do #456 sobre a `main` atual. O PR original foi escrito contra o modelo de identidade anterior ao #440 e **não aplica**: colide em tipo de retorno com `remove_response_equivalence` (42P13 mantendo o timestamp, 42723 renumerando), redefiniria quatro helpers canônicos e derrubaria policies de escrita que a arbitragem por ciclos usa hoje. Este PR entrega apenas o que **medi** como gap real.

## Auditoria (issue #134)

Medida contra o catálogo reconstruído do zero: 106 migrations, 28 tabelas (100% com RLS), 4 views, 64 policies, 79 funções (64 `SECURITY DEFINER`), 78 FKs, 14 suítes.

Cinco invariantes já estavam limpas. Duas acusaram quatro gaps:

1. **`handle_new_user()` era `SECURITY DEFINER` sem `search_path` fixado.** O corpo já qualificava `public.`, então fixar não muda comportamento — só fecha o vetor.
2. **Sete funções de trigger eram executáveis por papel de cliente**, isto é, chamáveis como RPC pelo PostgREST. `handle_new_user` estava nas duas listas — o cruzamento mais grave. A revogação é de `PUBLIC`: toda função nasce com EXECUTE para PUBLIC, e revogar só dos papéis nomeados deixaria a herança intacta.
3. **`replace_and_add_documents` e `apply_lottery_assignments` eram executáveis por `anon`.** Ambas só são chamadas pelo client de sessão (nunca pelo admin nem pelo backend) — `authenticated` basta.
4. **`remove_answer_key(uuid,text)` sem nenhum call site.** Removida.

## Suíte nova como gate

`rls_audit.test.sql` entra em `GATE_SUITES`. As invariantes são **estruturais**, não listas de nomes: uma tabela nova sem RLS, ou uma função de trigger nova deixada aberta, derrubam o gate sem ninguém precisar cadastrá-la — o modo de falha que a #557 expôs em outra camada.

## Contrato de conta-alias (issue #474)

**A premissa da issue não se sustenta mais, e medi isso.** `author_id = user.id` existe desde 11/06 e o #440 tornou `auth_user_project_memberships()` alias-aware; juntos resolveram o sintoma antes de a issue ser aberta (16/07). Medição atual, com conta-alias autenticada: herda o acesso, **cria** a pendência de ambiguidade, **remove** a que criou, e **não consegue** atribuí-la ao membro canônico (42501).

O critério de aceite nº 3 pede autoria canônica — o que contradiz a decisão registrada em `20260716155000` ("a conta bruta continua sendo a fonte de autoria global") e exigiria afrouxar a policy de INSERT sem bug por trás. Não tratei como correção; travei os três comportamentos como invariantes **pareadas** (sozinha, cada metade passa por vácuo).

## Verificação

- `test:db` verde **duas vezes** sobre banco resetado: `PASS=12  FAIL(gate)=0  RED*=2` (as duas RED são #571/#572, pré-existentes), exit code lido diretamente — não através de pipe.
- Fingerprint de migrations **idêntico antes e depois** de cada execução, para descartar interferência das sessões paralelas que compartilham o container.
- **Prova do vermelho**: as 8 invariantes novas provadas por mutação em transações isoladas (função de trigger reaberta, `anon` ganhando EXECUTE, `authenticated` perdendo EXECUTE, RPC órfã ressuscitada, DEFINER perdendo `search_path`, tabela sem RLS, policy `USING (true)`, view sem `security_invoker`). Todas detectadas.
- typecheck, lint (0 erros) e vitest (178 arquivos, 1863 testes) verdes.

O `test:db` do pre-push foi pulado **com autorização explícita**: 2-3 sessões paralelas resetam o banco local compartilhado a cada poucos minutos, e comprovei que as falhas do hook eram contaminação (durante a execução o banco passou a ter 107 migrations com topo `20260725120000`, de outra branch, e a migration deste PR desaparecera). O gate rodou verde nas duas execuções controladas acima.

## Deliberadamente fora de escopo

- **RPCs atômicas de comparação/auto-revisão/arbitragem**: a `main` as construiu por outro caminho depois do #456. Portar regrediria #416, #490 e #521.
- **Guards de coluna por trigger**: o padrão `to_jsonb(NEW) - ARRAY[...]` nunca dá `{}` depois de qualquer `ADD COLUMN`, porque `to_jsonb` materializa colunas nulas. A reescrita correta existe, mas é camada fail-closed nova no write path e um dos guards validaria `response_snapshot` contra o estado corrente de `responses` — resposta que mude entre montar a tela e gravar derrubaria o INSERT. Exige tier com replay.
- **DDL estrutural** (9 `SET NOT NULL`, 20 FKs compostas): medi produção — **zero nulos** nas 9 colunas — e confirmei que os embeds `documents!inner` do PostgREST seguem resolvendo após a troca (sonda validada com controle, que acusou `PGRST200` em embed inválido). Falta medir divergência cross-project, sem a qual o `VALIDATE` pode abortar o deploy.

Os dois últimos viram issues de continuação com as medições anexadas.

Closes #134
