### PR TITLE
fix(db): unicidade da resposta humana corrente em `responses` (#609)

### DIFF
--- a/.github/workflows/database-tests.yml
+++ b/.github/workflows/database-tests.yml
@@ -57,8 +57,12 @@ jobs:
         run: npm run test:db:member-permissions
       - name: Column guard de project_members
         run: npm run test:db:column-guard
+      - name: Unicidade da resposta humana corrente
+        run: npm run test:db:responses-human-latest
 
-      # As fixtures deste precisam estar commitadas (duas conexões dblink veem
-      # o mesmo estado), então ele suja o banco e fica por último.
+      # As fixtures destes precisam estar commitadas (duas conexões dblink veem
+      # o mesmo estado), então eles sujam o banco e ficam por último.
       - name: Concorrência da auto-revisão
         run: npm run test:db:auto-review-concurrency
+      - name: Concorrência do save humano
+        run: npm run test:db:responses-human-concurrency

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,8 @@
     "test:db:llm-rate-limit": "npm run test:db:psql -- supabase/tests/llm_rate_limit.test.sql",
     "test:db:member-permissions": "npm run test:db:psql -- supabase/tests/member_permission_rpcs.test.sql",
     "test:db:column-guard": "npm run test:db:psql -- supabase/tests/project_members_column_guard.test.sql",
+    "test:db:responses-human-latest": "npm run test:db:psql -- supabase/tests/responses_one_latest_human.test.sql",
+    "test:db:responses-human-concurrency": "npm run test:db:psql -- supabase/tests/responses_latest_human_concurrency.test.sql",
     "test:db:remove-member": "npm run test:db:psql -- supabase/tests/remove_project_member_self_identity.test.sql",
     "test:db:unmark-equivalence": "npm run test:db:psql -- supabase/tests/unmark_equivalence_atomic.test.sql",
     "test:db:arbitration-reopen": "npm run test:db:psql -- supabase/tests/arbitration_reopen.test.sql",

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -106,7 +106,7 @@ const invariants: Invariant[] = [
   {
     name: "responses-is-latest-unica",
     motivation:
-      "família de duplicatas por corrida/re-import (#490, dedup Zolgensma): no máximo 1 response is_latest por (documento, respondente)",
+      "invariante dos índices responses_one_latest_human_per_document (#609) e responses_one_latest_llm_per_document; até a #609 a regra humana vivia só na aplicação, e a família de duplicatas por corrida/re-import (#490, dedup Zolgensma) nascia daí. FAIL aqui deixou de ser 'mais uma corrida': é índice dropado ou canal de escrita que o contorna",
     run: async () => {
       const rows = await fetchAll<{
         id: string;

--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -51,7 +51,9 @@ GATE_SUITES=(
   llm_rate_limit
   member_permission_rpcs
   project_members_column_guard
+  responses_one_latest_human
   auto_review_assignment_concurrency
+  responses_latest_human_concurrency
   unmark_equivalence_atomic
   auto_review_reconciliation_outbox
   arbitration_reopen

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -828,6 +828,18 @@ describe("saveResponse — unicidade da resposta corrente (#609)", () => {
     expect(state.existingReadCount).toBe(2);
   });
 
+  it("projeto sem schema grava a resposta e NÃO sincroniza fila de codificação", async () => {
+    // Sem campos não há régua de completude a aplicar, então não há status de
+    // assignment a derivar. É o único caso em que o sync é pulado.
+    state.pydanticFields = [];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", {});
+
+    expect(r.success).toBe(true);
+    expect(state.responseInsertPayload).not.toBeNull();
+    expect(state.assignmentUpdatePayload).toBeNull();
+  });
+
   it("falha ao LER a resposta corrente aborta o save — não cria linha nova", async () => {
     // O bug que transformava uma duplicata em série: o erro do SELECT era
     // descartado, `existing` vinha nulo e o save seguia para o INSERT.

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -40,6 +40,17 @@ interface State {
     answers?: Record<string, unknown>;
     answer_field_hashes?: Record<string, string | null> | null;
   } | null;
+  existingResponseError: { message: string; code?: string } | null;
+  // Respostas sucessivas do lookup de `existing`, na ordem das leituras.
+  // Vazia = todas as leituras devolvem `existingResponse`.
+  existingResponseQueue: Array<State["existingResponse"]>;
+  existingReadCount: number;
+  responseUpdateFilters: Array<{ column: string; value: unknown }>;
+  // Quantas linhas o UPDATE por chave lógica afeta. Default: 1 quando há
+  // resposta corrente, 0 quando não há — o que o banco faria.
+  responseUpdateMatchedRows: () => boolean;
+  // Erros devolvidos pelo INSERT, na ordem das tentativas.
+  responseInsertErrorQueue: Array<{ message: string; code?: string }>;
   currentAssignmentStatus: string | null;
   pydanticFields: Array<{
     name: string;
@@ -62,6 +73,12 @@ beforeEach(() => {
     responseUpdatePayload: null,
     assignmentUpdatePayload: null,
     existingResponse: null,
+    existingResponseError: null,
+    existingResponseQueue: [],
+    existingReadCount: 0,
+    responseUpdateFilters: [],
+    responseUpdateMatchedRows: () => state.existingResponse !== null,
+    responseInsertErrorQueue: [],
     currentAssignmentStatus: "pendente",
     pydanticFields: [
       { name: "q1", type: "single", required: true, options: ["a", "b"] },
@@ -125,17 +142,44 @@ vi.mock("@/lib/supabase/server", () => ({
           select: () => {
             const c: Record<string, unknown> = {};
             c.eq = () => c;
-            c.single = async () => ({ data: state.existingResponse });
-            c.maybeSingle = async () => ({ data: state.existingResponse });
+            const read = async () => {
+              state.existingReadCount += 1;
+              // Fila opcional: permite que a releitura do retry veja um estado
+              // diferente do da primeira tentativa, que é o cenário real de
+              // conflito (outra sessão criou a linha no meio).
+              const queued = state.existingResponseQueue?.shift();
+              if (queued !== undefined) return { data: queued, error: null };
+              return { data: state.existingResponse, error: state.existingResponseError };
+            };
+            c.single = read;
+            c.maybeSingle = read;
             return c;
           },
           insert: async (payload: Record<string, unknown>) => {
             state.responseInsertPayload = payload;
-            return { error: null };
+            const err = state.responseInsertErrorQueue?.shift() ?? null;
+            return { error: err };
           },
+          // O canal de escrita passou a ser UPDATE-por-chave-lógica +
+          // .select("id"): o rowcount devolvido aqui é o que decide se o save
+          // cai no INSERT. Registrar os filtros é o que permite provar que a
+          // chave lógica — e não `id` — é quem endereça a linha (#609).
           update: (payload: Record<string, unknown>) => {
             state.responseUpdatePayload = payload;
-            return thenableOk();
+            state.responseUpdateFilters = [];
+            const c: Record<string, unknown> = {};
+            c.eq = (column: string, value: unknown) => {
+              state.responseUpdateFilters.push({ column, value });
+              return c;
+            };
+            c.select = () => ({
+              then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+                resolve({
+                  data: state.responseUpdateMatchedRows() ? [{ id: "resp-1" }] : [],
+                  error: null,
+                }),
+            });
+            return c;
           },
         };
       }
@@ -654,5 +698,145 @@ describe("saveResponse — documento excluído (fora do escopo aprovado)", () =>
     const saveResponse = await loadSaveResponse();
     const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
     expect(r.success).toBe(true);
+  });
+});
+
+describe("saveResponse — unicidade da resposta corrente (#609)", () => {
+  it("UPDATE endereça a linha pela CHAVE LÓGICA, nunca por id", async () => {
+    // Este é o guard que impede a volta ao read-then-write: se o UPDATE
+    // voltasse a filtrar por `existing.id`, quem decidiria INSERT vs UPDATE
+    // seria de novo a leitura, feita em outra transação.
+    state.existingResponse = { id: "resp-1", is_partial: true };
+    const saveResponse = await loadSaveResponse();
+    await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    const columns = state.responseUpdateFilters.map((f) => f.column);
+    expect(columns).toEqual([
+      "project_id",
+      "document_id",
+      "respondent_id",
+      "respondent_type",
+      "is_latest",
+    ]);
+    expect(state.responseUpdateFilters).toContainEqual({
+      column: "respondent_id",
+      value: "user-1",
+    });
+    expect(columns).not.toContain("id");
+    expect(state.responseInsertPayload).toBeNull();
+  });
+
+  it("UPDATE que não afeta linha nenhuma cai para INSERT, mesmo com existing lido", async () => {
+    // A linha foi demovida entre a leitura e a escrita (unificação de membros,
+    // por exemplo). O rowcount é a autoridade, não o `existing`.
+    state.existingResponse = { id: "resp-1", is_partial: true };
+    state.responseUpdateMatchedRows = () => false;
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r.success).toBe(true);
+    expect(state.responseInsertPayload).not.toBeNull();
+    expect(state.responseInsertPayload?.is_latest).toBe(true);
+    expect(state.responseInsertPayload?.respondent_type).toBe("humano");
+  });
+
+  it("23505 do índice humano relê o estado e o segundo payload preserva o que a vencedora gravou", async () => {
+    // Primeira leitura não vê linha -> INSERT -> perde a corrida. A releitura
+    // enxerga a linha da vencedora, e é dela que sai o snapshot preservado
+    // (#484): reaplicar o payload da primeira tentativa apagaria esse valor.
+    //
+    // `q2` guarda um valor que o schema atual não sabe exibir (fora das
+    // opções). É exatamente o caso que o #484 protege: o formulário nunca o
+    // apresentou, então o submit sem ele não significa apagar — e só se
+    // preserva quem leu a linha da vencedora.
+    state.existingResponse = null;
+    state.existingResponseQueue = [
+      null,
+      {
+        id: "resp-vencedora",
+        is_partial: false,
+        answers: { q1: "a", q2: "valor-da-vencedora" },
+        answer_field_hashes: null,
+      },
+    ];
+    state.responseInsertErrorQueue = [
+      {
+        code: "23505",
+        message:
+          'duplicate key value violates unique constraint "responses_one_latest_human_per_document"',
+      },
+    ];
+    // Na segunda volta existe linha corrente, então o UPDATE afeta 1.
+    let attempt = 0;
+    state.responseUpdateMatchedRows = () => {
+      attempt += 1;
+      return attempt > 1;
+    };
+    state.pydanticFields = [
+      { name: "q1", type: "single", required: true, options: ["a", "b"] },
+      { name: "q2", type: "single", options: ["x", "y"] },
+    ];
+
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r.success).toBe(true);
+    expect(state.existingReadCount).toBe(2);
+    const answers = state.responseUpdatePayload?.answers as Record<string, unknown>;
+    expect(answers.q2).toBe("valor-da-vencedora");
+  });
+
+  it("23505 de OUTRA constraint não vira retry — propaga o erro", async () => {
+    state.existingResponse = null;
+    state.responseInsertErrorQueue = [
+      { code: "23505", message: 'duplicate key value violates unique constraint "outra_coisa"' },
+    ];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r.success).toBe(false);
+    expect(state.existingReadCount).toBe(1);
+  });
+
+  it("erro do trigger (23514) propaga sem retry", async () => {
+    state.existingResponse = null;
+    state.responseInsertErrorQueue = [
+      { code: "23514", message: "codificador não pode responder documento em comparação" },
+    ];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r).toEqual({
+      success: false,
+      error: "codificador não pode responder documento em comparação",
+    });
+    expect(state.existingReadCount).toBe(1);
+  });
+
+  it("conflito nas DUAS tentativas devolve erro explícito, sem girar", async () => {
+    state.existingResponse = null;
+    const conflict = {
+      code: "23505",
+      message:
+        'duplicate key value violates unique constraint "responses_one_latest_human_per_document"',
+    };
+    state.responseInsertErrorQueue = [conflict, conflict];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r.success).toBe(false);
+    expect(state.existingReadCount).toBe(2);
+  });
+
+  it("falha ao LER a resposta corrente aborta o save — não cria linha nova", async () => {
+    // O bug que transformava uma duplicata em série: o erro do SELECT era
+    // descartado, `existing` vinha nulo e o save seguia para o INSERT.
+    state.existingResponseError = { message: "timeout ao ler responses" };
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r).toEqual({ success: false, error: "timeout ao ler responses" });
+    expect(state.responseInsertPayload).toBeNull();
+    expect(state.responseUpdatePayload).toBeNull();
   });
 });

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -38,15 +38,27 @@ interface ExistingResponseRow {
 // Fetch profile, existing response, and project config in parallel.
 // O lookup de existing filtra is_latest: após uma unificação de membros o
 // conjunto fundido pode ter respostas antigas (is_latest=false) no mesmo
-// documento — .single() sem o filtro erraria com múltiplas linhas.
+// documento — .single() sem o filtro erraria com múltiplas linhas. Desde a
+// migration 20260727120000 quem garante a linha única é o índice
+// responses_one_latest_human_per_document, não este filtro.
+//
+// O erro DESTA leitura é propagado (existingErr), e não descartado como era
+// até a #609: `existing` ausente por falha de rede/RLS levava o save a
+// construir o snapshot com storedAnswers indefinido, apagando os valores
+// brutos que buildPersistedResponseSnapshot preserva (#484) — e, antes do
+// índice, a criar uma linha duplicada por cima.
 async function fetchSaveContext(
   supabase: SupabaseServerClient,
   projectId: string,
   documentId: string,
   effectiveId: string,
 ) {
-  const [{ data: profile }, { data: existing }, { data: project, error: projErr }, { data: doc }] =
-    await Promise.all([
+  const [
+    { data: profile },
+    { data: existing, error: existingErr },
+    { data: project, error: projErr },
+    { data: doc },
+  ] = await Promise.all([
       supabase
         .from("profiles")
         .select("first_name, last_name")
@@ -75,7 +87,7 @@ async function fetchSaveContext(
         .eq("project_id", projectId)
         .maybeSingle(),
     ]);
-  return { profile, existing, project, projErr, doc };
+  return { profile, existing, existingErr, project, projErr, doc };
 }
 
 interface SaveResponseProjectFields {
@@ -211,9 +223,8 @@ function buildResponsePayload({
   return payload;
 }
 
-interface UpsertResponseRowParams {
+interface PersistResponseRowParams {
   supabase: SupabaseServerClient;
-  existing: { id: string } | null | undefined;
   projectId: string;
   documentId: string;
   effectiveId: string;
@@ -221,21 +232,53 @@ interface UpsertResponseRowParams {
   payload: Record<string, unknown>;
 }
 
-async function upsertResponseRow({
+// "conflict" = outra sessão criou a resposta corrente entre o UPDATE e o
+// INSERT desta. Não é erro do usuário: o save precisa reler e repetir.
+type PersistOutcome = { status: "ok" } | { status: "conflict" } | { status: "error"; error: string };
+
+// O índice único parcial que sustenta o ramo de conflito abaixo. Conferir o
+// nome é o que separa "perdi a corrida, releia" de qualquer outra violação de
+// unicidade que a tabela venha a ter.
+const HUMAN_LATEST_UNIQUE_INDEX = "responses_one_latest_human_per_document";
+
+// Escrita idempotente sobre a CHAVE LÓGICA (#609). O UPDATE filtra pela chave
+// — não por `id` — e o rowcount que ele devolve é quem decide se havia linha
+// corrente; a leitura de `existing` deixou de ser o árbitro dessa decisão e
+// serve só como insumo do snapshot. A diferença importa porque a leitura
+// acontece em outra transação: entre ela e a escrita, a linha pode ter nascido
+// ou sido demovida.
+//
+// Não dá para usar `.upsert({ onConflict })`: o Postgres exige que a
+// inferência do arbiter reproduza o predicado do índice parcial
+// (`ON CONFLICT (...) WHERE ...`), e o `on_conflict` do PostgREST só transporta
+// a lista de colunas. `ON CONFLICT ON CONSTRAINT` também está fora — índice
+// parcial não é constraint. Verificado por EXPLAIN contra o índice parcial do
+// lado LLM: sem o predicado o Postgres responde "there is no unique or
+// exclusion constraint matching the ON CONFLICT specification".
+async function persistResponseRow({
   supabase,
-  existing,
   projectId,
   documentId,
   effectiveId,
   respondentName,
   payload,
-}: UpsertResponseRowParams): Promise<{ error?: string }> {
-  if (existing) {
-    const { error } = await supabase.from("responses").update(payload).eq("id", existing.id);
-    if (error) return { error: error.message };
-    return {};
-  }
-  const { error } = await supabase.from("responses").insert({
+}: PersistResponseRowParams): Promise<PersistOutcome> {
+  // O payload não toca coluna-chave, então este UPDATE não dispara
+  // enforce_comparison_response_actor_trigger, que só observa project_id,
+  // document_id, respondent_id, respondent_type e is_latest.
+  const { data: updated, error: updErr } = await supabase
+    .from("responses")
+    .update(payload)
+    .eq("project_id", projectId)
+    .eq("document_id", documentId)
+    .eq("respondent_id", effectiveId)
+    .eq("respondent_type", "humano")
+    .eq("is_latest", true)
+    .select("id");
+  if (updErr) return { status: "error", error: updErr.message };
+  if (updated && updated.length > 0) return { status: "ok" };
+
+  const { error: insErr } = await supabase.from("responses").insert({
     project_id: projectId,
     document_id: documentId,
     respondent_id: effectiveId,
@@ -244,8 +287,11 @@ async function upsertResponseRow({
     is_latest: true,
     ...payload,
   });
-  if (error) return { error: error.message };
-  return {};
+  if (!insErr) return { status: "ok" };
+  if (insErr.code === "23505" && insErr.message.includes(HUMAN_LATEST_UNIQUE_INDEX)) {
+    return { status: "conflict" };
+  }
+  return { status: "error", error: insErr.message };
 }
 
 // Auto-save nao revalida o RSC tree — evita re-fetch do servidor a cada
@@ -262,6 +308,139 @@ function revalidateAfterSave(projectId: string, isAutoSave: boolean): void {
   revalidateTag(`project-${projectId}-progress`, { expire: 60 });
 }
 
+interface SaveAttemptParams {
+  supabase: SupabaseServerClient;
+  projectId: string;
+  documentId: string;
+  effectiveId: string;
+  userEmail: string;
+  answers: Record<string, unknown>;
+  notes?: string;
+  isAutoSave: boolean;
+}
+
+// Uma tentativa completa de gravação: lê o contexto, monta o snapshot a partir
+// do que está gravado AGORA e persiste. Devolve "conflict" quando outra sessão
+// criou a resposta corrente no meio do caminho.
+//
+// A releitura do contexto faz parte da tentativa de propósito. No retry, o
+// payload da tentativa anterior foi montado com `existing` ausente (foi por
+// isso que ela caiu no INSERT); reaplicá-lo sobrescreveria os `answers` e
+// `answer_field_hashes` que a linha vencedora acabou de gravar — exatamente a
+// proveniência bruta que buildPersistedResponseSnapshot existe para preservar
+// (#484). `is_partial` e `hadCompletedResponse` também dependem do que foi
+// lido, e mudam junto.
+async function runSaveAttempt({
+  supabase,
+  projectId,
+  documentId,
+  effectiveId,
+  userEmail,
+  answers,
+  notes,
+  isAutoSave,
+}: SaveAttemptParams): Promise<SaveResponseResult | { conflict: true }> {
+  const { profile, existing, existingErr, project, projErr, doc } = await fetchSaveContext(
+    supabase,
+    projectId,
+    documentId,
+    effectiveId,
+  );
+
+  if (projErr) return { success: false, error: projErr.message };
+
+  // Falha ao LER a resposta corrente aborta o save. Seguir como se não
+  // existisse gravaria por cima dela um snapshot construído sem os valores
+  // preservados (#484) — perda silenciosa, sem rastro. Falhar fechado aqui é
+  // o que a #609 corrige junto com o índice.
+  if (existingErr) return { success: false, error: existingErr.message };
+
+  // Doc já excluído (soft delete) não aceita mais respostas. Pedido de
+  // exclusão apenas PENDENTE não bloqueia: é reversível e o dado humano
+  // digitado é preservado.
+  if (doc?.excluded_at) {
+    return {
+      success: false,
+      error: "Documento removido do escopo do projeto",
+    };
+  }
+
+  const respondentName =
+    [profile?.first_name, profile?.last_name].filter(Boolean).join(" ") || userEmail;
+
+  const fields = (project?.pydantic_fields as PydanticField[]) || [];
+
+  // O formulário devolve um snapshot sanitizado, não um patch. A reconciliação
+  // compara esse snapshot com a projeção que foi apresentada e preserva o
+  // valor bruto + sua proveniência quando o campo não mudou (#484).
+  const snapshot = buildPersistedResponseSnapshot({
+    fields,
+    existing: existing ? { answers: existing.answers, hashes: existing.answer_field_hashes } : null,
+    rawSubmittedAnswers: answers,
+    // Só um submit explícito atesta a codificação inteira; auto-save não pode
+    // promover uma response legacy à versão corrente (#548).
+    promoteLegacyIfComplete: !isAutoSave,
+  });
+
+  // Régua de completude aplicada UMA vez, ao conjunto que vai ser gravado
+  // (`snapshot.persistedAnswers`) e com o carimbo per-campo da própria escrita —
+  // não ao que a tela mostrava. Dela saem os dois consumidores: o `is_partial`
+  // gravado e o `missingRequired` devolvido ao cliente. Se o schema mudou desde
+  // o carregamento do formulário, é esta contagem que impede o feedback de
+  // sucesso de anunciar uma conclusão que não houve (#519).
+  const missingRequired = missingRequiredHumanFields(
+    fields,
+    snapshot.persistedAnswers,
+    snapshot.answerFieldHashes,
+  ).length;
+
+  const payload = buildResponsePayload({
+    codingIsComplete: missingRequired === 0,
+    answersToPersist: snapshot.persistedAnswers,
+    answerFieldHashes: snapshot.answerFieldHashes,
+    stampsCurrentSchema: snapshot.stampsCurrentSchema,
+    project,
+    existing,
+    isAutoSave,
+    notes,
+  });
+
+  const outcome = await persistResponseRow({
+    supabase,
+    projectId,
+    documentId,
+    effectiveId,
+    respondentName,
+    payload,
+  });
+  if (outcome.status === "error") return { success: false, error: outcome.error };
+  if (outcome.status === "conflict") return { conflict: true };
+
+  if (fields.length > 0) {
+    const { error: syncErr } = await syncCodingAssignmentStatus(supabase, {
+      projectId,
+      documentId,
+      userId: effectiveId,
+      fields,
+      sanitizedAnswers: snapshot.submittedAnswers,
+      isAutoSave,
+      automationMode: project?.automation_mode,
+      hadCompletedResponse: existing?.is_partial === false,
+    });
+    if (syncErr) return { success: false, error: syncErr };
+  }
+
+  revalidateAfterSave(projectId, isAutoSave);
+  return { success: true, missingRequired };
+}
+
+// Duas tentativas, não mais: o conflito só acontece quando outra sessão criou
+// a resposta corrente entre a leitura e a escrita desta, e a segunda tentativa
+// já enxerga essa linha e cai no ramo de UPDATE. Um terceiro conflito seguido
+// indicaria algo além de corrida — girar em cima disso esconderia o problema
+// em vez de reportá-lo.
+const SAVE_ATTEMPTS = 2;
+
 export async function saveResponse(
   projectId: string,
   documentId: string,
@@ -277,94 +456,32 @@ export async function saveResponse(
 
     const supabase = await createSupabaseServer();
 
-    const { profile, existing, project, projErr, doc } = await fetchSaveContext(
-      supabase,
-      projectId,
-      documentId,
-      effectiveId,
-    );
-
-    if (projErr) return { success: false, error: projErr.message };
-
-    // Doc já excluído (soft delete) não aceita mais respostas. Pedido de
-    // exclusão apenas PENDENTE não bloqueia: é reversível e o dado humano
-    // digitado é preservado.
-    if (doc?.excluded_at) {
-      return {
-        success: false,
-        error: "Documento removido do escopo do projeto",
-      };
-    }
-
-    const respondentName =
-      [profile?.first_name, profile?.last_name].filter(Boolean).join(" ") || user.email;
-
-    const fields = (project?.pydantic_fields as PydanticField[]) || [];
-
-    // O formulário devolve um snapshot sanitizado, não um patch. A reconciliação
-    // compara esse snapshot com a projeção que foi apresentada e preserva o
-    // valor bruto + sua proveniência quando o campo não mudou (#484).
-    const snapshot = buildPersistedResponseSnapshot({
-      fields,
-      existing: existing
-        ? { answers: existing.answers, hashes: existing.answer_field_hashes }
-        : null,
-      rawSubmittedAnswers: answers,
-      // Só um submit explícito atesta a codificação inteira; auto-save não pode
-      // promover uma response legacy à versão corrente (#548).
-      promoteLegacyIfComplete: !isAutoSave,
-    });
-
-    // Régua de completude aplicada UMA vez, ao conjunto que vai ser gravado
-    // (`snapshot.persistedAnswers`) e com o carimbo per-campo da própria escrita —
-    // não ao que a tela mostrava. Dela saem os dois consumidores: o `is_partial`
-    // gravado e o `missingRequired` devolvido ao cliente. Se o schema mudou desde
-    // o carregamento do formulário, é esta contagem que impede o feedback de
-    // sucesso de anunciar uma conclusão que não houve (#519).
-    const missingRequired = missingRequiredHumanFields(
-      fields,
-      snapshot.persistedAnswers,
-      snapshot.answerFieldHashes,
-    ).length;
-
-    const payload = buildResponsePayload({
-      codingIsComplete: missingRequired === 0,
-      answersToPersist: snapshot.persistedAnswers,
-      answerFieldHashes: snapshot.answerFieldHashes,
-      stampsCurrentSchema: snapshot.stampsCurrentSchema,
-      project,
-      existing,
-      isAutoSave,
-      notes,
-    });
-
-    const { error: upsertErr } = await upsertResponseRow({
-      supabase,
-      existing,
-      projectId,
-      documentId,
-      effectiveId,
-      respondentName,
-      payload,
-    });
-    if (upsertErr) return { success: false, error: upsertErr };
-
-    if (fields.length > 0) {
-      const { error: syncErr } = await syncCodingAssignmentStatus(supabase, {
+    for (let attempt = 1; attempt <= SAVE_ATTEMPTS; attempt++) {
+      const result = await runSaveAttempt({
+        supabase,
         projectId,
         documentId,
-        userId: effectiveId,
-        fields,
-        sanitizedAnswers: snapshot.submittedAnswers,
+        effectiveId,
+        userEmail: user.email,
+        answers,
+        notes,
         isAutoSave,
-        automationMode: project?.automation_mode,
-        hadCompletedResponse: existing?.is_partial === false,
       });
-      if (syncErr) return { success: false, error: syncErr };
+      if (!("conflict" in result)) return result;
+
+      // Sinal de frequência: se isto aparecer com regularidade nos logs, a
+      // corrida deixou de ser rara e o caso passa a justificar uma RPC
+      // transacional no lugar do par UPDATE/INSERT.
+      console.warn(
+        `[saveResponse] conflito de resposta corrente (tentativa ${attempt}/${SAVE_ATTEMPTS})`,
+        { projectId, documentId, respondentId: effectiveId },
+      );
     }
 
-    revalidateAfterSave(projectId, isAutoSave);
-    return { success: true, missingRequired };
+    return {
+      success: false,
+      error: "Outra gravação desta mesma codificação chegou primeiro; tente novamente",
+    };
   } catch (e) {
     return {
       success: false,

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -1,9 +1,6 @@
 "use server";
 
-import {
-  createSupabaseServer,
-  type SupabaseServerClient,
-} from "@/lib/supabase/server";
+import { createSupabaseServer, type SupabaseServerClient } from "@/lib/supabase/server";
 import { resolveProjectMemberActor } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
@@ -152,10 +149,7 @@ function resolveSchemaProvenance({
   project,
   stampsCurrentSchema,
   existing,
-}: Pick<
-  BuildResponsePayloadParams,
-  "project" | "stampsCurrentSchema" | "existing"
->) {
+}: Pick<BuildResponsePayloadParams, "project" | "stampsCurrentSchema" | "existing">) {
   if (!!existing && !stampsCurrentSchema) return {};
   // O fallback {major 0, minor 1, patch 0} é canônico e vive uma única vez em
   // `deriveProjectVersionContext` — reusá-lo evita a duplicação que o cabeçalho
@@ -186,9 +180,7 @@ function buildResponsePayload({
   const justifications = notes ? { _notes: notes } : null;
 
   const roundIdToPersist =
-    project?.round_strategy === "manual"
-      ? (project?.current_round_id ?? null)
-      : null;
+    project?.round_strategy === "manual" ? (project?.current_round_id ?? null) : null;
 
   // Para humanos is_partial descreve O QUE FOI GRAVADO, não por qual canal a
   // escrita chegou: uma resposta só deixa de ser parcial quando o conjunto
@@ -214,8 +206,7 @@ function buildResponsePayload({
   // deixou de estar completo). A imutabilidade descrita na migration
   // 20260425000000 vale so para o fluxo LLM.
   const submittedBefore = existing?.is_partial === false;
-  const isPartialToWrite =
-    !codingIsComplete || (isAutoSave && !submittedBefore);
+  const isPartialToWrite = !codingIsComplete || (isAutoSave && !submittedBefore);
 
   const payload = {
     answers: answersToPersist,

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -1,6 +1,9 @@
 "use server";
 
-import { createSupabaseServer, type SupabaseServerClient } from "@/lib/supabase/server";
+import {
+  createSupabaseServer,
+  type SupabaseServerClient,
+} from "@/lib/supabase/server";
 import { resolveProjectMemberActor } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import { buildPersistedResponseSnapshot } from "@/lib/response-snapshot";
@@ -59,34 +62,34 @@ async function fetchSaveContext(
     { data: project, error: projErr },
     { data: doc },
   ] = await Promise.all([
-      supabase
-        .from("profiles")
-        .select("first_name, last_name")
-        .eq("id", effectiveId)
-        .single(),
-      supabase
-        .from("responses")
-        .select("id, is_partial, answers, answer_field_hashes")
-        .eq("project_id", projectId)
-        .eq("document_id", documentId)
-        .eq("respondent_id", effectiveId)
-        .eq("respondent_type", "humano")
-        .eq("is_latest", true)
-        .maybeSingle<ExistingResponseRow>(),
-      supabase
-        .from("projects")
-        .select(
-          "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, round_strategy, current_round_id, automation_mode",
-        )
-        .eq("id", projectId)
-        .single(),
-      supabase
-        .from("documents")
-        .select("excluded_at")
-        .eq("id", documentId)
-        .eq("project_id", projectId)
-        .maybeSingle(),
-    ]);
+    supabase
+      .from("profiles")
+      .select("first_name, last_name")
+      .eq("id", effectiveId)
+      .single(),
+    supabase
+      .from("responses")
+      .select("id, is_partial, answers, answer_field_hashes")
+      .eq("project_id", projectId)
+      .eq("document_id", documentId)
+      .eq("respondent_id", effectiveId)
+      .eq("respondent_type", "humano")
+      .eq("is_latest", true)
+      .maybeSingle<ExistingResponseRow>(),
+    supabase
+      .from("projects")
+      .select(
+        "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, round_strategy, current_round_id, automation_mode",
+      )
+      .eq("id", projectId)
+      .single(),
+    supabase
+      .from("documents")
+      .select("excluded_at")
+      .eq("id", documentId)
+      .eq("project_id", projectId)
+      .maybeSingle(),
+  ]);
   return { profile, existing, existingErr, project, projErr, doc };
 }
 
@@ -149,7 +152,10 @@ function resolveSchemaProvenance({
   project,
   stampsCurrentSchema,
   existing,
-}: Pick<BuildResponsePayloadParams, "project" | "stampsCurrentSchema" | "existing">) {
+}: Pick<
+  BuildResponsePayloadParams,
+  "project" | "stampsCurrentSchema" | "existing"
+>) {
   if (!!existing && !stampsCurrentSchema) return {};
   // O fallback {major 0, minor 1, patch 0} é canônico e vive uma única vez em
   // `deriveProjectVersionContext` — reusá-lo evita a duplicação que o cabeçalho
@@ -180,7 +186,9 @@ function buildResponsePayload({
   const justifications = notes ? { _notes: notes } : null;
 
   const roundIdToPersist =
-    project?.round_strategy === "manual" ? (project?.current_round_id ?? null) : null;
+    project?.round_strategy === "manual"
+      ? (project?.current_round_id ?? null)
+      : null;
 
   // Para humanos is_partial descreve O QUE FOI GRAVADO, não por qual canal a
   // escrita chegou: uma resposta só deixa de ser parcial quando o conjunto
@@ -206,7 +214,8 @@ function buildResponsePayload({
   // deixou de estar completo). A imutabilidade descrita na migration
   // 20260425000000 vale so para o fluxo LLM.
   const submittedBefore = existing?.is_partial === false;
-  const isPartialToWrite = !codingIsComplete || (isAutoSave && !submittedBefore);
+  const isPartialToWrite =
+    !codingIsComplete || (isAutoSave && !submittedBefore);
 
   const payload = {
     answers: answersToPersist,
@@ -234,7 +243,10 @@ interface PersistResponseRowParams {
 
 // "conflict" = outra sessão criou a resposta corrente entre o UPDATE e o
 // INSERT desta. Não é erro do usuário: o save precisa reler e repetir.
-type PersistOutcome = { status: "ok" } | { status: "conflict" } | { status: "error"; error: string };
+type PersistOutcome =
+  | { status: "ok" }
+  | { status: "conflict" }
+  | { status: "error"; error: string };
 
 // O índice único parcial que sustenta o ramo de conflito abaixo. Conferir o
 // nome é o que separa "perdi a corrida, releia" de qualquer outra violação de
@@ -288,7 +300,10 @@ async function persistResponseRow({
     ...payload,
   });
   if (!insErr) return { status: "ok" };
-  if (insErr.code === "23505" && insErr.message.includes(HUMAN_LATEST_UNIQUE_INDEX)) {
+  if (
+    insErr.code === "23505" &&
+    insErr.message.includes(HUMAN_LATEST_UNIQUE_INDEX)
+  ) {
     return { status: "conflict" };
   }
   return { status: "error", error: insErr.message };
@@ -306,6 +321,97 @@ function revalidateAfterSave(projectId: string, isAutoSave: boolean): void {
   revalidatePath(`/projects/${projectId}/analyze/arbitragem`);
   revalidatePath(`/projects/${projectId}/reviews`);
   revalidateTag(`project-${projectId}-progress`, { expire: 60 });
+}
+
+interface BuildSaveWriteParams {
+  fields: PydanticField[];
+  existing: ExistingResponseRow | null | undefined;
+  project: SaveResponseProjectFields | null | undefined;
+  answers: Record<string, unknown>;
+  isAutoSave: boolean;
+  notes?: string;
+}
+
+// Tudo que é derivado do que está gravado AGORA: o snapshot reconciliado, a
+// contagem de obrigatórias faltando e o payload. Separado da tentativa porque
+// é puro — e porque o retry precisa refazer exatamente estes três a partir da
+// releitura, nunca reaproveitar os da tentativa anterior.
+function buildSaveWrite({
+  fields,
+  existing,
+  project,
+  answers,
+  isAutoSave,
+  notes,
+}: BuildSaveWriteParams) {
+  // O formulário devolve um snapshot sanitizado, não um patch. A reconciliação
+  // compara esse snapshot com a projeção que foi apresentada e preserva o
+  // valor bruto + sua proveniência quando o campo não mudou (#484).
+  const snapshot = buildPersistedResponseSnapshot({
+    fields,
+    existing: existing
+      ? { answers: existing.answers, hashes: existing.answer_field_hashes }
+      : null,
+    rawSubmittedAnswers: answers,
+    // Só um submit explícito atesta a codificação inteira; auto-save não pode
+    // promover uma response legacy à versão corrente (#548).
+    promoteLegacyIfComplete: !isAutoSave,
+  });
+
+  // Régua de completude aplicada UMA vez, ao conjunto que vai ser gravado
+  // (`snapshot.persistedAnswers`) e com o carimbo per-campo da própria escrita —
+  // não ao que a tela mostrava. Dela saem os dois consumidores: o `is_partial`
+  // gravado e o `missingRequired` devolvido ao cliente. Se o schema mudou desde
+  // o carregamento do formulário, é esta contagem que impede o feedback de
+  // sucesso de anunciar uma conclusão que não houve (#519).
+  const missingRequired = missingRequiredHumanFields(
+    fields,
+    snapshot.persistedAnswers,
+    snapshot.answerFieldHashes,
+  ).length;
+
+  const payload = buildResponsePayload({
+    codingIsComplete: missingRequired === 0,
+    answersToPersist: snapshot.persistedAnswers,
+    answerFieldHashes: snapshot.answerFieldHashes,
+    stampsCurrentSchema: snapshot.stampsCurrentSchema,
+    project,
+    existing,
+    isAutoSave,
+    notes,
+  });
+
+  return { snapshot, missingRequired, payload };
+}
+
+// Os motivos para não gravar, avaliados antes de montar qualquer payload.
+// Nenhum deles depende do que foi digitado — só do estado do projeto, da
+// leitura da resposta corrente e do documento.
+function rejectedSaveContext({
+  projErr,
+  existingErr,
+  doc,
+}: {
+  projErr: { message: string } | null;
+  existingErr: { message: string } | null;
+  doc: { excluded_at: string | null } | null;
+}): SaveResponseResult | null {
+  if (projErr) return { success: false, error: projErr.message };
+
+  // Falha ao LER a resposta corrente aborta o save. Seguir como se não
+  // existisse gravaria por cima dela um snapshot construído sem os valores
+  // preservados (#484) — perda silenciosa, sem rastro. Falhar fechado aqui é
+  // o que a #609 corrige junto com o índice.
+  if (existingErr) return { success: false, error: existingErr.message };
+
+  // Doc já excluído (soft delete) não aceita mais respostas. Pedido de
+  // exclusão apenas PENDENTE não bloqueia: é reversível e o dado humano
+  // digitado é preservado.
+  if (doc?.excluded_at) {
+    return { success: false, error: "Documento removido do escopo do projeto" };
+  }
+
+  return null;
 }
 
 interface SaveAttemptParams {
@@ -340,67 +446,20 @@ async function runSaveAttempt({
   notes,
   isAutoSave,
 }: SaveAttemptParams): Promise<SaveResponseResult | { conflict: true }> {
-  const { profile, existing, existingErr, project, projErr, doc } = await fetchSaveContext(
-    supabase,
-    projectId,
-    documentId,
-    effectiveId,
-  );
+  const { profile, existing, existingErr, project, projErr, doc } =
+    await fetchSaveContext(supabase, projectId, documentId, effectiveId);
 
-  if (projErr) return { success: false, error: projErr.message };
+  const rejection = rejectedSaveContext({ projErr, existingErr, doc });
+  if (rejection) return rejection;
 
-  // Falha ao LER a resposta corrente aborta o save. Seguir como se não
-  // existisse gravaria por cima dela um snapshot construído sem os valores
-  // preservados (#484) — perda silenciosa, sem rastro. Falhar fechado aqui é
-  // o que a #609 corrige junto com o índice.
-  if (existingErr) return { success: false, error: existingErr.message };
-
-  // Doc já excluído (soft delete) não aceita mais respostas. Pedido de
-  // exclusão apenas PENDENTE não bloqueia: é reversível e o dado humano
-  // digitado é preservado.
-  if (doc?.excluded_at) {
-    return {
-      success: false,
-      error: "Documento removido do escopo do projeto",
-    };
-  }
-
-  const respondentName =
-    [profile?.first_name, profile?.last_name].filter(Boolean).join(" ") || userEmail;
+  const respondentName = resolveRespondentName(profile, userEmail);
 
   const fields = (project?.pydantic_fields as PydanticField[]) || [];
-
-  // O formulário devolve um snapshot sanitizado, não um patch. A reconciliação
-  // compara esse snapshot com a projeção que foi apresentada e preserva o
-  // valor bruto + sua proveniência quando o campo não mudou (#484).
-  const snapshot = buildPersistedResponseSnapshot({
+  const { snapshot, missingRequired, payload } = buildSaveWrite({
     fields,
-    existing: existing ? { answers: existing.answers, hashes: existing.answer_field_hashes } : null,
-    rawSubmittedAnswers: answers,
-    // Só um submit explícito atesta a codificação inteira; auto-save não pode
-    // promover uma response legacy à versão corrente (#548).
-    promoteLegacyIfComplete: !isAutoSave,
-  });
-
-  // Régua de completude aplicada UMA vez, ao conjunto que vai ser gravado
-  // (`snapshot.persistedAnswers`) e com o carimbo per-campo da própria escrita —
-  // não ao que a tela mostrava. Dela saem os dois consumidores: o `is_partial`
-  // gravado e o `missingRequired` devolvido ao cliente. Se o schema mudou desde
-  // o carregamento do formulário, é esta contagem que impede o feedback de
-  // sucesso de anunciar uma conclusão que não houve (#519).
-  const missingRequired = missingRequiredHumanFields(
-    fields,
-    snapshot.persistedAnswers,
-    snapshot.answerFieldHashes,
-  ).length;
-
-  const payload = buildResponsePayload({
-    codingIsComplete: missingRequired === 0,
-    answersToPersist: snapshot.persistedAnswers,
-    answerFieldHashes: snapshot.answerFieldHashes,
-    stampsCurrentSchema: snapshot.stampsCurrentSchema,
-    project,
     existing,
+    project,
+    answers,
     isAutoSave,
     notes,
   });
@@ -413,25 +472,78 @@ async function runSaveAttempt({
     respondentName,
     payload,
   });
-  if (outcome.status === "error") return { success: false, error: outcome.error };
+  if (outcome.status === "error")
+    return { success: false, error: outcome.error };
   if (outcome.status === "conflict") return { conflict: true };
 
-  if (fields.length > 0) {
-    const { error: syncErr } = await syncCodingAssignmentStatus(supabase, {
-      projectId,
-      documentId,
-      userId: effectiveId,
-      fields,
-      sanitizedAnswers: snapshot.submittedAnswers,
-      isAutoSave,
-      automationMode: project?.automation_mode,
-      hadCompletedResponse: existing?.is_partial === false,
-    });
-    if (syncErr) return { success: false, error: syncErr };
-  }
+  const syncErr = await syncAssignmentAfterSave({
+    supabase,
+    projectId,
+    documentId,
+    effectiveId,
+    fields,
+    project,
+    existing,
+    snapshot,
+    isAutoSave,
+  });
+  if (syncErr) return { success: false, error: syncErr };
 
   revalidateAfterSave(projectId, isAutoSave);
   return { success: true, missingRequired };
+}
+
+// Propaga a gravação para a fila de codificação. Projeto sem schema não tem
+// fila a sincronizar, e é o único caso em que o sync é pulado.
+async function syncAssignmentAfterSave({
+  supabase,
+  projectId,
+  documentId,
+  effectiveId,
+  fields,
+  project,
+  existing,
+  snapshot,
+  isAutoSave,
+}: {
+  supabase: SupabaseServerClient;
+  projectId: string;
+  documentId: string;
+  effectiveId: string;
+  fields: PydanticField[];
+  project: { automation_mode?: string | null } | null | undefined;
+  existing: { is_partial: boolean | null } | null | undefined;
+  snapshot: { submittedAnswers: Record<string, unknown> };
+  isAutoSave: boolean;
+}): Promise<string | undefined> {
+  if (fields.length === 0) return undefined;
+  const { error } = await syncCodingAssignmentStatus(supabase, {
+    projectId,
+    documentId,
+    userId: effectiveId,
+    fields,
+    sanitizedAnswers: snapshot.submittedAnswers,
+    isAutoSave,
+    automationMode: project?.automation_mode,
+    // Lido ANTES da escrita: distingue "já estava concluída" de "concluiu
+    // agora", que é o que impede o rebaixamento descrito em
+    // buildResponsePayload.
+    hadCompletedResponse: existing?.is_partial === false,
+  });
+  return error;
+}
+
+// Nome exibido como autoria da resposta. O e-mail é o fallback de quem ainda
+// não preencheu o perfil.
+function resolveRespondentName(
+  profile:
+    { first_name: string | null; last_name: string | null } | null | undefined,
+  userEmail: string,
+): string {
+  return (
+    [profile?.first_name, profile?.last_name].filter(Boolean).join(" ") ||
+    userEmail
+  );
 }
 
 // Duas tentativas, não mais: o conflito só acontece quando outra sessão criou
@@ -480,7 +592,8 @@ export async function saveResponse(
 
     return {
       success: false,
-      error: "Outra gravação desta mesma codificação chegou primeiro; tente novamente",
+      error:
+        "Outra gravação desta mesma codificação chegou primeiro; tente novamente",
     };
   } catch (e) {
     return {

--- a/frontend/supabase/migrations/20260727120000_responses_one_latest_human_per_document.sql
+++ b/frontend/supabase/migrations/20260727120000_responses_one_latest_human_per_document.sql
@@ -1,0 +1,465 @@
+-- Unicidade da resposta humana corrente em `responses` (issue #609).
+--
+-- Até aqui o único índice único da tabela cobria o LLM
+-- (`responses_one_latest_llm_per_document`, 20260717120000). A chave lógica
+-- equivalente para humanos — uma resposta corrente por (projeto, documento,
+-- respondente) — vivia SÓ na aplicação, no SELECT de `fetchSaveContext`
+-- (frontend/src/actions/responses.ts), aplicado num read-then-write sem trava:
+-- o SELECT que decide "existe linha?" e o INSERT que age sobre essa decisão
+-- são requests PostgREST separados, em transações distintas. O estado "duas
+-- linhas is_latest=true da mesma pessoa no mesmo documento" era construível.
+--
+-- O que torna a duplicata perigosa não é ela existir, é ela não ser detectada:
+-- com duas linhas ativas o `.maybeSingle()` do save passa a errar sempre, o
+-- erro era descartado, e cada gravação seguinte caía no ramo de INSERT
+-- acrescentando mais uma linha. A jusante, quatro consumidores contam LINHAS e
+-- não PESSOAS (auto-comparison, compare-divergence, useCompareFieldData,
+-- compare-queue), então duas linhas da mesma pessoa satisfariam o gate
+-- minHumans=2 e disparariam auto-comparação sobre um respondente só.
+--
+-- Medição em produção (2026-07-27, harness/2026-07-27-duplicatas-responses/
+-- medir-duplicatas.mts, read-only, 1.180 linhas): 0 duplicatas humanas ativas,
+-- 0 duplicatas LLM (controle do índice existente), 0 respostas humanas com
+-- respondent_id NULL, sobre 629 humanas correntes. Esta migration fecha uma
+-- garantia ausente, não repara estrago em curso.
+
+BEGIN;
+
+-- Estabiliza o conjunto entre o preflight e a restrição. Sem ele existe janela
+-- entre medir e restringir — que é exatamente a corrida read-then-write que
+-- esta migration fecha. Não bloqueia leitura. Mesmo protocolo de
+-- 20260716154500_responses_llm_actor_integrity.sql.
+LOCK TABLE public.responses IN SHARE ROW EXCLUSIVE MODE;
+
+-- ========== Preflight: abortar nomeando o resíduo, nunca sanear ============
+--
+-- Demover `is_latest` NÃO é uma operação inerte nesta tabela: dispara o
+-- trigger AFTER UPDATE `archive_review_dependencies_on_response_change`
+-- (20260717120000), que APAGA field_reviews e response_equivalences cujo
+-- snapshot ficou obsoleto e reconcilia assignments de auto_revisao/arbitragem.
+-- Destruir revisão humana não pode ser efeito colateral silencioso de um
+-- `db push`. Por isso aqui se aborta, ao contrário do bloco de dedupe do lado
+-- LLM (20260717120000:846-868), onde a linha rebaixada era resposta de máquina
+-- regenerável.
+--
+-- Se o primeiro bloco disparar, o reparo determinístico — a MESMA regra de
+-- desempate que unify_project_members já usa — é este, para ser rodado
+-- conscientemente, sabendo do efeito em cascata acima:
+--
+--   WITH ranked AS (
+--     SELECT id, ROW_NUMBER() OVER (
+--              PARTITION BY project_id, document_id, respondent_id
+--              ORDER BY COALESCE(updated_at, created_at) DESC, id DESC) AS rn
+--     FROM public.responses
+--     WHERE respondent_type = 'humano' AND is_latest
+--       AND respondent_id IS NOT NULL
+--   )
+--   UPDATE public.responses r SET is_latest = false
+--   FROM ranked WHERE r.id = ranked.id AND ranked.rn > 1;
+--
+-- O segundo bloco (autoria ausente) não tem reparo automático possível:
+-- inventar autor é falsificar autoria, e demover para is_latest=false
+-- esconderia a codificação de alguém. Exige decisão humana.
+DO $preflight$
+DECLARE
+  v_offenders TEXT;
+BEGIN
+  SELECT pg_catalog.string_agg(
+           pg_catalog.format('(%s, %s): %s linhas',
+                             offender.document_id, offender.respondent_id,
+                             offender.total),
+           '; ' ORDER BY offender.document_id)
+    INTO v_offenders
+  FROM (
+    SELECT response.document_id,
+           response.respondent_id,
+           pg_catalog.count(*) AS total
+    FROM public.responses AS response
+    WHERE response.respondent_type = 'humano'
+      AND response.is_latest
+      AND response.respondent_id IS NOT NULL
+    GROUP BY response.project_id, response.document_id, response.respondent_id
+    HAVING pg_catalog.count(*) > 1
+  ) AS offender;
+
+  IF v_offenders IS NOT NULL THEN
+    RAISE EXCEPTION
+      'responses tem resposta humana corrente duplicada por (documento, respondente): %',
+      v_offenders
+      USING ERRCODE = '23505',
+            HINT = 'Ver o reparo determinístico no comentário desta migration; ele APAGA field_reviews/response_equivalences dependentes via trigger.';
+  END IF;
+END;
+$preflight$;
+
+DO $preflight_actor$
+DECLARE
+  v_offenders TEXT;
+BEGIN
+  SELECT pg_catalog.string_agg(response.id::text, ', ' ORDER BY response.id)
+    INTO v_offenders
+  FROM public.responses AS response
+  WHERE response.respondent_type = 'humano'
+    AND response.is_latest
+    AND response.respondent_id IS NULL;
+
+  IF v_offenders IS NOT NULL THEN
+    RAISE EXCEPTION
+      'responses tem resposta humana corrente sem respondent_id: %', v_offenders
+      USING ERRCODE = '23514',
+            HINT = 'Autoria não se conserta sozinha: identifique quem codificou antes de aplicar.';
+  END IF;
+END;
+$preflight_actor$;
+
+-- ========== A restrição ====================================================
+--
+-- O CHECK não é acessório do índice, é o que faz o índice restringir: NULL
+-- nunca colide em índice único, então N respostas humanas correntes sem autor
+-- passariam pelo índice abaixo sem violar nada — a restrição existiria e não
+-- restringiria. O braço `NOT is_latest` isenta histórico antigo sem autor, se
+-- houver. Fecha o par com responses_llm_has_no_human_actor_check
+-- (20260716154500): LLM nunca tem autor, humano corrente sempre tem.
+--
+-- Descartado NULLS NOT DISTINCT no índice (disponível desde o PG15): ele
+-- colapsaria todos os anônimos de um documento num slot só, confundindo duas
+-- pessoas diferentes numa — decisão sobre o dado disfarçada de constraint. O
+-- CHECK diz a coisa certa: resposta humana corrente sem autor é
+-- irrepresentável.
+ALTER TABLE public.responses
+  ADD CONSTRAINT responses_human_latest_has_actor_check CHECK (
+    respondent_type <> 'humano' OR NOT is_latest OR respondent_id IS NOT NULL
+  );
+
+-- Espelha responses_one_latest_llm_per_document, com respondent_id na chave:
+-- dois humanos DISTINTOS correntes no mesmo documento continuam permitidos —
+-- é a dupla independente, o método do produto. O que fica proibido é a MESMA
+-- pessoa duas vezes.
+--
+-- `AND is_latest` sem `= true` é seguro porque a coluna é NOT NULL desde
+-- 20260716160100:54-59. Não se aplica aqui o motivo do IS DISTINCT FROM de
+-- assignments_one_active_comparacao_per_doc, que existia por causa de status
+-- nulo caindo FORA do predicado.
+--
+-- Sem IF NOT EXISTS: mascararia um índice homônimo com predicado diferente, e
+-- este é novo. Sem CONCURRENTLY: não roda dentro de transação, e a transação
+-- (lock + preflight + índice) é justamente o ponto; a tabela é pequena.
+--
+-- project_id na chave é redundante em teoria (document_id já identifica o
+-- projeto) e é mantido por simetria com o índice LLM e com os .eq() do app.
+-- Residual assumido, idêntico ao do índice LLM: duas responses do mesmo
+-- documento com project_id divergente não seriam pegas.
+CREATE UNIQUE INDEX responses_one_latest_human_per_document
+  ON public.responses (project_id, document_id, respondent_id)
+  WHERE respondent_type = 'humano' AND is_latest;
+
+-- ========== unify_project_members: demover ANTES de repontar ===============
+--
+-- Esta função CONSTRÓI o estado agora proibido, de propósito, e só depois o
+-- desfaz: em 20260716155000 o bloco `-- ===== responses =====` primeiro
+-- reatribui respondent_id do source para o target e só então demove as
+-- perdedoras. Esse primeiro UPDATE é exatamente o que produz duas linhas
+-- (project_id, document_id, target, 'humano', is_latest) quando source e
+-- target codificaram o mesmo documento — o caso central da unificação.
+--
+-- Índice parcial NÃO pode ser DEFERRABLE (UNIQUE CONSTRAINT não aceita WHERE),
+-- então a checagem é imediata, dentro do statement do repoint: sem esta
+-- reordenação a unificação passaria a estourar 23505 para o coordenador em
+-- runtime, e preview_project_member_unification não avisaria — ele só antecipa
+-- colisões de review, arbitragem e comparação, não de responses.
+--
+-- A correção rankeia sobre a UNIÃO source ∪ target e demove antes de repontar.
+-- Mesmo vencedor, mesmo desempate (COALESCE(updated_at, created_at) DESC,
+-- id DESC): nenhuma semântica nova, a mesma decisão movida para antes. O corpo
+-- abaixo é o de 20260716155000 com esse único bloco trocado.
+CREATE OR REPLACE FUNCTION public.unify_project_members(
+  p_project_id UUID,
+  p_source_user_id UUID,
+  p_target_user_id UUID,
+  p_linked_user_id UUID,
+  p_link_email TEXT,
+  p_acting_user_id UUID,
+  p_expected_snapshot_version BIGINT
+) RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_locked_membership_count INTEGER;
+  v_review_conflicts BIGINT;
+  v_arbitration_conflicts BIGINT;
+  v_comparison_conflicts BIGINT;
+BEGIN
+  IF p_source_user_id = p_target_user_id THEN
+    RAISE EXCEPTION 'source e target devem ser membros distintos';
+  END IF;
+  IF btrim(p_link_email) = '' THEN
+    RAISE EXCEPTION 'e-mail do vínculo não pode ser vazio';
+  END IF;
+  IF p_linked_user_id = p_target_user_id THEN
+    RAISE EXCEPTION 'a conta vinculada já é o membro de destino'
+      USING ERRCODE = '23514';
+  END IF;
+
+  -- A gestão de identidade toma o lock global antes de qualquer linha.
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended('canonical-project-identity', 0)
+  );
+
+  PERFORM public.assert_identity_write_proof(
+    p_linked_user_id,
+    p_link_email,
+    p_expected_snapshot_version
+  );
+  IF p_linked_user_id <> p_source_user_id THEN
+    PERFORM public.assert_identity_write_proof(
+      p_source_user_id,
+      p_link_email,
+      NULL
+    );
+  END IF;
+
+  -- A ordem global dos UUIDs evita deadlocks entre unificações sobrepostas.
+  -- Depois de aguardar um lock, READ COMMITTED reavalia a linha atualizada ou
+  -- removida; por isso a contagem também é a validação de membership.
+  PERFORM pm.user_id
+  FROM public.project_members pm
+  WHERE pm.project_id = p_project_id
+    AND pm.user_id IN (p_source_user_id, p_target_user_id)
+  ORDER BY pm.user_id
+  FOR UPDATE;
+  GET DIAGNOSTICS v_locked_membership_count = ROW_COUNT;
+
+  IF v_locked_membership_count <> 2 THEN
+    RAISE EXCEPTION 'source e target devem ser membros do projeto';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.member_email_links mel
+    WHERE mel.project_id = p_project_id
+      AND mel.email = lower(btrim(p_link_email))
+      AND mel.member_user_id NOT IN (p_source_user_id, p_target_user_id)
+  ) THEN
+    RAISE EXCEPTION 'e-mail já está vinculado a outro membro do projeto'
+      USING ERRCODE = '23514';
+  END IF;
+
+  -- DML já em voo termina antes destes locks; novo DML espera o commit da
+  -- unificação. A ordem membership→tabelas acompanha as RPCs de permissão e
+  -- remoção, evitando ciclo com transações que já bloquearam a membership.
+  -- field_reviews precede assignments porque as RPCs de arbitragem atualizam
+  -- essas duas tabelas nessa ordem; reviews e responses precedem assignments
+  -- para acompanhar replace_and_add_documents.
+  LOCK TABLE
+    public.field_reviews,
+    public.reviews,
+    public.responses,
+    public.assignments,
+    public.researcher_field_orders,
+    public.response_equivalences,
+    public.verdict_acknowledgments
+  IN SHARE ROW EXCLUSIVE MODE;
+
+  SELECT
+    preview.review_conflicts,
+    preview.arbitration_conflicts,
+    preview.comparison_conflicts
+  INTO STRICT
+    v_review_conflicts,
+    v_arbitration_conflicts,
+    v_comparison_conflicts
+  FROM public.preview_project_member_unification(
+    p_project_id,
+    p_source_user_id,
+    p_target_user_id
+  ) preview;
+
+  IF v_arbitration_conflicts > 0 THEN
+    RAISE EXCEPTION
+      'source e target participam da mesma arbitragem pendente'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF v_review_conflicts > 0 THEN
+    RAISE EXCEPTION
+      'source e target possuem revisões do mesmo campo; a unificação preserva ambas e deve ser cancelada'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF v_comparison_conflicts > 0 THEN
+    RAISE EXCEPTION
+      'source e target tornariam revisor e codificador da mesma comparação a mesma pessoa'
+      USING ERRCODE = '23514';
+  END IF;
+
+  -- ===== assignments (colisão: target prevalece) =====
+  -- Precedência do target vale para a identidade e para o progresso: uma
+  -- codificação concluída do target supera uma em andamento do source, e o
+  -- DELETE abaixo descarta a do source sem dó.
+  --
+  -- Auto-revisão e arbitragem são as exceções, porque o trabalho delas não
+  -- vive no assignment e sim nos field_reviews, que a fusão transfere logo
+  -- adiante: field_reviews é
+  -- UNIQUE(document_id, field_name), então source e target podem deter campos
+  -- distintos do MESMO documento. Se o target já concluiu a fila daquele
+  -- documento e o source deixou campos sem veredito, descartar o assignment do
+  -- source faria os field_reviews pendentes migrarem para uma fila fechada —
+  -- estado que a pós-condição de 20260716160300 trata como erro de deploy, e
+  -- que sumiria o documento da fila do target sem volta. Reabrir só quando há
+  -- pendência real migrando mantém a regra estreita: nenhum outro tipo é
+  -- tocado, e nada é reaberto sem trabalho a fazer.
+  UPDATE public.assignments t
+  SET status = 'pendente',
+      completed_at = NULL
+  WHERE t.project_id = p_project_id
+    AND t.user_id = p_target_user_id
+    AND t.type = 'auto_revisao'
+    AND t.status = 'concluido'
+    AND EXISTS (
+      SELECT 1
+      FROM public.field_reviews fr
+      WHERE fr.project_id = p_project_id
+        AND fr.document_id = t.document_id
+        AND fr.self_reviewer_id = p_source_user_id
+        AND fr.self_verdict IS NULL
+    );
+
+  -- A arbitragem tem a MESMA anatomia (trabalho nos field_reviews, não no
+  -- assignment) e o mesmo buraco: campos contestados de levas distintas podem
+  -- deixar o source com fila pendente enquanto o target já concluiu a dele no
+  -- mesmo documento. Sem reabrir, o DELETE abaixo migraria final_verdict IS
+  -- NULL para debaixo de assignment 'concluido' — e nenhum caminho reabre
+  -- arbitragem depois (assign_arbitration_if_eligible só pega arbitrator_id
+  -- IS NULL; sync_arbitration_assignment_status só fecha): o documento
+  -- sumiria da fila de arbitragem para sempre.
+  UPDATE public.assignments t
+  SET status = 'pendente',
+      completed_at = NULL
+  WHERE t.project_id = p_project_id
+    AND t.user_id = p_target_user_id
+    AND t.type = 'arbitragem'
+    AND t.status = 'concluido'
+    AND EXISTS (
+      SELECT 1
+      FROM public.field_reviews fr
+      WHERE fr.project_id = p_project_id
+        AND fr.document_id = t.document_id
+        AND fr.arbitrator_id = p_source_user_id
+        AND fr.final_verdict IS NULL
+    );
+
+  DELETE FROM public.assignments s
+  WHERE s.project_id = p_project_id
+    AND s.user_id = p_source_user_id
+    AND EXISTS (
+      SELECT 1 FROM public.assignments t
+      WHERE t.project_id = p_project_id
+        AND t.user_id = p_target_user_id
+        AND t.document_id = s.document_id
+        AND t.type = s.type
+    );
+  UPDATE public.assignments
+  SET user_id = p_target_user_id
+  WHERE project_id = p_project_id AND user_id = p_source_user_id;
+
+  -- ===== responses =====
+  -- Demover ANTES de repontar (#609). O repoint sozinho produz duas linhas
+  -- correntes do target no mesmo documento sempre que source e target
+  -- codificaram o mesmo doc, e responses_one_latest_human_per_document é
+  -- imediato — índice parcial não pode ser DEFERRABLE. Rankear sobre a UNIÃO
+  -- source ∪ target dá o mesmo vencedor que o rank pós-repoint dava sobre o
+  -- conjunto fundido, com o mesmo desempate; só a ordem das duas mutações
+  -- mudou. Manter nesta ordem.
+  WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+             PARTITION BY document_id
+             ORDER BY COALESCE(updated_at, created_at) DESC, id DESC
+           ) AS rn
+    FROM public.responses
+    WHERE project_id = p_project_id
+      AND respondent_id IN (p_source_user_id, p_target_user_id)
+      AND respondent_type = 'humano'
+      AND is_latest
+  )
+  UPDATE public.responses r
+  SET is_latest = false
+  FROM ranked
+  WHERE r.id = ranked.id AND ranked.rn > 1;
+
+  UPDATE public.responses
+  SET respondent_id = p_target_user_id
+  WHERE project_id = p_project_id AND respondent_id = p_source_user_id;
+
+  -- ===== reviews =====
+  -- Colisões foram rejeitadas antes da primeira mutação para que nenhuma
+  -- revisão histórica seja descartada.
+  UPDATE public.reviews
+  SET reviewer_id = p_target_user_id
+  WHERE project_id = p_project_id AND reviewer_id = p_source_user_id;
+
+  -- ===== verdict_acknowledgments (target prevalece) =====
+  DELETE FROM public.verdict_acknowledgments s
+  WHERE s.respondent_id = p_source_user_id
+    AND s.review_id IN (
+      SELECT id FROM public.reviews WHERE project_id = p_project_id
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.verdict_acknowledgments t
+      WHERE t.review_id = s.review_id
+        AND t.respondent_id = p_target_user_id
+    );
+  UPDATE public.verdict_acknowledgments
+  SET respondent_id = p_target_user_id
+  WHERE respondent_id = p_source_user_id
+    AND review_id IN (
+      SELECT id FROM public.reviews WHERE project_id = p_project_id
+    );
+
+  -- ===== field_reviews =====
+  UPDATE public.field_reviews
+  SET self_reviewer_id = p_target_user_id
+  WHERE project_id = p_project_id AND self_reviewer_id = p_source_user_id;
+  UPDATE public.field_reviews
+  SET arbitrator_id = p_target_user_id
+  WHERE project_id = p_project_id AND arbitrator_id = p_source_user_id;
+
+  -- ===== response_equivalences =====
+  UPDATE public.response_equivalences
+  SET reviewer_id = p_target_user_id
+  WHERE project_id = p_project_id AND reviewer_id = p_source_user_id;
+
+  -- Preferência pessoal do source não é herdada.
+  DELETE FROM public.researcher_field_orders
+  WHERE project_id = p_project_id AND user_id = p_source_user_id;
+
+  -- Vínculos que tinham o source como identidade canônica passam ao target.
+  UPDATE public.member_email_links
+  SET member_user_id = p_target_user_id
+  WHERE project_id = p_project_id AND member_user_id = p_source_user_id;
+
+  -- A membership precisa sair antes do alias source→target: o trigger torna a
+  -- coexistência irrepresentável. Falha posterior reverte toda a transação.
+  DELETE FROM public.project_members
+  WHERE project_id = p_project_id AND user_id = p_source_user_id;
+
+  INSERT INTO public.member_email_links
+    (project_id, member_user_id, email, linked_user_id, created_by)
+  VALUES
+    (
+      p_project_id,
+      p_target_user_id,
+      lower(btrim(p_link_email)),
+      p_linked_user_id,
+      p_acting_user_id
+    )
+  ON CONFLICT (project_id, email) DO UPDATE
+  SET member_user_id = EXCLUDED.member_user_id,
+      linked_user_id = EXCLUDED.linked_user_id,
+      created_by = EXCLUDED.created_by;
+END;
+$$;
+
+COMMIT;

--- a/frontend/supabase/tests/atomic_replace_rpcs.test.sql
+++ b/frontend/supabase/tests/atomic_replace_rpcs.test.sql
@@ -30,11 +30,13 @@ INSERT INTO public.documents (id, project_id, external_id, title, text, text_has
 -- (#609) torna irrepresentável a linha humana is_latest sem respondent_id. O que
 -- este teste prova — que replace_and_add_documents apaga a response — não depende
 -- de quem respondeu, então a fixture apenas passa a nomear o respondente.
+-- UUID 7777… e não 5555…/6666…: esses dois já nomeiam outras entidades deste
+-- arquivo (a review logo abaixo e o assignment em seguida).
 INSERT INTO auth.users (id, email) VALUES
-  ('55555555-5555-5555-5555-555555555555', 'atomic-replace-respondent@example.test');
+  ('77777777-7777-7777-7777-777777777777', 'atomic-replace-respondent@example.test');
 
 INSERT INTO public.responses (id, project_id, document_id, respondent_id, respondent_type, answers) VALUES
-  ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '55555555-5555-5555-5555-555555555555', 'humano', '{"campo":"x"}');
+  ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '77777777-7777-7777-7777-777777777777', 'humano', '{"campo":"x"}');
 
 INSERT INTO public.reviews (id, project_id, document_id, field_name, verdict) VALUES
   ('55555555-5555-5555-5555-555555555555', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'campo', 'concordo');

--- a/frontend/supabase/tests/atomic_replace_rpcs.test.sql
+++ b/frontend/supabase/tests/atomic_replace_rpcs.test.sql
@@ -26,8 +26,15 @@ INSERT INTO public.documents (id, project_id, external_id, title, text, text_has
   ('22222222-2222-2222-2222-222222222222', '11111111-1111-1111-1111-111111111111', NULL,       'D1 alvo',  'texto d1', 'h-d1'),
   ('33333333-3333-3333-3333-333333333333', '11111111-1111-1111-1111-111111111111', 'EXISTING', 'D2 ativo', 'texto d2', 'h-d2');
 
-INSERT INTO public.responses (id, project_id, document_id, respondent_type, answers) VALUES
-  ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'humano', '{"campo":"x"}');
+-- A resposta humana corrente precisa de autor: responses_human_latest_has_actor_check
+-- (#609) torna irrepresentável a linha humana is_latest sem respondent_id. O que
+-- este teste prova — que replace_and_add_documents apaga a response — não depende
+-- de quem respondeu, então a fixture apenas passa a nomear o respondente.
+INSERT INTO auth.users (id, email) VALUES
+  ('55555555-5555-5555-5555-555555555555', 'atomic-replace-respondent@example.test');
+
+INSERT INTO public.responses (id, project_id, document_id, respondent_id, respondent_type, answers) VALUES
+  ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '55555555-5555-5555-5555-555555555555', 'humano', '{"campo":"x"}');
 
 INSERT INTO public.reviews (id, project_id, document_id, field_name, verdict) VALUES
   ('55555555-5555-5555-5555-555555555555', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', 'campo', 'concordo');

--- a/frontend/supabase/tests/responses_latest_human_concurrency.test.sql
+++ b/frontend/supabase/tests/responses_latest_human_concurrency.test.sql
@@ -54,8 +54,14 @@ VALUES (
   '6b000000-0000-0000-0000-000000000001',
   'issue 609 concurrency',
   '6a000000-0000-0000-0000-000000000001',
-  -- O campo carrega `id` UUID porque projects.pydantic_fields tem CHECK de
-  -- shape que o exige; sem ele o INSERT da fixture é recusado.
+  -- O campo carrega `id` UUID porque essa é a forma real de PydanticField
+  -- (ver frontend/src/lib/pydantic-field.ts), não porque alguma constraint o
+  -- exija: hoje projects.pydantic_fields não tem CHECK de shape em migration
+  -- nenhuma. A versão anterior deste comentário afirmava o contrário, descrevendo
+  -- uma CHECK que existia só no container local desta máquina, aplicada fora do
+  -- controle de versão — as demais suítes de banco inserem `[{"name":"q1"}]` sem
+  -- `id` e passam. Manter o `id` mesmo assim: custa nada e a fixture continua
+  -- válida se um dia a constraint entrar de verdade.
   '[{"id":"6e000000-0000-0000-0000-000000000001","name":"q1"}]'
 );
 

--- a/frontend/supabase/tests/responses_latest_human_concurrency.test.sql
+++ b/frontend/supabase/tests/responses_latest_human_concurrency.test.sql
@@ -8,7 +8,12 @@
 --
 -- Diferentemente dos testes transacionais comuns, as fixtures precisam estar
 -- commitadas para duas conexões dblink enxergarem o mesmo estado. O arquivo usa
--- UUIDs reservados e remove tudo ao final.
+-- UUIDs reservados e remove tudo no fim do caminho feliz — sob ON_ERROR_STOP=1
+-- um DO que falha aborta ANTES do cleanup, deixando as fixtures commitadas. O
+-- que devolve o banco ao estado limpo nesse caso são os DELETE do topo, que
+-- re-rodam sobre os mesmos UUIDs reservados na execução seguinte; as conexões
+-- dblink morrem junto com a sessão psql. Por isso uma falha aqui não exige
+-- limpeza manual, mas o resíduo sobrevive até a próxima execução.
 --
 -- O que aqui se prova NÃO é a unicidade — disso cuida
 -- responses_one_latest_human.test.sql, em uma sessão só. Aqui se prova o
@@ -259,6 +264,23 @@ SELECT extensions.dblink_send_query(
   $$SELECT pg_temp.try_insert_other_respondent()$$
 );
 SELECT pg_catalog.pg_sleep(0.2);
+
+-- Sem esta asserção o cenário degrada em silêncio: se a espera sumir, o INSERT
+-- roda sem disputa e o 'inserted' abaixo continua verde, provando bem menos do
+-- que o comentário acima afirma. A mensagem atribui a falha ao mutex, e não à
+-- unicidade, para que um vermelho futuro não seja lido como regressão da #609.
+DO $$
+BEGIN
+  IF extensions.dblink_is_busy('issue609_b') <> 1 THEN
+    RAISE EXCEPTION
+      'FALHOU: a gravação do OUTRO respondente não esperou. A espera vem do '
+      'FOR UPDATE em documents de enqueue_auto_review_reconciliation, não da '
+      'unicidade: se ele saiu, este cenário parou de exercer contenção.';
+  END IF;
+  RAISE NOTICE 'OK 3a: a gravação do outro respondente espera o mutex do documento';
+END;
+$$;
+
 SELECT extensions.dblink_exec('issue609_a', 'COMMIT');
 
 CREATE TEMP TABLE issue609_other_result AS

--- a/frontend/supabase/tests/responses_latest_human_concurrency.test.sql
+++ b/frontend/supabase/tests/responses_latest_human_concurrency.test.sql
@@ -1,0 +1,311 @@
+-- Prova concorrente do contrato de que o save humano depende (issue #609).
+--
+-- Como rodar após `npx supabase db reset`:
+--   npm run test:db:responses-human-concurrency
+-- ou, à mão:
+--   docker exec -i supabase_db_frontend psql -U postgres -d postgres \
+--     -X -v ON_ERROR_STOP=1 < supabase/tests/responses_latest_human_concurrency.test.sql
+--
+-- Diferentemente dos testes transacionais comuns, as fixtures precisam estar
+-- commitadas para duas conexões dblink enxergarem o mesmo estado. O arquivo usa
+-- UUIDs reservados e remove tudo ao final.
+--
+-- O que aqui se prova NÃO é a unicidade — disso cuida
+-- responses_one_latest_human.test.sql, em uma sessão só. Aqui se prova o
+-- contrato do qual persistResponseRow depende quando duas gravações do mesmo
+-- par disputam: que a segunda ESPERA a primeira e recebe um 23505 nomeado, e
+-- não deadlock, serialization failure ou espera indefinida — é isso que
+-- autoriza o app a tratar o conflito como "releia e repita" em vez de erro do
+-- usuário. E que o retry então CONVERGE: o UPDATE pela chave lógica encontra a
+-- linha da vencedora.
+--
+-- As conexões rodam como `postgres`. O alvo é o comportamento de bloqueio e do
+-- índice, não RLS — esta última é coberta pelas policies exercitadas em
+-- canonical_project_identity_rls.test.sql, e conceder DML permanente a
+-- `authenticated` aqui sujaria o banco, já que não há transação para reverter.
+
+CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA extensions;
+
+DELETE FROM public.projects
+WHERE id = '6b000000-0000-0000-0000-000000000001';
+DELETE FROM auth.users
+WHERE id IN (
+  '6a000000-0000-0000-0000-000000000001',
+  '6a000000-0000-0000-0000-000000000002'
+);
+
+INSERT INTO auth.users (id, email) VALUES
+  ('6a000000-0000-0000-0000-000000000001', 'issue609-concurrency-ana@example.test'),
+  ('6a000000-0000-0000-0000-000000000002', 'issue609-concurrency-bruno@example.test');
+
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+VALUES
+  ('issue609-concurrency-ana', '6a000000-0000-0000-0000-000000000001', 1),
+  ('issue609-concurrency-bruno', '6a000000-0000-0000-0000-000000000002', 1);
+
+INSERT INTO public.projects (id, name, created_by, pydantic_fields)
+VALUES (
+  '6b000000-0000-0000-0000-000000000001',
+  'issue 609 concurrency',
+  '6a000000-0000-0000-0000-000000000001',
+  -- O campo carrega `id` UUID porque projects.pydantic_fields tem CHECK de
+  -- shape que o exige; sem ele o INSERT da fixture é recusado.
+  '[{"id":"6e000000-0000-0000-0000-000000000001","name":"q1"}]'
+);
+
+INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
+  ('6c000000-0000-0000-0000-000000000001',
+   '6b000000-0000-0000-0000-000000000001', 'doc a', 'texto a', 'h-609-a');
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('6b000000-0000-0000-0000-000000000001',
+   '6a000000-0000-0000-0000-000000000001', 'pesquisador'),
+  ('6b000000-0000-0000-0000-000000000001',
+   '6a000000-0000-0000-0000-000000000002', 'pesquisador');
+
+SELECT extensions.dblink_connect(
+  'issue609_a',
+  'host=host.docker.internal port=54322 dbname=postgres user=postgres password=postgres'
+);
+SELECT extensions.dblink_connect(
+  'issue609_b',
+  'host=host.docker.internal port=54322 dbname=postgres user=postgres password=postgres'
+);
+
+-- ========== 1. Duas gravações do MESMO par: a segunda espera e é recusada ===
+--
+-- A exceção acontece na sessão remota, e dblink_get_result a propagaria para
+-- cá, abortando o teste em vez de o teste observá-la. O helper converte a
+-- violação em dado — capturando `unique_violation` NOMEADAMENTE, para não
+-- mascarar qualquer outra falha.
+SELECT extensions.dblink_exec(
+  'issue609_b',
+  $$CREATE FUNCTION pg_temp.try_insert_latest_human() RETURNS TEXT
+    LANGUAGE plpgsql AS $fn$
+    BEGIN
+      INSERT INTO public.responses
+        (project_id, document_id, respondent_id, respondent_type,
+         respondent_name, answers, is_latest, is_partial)
+      VALUES
+        ('6b000000-0000-0000-0000-000000000001',
+         '6c000000-0000-0000-0000-000000000001',
+         '6a000000-0000-0000-0000-000000000001', 'humano', 'Ana',
+         '{"q1":"de B"}'::jsonb, true, false);
+      RETURN 'unexpected-success';
+    EXCEPTION WHEN unique_violation THEN
+      RETURN pg_catalog.format('rejected:%s', SQLERRM);
+    END;
+    $fn$;$$
+);
+
+SELECT extensions.dblink_exec('issue609_a', 'BEGIN');
+SELECT extensions.dblink_exec(
+  'issue609_a',
+  $$INSERT INTO public.responses
+      (id, project_id, document_id, respondent_id, respondent_type,
+       respondent_name, answers, is_latest, is_partial)
+    VALUES
+      ('6d000000-0000-0000-0000-000000000001',
+       '6b000000-0000-0000-0000-000000000001',
+       '6c000000-0000-0000-0000-000000000001',
+       '6a000000-0000-0000-0000-000000000001', 'humano', 'Ana',
+       '{"q1":"de A"}'::jsonb, true, false)$$
+);
+
+SELECT extensions.dblink_send_query(
+  'issue609_b',
+  $$SELECT pg_temp.try_insert_latest_human()$$
+);
+SELECT pg_catalog.pg_sleep(0.2);
+
+DO $$
+BEGIN
+  IF extensions.dblink_is_busy('issue609_b') <> 1 THEN
+    RAISE EXCEPTION
+      'FALHOU: a segunda gravação do mesmo par não esperou a primeira';
+  END IF;
+  RAISE NOTICE 'OK 1a: a segunda gravação espera a primeira em vez de duplicar';
+END;
+$$;
+
+SELECT extensions.dblink_exec('issue609_a', 'COMMIT');
+
+-- O resultado só pode ser consumido uma vez; a temp table o materializa para
+-- as asserções abaixo. O segundo get_result drena o retorno vazio que o
+-- protocolo exige antes de a conexão voltar a ser usável.
+CREATE TEMP TABLE issue609_insert_result AS
+SELECT * FROM extensions.dblink_get_result('issue609_b') AS result(outcome TEXT);
+SELECT * FROM extensions.dblink_get_result('issue609_b') AS result(outcome TEXT);
+
+DO $$
+DECLARE
+  v_outcome TEXT;
+  v_rows INTEGER;
+BEGIN
+  SELECT outcome INTO v_outcome FROM issue609_insert_result;
+
+  IF v_outcome IS NULL OR v_outcome NOT LIKE 'rejected:%' THEN
+    RAISE EXCEPTION
+      'FALHOU: a gravação perdedora não foi recusada (resultado: %)',
+      COALESCE(v_outcome, '<nulo>');
+  END IF;
+
+  -- O app distingue "perdi a corrida, releia" de qualquer outra violação de
+  -- unicidade pelo NOME do índice na mensagem. Se ele sumir daqui, o
+  -- `insErr.message.includes(...)` de persistResponseRow para de reconhecer o
+  -- conflito e o conflito vira erro na cara do pesquisador.
+  IF v_outcome NOT LIKE '%responses_one_latest_human_per_document%' THEN
+    RAISE EXCEPTION
+      'FALHOU: a recusa não nomeia o índice que o app procura (mensagem: %)',
+      v_outcome;
+  END IF;
+
+  SELECT pg_catalog.count(*) INTO v_rows
+  FROM public.responses
+  WHERE document_id = '6c000000-0000-0000-0000-000000000001'
+    AND respondent_id = '6a000000-0000-0000-0000-000000000001'
+    AND respondent_type = 'humano'
+    AND is_latest;
+
+  IF v_rows <> 1 THEN
+    RAISE EXCEPTION
+      'FALHOU: sobraram % linhas correntes do mesmo par (esperado 1)', v_rows;
+  END IF;
+
+  RAISE NOTICE 'OK 1b: a perdedora recebe 23505 nomeado e sobra uma linha só';
+END;
+$$;
+
+-- ========== 2. O retry converge: UPDATE pela chave lógica acha a vencedora ==
+DO $$
+DECLARE
+  v_updated INTEGER;
+BEGIN
+  SELECT result.updated INTO v_updated
+  FROM extensions.dblink(
+    'issue609_b',
+    $q$WITH changed AS (
+        UPDATE public.responses
+        SET answers = '{"q1":"do retry de B"}'::jsonb
+        WHERE project_id = '6b000000-0000-0000-0000-000000000001'
+          AND document_id = '6c000000-0000-0000-0000-000000000001'
+          AND respondent_id = '6a000000-0000-0000-0000-000000000001'
+          AND respondent_type = 'humano'
+          AND is_latest = true
+        RETURNING id
+      )
+      SELECT pg_catalog.count(*)::INTEGER FROM changed$q$
+  ) AS result(updated INTEGER);
+
+  IF v_updated <> 1 THEN
+    RAISE EXCEPTION
+      'FALHOU: o retry pela chave lógica afetou % linhas (esperado 1)',
+      v_updated;
+  END IF;
+  RAISE NOTICE 'OK 2: o retry converge para a linha da vencedora';
+END;
+$$;
+
+-- ========== 3. Respondentes distintos: espera sim, recusa não ==============
+--
+-- A dupla independente é o método do produto, então o que a restrição NÃO pode
+-- fazer é recusar o segundo pesquisador no mesmo documento.
+--
+-- Ela também não é a razão da espera que se observa aqui: duas gravações
+-- COMPLETAS (is_partial = false) no mesmo documento já serializavam antes
+-- desta issue, porque `enqueue_auto_review_reconciliation` toma a linha de
+-- `documents` com FOR UPDATE — o mutex de publicação que ele compartilha com
+-- `publish_latest_llm_response`, para que um save humano observe uma geração
+-- LLM inteira ou nenhuma. Medido: a segunda sessão espera em
+-- `transactionid`/ShareLock, não no índice.
+--
+-- O que este cenário prova é o desfecho: ao ser liberada, a gravação do OUTRO
+-- respondente SUCEDE. Trocar o índice por um que colidisse entre pessoas
+-- distintas (esquecer `respondent_id` da chave, por exemplo) transformaria
+-- esse sucesso em 23505.
+SELECT extensions.dblink_exec(
+  'issue609_b',
+  $$CREATE FUNCTION pg_temp.try_insert_other_respondent() RETURNS TEXT
+    LANGUAGE plpgsql AS $fn$
+    BEGIN
+      INSERT INTO public.responses
+        (id, project_id, document_id, respondent_id, respondent_type,
+         respondent_name, answers, is_latest, is_partial)
+      VALUES
+        ('6d000000-0000-0000-0000-000000000002',
+         '6b000000-0000-0000-0000-000000000001',
+         '6c000000-0000-0000-0000-000000000001',
+         '6a000000-0000-0000-0000-000000000002', 'humano', 'Bruno',
+         '{"q1":"do bruno"}'::jsonb, true, false);
+      RETURN 'inserted';
+    EXCEPTION WHEN unique_violation THEN
+      RETURN pg_catalog.format('rejected:%s', SQLERRM);
+    END;
+    $fn$;$$
+);
+
+-- A segura o mutex do documento com uma gravação completa da própria Ana.
+SELECT extensions.dblink_exec('issue609_a', 'BEGIN');
+SELECT extensions.dblink_exec(
+  'issue609_a',
+  $$UPDATE public.responses
+    SET answers = '{"q1":"ana de novo"}'::jsonb
+    WHERE id = '6d000000-0000-0000-0000-000000000001'$$
+);
+
+SELECT extensions.dblink_send_query(
+  'issue609_b',
+  $$SELECT pg_temp.try_insert_other_respondent()$$
+);
+SELECT pg_catalog.pg_sleep(0.2);
+SELECT extensions.dblink_exec('issue609_a', 'COMMIT');
+
+CREATE TEMP TABLE issue609_other_result AS
+SELECT * FROM extensions.dblink_get_result('issue609_b') AS result(outcome TEXT);
+SELECT * FROM extensions.dblink_get_result('issue609_b') AS result(outcome TEXT);
+
+DO $$
+DECLARE
+  v_outcome TEXT;
+BEGIN
+  SELECT outcome INTO v_outcome FROM issue609_other_result;
+  IF v_outcome IS DISTINCT FROM 'inserted' THEN
+    RAISE EXCEPTION
+      'FALHOU: gravação de OUTRO respondente no mesmo documento foi recusada (%)',
+      COALESCE(v_outcome, '<nulo>');
+  END IF;
+  RAISE NOTICE 'OK 3: o segundo pesquisador do mesmo documento é aceito';
+END;
+$$;
+
+DO $$
+DECLARE
+  v_rows INTEGER;
+BEGIN
+  SELECT pg_catalog.count(*) INTO v_rows
+  FROM public.responses
+  WHERE document_id = '6c000000-0000-0000-0000-000000000001'
+    AND respondent_type = 'humano'
+    AND is_latest;
+
+  IF v_rows <> 2 THEN
+    RAISE EXCEPTION
+      'FALHOU: esperadas 2 correntes (uma por pesquisador), encontradas %',
+      v_rows;
+  END IF;
+  RAISE NOTICE 'OK 3b: a dupla independente continua representável';
+END;
+$$;
+
+-- ========== cleanup ========================================================
+SELECT extensions.dblink_disconnect('issue609_a');
+SELECT extensions.dblink_disconnect('issue609_b');
+
+DELETE FROM public.projects
+WHERE id = '6b000000-0000-0000-0000-000000000001';
+DELETE FROM auth.users
+WHERE id IN (
+  '6a000000-0000-0000-0000-000000000001',
+  '6a000000-0000-0000-0000-000000000002'
+);

--- a/frontend/supabase/tests/responses_one_latest_human.test.sql
+++ b/frontend/supabase/tests/responses_one_latest_human.test.sql
@@ -1,0 +1,294 @@
+-- Unicidade da resposta humana corrente em `responses` (issue #609).
+--
+-- Como rodar (após `npx supabase start` e `npx supabase db reset`):
+--   npm run test:db:responses-human-latest
+-- ou, à mão:
+--   docker exec -e PGPASSWORD=postgres -i supabase_db_frontend \
+--     psql -U postgres -d postgres -X -v ON_ERROR_STOP=1 \
+--     < supabase/tests/responses_one_latest_human.test.sql
+--
+-- O teste roda inteiro dentro de BEGIN ... ROLLBACK; nada sobrevive. Qualquer
+-- RAISE EXCEPTION marcado como FALHOU aborta com exit code != 0 sob
+-- ON_ERROR_STOP=1.
+--
+-- Cobre os dois lados da restrição, que é onde mora o risco de um índice mal
+-- escrito: o que ele DEVE recusar (mesma pessoa duas vezes) e o que ele NÃO
+-- pode passar a recusar (dupla independente, histórico, LLM). O cenário 9
+-- guarda o achado que a issue não previu: unify_project_members construía o
+-- estado proibido antes de desfazê-lo.
+
+BEGIN;
+
+-- ---------------------------------------------------------------- fixtures
+INSERT INTO auth.users (id, email) VALUES
+  ('60910000-0000-0000-0000-000000000001', 'issue609-coord@example.test'),
+  ('60910000-0000-0000-0000-000000000002', 'issue609-ana@example.test'),
+  ('60910000-0000-0000-0000-000000000003', 'issue609-bruno@example.test');
+
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+SELECT id::text, id, 1
+FROM auth.users
+WHERE id::text LIKE '60910000-0000-0000-0000-%';
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('60900000-0000-0000-0000-000000000001', 'Issue 609 - unicidade humana',
+   '60910000-0000-0000-0000-000000000001');
+
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('60900000-0000-0000-0000-000000000001',
+   '60910000-0000-0000-0000-000000000001', 'coordenador'),
+  ('60900000-0000-0000-0000-000000000001',
+   '60910000-0000-0000-0000-000000000002', 'pesquisador'),
+  ('60900000-0000-0000-0000-000000000001',
+   '60910000-0000-0000-0000-000000000003', 'pesquisador');
+
+INSERT INTO public.documents (id, project_id, title, text) VALUES
+  ('60920000-0000-0000-0000-000000000001',
+   '60900000-0000-0000-0000-000000000001', 'Doc A', 'texto A'),
+  ('60920000-0000-0000-0000-000000000002',
+   '60900000-0000-0000-0000-000000000001', 'Doc B', 'texto B');
+
+-- A resposta corrente de Ana no Doc A. Todo cenário abaixo parte daqui.
+INSERT INTO public.responses
+  (id, project_id, document_id, respondent_id, respondent_type,
+   respondent_name, answers, is_latest, is_partial)
+VALUES
+  ('60930000-0000-0000-0000-000000000001',
+   '60900000-0000-0000-0000-000000000001',
+   '60920000-0000-0000-0000-000000000001',
+   '60910000-0000-0000-0000-000000000002', 'humano', 'Ana',
+   '{"campo": "primeira"}'::jsonb, true, false);
+
+-- ============ 1. Segunda corrente da MESMA pessoa no MESMO doc =============
+DO $$
+DECLARE
+  blocked BOOLEAN := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.responses
+      (project_id, document_id, respondent_id, respondent_type,
+       respondent_name, answers, is_latest, is_partial)
+    VALUES
+      ('60900000-0000-0000-0000-000000000001',
+       '60920000-0000-0000-0000-000000000001',
+       '60910000-0000-0000-0000-000000000002', 'humano', 'Ana',
+       '{"campo": "segunda"}'::jsonb, true, false);
+  EXCEPTION WHEN unique_violation THEN
+    blocked := true;
+  END;
+
+  IF NOT blocked THEN
+    RAISE EXCEPTION
+      'FALHOU: segunda resposta humana corrente da mesma pessoa foi aceita';
+  END IF;
+  RAISE NOTICE 'OK 1: segunda corrente da mesma pessoa recusada com 23505';
+END;
+$$;
+
+-- ============ 2. Promover histórica do mesmo autor (caminho do unify) ======
+INSERT INTO public.responses
+  (id, project_id, document_id, respondent_id, respondent_type,
+   respondent_name, answers, is_latest, is_partial)
+VALUES
+  ('60930000-0000-0000-0000-000000000002',
+   '60900000-0000-0000-0000-000000000001',
+   '60920000-0000-0000-0000-000000000001',
+   '60910000-0000-0000-0000-000000000002', 'humano', 'Ana',
+   '{"campo": "historica"}'::jsonb, false, false);
+
+DO $$
+DECLARE
+  blocked BOOLEAN := false;
+BEGIN
+  BEGIN
+    UPDATE public.responses
+    SET is_latest = true
+    WHERE id = '60930000-0000-0000-0000-000000000002';
+  EXCEPTION WHEN unique_violation THEN
+    blocked := true;
+  END;
+
+  IF NOT blocked THEN
+    RAISE EXCEPTION
+      'FALHOU: UPDATE promoveu histórica a corrente com outra corrente viva';
+  END IF;
+  RAISE NOTICE 'OK 2: promoção de histórica recusada com 23505';
+END;
+$$;
+
+-- ============ 3. Humano corrente sem respondent_id =========================
+-- Sem este CHECK o índice não restringe nada nesse caso: NULL nunca colide.
+DO $$
+DECLARE
+  blocked BOOLEAN := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.responses
+      (project_id, document_id, respondent_id, respondent_type,
+       respondent_name, answers, is_latest, is_partial)
+    VALUES
+      ('60900000-0000-0000-0000-000000000001',
+       '60920000-0000-0000-0000-000000000002',
+       NULL, 'humano', 'Anônima',
+       '{"campo": "sem autor"}'::jsonb, true, false);
+  EXCEPTION WHEN check_violation THEN
+    blocked := true;
+  END;
+
+  IF NOT blocked THEN
+    RAISE EXCEPTION
+      'FALHOU: resposta humana corrente sem respondent_id foi aceita';
+  END IF;
+  RAISE NOTICE 'OK 3: humano corrente sem autor recusado com 23514';
+END;
+$$;
+
+-- ============ 4-8. O que a restrição NÃO pode passar a recusar =============
+-- Um índice mal escrito quebra o produto aqui, e não no caso 1.
+DO $$
+BEGIN
+  -- 4. Dupla independente: dois humanos DISTINTOS correntes no mesmo doc.
+  INSERT INTO public.responses
+    (id, project_id, document_id, respondent_id, respondent_type,
+     respondent_name, answers, is_latest, is_partial)
+  VALUES
+    ('60930000-0000-0000-0000-000000000003',
+     '60900000-0000-0000-0000-000000000001',
+     '60920000-0000-0000-0000-000000000001',
+     '60910000-0000-0000-0000-000000000003', 'humano', 'Bruno',
+     '{"campo": "do bruno"}'::jsonb, true, false);
+
+  -- 5. Mesma pessoa: 1 corrente + N históricas (a do caso 2 já é uma).
+  INSERT INTO public.responses
+    (project_id, document_id, respondent_id, respondent_type,
+     respondent_name, answers, is_latest, is_partial)
+  VALUES
+    ('60900000-0000-0000-0000-000000000001',
+     '60920000-0000-0000-0000-000000000001',
+     '60910000-0000-0000-0000-000000000002', 'humano', 'Ana',
+     '{"campo": "outra historica"}'::jsonb, false, false);
+
+  -- 6. LLM corrente convive com humano corrente no mesmo doc.
+  INSERT INTO public.responses
+    (project_id, document_id, respondent_id, respondent_type,
+     respondent_name, answers, is_latest, is_partial)
+  VALUES
+    ('60900000-0000-0000-0000-000000000001',
+     '60920000-0000-0000-0000-000000000001',
+     NULL, 'llm', 'gemini/flash',
+     '{"campo": "do llm"}'::jsonb, true, false);
+
+  -- 7. Histórico humano sem autor continua representável (o CHECK isenta).
+  INSERT INTO public.responses
+    (project_id, document_id, respondent_id, respondent_type,
+     respondent_name, answers, is_latest, is_partial)
+  VALUES
+    ('60900000-0000-0000-0000-000000000001',
+     '60920000-0000-0000-0000-000000000002',
+     NULL, 'humano', 'Legado sem autor',
+     '{"campo": "legado"}'::jsonb, false, false);
+
+  -- 8. Mesma pessoa corrente em documentos diferentes.
+  INSERT INTO public.responses
+    (project_id, document_id, respondent_id, respondent_type,
+     respondent_name, answers, is_latest, is_partial)
+  VALUES
+    ('60900000-0000-0000-0000-000000000001',
+     '60920000-0000-0000-0000-000000000002',
+     '60910000-0000-0000-0000-000000000002', 'humano', 'Ana',
+     '{"campo": "doc B"}'::jsonb, true, false);
+
+  RAISE NOTICE 'OK 4-8: dupla independente, histórico, LLM e outro doc seguem permitidos';
+END;
+$$;
+
+-- ============ 9. unify_project_members não colide com a restrição ==========
+-- Ana e Bruno têm, cada um, resposta corrente no Doc A (casos 1 e 4). Unificar
+-- Bruno em Ana faz a RPC repontar respondent_id — o statement que, na ordem
+-- anterior, produzia duas correntes da mesma pessoa e estouraria 23505.
+DO $$
+DECLARE
+  v_current_count INTEGER;
+  v_winner UUID;
+BEGIN
+  -- Source e target são memberships terminais; a própria RPC remove a
+  -- membership do source e registra o alias no fim. Por isso o vínculo NÃO é
+  -- inserido aqui: `linked_user_id` que ainda seja membro é recusado pelo
+  -- guard `enforce_terminal_member_email_alias`.
+  PERFORM public.unify_project_members(
+    '60900000-0000-0000-0000-000000000001',
+    '60910000-0000-0000-0000-000000000003',  -- source: Bruno
+    '60910000-0000-0000-0000-000000000002',  -- target: Ana
+    '60910000-0000-0000-0000-000000000003',  -- a conta do source vira o alias
+    'issue609-bruno@example.test',
+    '60910000-0000-0000-0000-000000000001',
+    0
+  );
+
+  SELECT pg_catalog.count(*) INTO v_current_count
+  FROM public.responses
+  WHERE document_id = '60920000-0000-0000-0000-000000000001'
+    AND respondent_type = 'humano'
+    AND is_latest;
+
+  IF v_current_count <> 1 THEN
+    RAISE EXCEPTION
+      'FALHOU: unificação deixou % respostas humanas correntes no Doc A (esperado 1)',
+      v_current_count;
+  END IF;
+
+  -- O vencedor tem de ser o mesmo que a ordem antiga elegia: a mais recente
+  -- por COALESCE(updated_at, created_at) DESC, id DESC. Bruno foi inserido
+  -- depois de Ana, então a linha dele prevalece — só que agora sob Ana.
+  SELECT id INTO v_winner
+  FROM public.responses
+  WHERE document_id = '60920000-0000-0000-0000-000000000001'
+    AND respondent_type = 'humano'
+    AND is_latest;
+
+  IF v_winner <> '60930000-0000-0000-0000-000000000003' THEN
+    RAISE EXCEPTION
+      'FALHOU: unificação elegeu vencedor % (esperado a linha mais recente)',
+      v_winner;
+  END IF;
+
+  RAISE NOTICE 'OK 9: unificação convive com a restrição e mantém o mesmo vencedor';
+END;
+$$;
+
+-- ============ Prova do vermelho ===========================================
+-- Sem isto o arquivo provaria apenas que ALGO recusou o INSERT do caso 1 — e a
+-- tabela tem três triggers próprios, qualquer um deles um suspeito plausível.
+-- Derrubar o índice e repetir o mesmo INSERT mostra que o 23505 vinha DELE, e
+-- de quebra prova que este teste é vermelho sem a migration. O ROLLBACK final
+-- devolve o índice.
+DROP INDEX public.responses_one_latest_human_per_document;
+
+DO $$
+DECLARE
+  accepted BOOLEAN := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.responses
+      (project_id, document_id, respondent_id, respondent_type,
+       respondent_name, answers, is_latest, is_partial)
+    VALUES
+      ('60900000-0000-0000-0000-000000000001',
+       '60920000-0000-0000-0000-000000000002',
+       '60910000-0000-0000-0000-000000000002', 'humano', 'Ana',
+       '{"campo": "duplicata sem indice"}'::jsonb, true, false);
+    accepted := true;
+  EXCEPTION WHEN unique_violation THEN
+    accepted := false;
+  END;
+
+  IF NOT accepted THEN
+    RAISE EXCEPTION
+      'FALHOU: o 23505 do caso 1 não vinha do índice — sem ele o INSERT ainda é recusado';
+  END IF;
+  RAISE NOTICE 'OK: prova do vermelho — sem o índice a duplicata passa';
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
Closes #609

## O problema

`responses` tinha índice único apenas para o lado LLM. A chave lógica equivalente para humanos — uma resposta corrente por (projeto, documento, respondente) — vivia **só na aplicação**, no `SELECT` de `fetchSaveContext`, aplicado num read-then-write sem trava: a leitura que decide "existe linha?" e a escrita que age sobre essa decisão são requests PostgREST separados, em transações distintas. O estado "duas linhas `is_latest = true` da mesma pessoa no mesmo documento" era construível.

Medido em produção em 27/07/2026 (`medir-duplicatas.mts`, read-only, 1.180 linhas), e reconfirmado imediatamente antes deste PR: **0 duplicatas humanas ativas**, 0 duplicatas LLM (controle), 0 respostas humanas com `respondent_id` NULL sobre 629 correntes. **É garantia ausente, não estrago em curso** — não há dado a reparar.

O que torna a corrigir mesmo sem casos: a duplicata **se auto-amplifica**. Com duas linhas ativas o `.maybeSingle()` passa a errar sempre; o erro era descartado, `existing` vinha nulo e cada gravação seguinte criava mais uma linha — apagando, de quebra, os valores brutos que o #484 preserva. A jusante, quatro consumidores contam linhas em vez de pessoas.

## Achado que a issue não previu (bloqueante)

`unify_project_members` **constrói o estado proibido de propósito** e só depois o desfaz: reatribui `respondent_id` do source para o target e *então* demove as perdedoras. Como índice parcial não pode ser `DEFERRABLE` (`UNIQUE CONSTRAINT` não aceita `WHERE`), a checagem é imediata, dentro do statement do repoint — a unificação passaria a estourar `23505` para o coordenador **em runtime, depois do deploy**, e `preview_project_member_unification` não avisaria: ele só antecipa colisões de review, arbitragem e comparação.

A correção inverte a ordem (demover antes de repontar), rankeando sobre a união source ∪ target. Mesmo vencedor, mesmo desempate, nenhuma semântica nova. **Provado empiricamente**: reinstalando a versão antiga dentro da transação do teste, o cenário 9 falha com `duplicate key value violates unique constraint "responses_one_latest_human_per_document"`.

A restrição também revelou uma fixture (`atomic_replace_rpcs`) que criava resposta humana corrente sem autor — corrigida para nomear o respondente, sem alterar o que o teste prova.

## O que muda

**Migration** (`20260727120000`), em transação única com `LOCK TABLE ... SHARE ROW EXCLUSIVE`:
- `responses_one_latest_human_per_document` — único parcial em `(project_id, document_id, respondent_id) WHERE respondent_type = 'humano' AND is_latest`. Dois humanos **distintos** correntes no mesmo documento seguem permitidos: é a dupla independente.
- `responses_human_latest_has_actor_check` — não é acessório: `NULL` nunca colide em índice único, então sem ele respostas humanas correntes sem autor passariam sem violar nada. A restrição existiria e não restringiria.
- **Preflight aborta, não saneia.** Demover `is_latest` dispara `archive_review_dependencies_on_response_change`, que apaga `field_reviews` e `response_equivalences` e reconcilia assignments — destruir revisão humana não pode ser efeito colateral de um `db push`. O SQL de reparo determinístico fica no comentário, para ser rodado conscientemente.

**Aplicação** (`actions/responses.ts`):
- `upsertResponseRow` → `persistResponseRow`: `UPDATE` filtrado pela **chave lógica** (não por `id`) com `.select("id")` — o rowcount decide, não a leitura. `INSERT` só quando 0 linhas; `23505` do índice vira retry com **releitura obrigatória** (reaplicar o payload anterior sobrescreveria o que a vencedora gravou). Teto de 2 tentativas, com `console.warn` no ramo de conflito como sinal de frequência.
- `.upsert({ onConflict })` do PostgREST está **descartado por prova**: o Postgres exige que a inferência do arbiter reproduza o predicado do índice parcial, e o `on_conflict` do PostgREST só transporta a lista de colunas. Verificado por `EXPLAIN` contra o índice parcial do lado LLM.
- **O erro do `SELECT` deixa de ser descartado.** Isso importa *mais* depois do índice: falha de leitura levaria o UPDATE a acertar a linha real e sobrescrever a proveniência bruta, sem deixar rastro.

## Verificação

Tier 1. **Prova do vermelho de cada guard**, não do conjunto:
- `responses_one_latest_human.test.sql` — 3 casos que devem falhar, 5 que **não podem passar a falhar** (dupla independente, histórico, LLM, outro doc) e o cenário do `unify`. Prova do vermelho embutida: `DROP INDEX` na própria transação e repetição do INSERT, que **deve** passar — isso mostra que o `23505` vinha do índice e não de um dos três triggers da tabela.
- `responses_latest_human_concurrency.test.sql` (dblink) — prova o contrato de que o app depende: a perdedora espera, recebe `23505` **nomeado** (o `insErr.message.includes(...)` distingue o conflito pelo nome do índice) e o retry pela chave lógica converge. Rodada sem o índice, falha com `a gravação perdedora não foi recusada (resultado: unexpected-success)`.
- Vitest: 8 casos novos, cada guard **provado por mutação** (filtro por `id`, erro do SELECT descartado, `23505` de outra constraint, rowcount ignorado, teto de tentativas, guarda de `fields` vazio). O refactor de complexidade expôs uma lacuna de cobertura anterior à issue, agora fechada.
- `npm run test:db` completo, 1999 testes Vitest, `npm run invariants` 13/13 PASS contra produção.

A invariante `responses-is-latest-unica` já existia e não foi recriada; sua motivação passa a nomear os índices, porque um FAIL agora significa índice dropado ou canal de escrita que o contorna.

**Nota registrada na suíte**: a espera entre respondentes *distintos* no mesmo documento é pré-existente e vem do `FOR UPDATE` em `documents` de `enqueue_auto_review_reconciliation` (mutex de publicação compartilhado com `publish_latest_llm_response`), não da unicidade — medido em `transactionid`/ShareLock.

## Antes do merge

A migration precisa ser aplicada no remoto **antes** do merge (regra do projeto para constraint fail-closed, #135/#455). O preflight foi reconfirmado com 0 resíduo.

**A sequência `db push` → merge → deploy tem de ser contígua.** Entre aplicar a migration e o deploy do frontend, o código **antigo** roda contra o índice **novo**: o ramo de INSERT dele não conhece `23505`, então uma corrida perdida nessa janela apareceria para o pesquisador como a mensagem crua do Postgres. Não há mitigação em código — o código novo já é agnóstico à ordem (sem o índice, o ramo de conflito simplesmente não dispara), e é o código antigo, que não posso alterar, quem quebra. A probabilidade é baixa (corrida rara, 0 duplicatas medidas), mas a mitigação é encurtar a janela, não documentá-la.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UWeHXP4CUZhUFqxU9sRsJ
