### PR TITLE
fix(security): revoga acesso de anon às views de public (#134)

### DIFF
--- a/frontend/supabase/migrations/20260724140000_revoke_anon_from_public_views.sql
+++ b/frontend/supabase/migrations/20260724140000_revoke_anon_from_public_views.sql
@@ -1,0 +1,42 @@
+-- Fecha o acesso de `anon` às views de `public` (continuação da #134).
+--
+-- A auditoria do #601 rodou contra o catálogo local e passou; rodada contra
+-- PRODUÇÃO, acusou o que o ambiente local não modela — o remoto concede DML por
+-- default no schema public, o local não. Medido em 24/07/2026:
+--
+--   lottery_doc_stats  ->  anon=arwdDxtm   (inclui SELECT)
+--   final_answers      ->  anon=awdDxtm    (sem SELECT, mas com INSERT/UPDATE/DELETE)
+--
+-- O `final_answers` é o caso instrutivo: alguém já revogou o SELECT em algum
+-- momento e deixou os bits de escrita para trás. Uma asserção que olhasse só
+-- SELECT — como a primeira versão desta auditoria — daria o arquivo por limpo.
+--
+-- A exposição efetiva era pequena, porque as quatro views têm
+-- `security_invoker = true` e uma leitura de `anon` esbarra na RLS das tabelas
+-- de base. Isso é o motivo de a correção ser barata, não de ela ser dispensável:
+-- a garantia não deve depender de duas camadas estarem simultaneamente certas.
+--
+-- O REVOKE é varrido sobre TODAS as views de `public`, e não sobre uma lista de
+-- nomes, para que uma view futura nasça fechada mesmo que ninguém lembre de
+-- editar esta migration. `anon` não tem caso de uso em nenhuma delas: toda
+-- leitura do produto passa por sessão autenticada.
+DO $$
+DECLARE
+  view_name text;
+BEGIN
+  FOR view_name IN
+    SELECT relation.oid::regclass::text
+    FROM pg_class AS relation
+    WHERE relation.relnamespace = 'public'::regnamespace
+      AND relation.relkind = 'v'
+    ORDER BY 1
+  LOOP
+    EXECUTE format('REVOKE ALL ON %s FROM anon', view_name);
+  END LOOP;
+END;
+$$;
+
+-- Default privileges: sem isto, a próxima view criada pelo owner volta a nascer
+-- com os grants que o bootstrap do Supabase concede a `anon`, e a varredura
+-- acima vira um reparo que precisa ser repetido a cada view nova.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM anon;

--- a/frontend/supabase/tests/rls_audit.test.sql
+++ b/frontend/supabase/tests/rls_audit.test.sql
@@ -184,9 +184,28 @@ BEGIN
     RAISE EXCEPTION 'FALHOU contrato: grants de apply_lottery_assignments';
   END IF;
 
-  IF has_table_privilege('anon', 'public.final_answers', 'SELECT')
-     OR has_table_privilege('anon', 'public.lottery_doc_stats', 'SELECT') THEN
-    RAISE EXCEPTION 'FALHOU contrato: anon tem SELECT em view de public';
+  -- Varredura sobre TODAS as views e TODOS os privilégios, não sobre uma lista
+  -- de nomes com SELECT. A primeira versão desta asserção checava apenas SELECT
+  -- em `final_answers` e `lottery_doc_stats`, e por isso daria produção por
+  -- limpa: lá, `final_answers` tinha o SELECT revogado mas conservava
+  -- INSERT/UPDATE/DELETE para `anon` (ver 20260724140000).
+  --
+  -- Limitação conhecida: o Supabase local não reproduz os default privileges do
+  -- remoto, então esta asserção passa localmente mesmo quando o remoto viola.
+  -- Ela é uma rede contra regressão introduzida por migration, não substituto de
+  -- auditar o catálogo de produção.
+  SELECT relation.oid::regclass::text INTO achado
+  FROM pg_class AS relation
+  WHERE relation.relnamespace = 'public'::regnamespace
+    AND relation.relkind = 'v'
+    AND has_table_privilege(
+      'anon', relation.oid,
+      'SELECT,INSERT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER'
+    )
+  ORDER BY 1
+  LIMIT 1;
+  IF achado IS NOT NULL THEN
+    RAISE EXCEPTION 'FALHOU contrato: anon tem privilégio em view de public: %', achado;
   END IF;
 
   -- RPC alcançável sem call site é superfície sem contrapartida.


### PR DESCRIPTION
Continuação imediata do #601. A auditoria entregue lá passou no catálogo local; **rodada contra produção, acusou uma violação que o ambiente local não modela** — o remoto concede DML por default no schema `public`, o local não.

Medido em 24/07/2026, por consulta somente-leitura ao catálogo de produção:

```
lottery_doc_stats  ->  anon=arwdDxtm   (inclui SELECT)
final_answers      ->  anon=awdDxtm    (sem SELECT, mas com INSERT/UPDATE/DELETE)
```

`final_answers` é o caso instrutivo: o SELECT já havia sido revogado em algum momento e os bits de escrita ficaram para trás. **A asserção original desta auditoria olhava apenas SELECT em duas views nomeadas, então daria produção por limpa.** A invariante passa a varrer todas as views e todos os privilégios.

A exposição efetiva era pequena: as quatro views têm `security_invoker = true`, então uma leitura de `anon` esbarra na RLS das tabelas de base. Isso é o que torna a correção barata, não o que a torna dispensável — a garantia não deveria depender de duas camadas estarem simultaneamente certas.

## Mudanças

- `REVOKE ALL ... FROM anon` varrido sobre **todas** as views de `public`, não sobre uma lista de nomes, para que uma view futura nasça fechada sem depender de alguém editar a migration.
- `ALTER DEFAULT PRIVILEGES IN SCHEMA public REVOKE ALL ON TABLES FROM anon`, senão a varredura vira um reparo a repetir a cada view nova.
- Invariante de `rls_audit.test.sql` generalizada de "SELECT em duas views" para "qualquer privilégio em qualquer view".

## Limitação registrada

O Supabase local não reproduz os default privileges do remoto, então **esta asserção passa localmente mesmo quando o remoto viola**. Isso está escrito no próprio teste. Ela é rede contra regressão introduzida por migration, não substituto de auditar o catálogo de produção — foi a auditoria de produção que achou este caso.

## Verificação

- `test:db` verde sobre banco resetado: `PASS=13  FAIL(gate)=0  RED*=2` (#571/#572, pré-existentes), exit code lido diretamente.
- Prova do vermelho da invariante nova por mutação em transação isolada: `GRANT SELECT ON public.lottery_doc_stats TO anon` → detectado.

Refs #134
