### PR TITLE
fix(codificação): resposta de campo que virou grupo de subcampos fica visível e não é apagada ao editar

### DIFF
--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -11,6 +11,17 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Check, Info, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { OTHER_PREFIX, isOtherValue } from "@/lib/other-option";
@@ -405,9 +416,10 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
 
   // text with subfields
   if (field.type === "text" && field.subfields && field.subfields.length > 0) {
-    const objValue = isSubfieldRecord(value)
-      ? (value as Record<string, string>)
-      : {};
+    // Sem cast: o guard devolve `Record<string, unknown>` e é essa a verdade —
+    // o jsonb pode guardar `{anos: 42}`. A conversão para texto acontece na
+    // leitura do input, uma vez, em vez de ser prometida pelo tipo aqui.
+    const objValue = isSubfieldRecord(value) ? value : {};
     const isNotInformed = value === NOT_INFORMED;
     // Resposta coletada quando o campo ainda era texto simples. A régua de
     // completude a conta como respondida (`coding-completeness.ts`), então ela
@@ -415,7 +427,11 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
     // valor está nesta forma os subcampos ficam inertes, e a única transição
     // para a forma do grupo é o clique num destino nomeado (#607).
     const legacyText = readLegacyGroupText(value);
-    const legacyNoteId = `${subfieldIdPrefix}-legado`;
+    // O id fica no bloco de texto, não na região inteira: `role="note"` inclui
+    // os botões, e um leitor de tela que a usasse como descrição de cada input
+    // anunciaria "Mover para Anos Meses Substituir por..." depois de cada
+    // rótulo. O `aria-describedby` aponta só para a explicação + o valor.
+    const legacyDescriptionId = `${subfieldIdPrefix}-legado-descricao`;
     const subfields = field.subfields;
     // Sob `all`, mover o texto para um subcampo deixa os outros obrigatórios
     // em branco e rebaixa a codificação. É o comportamento correto — a anistia
@@ -426,6 +442,9 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
         ? []
         : subfields.filter((sf) => resolveSubfieldRequired(sf.required));
 
+    // Só entra em cena quando NÃO há texto legado (abaixo), então o ramo que
+    // desmarca (`{}`) é alcançável: quem já está em "Não informada" não tem
+    // texto legado a proteger. A substituição destrutiva mora no aviso.
     const notInformedButton = (
       <Button
         type="button"
@@ -447,12 +466,11 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
         {legacyText !== null && (
           <div
             role="note"
-            id={legacyNoteId}
             className="space-y-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2.5"
           >
             <div className="flex items-start gap-2">
               <Info className="mt-0.5 size-3.5 shrink-0 text-amber-600" />
-              <div className="min-w-0 space-y-1.5">
+              <div id={legacyDescriptionId} className="min-w-0 space-y-1.5">
                 <p className="text-xs text-amber-800 dark:text-amber-300">
                   Resposta registrada antes de esta pergunta ganhar subcampos.
                   Ela continua valendo — nada se perde enquanto você não
@@ -488,7 +506,57 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
               <span className="text-xs text-muted-foreground">
                 Substituir por:
               </span>
-              {notInformedButton}
+              {/* O único caminho que ainda descarta o texto legado, e o único
+                  irreversível: "Mover para" deixa o texto num input à vista,
+                  daí bastar o clique; aqui a resposta anterior some da tela e
+                  do banco. A confirmação é o que impede que um clique errado
+                  faça sozinho o que a tecla deixou de fazer (#607).
+
+                  AlertDialog cru, e não `ConfirmActionDialog`: aquele é
+                  controlado (`open`/`isPending`), desenhado para server
+                  action, e exigiria `useState` AQUI. O `FieldRenderer` não
+                  remonta ao trocar de documento no modo Atribuídos, então
+                  estado próprio vazaria entre documentos; sem `open`, o
+                  diálogo se desmonta junto do aviso quando o valor deixa de
+                  ser legado, e o reset é por construção. */}
+              <AlertDialog>
+                <AlertDialogTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 text-xs"
+                  >
+                    Não informada
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle>
+                      Descartar a resposta anterior?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      A resposta registrada antes de esta pergunta ganhar
+                      subcampos —{" "}
+                      <span className="font-medium text-foreground">
+                        {legacyText}
+                      </span>{" "}
+                      — será substituída por &ldquo;Não informada&rdquo;. Não há
+                      como recuperá-la depois. Para preservar o texto, use
+                      &ldquo;Mover para&rdquo;.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                    <AlertDialogAction
+                      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                      onClick={() => onChange(NOT_INFORMED)}
+                    >
+                      Descartar
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </div>
           </div>
         )}
@@ -528,14 +596,16 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
                 <Input
                   id={`${subfieldIdPrefix}-${sf.key}`}
                   className={cn("text-sm", legacyText !== null && "opacity-60")}
-                  value={legacyText !== null ? "" : objValue[sf.key] || ""}
+                  value={
+                    legacyText !== null ? "" : String(objValue[sf.key] ?? "")
+                  }
                   // `readOnly` é o que impede a perda: sem caminho de tecla,
                   // não há como a digitação emitir um objeto que já perdeu o
                   // texto legado. Mesmo mecanismo que o ramo de texto usa
                   // quando um preset está ativo.
                   readOnly={legacyText !== null}
                   aria-describedby={
-                    legacyText !== null ? legacyNoteId : undefined
+                    legacyText !== null ? legacyDescriptionId : undefined
                   }
                   onChange={(e) =>
                     onChange({ ...objValue, [sf.key]: e.target.value })

--- a/frontend/src/components/coding/FieldRenderer.tsx
+++ b/frontend/src/components/coding/FieldRenderer.tsx
@@ -14,6 +14,8 @@ import {
 import { Check, Info, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { OTHER_PREFIX, isOtherValue } from "@/lib/other-option";
+import { NOT_INFORMED } from "@/lib/sentinels";
+import { isSubfieldRecord, readLegacyGroupText } from "@/lib/subfield-value";
 import {
   arePartsValid,
   buildDateValue,
@@ -34,7 +36,6 @@ interface FieldRendererProps {
   onChange: (value: unknown) => void;
 }
 
-const NOT_INFORMED = "Não informada";
 const otherText = (v: string) => v.slice(OTHER_PREFIX.length);
 
 // Pure handler: backspace on an empty date part jumps focus to the previous
@@ -404,29 +405,96 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
 
   // text with subfields
   if (field.type === "text" && field.subfields && field.subfields.length > 0) {
-    const objValue =
-      value && typeof value === "object" && !Array.isArray(value)
-        ? (value as Record<string, string>)
-        : {};
-    const isNotInformed = value === "Não informada";
+    const objValue = isSubfieldRecord(value)
+      ? (value as Record<string, string>)
+      : {};
+    const isNotInformed = value === NOT_INFORMED;
+    // Resposta coletada quando o campo ainda era texto simples. A régua de
+    // completude a conta como respondida (`coding-completeness.ts`), então ela
+    // precisa estar VISÍVEL — e nenhuma tecla pode descartá-la. Enquanto o
+    // valor está nesta forma os subcampos ficam inertes, e a única transição
+    // para a forma do grupo é o clique num destino nomeado (#607).
+    const legacyText = readLegacyGroupText(value);
+    const legacyNoteId = `${subfieldIdPrefix}-legado`;
+    const subfields = field.subfields;
+    // Sob `all`, mover o texto para um subcampo deixa os outros obrigatórios
+    // em branco e rebaixa a codificação. É o comportamento correto — a anistia
+    // descrevia um valor que ninguém tinha tocado —, mas tem que ser
+    // anunciado antes do clique, não descoberto depois.
+    const requiredSubfields =
+      resolveSubfieldRule(field.subfield_rule) === "at_least_one"
+        ? []
+        : subfields.filter((sf) => resolveSubfieldRequired(sf.required));
+
+    const notInformedButton = (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className={cn(
+          "h-7 text-xs",
+          isNotInformed && "bg-brand-muted text-brand border-brand",
+        )}
+        onClick={() => onChange(isNotInformed ? {} : NOT_INFORMED)}
+      >
+        {isNotInformed && <Check className="mr-1 size-3" />}
+        Não informada
+      </Button>
+    );
 
     return (
       <div className="space-y-2">
-        <div className="flex items-center gap-1.5">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className={cn(
-              "h-7 text-xs",
-              isNotInformed && "bg-brand-muted text-brand border-brand",
-            )}
-            onClick={() => onChange(isNotInformed ? {} : "Não informada")}
+        {legacyText !== null && (
+          <div
+            role="note"
+            id={legacyNoteId}
+            className="space-y-2 rounded-md border border-amber-500/50 bg-amber-500/10 px-3 py-2.5"
           >
-            {isNotInformed && <Check className="mr-1 size-3" />}
-            Não informada
-          </Button>
-          {field.subfield_rule === "at_least_one" && (
+            <div className="flex items-start gap-2">
+              <Info className="mt-0.5 size-3.5 shrink-0 text-amber-600" />
+              <div className="min-w-0 space-y-1.5">
+                <p className="text-xs text-amber-800 dark:text-amber-300">
+                  Resposta registrada antes de esta pergunta ganhar subcampos.
+                  Ela continua valendo — nada se perde enquanto você não
+                  substituir.
+                </p>
+                <p className="text-sm font-medium break-words">{legacyText}</p>
+                {requiredSubfields.length > 0 && (
+                  <p className="text-xs text-amber-800 dark:text-amber-300">
+                    Esta pergunta exige preencher{" "}
+                    {requiredSubfields.map((sf) => sf.label).join(", ")}. Ao
+                    mover o texto para um deles, os outros seguirão pendentes.
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">Mover para:</span>
+              {subfields.map((sf) => (
+                <Button
+                  key={sf.key}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs"
+                  aria-label={`Mover para ${sf.label}`}
+                  onClick={() => onChange({ [sf.key]: legacyText })}
+                >
+                  {sf.label}
+                </Button>
+              ))}
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">
+                Substituir por:
+              </span>
+              {notInformedButton}
+            </div>
+          </div>
+        )}
+        <div className="flex items-center gap-1.5">
+          {legacyText === null && notInformedButton}
+          {resolveSubfieldRule(field.subfield_rule) === "at_least_one" && (
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -444,7 +512,7 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
         </div>
         {!isNotInformed && (
           <div className="space-y-2">
-            {field.subfields.map((sf) => (
+            {subfields.map((sf) => (
               <div key={sf.key} className="flex items-center gap-2">
                 <label
                   htmlFor={`${subfieldIdPrefix}-${sf.key}`}
@@ -459,8 +527,16 @@ export function FieldRenderer({ field, value, onChange }: FieldRendererProps) {
                 </label>
                 <Input
                   id={`${subfieldIdPrefix}-${sf.key}`}
-                  className="text-sm"
-                  value={objValue[sf.key] || ""}
+                  className={cn("text-sm", legacyText !== null && "opacity-60")}
+                  value={legacyText !== null ? "" : objValue[sf.key] || ""}
+                  // `readOnly` é o que impede a perda: sem caminho de tecla,
+                  // não há como a digitação emitir um objeto que já perdeu o
+                  // texto legado. Mesmo mecanismo que o ramo de texto usa
+                  // quando um preset está ativo.
+                  readOnly={legacyText !== null}
+                  aria-describedby={
+                    legacyText !== null ? legacyNoteId : undefined
+                  }
                   onChange={(e) =>
                     onChange({ ...objValue, [sf.key]: e.target.value })
                   }

--- a/frontend/src/components/coding/__tests__/FieldRenderer.test.tsx
+++ b/frontend/src/components/coding/__tests__/FieldRenderer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FieldRenderer } from "@/components/coding/FieldRenderer";
 import type { PydanticField } from "@/lib/types";
@@ -138,6 +138,10 @@ describe("FieldRenderer (grupo de subcampos) — valor legado em texto (#607)", 
       ([emitido]) => !JSON.stringify(emitido ?? null).includes(LEGACY_TEXT),
     );
     expect(perdeuOLegado).toBe(false);
+    // Sem esta linha o caso passaria com ZERO chamadas — `[].some()` é `false`,
+    // e "nenhuma emissão ruim" não distingue "nada se perdeu" de "nada
+    // aconteceu". A sobrevivência é afirmada, não inferida da ausência.
+    expect(screen.getByText(LEGACY_TEXT)).toBeTruthy();
   });
 
   it("mantém os subcampos inertes enquanto o valor for legado", () => {
@@ -162,7 +166,7 @@ describe("FieldRenderer (grupo de subcampos) — valor legado em texto (#607)", 
     expect(lastOnChangeCall(onChange)).toEqual({ anos: LEGACY_TEXT });
   });
 
-  // O mesmo botão que hoje troca o texto legado pela sentinela em um clique
+  // O mesmo botão que antes trocava o texto legado pela sentinela em um clique
   // silencioso. Dentro do aviso, ele fica sob o mesmo enquadramento de ato
   // consciente que os botões de destino.
   it("põe o botão 'Não informada' dentro do aviso, junto das outras substituições", () => {
@@ -173,6 +177,60 @@ describe("FieldRenderer (grupo de subcampos) — valor legado em texto (#607)", 
     const aviso = screen.getByRole("note");
     const naoInformada = screen.getByRole("button", { name: "Não informada" });
     expect(aviso.contains(naoInformada)).toBe(true);
+  });
+
+  // A substituição pela sentinela é o único caminho irreversível que sobrou:
+  // "Mover para" deixa o texto num input à vista, este apaga a resposta.
+  // `pointerEventsCheck: 0` porque o overlay do Radix confunde o userEvent —
+  // mesma razão do DocumentSelector.test.tsx.
+  describe("substituir pela sentinela exige confirmação", () => {
+    const abrirConfirmacao = async () => {
+      const user = userEvent.setup({ pointerEventsCheck: 0 });
+      const onChange = vi.fn();
+      render(
+        <FieldRenderer field={grupo} value={LEGACY_TEXT} onChange={onChange} />,
+      );
+      await user.click(screen.getByRole("button", { name: "Não informada" }));
+      return { user, onChange };
+    };
+
+    // Enquanto o diálogo está em cena o Radix marca o resto da página como
+    // `aria-hidden`, então o aviso sai da árvore de acessibilidade e não dá
+    // para consultá-lo por papel aqui — a sobrevivência do texto é afirmada no
+    // caso do Cancelar, com o diálogo já fechado. O que este caso sustenta é o
+    // essencial: o clique abriu uma pergunta em vez de gravar.
+    it("o clique no botão não descarta o texto sozinho", async () => {
+      const { onChange } = await abrirConfirmacao();
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(await screen.findByRole("alertdialog")).toBeTruthy();
+    });
+
+    it("a confirmação cita o texto que será perdido", async () => {
+      await abrirConfirmacao();
+
+      const dialogo = await screen.findByRole("alertdialog");
+      expect(dialogo.textContent).toContain(LEGACY_TEXT);
+    });
+
+    it("só depois de confirmar a sentinela é gravada", async () => {
+      const { user, onChange } = await abrirConfirmacao();
+
+      await user.click(await screen.findByRole("button", { name: "Descartar" }));
+
+      expect(lastOnChangeCall(onChange)).toBe("Não informada");
+    });
+
+    it("cancelar preserva a resposta anterior", async () => {
+      const { user, onChange } = await abrirConfirmacao();
+
+      await user.click(await screen.findByRole("button", { name: "Cancelar" }));
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(
+        within(screen.getByRole("note")).getByText(LEGACY_TEXT),
+      ).toBeTruthy();
+    });
   });
 
   it("depois de mover, o subcampo seguinte se soma ao que já foi movido", async () => {

--- a/frontend/src/components/coding/__tests__/FieldRenderer.test.tsx
+++ b/frontend/src/components/coding/__tests__/FieldRenderer.test.tsx
@@ -91,3 +91,183 @@ describe("FieldRenderer (date) — race condition regression", () => {
     expect(dayInput.selectionEnd).toBe(2);
   });
 });
+
+// Campo que era `text` simples, ganhou subcampos depois, e cujas respostas
+// antigas continuam gravadas como string. 182 casos medidos em produção
+// (#607). A régua de completude anistia esse valor de propósito
+// (`coding-completeness.ts`, fronteira do #606), então a pergunta aparece com
+// ✓ — e o renderizador precisa concordar com esse ✓ em vez de exibir vazio.
+const LEGACY_TEXT = "18 anos e 6 meses";
+
+const grupo: PydanticField = {
+  name: "q7_idade_paciente",
+  type: "text",
+  options: null,
+  description: "Idade do paciente",
+  subfields: [
+    { key: "anos", label: "Anos" },
+    { key: "meses", label: "Meses" },
+  ],
+  subfield_rule: "at_least_one",
+};
+
+describe("FieldRenderer (grupo de subcampos) — valor legado em texto (#607)", () => {
+  it("exibe na tela o valor coletado antes de o campo virar grupo", () => {
+    render(
+      <FieldRenderer field={grupo} value={LEGACY_TEXT} onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByText(LEGACY_TEXT)).toBeTruthy();
+  });
+
+  // Asserção deliberadamente agnóstica ao mecanismo: não exige que o input
+  // seja `readOnly`, só que nenhum valor emitido pela digitação tenha perdido
+  // o texto legado. Amarrar o teste ao mecanismo o tornaria vácuo no dia em
+  // que a via de escrita mudasse.
+  it("digitar em um subcampo não descarta o valor legado", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <FieldRenderer field={grupo} value={LEGACY_TEXT} onChange={onChange} />,
+    );
+
+    await user.type(screen.getByRole("textbox", { name: /Meses/ }) as HTMLInputElement, "6");
+
+    const perdeuOLegado = onChange.mock.calls.some(
+      ([emitido]) => !JSON.stringify(emitido ?? null).includes(LEGACY_TEXT),
+    );
+    expect(perdeuOLegado).toBe(false);
+  });
+
+  it("mantém os subcampos inertes enquanto o valor for legado", () => {
+    render(
+      <FieldRenderer field={grupo} value={LEGACY_TEXT} onChange={vi.fn()} />,
+    );
+
+    const meses = screen.getByRole("textbox", { name: /Meses/ }) as HTMLInputElement;
+    expect(meses.readOnly).toBe(true);
+  });
+
+  it("só converte por clique, e o destino é o subcampo escolhido", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <FieldRenderer field={grupo} value={LEGACY_TEXT} onChange={onChange} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Mover para Anos/i }));
+
+    expect(lastOnChangeCall(onChange)).toEqual({ anos: LEGACY_TEXT });
+  });
+
+  // O mesmo botão que hoje troca o texto legado pela sentinela em um clique
+  // silencioso. Dentro do aviso, ele fica sob o mesmo enquadramento de ato
+  // consciente que os botões de destino.
+  it("põe o botão 'Não informada' dentro do aviso, junto das outras substituições", () => {
+    render(
+      <FieldRenderer field={grupo} value={LEGACY_TEXT} onChange={vi.fn()} />,
+    );
+
+    const aviso = screen.getByRole("note");
+    const naoInformada = screen.getByRole("button", { name: "Não informada" });
+    expect(aviso.contains(naoInformada)).toBe(true);
+  });
+
+  it("depois de mover, o subcampo seguinte se soma ao que já foi movido", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    const { rerender } = render(
+      <FieldRenderer field={grupo} value={LEGACY_TEXT} onChange={onChange} />,
+    );
+    onChange.mockImplementation((v: unknown) => {
+      rerender(<FieldRenderer field={grupo} value={v} onChange={onChange} />);
+    });
+
+    await user.click(screen.getByRole("button", { name: /Mover para Anos/i }));
+    await user.type(screen.getByRole("textbox", { name: /Meses/ }), "6");
+
+    expect(lastOnChangeCall(onChange)).toEqual({
+      anos: LEGACY_TEXT,
+      meses: "6",
+    });
+  });
+
+  it("anuncia a pendência antes do clique quando a regra é 'all'", () => {
+    const grupoAll: PydanticField = {
+      ...grupo,
+      subfield_rule: "all",
+      subfields: [
+        { key: "anos", label: "Anos", required: true },
+        { key: "meses", label: "Meses", required: true },
+      ],
+    };
+
+    render(
+      <FieldRenderer field={grupoAll} value={LEGACY_TEXT} onChange={vi.fn()} />,
+    );
+
+    expect(screen.getByRole("note").textContent).toContain("Meses");
+  });
+});
+
+// O aviso é para quem tem valor legado. Aparecer para os demais viraria ruído
+// permanente na tela de codificação — e o guard do ramo de subcampos precisa
+// continuar sendo o primeiro a decidir, senão um campo sem subcampos deixa de
+// cair no textarea que hoje exibe o texto corretamente.
+describe("FieldRenderer (grupo de subcampos) — quem não vê o aviso (#607)", () => {
+  it("registro genuíno renderiza normalmente, sem aviso", () => {
+    render(
+      <FieldRenderer field={grupo} value={{ anos: "18" }} onChange={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole("note")).toBeNull();
+    const anos = screen.getByRole("textbox", { name: /Anos/ }) as HTMLInputElement;
+    expect(anos.value).toBe("18");
+    expect(anos.readOnly).toBe(false);
+  });
+
+  it("a sentinela continua sendo a sentinela, não um valor legado", () => {
+    render(
+      <FieldRenderer field={grupo} value="Não informada" onChange={vi.fn()} />,
+    );
+
+    expect(screen.queryByRole("note")).toBeNull();
+    expect(screen.queryByRole("textbox", { name: /Anos/ })).toBeNull();
+  });
+
+  it("campo sem subcampos exibe a string no textarea, como sempre", () => {
+    const semSubcampos: PydanticField = {
+      name: "q7",
+      type: "text",
+      options: null,
+      description: "Idade",
+    };
+
+    render(
+      <FieldRenderer
+        field={semSubcampos}
+        value={LEGACY_TEXT}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByRole("note")).toBeNull();
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe(
+      LEGACY_TEXT,
+    );
+  });
+
+  // Valor fora da forma do grupo e sem texto a mostrar: a régua o anistia, mas
+  // não há evidência para exibir verbatim. Comportamento de hoje preservado.
+  it("valor sem texto legível não fabrica aviso", () => {
+    render(<FieldRenderer field={grupo} value={42} onChange={vi.fn()} />);
+
+    expect(screen.queryByRole("note")).toBeNull();
+    const anos = screen.getByRole("textbox", { name: /Anos/ }) as HTMLInputElement;
+    expect(anos.value).toBe("");
+    expect(anos.readOnly).toBe(false);
+  });
+});

--- a/frontend/src/lib/__tests__/coding-completeness.test.ts
+++ b/frontend/src/lib/__tests__/coding-completeness.test.ts
@@ -310,4 +310,57 @@ describe("isFieldAnswered — grupo cujo valor foi coletado em outra forma", () 
   it("objeto vazio na forma do grupo continua não respondido", () => {
     expect(isFieldAnswered(grupo, { ano: "", meses: "" })).toBe(false);
   });
+
+  // A anistia é MAIS LARGA que o texto legado que o FieldRenderer sabe exibir
+  // (`readLegacyGroupText`): ela alcança qualquer valor fora da forma do grupo.
+  // Estreitá-la para casar com o display rebaixaria codificações que o #606
+  // preservou de propósito — os dois predicados divergem por decisão, não por
+  // descuido (#607).
+  it("a anistia alcança qualquer valor fora da forma do grupo", () => {
+    expect(isFieldAnswered(grupo, 42)).toBe(true);
+    expect(isFieldAnswered(grupo, ["a"])).toBe(true);
+    expect(isFieldAnswered(grupo, "Não informada")).toBe(true);
+  });
+
+  // A ordem dos guards é o que mantém `null` fora da anistia: `typeof null` é
+  // "object", então trocar a fronteira por um predicado que testa null muda o
+  // que aconteceria AQUI se o guard de cima saísse.
+  it("null continua não respondido", () => {
+    expect(isFieldAnswered(grupo, null)).toBe(false);
+  });
+});
+
+// O que acontece quando a pesquisadora move o texto legado para um subcampo
+// (#607). Sob `at_least_one` — a regra dos três campos reais — a codificação
+// segue completa; sob `all` ela é rebaixada, e isso é correto: a anistia
+// descrevia um valor que ninguém tinha tocado, e no formato novo a resposta
+// está de fato incompleta. Por isso o FieldRenderer anuncia a pendência antes
+// do clique em vez de deixá-la ser descoberta depois.
+describe("isFieldAnswered — depois de mover o valor legado para um subcampo", () => {
+  const subfields = [
+    { key: "anos", label: "Anos", required: true },
+    { key: "meses", label: "Meses", required: true },
+  ];
+
+  it("sob at_least_one, mover para um subcampo mantém a codificação completa", () => {
+    const grupo = field({
+      name: "q7",
+      type: "text",
+      options: null,
+      subfields,
+      subfield_rule: "at_least_one",
+    });
+    expect(isFieldAnswered(grupo, { anos: "18 anos e 6 meses" })).toBe(true);
+  });
+
+  it("sob all, mover deixa os outros obrigatórios pendentes", () => {
+    const grupo = field({
+      name: "q7",
+      type: "text",
+      options: null,
+      subfields,
+      subfield_rule: "all",
+    });
+    expect(isFieldAnswered(grupo, { anos: "18 anos e 6 meses" })).toBe(false);
+  });
 });

--- a/frontend/src/lib/__tests__/response-snapshot.test.ts
+++ b/frontend/src/lib/__tests__/response-snapshot.test.ts
@@ -502,6 +502,58 @@ describe("buildPersistedResponseSnapshot", () => {
     expect(result.persistedAnswers).toEqual({ legado: "valor" });
     expect(result.answerFieldHashes).toEqual({ legado: "hash-antigo" });
   });
+
+  // Caracterização do write path para a resposta em texto de um campo que
+  // virou grupo de subcampos (#607). A UI garante que nenhuma tecla descarte
+  // esse valor; aqui se fixa a outra metade da garantia — que a projeção
+  // apresentada ao formulário não seja a via que o elimina. `keepIfStillPresentable`
+  // devolve o valor cru porque esses campos têm `options: null`, e o campo não
+  // revisado fica fora de `changedFieldNames`.
+  describe("grupo de subcampos com valor coletado em outra forma (#607)", () => {
+    const grupo = field({
+      name: "q7",
+      type: "text",
+      options: null,
+      hash: "q7-novo",
+      subfields: [
+        { key: "anos", label: "Anos" },
+        { key: "meses", label: "Meses" },
+      ],
+      subfield_rule: "at_least_one",
+    });
+
+    it("o texto legado sobrevive quando o campo não é tocado", () => {
+      const result = buildPersistedResponseSnapshot({
+        fields: [grupo],
+        existing: {
+          answers: { q7: "18 anos e 6 meses" },
+          hashes: { q7: "q7-antigo" },
+        },
+        rawSubmittedAnswers: { q7: "18 anos e 6 meses" },
+        promoteLegacyIfComplete: false,
+      });
+
+      expect(result.persistedAnswers.q7).toBe("18 anos e 6 meses");
+      // Hash da época preservado: o campo não entrou como revisado.
+      expect(result.answerFieldHashes.q7).toBe("q7-antigo");
+    });
+
+    it("mover o texto para um subcampo grava o registro sob o schema de hoje", () => {
+      const result = buildPersistedResponseSnapshot({
+        fields: [grupo],
+        existing: {
+          answers: { q7: "18 anos e 6 meses" },
+          hashes: { q7: "q7-antigo" },
+        },
+        rawSubmittedAnswers: { q7: { anos: "18 anos e 6 meses" } },
+        promoteLegacyIfComplete: false,
+      });
+
+      expect(result.persistedAnswers.q7).toEqual({ anos: "18 anos e 6 meses" });
+      expect(result.answerFieldHashes.q7).toBe("q7-novo");
+      expect(result.stampsCurrentSchema).toBe(true);
+    });
+  });
 });
 
 describe("buildPersistedResponseSnapshot — stampsCurrentSchema (#529/#548)", () => {

--- a/frontend/src/lib/__tests__/response-snapshot.test.ts
+++ b/frontend/src/lib/__tests__/response-snapshot.test.ts
@@ -509,6 +509,13 @@ describe("buildPersistedResponseSnapshot", () => {
   // apresentada ao formulário não seja a via que o elimina. `keepIfStillPresentable`
   // devolve o valor cru porque esses campos têm `options: null`, e o campo não
   // revisado fica fora de `changedFieldNames`.
+  //
+  // O fixture diverge do #607 real de propósito: `computeFieldHash` é
+  // `name|type|options|description` (schema-utils.ts) e NÃO inclui `subfields`,
+  // então ganhar subcampos não muda o hash — no banco, `q7-antigo` e `q7-novo`
+  // seriam o mesmo valor. Com hashes iguais a asserção não discriminaria nada
+  // ("preservou o da época" e "estampou o de hoje" dariam o mesmo resultado);
+  // a diferença artificial é o que faz o teste distinguir os dois caminhos.
   describe("grupo de subcampos com valor coletado em outra forma (#607)", () => {
     const grupo = field({
       name: "q7",

--- a/frontend/src/lib/__tests__/subfield-value.test.ts
+++ b/frontend/src/lib/__tests__/subfield-value.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isSubfieldRecord, readLegacyGroupText } from "@/lib/subfield-value";
+import { NOT_INFORMED } from "@/lib/sentinels";
+
+describe("isSubfieldRecord", () => {
+  it("reconhece a forma que o grupo produz", () => {
+    expect(isSubfieldRecord({})).toBe(true);
+    expect(isSubfieldRecord({ anos: "18" })).toBe(true);
+  });
+
+  it("rejeita o que não é registro", () => {
+    expect(isSubfieldRecord("01 ano")).toBe(false);
+    expect(isSubfieldRecord(42)).toBe(false);
+    expect(isSubfieldRecord(true)).toBe(false);
+    expect(isSubfieldRecord(["a"])).toBe(false);
+    expect(isSubfieldRecord(undefined)).toBe(false);
+  });
+
+  // `typeof null === "object"`: sem o teste explícito, um valor nulo passaria
+  // por registro e estouraria na primeira leitura de subcampo.
+  it("rejeita null", () => {
+    expect(isSubfieldRecord(null)).toBe(false);
+  });
+});
+
+describe("readLegacyGroupText", () => {
+  it("devolve o texto coletado antes de o campo virar grupo", () => {
+    expect(readLegacyGroupText("18 anos e 6 meses")).toBe("18 anos e 6 meses");
+    expect(readLegacyGroupText("Quase 2 meses")).toBe("Quase 2 meses");
+  });
+
+  // A sentinela também é uma string, mas é a forma CORRENTE de responder o
+  // grupo — não um resíduo do formato antigo. Tratá-la como legado poria a UI
+  // de recuperação na frente de quem respondeu normalmente.
+  it("não confunde a sentinela com valor legado", () => {
+    expect(readLegacyGroupText(NOT_INFORMED)).toBeNull();
+  });
+
+  it("não vê texto onde não há", () => {
+    expect(readLegacyGroupText("")).toBeNull();
+    expect(readLegacyGroupText("   ")).toBeNull();
+    expect(readLegacyGroupText({ anos: "18" })).toBeNull();
+    expect(readLegacyGroupText([])).toBeNull();
+    expect(readLegacyGroupText(null)).toBeNull();
+    expect(readLegacyGroupText(undefined)).toBeNull();
+  });
+});
+
+// Os dois predicados não são complementares, e é de propósito: a régua de
+// completude é permissiva por decreto (anistiar tudo que não seja registro
+// evita rebaixar as codificações do #606), o display é conservador por
+// evidência (só mostra o que é texto de fato). Um número num campo-grupo cai
+// nas duas frestas ao mesmo tempo: não é registro, e não é legado exibível.
+describe("a assimetria entre a régua e o display", () => {
+  it("um valor pode não ser registro e ainda assim não ser legado exibível", () => {
+    expect(isSubfieldRecord(42)).toBe(false);
+    expect(readLegacyGroupText(42)).toBeNull();
+
+    expect(isSubfieldRecord(["a"])).toBe(false);
+    expect(readLegacyGroupText(["a"])).toBeNull();
+  });
+});

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -7,6 +7,7 @@ import {
   resolveSubfieldRule,
   resolveTarget,
 } from "@/lib/pydantic-field";
+import { isSubfieldRecord } from "@/lib/subfield-value";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 // Campos que o humano precisa responder para a codificação contar como
@@ -68,8 +69,13 @@ function isSubfieldGroupAnswered(field: PydanticField, value: unknown): boolean 
   // fronteira, a régua reclassificava 125 codificações concluídas do Zolgensma
   // e do Judiciário, TODAS por essa mudança de forma e nenhuma por subcampo
   // obrigatório em branco (harness/2026-07-24-subfield-completeness).
-  if (typeof value !== "object" || Array.isArray(value)) return true;
-  const answers = value as Record<string, unknown>;
+  //
+  // A fronteira mora em `subfield-value.ts` porque o FieldRenderer decide pela
+  // MESMA leitura o que exibir. Enquanto cada lado a escrevia por conta
+  // própria, a resposta anistiada aqui era a que o renderizador não sabia
+  // mostrar — o ✓ com a tela vazia da #607.
+  if (!isSubfieldRecord(value)) return true;
+  const answers = value;
   const subfields = field.subfields ?? [];
 
   if (resolveSubfieldRule(field.subfield_rule) === "at_least_one") {

--- a/frontend/src/lib/date-parts.ts
+++ b/frontend/src/lib/date-parts.ts
@@ -3,7 +3,7 @@
 // inform (e.g. `XX/03/2024` when only month+year are known). UI exposes
 // these as empty inputs; storage round-trip is preserved by buildDateValue.
 
-const NOT_INFORMED = "Não informada";
+import { NOT_INFORMED } from "@/lib/sentinels";
 
 export type DateParts = [day: string, month: string, year: string];
 export type DatePartName = "day" | "month" | "year";

--- a/frontend/src/lib/sentinels.ts
+++ b/frontend/src/lib/sentinels.ts
@@ -1,0 +1,11 @@
+// Sentinelas gravados no lugar de uma resposta: valores que a pesquisadora
+// escolhe explicitamente para dizer que o documento não traz o dado, em
+// oposição a "ainda não codifiquei".
+//
+// Fonte única porque a comparação é sempre por igualdade EXATA contra conteúdo
+// que já está no banco — nenhum consumidor normaliza acento, caixa ou espaço
+// antes de comparar. Uma cópia que derive num caractere deixa de reconhecer as
+// respostas já gravadas e passa a tratá-las como valor comum, em silêncio.
+// Módulo puro/client-safe (sem React) para ser importado tanto em componentes
+// 'use client' quanto em server actions e testes Vitest.
+export const NOT_INFORMED = "Não informada";

--- a/frontend/src/lib/subfield-value.ts
+++ b/frontend/src/lib/subfield-value.ts
@@ -1,0 +1,41 @@
+// A forma que um campo com `subfields` produz, e o que fazer com um valor que
+// não está nela.
+//
+// Um campo `text` pode ganhar subcampos depois que respostas já foram
+// coletadas; as antigas seguem gravadas como string. A pergunta "este valor
+// está na forma do grupo?" era respondida em dois lugares — na régua de
+// completude e no renderizador de codificação — e cada um tirava dela uma
+// conclusão oposta: a régua anistiava o valor ("respondido"), o renderizador o
+// colapsava em `{}` ("não sei exibir"). O resultado era a pergunta aparecer com
+// ✓ e a tela vazia, e a primeira tecla digitada apagar a resposta (#607). A
+// fronteira mora aqui para que os dois lados leiam o mesmo fato.
+//
+// Módulo puro/client-safe (sem React), no molde de `other-option.ts`, para ser
+// importado tanto em componentes 'use client' quanto em server actions e testes.
+import { NOT_INFORMED } from "@/lib/sentinels";
+
+// A forma do grupo. `null` é objeto para o `typeof`, daí o teste explícito: sem
+// ele, um valor nulo seria tratado como registro e estouraria na primeira
+// leitura de subcampo.
+export function isSubfieldRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// O texto de uma resposta coletada antes de o campo virar grupo, ou `null`
+// quando não há texto legado que valha exibir.
+//
+// Este predicado é mais ESTREITO que a anistia da régua de completude, de
+// propósito, e os dois não são complementares. A régua é permissiva por
+// decreto: anistia tudo que não seja registro — número, boolean, array —
+// porque rejeitar rebaixaria codificações já concluídas (#606). Aqui a régua é
+// a evidência: só existe algo a mostrar, e a mostrar verbatim, quando o valor é
+// texto de fato. Um número solto num campo-grupo não é resposta legada
+// reconhecível, e transformá-lo em texto seria inventar evidência.
+//
+// A sentinela fica de fora porque também é uma string, mas é a forma CORRENTE
+// de responder o grupo ("não informada"), não um resíduo do formato antigo.
+export function readLegacyGroupText(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  if (v === NOT_INFORMED) return null;
+  return v.trim() === "" ? null : v;
+}


### PR DESCRIPTION
Closes #607

## O problema

Três campos de produção eram `type: "text"` simples e ganharam `subfields` depois que respostas já tinham sido coletadas. As antigas seguem gravadas como string. A pergunta aparecia com ✓ e a borda da marca, os inputs renderizavam vazios, e a primeira tecla digitada apagava o texto original em silêncio.

A causa é a **mesma fronteira escrita duas vezes, com conclusões opostas**. A pergunta "este valor está na forma que o grupo produz?" vivia em dois lugares:

- `coding-completeness.ts` — invertida: *"não é objeto ⇒ anistia, conta como respondido"*. Fronteira deliberada do #606; rejeitar reabriria 125 codificações concluídas.
- `FieldRenderer.tsx` — positiva: *"não é objeto ⇒ `{}`, não sei exibir"*, e o spread do `onChange` sobre esse `{}` descartava o texto.

O ✓ com a tela vazia é exatamente essa contradição. Por isso a correção não é só no renderizador: a fronteira passa a existir uma vez só, em `subfield-value.ts`, lida pelos dois lados.

## Alcance medido (refinamento da issue)

A issue relata 182 respostas. Medindo com a classificação que o produto passa a usar (`harness/2026-07-27-subcampo-legado/classificar-legado-vs-sentinela.mts`, read-only), 30 delas são a sentinela `"Não informada"` — que é a forma **corrente** de responder o grupo e nunca esteve quebrada (renderiza hoje com o botão marcado e os subcampos escondidos). O harness original as contava como legado porque a sentinela também é uma string.

| Campo | Texto legado (bug) | Sentinela (nunca afetada) | Objeto |
|---|---|---|---|
| `Zolgensma :: q7_idade_paciente` | 138 | 28 | 87 |
| `Zolgensma :: q5_doenca_paciente` | 14 | 0 | 246 |
| `Zolgensma - Judiciario :: q4_doenca_paciente` | **0** | 2 | 60 |
| **Total** | **152** | **30** | 393 |

`outro-não-objeto = 0`, e 152 + 30 = 182 — a classificação é exaustiva. Nota: os 2 casos do Judiciário eram ambos sentinela, então aquele campo não tem nenhuma ocorrência do bug.

## A correção

No renderizador, o valor legado ganha um **estado próprio** em vez de virar `{}`:

- o texto aparece **verbatim** num aviso âmbar (`role="note"`), identificado como resposta anterior ao formato;
- os subcampos ficam `readOnly` — **sem caminho de tecla, a perda deixa de ser construível**;
- a única transição para a forma do grupo é o clique num **destino nomeado** ("Mover para: [Anos] [Meses]").

Quem escolhe o subcampo é a pesquisadora. Mover para `subfields[0]` por conta própria não perderia o texto, mas gravaria uma atribuição que pode estar errada e que o `at_least_one` nunca mais sinalizaria — e o export passaria de `18 anos e 6 meses` para `anos: 18 anos e 6 meses`. O sistema não adivinha a estrutura.

**Fora do escopo da issue, mesma classe de perda:** o botão "Não informada" trocava o texto legado pela sentinela em um clique silencioso (e um segundo clique o transformava em `{}`). Migra para dentro do aviso, sob "Substituir por:".

**Rebaixamento sob `all`:** mover o texto deixa os outros obrigatórios em branco e a codificação vira incompleta. É correto — a anistia descrevia um valor que ninguém tinha tocado —, então o aviso **anuncia a pendência antes do clique** em vez de deixá-la ser descoberta depois. Os três campos reais usam `at_least_one`, onde não há rebaixamento.

`response-snapshot.ts` **não muda**: `keepIfStillPresentable` já devolve o valor cru (esses campos têm `options: null`) e o campo não revisado fica fora de `changedFieldNames`. O round-trip já era lossless; o que faltava era teste.

## Prova do vermelho

Os cinco casos novos do `FieldRenderer`, rodados contra `origin/main` com os seletores finais:

```
× exibe na tela o valor coletado antes de o campo virar grupo
× digitar em um subcampo não descarta o valor legado
× mantém os subcampos inertes enquanto o valor for legado
× só converte por clique, e o destino é o subcampo escolhido
× põe o botão 'Não informada' dentro do aviso, junto das outras substituições

TestingLibraryElementError: Unable to find an element with the text: 18 anos e 6 meses
AssertionError: expected true to be false      ← perdeuOLegado
AssertionError: expected false to be true      ← readOnly
TestingLibraryElementError: Unable to find an accessible element with the role "button" and name `/Mover para Anos/i`
TestingLibraryElementError: Unable to find an accessible element with the role "note"
      Tests  5 failed | 3 passed (8)
```

O segundo é o que importa como evidência: não falha por falta de elemento na tela, e sim **observando a perda acontecer** — o valor emitido pela primeira tecla já não continha o texto legado. Os outros quatro falham por ausência de UI, que é mais fraco.

**Portão do #606:** o bloco `describe("isFieldAnswered — grupo cujo valor foi coletado em outra forma")` permanece verde **sem uma linha editada** (`git diff` do arquivo vazio nessa região). Era a condição para o refactor da fronteira ser considerado mecânico.

## Verificação

- `vitest`: 187 arquivos, 1988 testes verdes (+21 novos).
- `tsc --noEmit` e `eslint` limpos.
- Gates de pre-push: typecheck, vitest, **e2e smoke**, lint:types, fallow audit, semgrep — todos passaram.
- `npm run invariants`: **13/13 OK**.
- Harness re-medido: as contagens de legado **não caíram** (182 não-objeto, idêntico) — a correção não migra dados.

### O que ainda pede olho humano

- **Risco aceito, não eliminado:** depois que a pesquisadora move o texto, `{anos: "18 anos e 6 meses"}` satisfaz `at_least_one` e o export emite `anos: 18 anos e 6 meses`. Os botões nomeados tornam a atribuição humana; guardar texto e registro lado a lado exigiria inventar formato de armazenamento.
- **Manual sugerido:** num documento real, abrir → conferir o aviso; **trocar de documento no modo Atribuídos** e confirmar que o aviso some (o `FieldRenderer` não remonta ali — é o teste do vazamento de estado, e por isso o desenho não usa `useState`); clicar um destino, recarregar e confirmar que o texto está dentro do input nomeado.

## Commits

1. `refactor` — centraliza a sentinela `"Não informada"` (era 5 declarações). Separado para o diff do fix ler limpo.
2. `fix` — a fronteira compartilhada, o estado legado no renderizador e os testes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017YHMoavA18T7kWQQXXY65g
