### PR TITLE
fix(codificação): régua de completude passa a exigir subcampo

### DIFF
--- a/frontend/src/lib/__tests__/coding-completeness.test.ts
+++ b/frontend/src/lib/__tests__/coding-completeness.test.ts
@@ -199,3 +199,115 @@ describe("requiredHumanFields", () => {
     expect(requiredHumanFields(fields, {}, { q1: "h1" }).map((f) => f.name)).toEqual(["q1"]);
   });
 });
+
+// Um campo com subcampos guarda um objeto, e `isFieldAnswered` só checava se o
+// valor era vazio: qualquer objeto não-vazio passava, inclusive um em que o
+// subcampo obrigatório está em branco. O asterisco do FieldRenderer e o texto
+// "pelo menos um" da UI não tinham contrapartida em régua nenhuma — nem aqui,
+// nem no gate inline do saveResponse, nem no backlog de auto-revisão (#491).
+describe("isFieldAnswered — grupos de subcampos", () => {
+  const grupo = (
+    subfields: { key: string; label: string; required?: boolean }[],
+    subfield_rule?: "all" | "at_least_one",
+  ) =>
+    field({
+      name: "q5",
+      type: "text",
+      options: null,
+      subfields,
+      subfield_rule,
+    });
+
+  describe('regra "at_least_one"', () => {
+    const f = grupo(
+      [
+        { key: "doenca", label: "Doença", required: true },
+        { key: "cid", label: "CID", required: true },
+      ],
+      "at_least_one",
+    );
+
+    it("um subcampo preenchido basta", () => {
+      expect(isFieldAnswered(f, { doenca: "AME tipo 1", cid: "" })).toBe(true);
+    });
+
+    it("nenhum subcampo preenchido → não respondido", () => {
+      expect(isFieldAnswered(f, { doenca: "", cid: "" })).toBe(false);
+    });
+
+    it("objeto vazio → não respondido", () => {
+      expect(isFieldAnswered(f, {})).toBe(false);
+    });
+
+    it("só espaço em branco não conta como preenchido", () => {
+      expect(isFieldAnswered(f, { doenca: "   ", cid: "" })).toBe(false);
+    });
+  });
+
+  describe('regra "all" (default)', () => {
+    const f = grupo([
+      { key: "ano", label: "Ano", required: true },
+      { key: "meses", label: "Meses" },
+    ]);
+
+    it("subcampo obrigatório preenchido basta — o opcional não é exigido", () => {
+      expect(isFieldAnswered(f, { ano: "2019", meses: "" })).toBe(true);
+    });
+
+    it("subcampo obrigatório em branco → não respondido", () => {
+      expect(isFieldAnswered(f, { ano: "", meses: "3" })).toBe(false);
+    });
+
+    // O par que impede a régua de virar "todo subcampo é obrigatório": um grupo
+    // sem nenhum subcampo obrigatório continua valendo por presença, como antes.
+    it("grupo sem subcampo obrigatório continua valendo por presença", () => {
+      const semObrigatorio = grupo([{ key: "obs", label: "Observação" }]);
+      expect(isFieldAnswered(semObrigatorio, { obs: "" })).toBe(true);
+    });
+
+    // `required` ausente é opcional (resolveSubfieldRequired), o oposto do
+    // default de campo — não pode ser lido como obrigatório aqui.
+    it("subcampo legado sem a chave `required` não é exigido", () => {
+      const legado = grupo([{ key: "cid", label: "CID" }]);
+      expect(isFieldAnswered(legado, { cid: "" })).toBe(true);
+    });
+  });
+
+  it("a régua sobe para isCodingComplete", () => {
+    const f = grupo([{ key: "cid", label: "CID", required: true }]);
+    expect(isCodingComplete([f], { q5: { cid: "" } })).toBe(false);
+    expect(isCodingComplete([f], { q5: { cid: "G12.0" } })).toBe(true);
+  });
+});
+
+// A fronteira da régua, achada pelo replay com dados de produção: 125
+// codificações concluídas do Zolgensma guardam `q7_idade_paciente` como string
+// porque o campo era texto simples quando foram coletadas e virou grupo depois.
+// `computeFieldHash` exclui as propriedades estruturais de propósito — mexer
+// nelas não invalida resposta já coletada —, então a régua de subcampo não pode
+// ser a peça que rebaixa essas codificações.
+describe("isFieldAnswered — grupo cujo valor foi coletado em outra forma", () => {
+  const grupo = field({
+    name: "q7",
+    type: "text",
+    options: null,
+    subfields: [
+      { key: "ano", label: "Ano", required: true },
+      { key: "meses", label: "Meses", required: true },
+    ],
+    subfield_rule: "at_least_one",
+  });
+
+  it("valor string de antes do grupo continua respondido", () => {
+    expect(isFieldAnswered(grupo, "01 ano")).toBe(true);
+  });
+
+  it("string vazia continua não respondida", () => {
+    expect(isFieldAnswered(grupo, "")).toBe(false);
+  });
+
+  // O par: a tolerância é à FORMA antiga, não ao grupo vazio na forma nova.
+  it("objeto vazio na forma do grupo continua não respondido", () => {
+    expect(isFieldAnswered(grupo, { ano: "", meses: "" })).toBe(false);
+  });
+});

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -1,7 +1,12 @@
 import { isFieldVisible } from "@/lib/conditional";
 import { isIncompleteOther } from "@/lib/other-option";
 import { fieldExistedWhenCoded } from "@/lib/answer-staleness";
-import { resolveRequired, resolveTarget } from "@/lib/pydantic-field";
+import {
+  resolveRequired,
+  resolveSubfieldRequired,
+  resolveSubfieldRule,
+  resolveTarget,
+} from "@/lib/pydantic-field";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 // Campos que o humano precisa responder para a codificação contar como
@@ -39,7 +44,49 @@ export function isFieldAnswered(field: PydanticField, value: unknown): boolean {
     if (value.length === 0) return false;
     if (value.some(isIncompleteOther)) return false;
   }
+  if (field.subfields?.length) return isSubfieldGroupAnswered(field, value);
   return true;
+}
+
+// Um grupo guarda um objeto, e objeto não-vazio sempre passou o check acima —
+// então `{doenca: "x", cid: ""}` contava como respondido mesmo com `cid`
+// obrigatório, e um grupo `at_least_one` sem nada preenchido também. O
+// asterisco do FieldRenderer e o texto "pelo menos um" não tinham
+// contrapartida em régua nenhuma (#491).
+//
+// As duas regras que o schema já declara, e nada além delas: `at_least_one`
+// exige um subcampo qualquer; `all` exige os subcampos marcados como
+// obrigatórios — os demais seguem opcionais, e um grupo sem nenhum obrigatório
+// continua valendo por presença, como antes.
+function isSubfieldGroupAnswered(field: PydanticField, value: unknown): boolean {
+  // A régua vale para o valor NA FORMA que o grupo produz. Um valor de outra
+  // forma — string, tipicamente — é resposta coletada quando o campo ainda era
+  // texto simples, antes de ganhar subcampos, e já era completa sob o schema da
+  // época. Rejeitá-la aqui contradiria a postura que o sistema toma em
+  // `computeFieldHash`, que exclui as propriedades estruturais justamente para
+  // que mexer nelas não invalide resposta já coletada. Medido: sem esta
+  // fronteira, a régua reclassificava 125 codificações concluídas do Zolgensma
+  // e do Judiciário, TODAS por essa mudança de forma e nenhuma por subcampo
+  // obrigatório em branco (harness/2026-07-24-subfield-completeness).
+  if (typeof value !== "object" || Array.isArray(value)) return true;
+  const answers = value as Record<string, unknown>;
+  const subfields = field.subfields ?? [];
+
+  if (resolveSubfieldRule(field.subfield_rule) === "at_least_one") {
+    return subfields.some((sf) => isSubfieldFilled(answers[sf.key]));
+  }
+  return subfields.every(
+    (sf) =>
+      !resolveSubfieldRequired(sf.required) || isSubfieldFilled(answers[sf.key]),
+  );
+}
+
+// Subcampo é sempre texto livre no gerador (`str`/`Optional[str]`), então só
+// espaço em branco é vazio — mesma normalização que `_normalize_optional_str`
+// aplica no backend ao ler o valor de volta.
+function isSubfieldFilled(value: unknown): boolean {
+  if (typeof value === "string") return value.trim() !== "";
+  return value !== undefined && value !== null;
 }
 
 // Campos obrigatórios que ainda faltam — a régua de completude na forma que a UI


### PR DESCRIPTION
## Problema

`isFieldAnswered` devolvia `true` para qualquer objeto não-vazio, então um campo com subcampos contava como respondido mesmo com o subcampo obrigatório em branco (`{doenca: "x", cid: ""}`), e um grupo `at_least_one` contava mesmo sem nada preenchido. O asterisco do `FieldRenderer` e o texto "pelo menos um" da UI não tinham contrapartida em régua nenhuma — nem na UI (`useQuestionValidation`), nem no gate inline do `saveResponse`, nem no backlog de auto-revisão, nem em SQL. Achado na revisão do #587; mesma família do #511 ("gate de presença não valida conteúdo").

## Correção

Passa a valer o que o schema já declara, e nada além:

- `subfield_rule: "at_least_one"` → pelo menos um subcampo com texto não-branco;
- regra `all` (default) → todo subcampo marcado como obrigatório precisa de texto não-branco.

Grupo sem nenhum subcampo obrigatório e subcampo legado sem a chave `required` continuam valendo por presença — `resolveSubfieldRequired` resolve ausente como opcional, o oposto do default de campo. Só espaço em branco conta como vazio, como `_normalize_optional_str` já faz no backend.

## A fronteira veio do replay, não do raciocínio

A primeira versão da regra reclassificava **125 codificações concluídas** do Zolgensma e do Judiciário. O replay classificou todas por causa e a distribuição decidiu o escopo: **125 de 125** por um motivo só — o valor está gravado como string porque o campo era texto simples quando a resposta foi coletada e virou grupo depois — e **zero** por subcampo obrigatório em branco.

Rejeitar essas respostas contradiria a postura que o próprio sistema toma em `computeFieldHash`, que exclui as propriedades estruturais justamente para que mexer nelas não invalide resposta já coletada. Por isso a régua só se aplica ao valor **na forma que o grupo produz**; valor de outra forma segue respondido, com teste fixando que a tolerância é à forma antiga e não ao grupo vazio na forma nova.

(Vale registrar que uma medição anterior, por `jq` sobre o JSON cru, dizia "0 reclassificações": ela filtrava por `type=="object"` e por isso pulava em silêncio exatamente os casos que quebravam. Foi o replay importando a função real que achou.)

## Verificação (write path — tier de `docs/VERIFICATION.md`)

- **Prova do vermelho**: os 5 testes novos falham contra o código atual antes do fix.
- **Mutação braço a braço**, 5 mutantes, todos mortos: `some`→`every` no `at_least_one`; ignorar o `required` na regra `all`; tirar o `trim`; inverter a fronteira da forma antiga; não checar o grupo (comportamento anterior).
- **Replay com dados de produção** sobre as **856 respostas `is_latest`** de todos os projetos, importando `isCodingComplete` em vez de reimplementá-la: **0 reclassificações** (`harness/2026-07-24-subfield-completeness`).
- vitest 1947, typecheck, eslint (só os 2 warnings pré-existentes) e os gates de pre-push.

Nota sobre o e2e: o `coding-save.smoke` falhou nas duas primeiras execuções e passou nas seguintes com o mesmo código. O projeto-fixture não tem nenhum grupo de subcampos, então o ramo novo não executa para ele, e a asserção que caía era a contagem de textareas — sensível ao estado do fixture, não à régua.

Refs #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)