### PR TITLE
fix(comparação): veredito carrega o campo de origem; campo atual rastreado por nome

### DIFF
--- a/frontend/.env.e2e.example
+++ b/frontend/.env.e2e.example
@@ -61,6 +61,20 @@ E2E_LOTTERY_PROJECT_ID=
 #   cd frontend && npm run e2e:fixture:coding
 E2E_CODING_PROJECT_ID=
 
+# compare-field-switch.smoke.spec.ts — projeto dedicado do smoke de troca de
+# campo na Comparação (#613). 6 campos `single` com conjuntos de opções
+# DISJUNTOS (ALFA-opcao-1, BETA-opcao-1, ...), 2 documentos e 2 respondentes
+# humanos divergentes em todos os campos. As opções disjuntas são a propriedade
+# que torna "veredito gravado no campo errado" detectável sem ambiguidade — se
+# alguém uniformizar as opções, o smoke fica verde e para de testar o bug.
+#
+# O spec APAGA `reviews` do projeto a cada run, por isso ele precisa ser
+# exclusivo — não reutilizar o de config-guard/export/codificação.
+#
+# Para provisionar (idempotente, imprime o id no fim):
+#   cd frontend && npm run e2e:fixture:compare
+E2E_COMPARE_PROJECT_ID=
+
 # Opcional: URL base do Playwright.
 # - Manual (`npm run test:e2e`): default http://localhost:3000 e pode
 #   reaproveitar um dev server existente.

--- a/frontend/e2e/compare-field-switch.smoke.spec.ts
+++ b/frontend/e2e/compare-field-switch.smoke.spec.ts
@@ -127,7 +127,13 @@ async function fixtureDocIds(
 async function goToField(page: Page, target: number): Promise<void> {
   const header = page.getByText(new RegExp(`Campo \\d+/${TOTAL_FIELDS}`)).first();
   for (let attempt = 0; attempt < TOTAL_FIELDS * 2; attempt++) {
-    const text = await header.innerText();
+    // A leitura do cabeçalho vai por `expect.poll` — e não por um `innerText`
+    // direto — porque um re-render entre a asserção de visibilidade e a leitura
+    // desanexa o nó, e aí o `innerText` cru estoura em vez de tentar de novo.
+    let text = "";
+    await expect
+      .poll(async () => (text = await header.innerText()), { timeout: 10_000 })
+      .toContain("Campo");
     if (text.includes(`Campo ${target}/${TOTAL_FIELDS}`)) return;
     await page.keyboard.press("n");
     await expect

--- a/frontend/e2e/compare-field-switch.smoke.spec.ts
+++ b/frontend/e2e/compare-field-switch.smoke.spec.ts
@@ -1,0 +1,287 @@
+import { test, expect, type Page } from "@playwright/test";
+import { clerk, setupClerkTestingToken } from "@clerk/testing/playwright";
+import { createClient } from "@supabase/supabase-js";
+import { withClerkCleanup } from "./clerk-cleanup";
+
+// Regressão da #613: navegar entre campos na Comparação deixava os cards do
+// campo ANTERIOR na tela, e clicar num deles gravava aquele valor no campo
+// atual — 2 vereditos corrompidos em produção.
+//
+// A causa foi medida, não suposta: os três filhos do container de scroll do
+// `ComparisonPanel` usavam a MESMA `key` (`documentId|fieldName|readOnly`).
+// Em `reconcileChildrenArray` o React indexa os filhos antigos por chave, e o
+// último duplicado sobrescrevia o primeiro no mapa — então o fiber do
+// `AgreementGroup` nunca entrava em `deletions` e a subárvore continuava
+// MONTADA, com handlers vivos. Não era DOM órfão: era vazamento de montagem.
+// O React avisava (`Encountered two children with the same key`), mas o aviso
+// se perdia no console.
+//
+// Por isso a asserção central é a CONTAGEM DE RAÍZES, não a aparência: é ela
+// que pega a duplicação de chave se alguém reintroduzir um irmão keyado igual.
+// A segunda asserção fecha a ponta de escrita — o valor que chega ao banco.
+//
+// O fixture (npm run e2e:fixture:compare) tem uma propriedade que o teste
+// depende: os 6 campos têm conjuntos de opções DISJUNTOS, prefixados pelo nome
+// do campo. Um veredito fora do conjunto do campo é prova de corrupção, não
+// indício. Preservar.
+//
+// Como o coding-save.smoke, este spec MUTA o projeto de teste dedicado
+// (E2E_COMPARE_PROJECT_ID) com a service key. Serial dentro do arquivo (#198).
+test.describe.configure({ mode: "default" });
+
+const hasClerkTestingEnv =
+  !!process.env.CLERK_SECRET_KEY &&
+  !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+const hasSupabaseAdminEnv =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const PROJECT_NAME = "Comparação campo-trocado — teste E2E";
+const DOC_TITLES = ["Doc campo-trocado 1", "Doc campo-trocado 2"];
+const TOTAL_FIELDS = 6;
+
+function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false } },
+  );
+}
+
+interface FixtureField {
+  name: string;
+  options: string[];
+}
+
+/**
+ * Interlock de segurança. Este spec apaga linhas de `reviews` com a service key
+ * contra o banco de PRODUÇÃO a cada `git push`; se `E2E_COMPARE_PROJECT_ID`
+ * apontar para um projeto real (id colado errado, `.env.e2e` copiado de outra
+ * máquina), o estrago seria irreversível. As três travas abaixo abortam ANTES
+ * de qualquer escrita, e a terceira é a que nenhum projeto real satisfaz.
+ */
+async function assertFixtureProject(
+  admin: ReturnType<typeof createAdminClient>,
+  projectId: string,
+): Promise<FixtureField[]> {
+  const { data: project } = await admin
+    .from("projects")
+    .select("id, name, pydantic_fields")
+    .eq("id", projectId)
+    .maybeSingle();
+
+  expect(project, `projeto ${projectId} não existe`).not.toBeNull();
+  expect(
+    project!.name,
+    "E2E_COMPARE_PROJECT_ID não é o projeto do fixture",
+  ).toBe(PROJECT_NAME);
+
+  const fields = (project!.pydantic_fields ?? []) as FixtureField[];
+  expect(fields).toHaveLength(TOTAL_FIELDS);
+
+  // Opções disjuntas entre TODOS os campos: a propriedade que define o fixture
+  // e que nenhum codebook real tem.
+  const seen = new Set<string>();
+  for (const f of fields) {
+    for (const option of f.options ?? []) {
+      expect(seen.has(option), `opção "${option}" repetida entre campos`).toBe(
+        false,
+      );
+      seen.add(option);
+    }
+  }
+  return fields;
+}
+
+/**
+ * Documentos do fixture por TÍTULO EXATO — nunca `.limit(1)` posicional (mesma
+ * trava do coding-save). Serve para confirmar que o veredito gravado pertence
+ * ao fixture, sem presumir QUAL dos dois a fila exibiu primeiro.
+ */
+async function fixtureDocIds(
+  admin: ReturnType<typeof createAdminClient>,
+  projectId: string,
+): Promise<string[]> {
+  const { data } = await admin
+    .from("documents")
+    .select("id, title")
+    .eq("project_id", projectId)
+    .in("title", DOC_TITLES);
+  expect(data, "documentos do fixture não encontrados").not.toBeNull();
+  expect(data!).toHaveLength(DOC_TITLES.length);
+  return data!.map((d) => d.id as string);
+}
+
+/**
+ * Avança até o campo `target` pela tecla `n`, de forma IDEMPOTENTE: só pressiona
+ * enquanto o cabeçalho ainda não chegou lá.
+ *
+ * Não é preciosismo. A tecla apertada antes da hidratação é engolida em
+ * silêncio — o listener de `keydown` ainda não existe —, e não há sinal de DOM
+ * confiável para "já hidratou" (`toHaveCount` é satisfeito pelo HTML do
+ * servidor). Um `press` único falha de forma intermitente, e um `toPass`
+ * envolvendo o press passaria do alvo quando a asserção fosse só lenta. Reler o
+ * cabeçalho a cada tentativa resolve os dois: nunca ultrapassa, nunca depende
+ * de timing.
+ */
+async function goToField(page: Page, target: number): Promise<void> {
+  const header = page.getByText(new RegExp(`Campo \\d+/${TOTAL_FIELDS}`)).first();
+  for (let attempt = 0; attempt < TOTAL_FIELDS * 2; attempt++) {
+    const text = await header.innerText();
+    if (text.includes(`Campo ${target}/${TOTAL_FIELDS}`)) return;
+    await page.keyboard.press("n");
+    await expect
+      .poll(async () => (await header.innerText()).trim(), { timeout: 3_000 })
+      .not.toBe(text.trim())
+      .catch(() => {
+        /* tecla engolida na hidratação: a próxima volta tenta de novo */
+      });
+  }
+  await expect(header).toHaveText(
+    new RegExp(`Campo ${target}/${TOTAL_FIELDS}`),
+  );
+}
+
+function skipUnlessConfigured() {
+  const email = process.env.E2E_COORDINATOR_EMAIL;
+  const projectId = process.env.E2E_COMPARE_PROJECT_ID;
+  test.skip(
+    !hasClerkTestingEnv || !hasSupabaseAdminEnv || !email || !projectId,
+    "defina CLERK_SECRET_KEY, NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, " +
+      "NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, " +
+      "E2E_COORDINATOR_EMAIL e E2E_COMPARE_PROJECT_ID",
+  );
+  return { email: email!, projectId: projectId! };
+}
+
+test("comparação: navegar entre campos mostra só os cards do campo atual", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  const { email, projectId } = skipUnlessConfigured();
+
+  const admin = createAdminClient();
+  const fields = await assertFixtureProject(admin, projectId);
+  await admin.from("reviews").delete().eq("project_id", projectId);
+
+  await setupClerkTestingToken({ page });
+  await page.goto("/auth/login");
+  await clerk.signIn({ page, emailAddress: email });
+
+  await withClerkCleanup({
+    page,
+    context: "compare-field-switch/exibicao",
+    // `signOut` direto numa página de análise trava no `waitForFunction` de
+    // `window.Clerk.loaded`; voltar ao dashboard antes é o padrão dos demais
+    // smokes.
+    prepareSignOut: async () => {
+      await page.goto("/dashboard");
+    },
+    run: async () => {
+      await page.goto(`/projects/${projectId}/analyze/compare?queue=all`);
+
+      await expect(
+        page.getByText(new RegExp(`Campo 1/${TOTAL_FIELDS}`)),
+      ).toBeVisible({
+        timeout: 60_000,
+      });
+      // Espera a hidratação antes da primeira tecla: sem isso o `n` é engolido e
+      // toda a contagem sai deslocada em um campo (medido ao investigar a #613).
+      await expect(page.getByTestId("agreement-group")).toHaveCount(1);
+
+      for (let i = 0; i < TOTAL_FIELDS; i++) {
+        await expect(
+          page.getByText(new RegExp(`Campo ${i + 1}/${TOTAL_FIELDS}`)),
+        ).toBeVisible();
+
+        // Critério de aceitação 1 da #613: uma raiz, sempre. Antes do fix isto
+        // ia 1, 2, 3, 4, 5, 6.
+        await expect(page.getByTestId("agreement-group")).toHaveCount(1);
+
+        // Contagem exata dos cards: a igualdade de CONJUNTO sozinha mascararia um
+        // card duplicado com o mesmo rótulo.
+        const cards = page.locator("button[data-vote-target]");
+        await expect(cards).toHaveCount(2);
+
+        // E o conteúdo é do campo atual — as opções são disjuntas, então isto é
+        // um discriminador, não uma coincidência.
+        const labels = await cards.evaluateAll((els) =>
+          els.map((el) => el.getAttribute("aria-label") ?? ""),
+        );
+        for (const option of fields[i].options.slice(0, 2)) {
+          expect(
+            labels.some((l) => l.includes(option)),
+            `campo ${fields[i].name}: esperava um card com "${option}", vi ${JSON.stringify(labels)}`,
+          ).toBe(true);
+        }
+
+        if (i < TOTAL_FIELDS - 1) await page.keyboard.press("n");
+      }
+    },
+  });
+});
+
+test("comparação: veredito confirmado após navegar grava no campo exibido", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  const { email, projectId } = skipUnlessConfigured();
+
+  const admin = createAdminClient();
+  const fields = await assertFixtureProject(admin, projectId);
+  const fixtureDocs = await fixtureDocIds(admin, projectId);
+  await admin.from("reviews").delete().eq("project_id", projectId);
+
+  const targetField = fields[1];
+
+  await setupClerkTestingToken({ page });
+  await page.goto("/auth/login");
+  await clerk.signIn({ page, emailAddress: email });
+
+  await withClerkCleanup({
+    page,
+    context: "compare-field-switch/escrita",
+    prepareSignOut: async () => {
+      await page.goto("/dashboard");
+    },
+    run: async () => {
+      await page.goto(`/projects/${projectId}/analyze/compare?queue=all`);
+
+      // Espera o cabeçalho E os cards antes da primeira tecla: `toHaveCount`
+      // sozinho é satisfeito pelo HTML do servidor, e a tecla apertada antes da
+      // hidratação é engolida em silêncio — a navegação não acontece e a
+      // asserção seguinte falha por um motivo que não é o do teste.
+      await expect(
+        page.getByText(new RegExp(`Campo 1/${TOTAL_FIELDS}`)),
+      ).toBeVisible({ timeout: 60_000 });
+      await expect(page.getByTestId("agreement-group")).toHaveCount(1);
+
+      await goToField(page, 2);
+
+      // Clica no PRIMEIRO card na tela: é a posição natural do clique e era
+      // exatamente onde ficava o card fantasma do campo anterior.
+      await page.locator("button[data-vote-target]").first().click();
+      await page.getByRole("button", { name: /^Confirmar$/ }).click();
+      await expect(page.getByText("Veredito salvo!")).toBeVisible({
+        timeout: 30_000,
+      });
+    },
+  });
+
+  // A prova é o banco, não o toast. Consulta pelo PROJETO, não por um documento
+  // escolhido a priori: qual dos dois a fila exibe primeiro é decisão do
+  // servidor (ordena por pendências), então fixar o documento aqui testaria a
+  // ordenação em vez do que interessa.
+  const { data: reviews } = await admin
+    .from("reviews")
+    .select("document_id, field_name, verdict")
+    .eq("project_id", projectId);
+
+  expect(reviews).toHaveLength(1);
+  expect(fixtureDocs).toContain(reviews![0].document_id as string);
+  // O coração do teste: o veredito foi para o campo EXIBIDO, com um valor do
+  // conjunto desse campo. Como as opções são disjuntas, um valor do campo
+  // anterior aqui seria prova de campo trocado — o bug da #613.
+  expect(reviews![0].field_name).toBe(targetField.name);
+  expect(targetField.options).toContain(reviews![0].verdict as string);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "invariants": "tsx scripts/invariants/check-invariants.ts",
-    "e2e:fixture:coding": "tsx scripts/e2e-fixtures/create-coding-save-fixture.mts"
+    "e2e:fixture:coding": "tsx scripts/e2e-fixtures/create-coding-save-fixture.mts",
+    "e2e:fixture:compare": "tsx scripts/e2e-fixtures/create-compare-field-switch-fixture.mts"
   },
   "dependencies": {
     "@clerk/localizations": "^4.13.4",

--- a/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
+++ b/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
@@ -1,0 +1,208 @@
+// Cria o projeto E2E dedicado ao smoke de troca de campo na Comparação
+// (frontend/e2e/compare-field-switch.smoke.spec.ts) e imprime o
+// E2E_COMPARE_PROJECT_ID para colar no .env.e2e.
+//
+// Versionado (e não deixado no harness local) porque E2E_COMPARE_PROJECT_ID é
+// obrigatória no gate de pre-push: sem a receita no repo, um clone novo trava
+// no gate sem caminho para destravar. Mesmo raciocínio de
+// create-coding-save-fixture.mts.
+//
+// PROPRIEDADE LOAD-BEARING — os 6 campos têm conjuntos de opções DISJUNTOS,
+// prefixados pelo nome do campo (ALFA-opcao-1, BETA-opcao-1, ...). É isso que
+// torna "veredito gravado no campo errado" detectável sem ambiguidade: uma
+// opção só existe em um campo, então um valor fora do conjunto do campo é
+// prova, não indício. Se alguém uniformizar as opções "para simplificar", o
+// smoke continua verde e para de testar o que interessa (#613).
+//
+// Idempotente: reutiliza projeto, documentos, membros e respostas pelo nome/
+// título, então rodar de novo é seguro e devolve sempre o mesmo id.
+//
+// Rodar de frontend/:  npm run e2e:fixture:compare
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createClient } from "@supabase/supabase-js";
+import {
+  applyEnvironment,
+  readOptionalEnvironmentFile,
+} from "../worktree-env/env-contract.mjs";
+
+// Mesmo par de arquivos, na mesma ordem de precedência, que o
+// playwright.config.ts carrega, ancorado no diretório do próprio script (não no
+// cwd): rodar da raiz do repo acharia o contrato e nenhum valor.
+const frontendDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+applyEnvironment(process.env, readOptionalEnvironmentFile(join(frontendDir, ".env.local")));
+applyEnvironment(process.env, readOptionalEnvironmentFile(join(frontendDir, ".env.e2e")), {
+  override: true,
+});
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) {
+  throw new Error("NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY ausentes");
+}
+// Os dois respondentes humanos são os usuários de teste que o contrato já
+// exige — evita uma terceira variável de ambiente só para este fixture. O
+// coordenador entra como respondente porque a fila de Comparação pede 2
+// humanos, e coordenador também codifica no produto.
+const COORDINATOR_EMAIL = process.env.E2E_COORDINATOR_EMAIL;
+const MEMBER_EMAIL = process.env.E2E_MEMBER_EMAIL;
+if (!COORDINATOR_EMAIL || !MEMBER_EMAIL) {
+  throw new Error("E2E_COORDINATOR_EMAIL / E2E_MEMBER_EMAIL ausentes (.env.e2e)");
+}
+
+const supabase = createClient(url, key, { auth: { persistSession: false } });
+
+export const PROJECT_NAME = "Comparação campo-trocado — teste E2E";
+const SCHEMA_HASH = "e2e-campotrocado-schema-hash";
+const LETTERS = ["ALFA", "BETA", "GAMA", "DELTA", "EPSILON", "ZETA"];
+
+const FIELDS = LETTERS.map((letter, i) => ({
+  hash: `e2e-ct-f${i + 1}`,
+  name: `q${i + 1}_${letter.toLowerCase()}`,
+  type: "single" as const,
+  options: [`${letter}-opcao-1`, `${letter}-opcao-2`, `${letter}-opcao-3`],
+  description: `Pergunta ${i + 1} (${letter}) — opções exclusivas deste campo`,
+}));
+
+const DOC_TITLES = ["Doc campo-trocado 1", "Doc campo-trocado 2"];
+
+async function profileId(email: string): Promise<string> {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("email", email)
+    .single();
+  if (error || !data) throw new Error(`profile ${email}: ${error?.message}`);
+  return data.id as string;
+}
+
+async function main() {
+  const [coordId, memberId] = await Promise.all([
+    profileId(COORDINATOR_EMAIL!),
+    profileId(MEMBER_EMAIL!),
+  ]);
+
+  const { data: existing } = await supabase
+    .from("projects")
+    .select("id")
+    .eq("name", PROJECT_NAME)
+    .maybeSingle();
+
+  let projectId: string;
+  const schema = {
+    pydantic_fields: FIELDS,
+    pydantic_hash: SCHEMA_HASH,
+    automation_mode: "compare_humans",
+  };
+  if (existing) {
+    projectId = existing.id as string;
+    const { error } = await supabase.from("projects").update(schema).eq("id", projectId);
+    if (error) throw new Error(`update projects: ${error.message}`);
+  } else {
+    const { data, error } = await supabase
+      .from("projects")
+      .insert({
+        ...schema,
+        name: PROJECT_NAME,
+        description:
+          "Fixture sintético do smoke de troca de campo na Comparação (#613). Opções disjuntas por campo — ver o script que o cria.",
+        created_by: coordId,
+        schema_version_major: 1,
+        schema_version_minor: 0,
+        schema_version_patch: 0,
+      })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`insert projects: ${error?.message}`);
+    projectId = data.id as string;
+  }
+
+  for (const [userId, role] of [
+    [coordId, "coordenador"],
+    [memberId, "pesquisador"],
+  ] as const) {
+    const { error } = await supabase
+      .from("project_members")
+      .upsert({ project_id: projectId, user_id: userId, role }, { onConflict: "project_id,user_id" });
+    if (error) throw new Error(`upsert project_members: ${error.message}`);
+  }
+
+  const text = "Texto sintetico do documento de teste. ".repeat(30);
+  const docIds: string[] = [];
+  for (const [i, title] of DOC_TITLES.entries()) {
+    const { data: doc } = await supabase
+      .from("documents")
+      .select("id")
+      .eq("project_id", projectId)
+      .eq("title", title)
+      .maybeSingle();
+    if (doc) {
+      docIds.push(doc.id as string);
+      continue;
+    }
+    const { data, error } = await supabase
+      .from("documents")
+      .insert({ project_id: projectId, external_id: `E2E-CT-${i + 1}`, title, text })
+      .select("id")
+      .single();
+    if (error || !data) throw new Error(`insert documents: ${error?.message}`);
+    docIds.push(data.id as string);
+  }
+
+  // Divergência em TODOS os campos: um respondente sempre na opção 1, o outro
+  // sempre na 2. Sem isso a fila não teria 6 campos para navegar.
+  for (const docId of docIds) {
+    for (const [userId, optionIndex] of [
+      [coordId, 0],
+      [memberId, 1],
+    ] as const) {
+      const answers: Record<string, string> = {};
+      for (const f of FIELDS) answers[f.name] = f.options[optionIndex];
+      const row = {
+        project_id: projectId,
+        document_id: docId,
+        respondent_type: "humano",
+        respondent_id: userId,
+        answers,
+        is_latest: true,
+        is_partial: false,
+        pydantic_hash: SCHEMA_HASH,
+        schema_version_major: 1,
+        schema_version_minor: 0,
+        schema_version_patch: 0,
+      };
+      const { data: ex } = await supabase
+        .from("responses")
+        .select("id")
+        .eq("project_id", projectId)
+        .eq("document_id", docId)
+        .eq("respondent_id", userId)
+        .maybeSingle();
+      const { error } = ex
+        ? await supabase.from("responses").update(row).eq("id", ex.id)
+        : await supabase.from("responses").insert(row);
+      if (error) throw new Error(`responses: ${error.message}`);
+    }
+  }
+
+  // O fixture é AUTORITATIVO sobre os respondentes do projeto: qualquer outra
+  // resposta humana é removida. Sem isto o projeto acumula respondentes de
+  // seeds antigos (aconteceu: o seed descartável do harness usava um par de
+  // usuários diferente, e o projeto ficou com três), a contagem de grupos muda
+  // e o spec passa a medir uma fila que não é a que o script descreve.
+  const { error: pruneError } = await supabase
+    .from("responses")
+    .delete()
+    .eq("project_id", projectId)
+    .eq("respondent_type", "humano")
+    .not("respondent_id", "in", `(${coordId},${memberId})`);
+  if (pruneError) throw new Error(`prune responses: ${pruneError.message}`);
+
+  // A limpeza de `reviews` é responsabilidade do SPEC, não do seed: assim o
+  // teste é idempotente sem depender de alguém ter rodado o seed antes.
+  console.log(`E2E_COMPARE_PROJECT_ID=${projectId}`);
+  console.log(`docs: ${docIds.join(", ")}`);
+  console.log(`campos: ${FIELDS.map((f) => f.name).join(", ")}`);
+}
+
+await main();

--- a/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
+++ b/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
@@ -14,6 +14,12 @@
 // prova, não indício. Se alguém uniformizar as opções "para simplificar", o
 // smoke continua verde e para de testar o que interessa (#613).
 //
+// Segunda propriedade load-bearing: os 6 campos são `single`. A asserção
+// central do spec conta `data-testid="agreement-group"`, que só o
+// `AgreementGroup` emite — um campo `multi` renderiza `MultiOptionReview`, sem
+// esse testid, e a contagem passaria a valer vacuamente para ele. Ao acrescentar
+// campo aqui, ou mantenha `single`, ou dê ao spec uma âncora equivalente.
+//
 // Idempotente: reutiliza projeto, documentos, membros e respostas pelo nome/
 // título, então rodar de novo é seguro e devolve sempre o mesmo id.
 //

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -94,6 +94,35 @@ async function fetchAll<T>(
   }
 }
 
+/**
+ * Busca linhas por um conjunto conhecido de ids, em lotes. Existe para as
+ * colunas JSONB volumosas (`answers`, `response_snapshot`), em que varrer a
+ * tabela inteira com `fetchAll` traria megabytes que a invariante descarta.
+ *
+ * O lote é de 100 e não maior porque o `.in()` do PostgREST vai na URL: ~500
+ * UUIDs estouram o limite e a query volta como erro de request, não de dados.
+ */
+async function fetchByIds<T>(
+  table: string,
+  columns: string,
+  ids: readonly string[],
+): Promise<T[]> {
+  const CHUNK = 100;
+  const rows: T[] = [];
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const batch = ids.slice(i, i + CHUNK);
+    const { data, error } = await supabase
+      .from(table)
+      .select(columns)
+      .in("id", batch);
+    if (error) {
+      throw new Error(`${table} por id (lote de ${batch.length}): ${error.message}`);
+    }
+    rows.push(...((data ?? []) as T[]));
+  }
+  return rows;
+}
+
 // Documentos soft-deletados ficam fora das invariantes de fila/status: o dedup
 // de 2026-06 deixa de propósito, na cópia excluída, linhas que conflitariam
 // com UNIQUE na sobrevivente (ver pipeline-processos/dedup, local). Elas são
@@ -667,25 +696,34 @@ const invariants: Invariant[] = [
   {
     name: "review-verdict-do-campo-declarado",
     motivation:
-      "#613: card do campo ANTERIOR sobrevivia à troca de campo e o clique gravava aquele valor no campo atual — 2 casos provados em 1.016 reviews com chosen_response_id. A régua é a `response_snapshot`, gravada no MESMO closure que decide `field_name`: se o veredito não bate com o que a tela mostrava para a resposta escolhida, e o valor pertence a outro campo dela, a decisão foi tomada num campo e gravada em outro",
+      "#613: card do campo ANTERIOR sobrevivia à troca de campo e o clique gravava aquele valor no campo atual — 2 casos provados em 1.016 reviews com chosen_response_id. A régua é a `response_snapshot`, gravada no MESMO closure que decide `field_name`: se o veredito não bate com o que a tela mostrava para a resposta escolhida, e o valor pertence a outro campo dela, a decisão foi tomada num campo e gravada em outro. As violações conhecidas em 2026-07-27 estão rastreadas na #623; elas NÃO são resíduo antigo — foram gravadas no mesmo dia, com o defeito ainda ativo em produção, então uma contagem que SOBE aqui é sinal de que a causa voltou",
     run: async () => {
-      const [reviews, responses, projects] = await Promise.all([
+      const [reviews, projects] = await Promise.all([
         fetchAll<ReviewVerdictRow>(
           "reviews",
           "id, project_id, field_name, verdict, chosen_response_id",
           (q) => q.not("chosen_response_id", "is", null),
-        ),
-        fetchAll<{ id: string; answers: Record<string, unknown> | null }>(
-          "responses",
-          "id, answers",
         ),
         fetchAll<{ id: string; pydantic_fields: PydanticField[] | null }>(
           "projects",
           "id, pydantic_fields",
         ),
       ]);
-      const answersOf = new Map(responses.map((r) => [r.id, r.answers ?? {}]));
       const fieldsOf = new Map(projects.map((p) => [p.id, p.pydantic_fields ?? []]));
+
+      // `answers` é JSONB da codificação inteira: buscar só as respostas de fato
+      // ESCOLHIDAS por algum veredito faz o custo escalar com `reviews`, não com
+      // o corpus de `responses` (mesmo motivo da fase 2 abaixo).
+      const chosenIds = [
+        ...new Set(reviews.map((rv) => rv.chosen_response_id!)),
+      ];
+      const answersOf = new Map<string, Record<string, unknown>>();
+      for (const row of await fetchByIds<{
+        id: string;
+        answers: Record<string, unknown> | null;
+      }>("responses", "id, answers", chosenIds)) {
+        answersOf.set(row.id, row.answers ?? {});
+      }
 
       // Fase 1 (metadados): candidato = divergência crua num campo `single` com
       // opções. O recorte por TIPO é o que exclui as duas famílias de ruído
@@ -707,18 +745,14 @@ const invariants: Invariant[] = [
         );
       });
 
-      // Fase 2: `response_snapshot` é JSONB volumoso — só dos candidatos, em
-      // lotes de 100 ids (500 UUIDs estouram a URL do PostgREST).
-      const CHUNK = 100;
+      // Fase 2: `response_snapshot` é JSONB volumoso — só dos candidatos.
       const snapshotOf = new Map<string, unknown>();
-      for (let i = 0; i < candidates.length; i += CHUNK) {
-        const ids = candidates.slice(i, i + CHUNK).map((c) => c.id);
-        const { data, error } = await supabase
-          .from("reviews")
-          .select("id, response_snapshot")
-          .in("id", ids);
-        if (error) throw new Error(`reviews snapshot (lote de ${ids.length}): ${error.message}`);
-        for (const row of data ?? []) snapshotOf.set(row.id as string, row.response_snapshot);
+      for (const row of await fetchByIds<{ id: string; response_snapshot: unknown }>(
+        "reviews",
+        "id, response_snapshot",
+        candidates.map((c) => c.id),
+      )) {
+        snapshotOf.set(row.id, row.response_snapshot);
       }
 
       const violations: Violation[] = [];

--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -25,6 +25,10 @@ import {
   type PersistedLogEntryRow,
 } from "@/lib/schema-backfill";
 import { computeFieldHash } from "@/lib/schema-utils";
+// Mesma primitiva de igualdade que o produto usa para decidir divergência
+// (`lib/compare-divergence.ts`, `lib/equivalence.ts`): se as duas réguas
+// divergirem, é bug de contrato e a invariante deve enxergar.
+import { normalizeForComparison } from "@/lib/utils";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 import { loadEnv } from "../comentarios-relatorio/load-env";
 
@@ -660,7 +664,150 @@ const invariants: Invariant[] = [
         .map((r) => ({ key: r.id, detail: "final_verdict=llm sem question_improvement_suggestion" }));
     },
   },
+  {
+    name: "review-verdict-do-campo-declarado",
+    motivation:
+      "#613: card do campo ANTERIOR sobrevivia à troca de campo e o clique gravava aquele valor no campo atual — 2 casos provados em 1.016 reviews com chosen_response_id. A régua é a `response_snapshot`, gravada no MESMO closure que decide `field_name`: se o veredito não bate com o que a tela mostrava para a resposta escolhida, e o valor pertence a outro campo dela, a decisão foi tomada num campo e gravada em outro",
+    run: async () => {
+      const [reviews, responses, projects] = await Promise.all([
+        fetchAll<ReviewVerdictRow>(
+          "reviews",
+          "id, project_id, field_name, verdict, chosen_response_id",
+          (q) => q.not("chosen_response_id", "is", null),
+        ),
+        fetchAll<{ id: string; answers: Record<string, unknown> | null }>(
+          "responses",
+          "id, answers",
+        ),
+        fetchAll<{ id: string; pydantic_fields: PydanticField[] | null }>(
+          "projects",
+          "id, pydantic_fields",
+        ),
+      ]);
+      const answersOf = new Map(responses.map((r) => [r.id, r.answers ?? {}]));
+      const fieldsOf = new Map(projects.map((p) => [p.id, p.pydantic_fields ?? []]));
+
+      // Fase 1 (metadados): candidato = divergência crua num campo `single` com
+      // opções. O recorte por TIPO é o que exclui as duas famílias de ruído
+      // medidas em 2026-07-27 sobre produção — 196 casos de subcampo (família
+      // #607) e 11 de data/texto reformatados, nenhum deles campo trocado.
+      const candidates = reviews.filter((rv) => {
+        if (rv.verdict === "ambiguo" || rv.verdict === "pular") return false;
+        const t = rv.verdict.trim();
+        if (t.startsWith("[") || t.startsWith("{")) return false;
+        const field = fieldsOf
+          .get(rv.project_id)
+          ?.find((f) => f.name === rv.field_name);
+        if (!field || field.type !== "single" || !field.options?.length) return false;
+        const answers = answersOf.get(rv.chosen_response_id!);
+        if (!answers) return false; // coberto por review-chosen-response-do-mesmo-documento
+        return (
+          normalizeForComparison(rv.verdict) !==
+          normalizeForComparison(answers[rv.field_name])
+        );
+      });
+
+      // Fase 2: `response_snapshot` é JSONB volumoso — só dos candidatos, em
+      // lotes de 100 ids (500 UUIDs estouram a URL do PostgREST).
+      const CHUNK = 100;
+      const snapshotOf = new Map<string, unknown>();
+      for (let i = 0; i < candidates.length; i += CHUNK) {
+        const ids = candidates.slice(i, i + CHUNK).map((c) => c.id);
+        const { data, error } = await supabase
+          .from("reviews")
+          .select("id, response_snapshot")
+          .in("id", ids);
+        if (error) throw new Error(`reviews snapshot (lote de ${ids.length}): ${error.message}`);
+        for (const row of data ?? []) snapshotOf.set(row.id as string, row.response_snapshot);
+      }
+
+      const violations: Violation[] = [];
+      for (const rv of candidates) {
+        const snap = snapshotOf.get(rv.id);
+        // Sem snapshot (review anterior à migration 20260401210000) o caso é
+        // NÃO AVALIÁVEL, não violação: sem a régua do instante do veredito, uma
+        // recodificação posterior é explicação igualmente suficiente. Medido:
+        // os 2 casos de 2026-03-27 que a #613 listava caem aqui, e as respostas
+        // que eles escolheram foram editadas em 2026-06-17 — quase três meses
+        // depois. A cobertura dessa faixa é a invariante inversa abaixo.
+        if (!Array.isArray(snap)) continue;
+        const entry = (snap as { id?: string; answer?: unknown }[]).find(
+          (e) => e?.id === rv.chosen_response_id,
+        );
+        if (!entry) continue;
+        // Bate com o que a tela mostrava: a codificação mudou DEPOIS do
+        // veredito (família #607). O veredito estava certo quando foi dado.
+        if (normalizeForComparison(rv.verdict) === normalizeForComparison(entry.answer)) {
+          continue;
+        }
+        // Discriminador: o valor pertence a OUTRO campo da MESMA resposta.
+        //
+        // NÃO morde hoje — medido por mutação em 2026-07-27: remover esta
+        // conjunção mantém as mesmas 2 violações. A razão é de construção do
+        // produtor: a resposta customizada ("Nenhuma correta" + texto livre)
+        // grava `chosen_response_id = null` (voto sempre carrega o id; custom
+        // nunca), então o filtro `not.is.null` lá em cima já a excluiu.
+        //
+        // Fica assim mesmo, com a condição de ativação nomeada: passa a importar
+        // quando o veredito for um valor de EXIBIÇÃO que não é igual a nenhuma
+        // resposta crua — caso de `confirmEquivalentVerdict`, que grava o
+        // `displayAnswer` formatado do grupo gabarito. Hoje isso não diverge em
+        // campo `single` (formatação é identidade para string), mas passaria a
+        // divergir se a formatação de `single` mudar. Sem esta conjunção, essa
+        // mudança de formatação faria a invariante acusar o projeto inteiro.
+        const answers = answersOf.get(rv.chosen_response_id!) ?? {};
+        const dono = Object.keys(answers).find(
+          (k) =>
+            k !== rv.field_name &&
+            normalizeForComparison(answers[k]) === normalizeForComparison(rv.verdict),
+        );
+        if (!dono) continue;
+        violations.push({
+          key: rv.id,
+          detail: `veredito de '${rv.field_name}' vale ${JSON.stringify(rv.verdict)}, que pertence a '${dono}' na resposta escolhida`,
+        });
+      }
+      return violations;
+    },
+  },
+  {
+    name: "review-com-escolha-tem-snapshot-da-escolhida",
+    motivation:
+      "inversa da anterior: sem uma entry da resposta escolhida em `response_snapshot`, o par (escolha, veredito) é INAUDITÁVEL — a regra acima não tem régua e passa em silêncio. Ausência aqui significa gravação por canal que não passa pelo `submitVerdict` do produto. Medido em 2026-07-27: 0 em 970 reviews posteriores ao corte",
+    run: async () => {
+      // Corte = migration 20260401210000_review_response_snapshot.sql. Reviews
+      // anteriores não têm a coluna preenchida por construção (46 hoje).
+      const CUTOFF = "2026-04-02T00:00:00Z";
+      const rows = await fetchAll<{
+        id: string;
+        created_at: string;
+        chosen_response_id: string | null;
+        response_snapshot: unknown;
+      }>("reviews", "id, created_at, chosen_response_id, response_snapshot", (q) =>
+        q.not("chosen_response_id", "is", null).gte("created_at", CUTOFF),
+      );
+      return rows
+        .filter((rv) => {
+          const snap = rv.response_snapshot;
+          if (!Array.isArray(snap)) return true;
+          return !(snap as { id?: string }[]).some((e) => e?.id === rv.chosen_response_id);
+        })
+        .map((rv) => ({
+          key: rv.id,
+          detail: `review de ${rv.created_at.slice(0, 10)} escolheu ${rv.chosen_response_id} mas o snapshot não tem entry dessa resposta`,
+        }));
+    },
+  },
 ];
+
+/** Linhas de `reviews` usadas pela invariante de coerência veredito×campo. */
+interface ReviewVerdictRow {
+  id: string;
+  project_id: string;
+  field_name: string;
+  verdict: string;
+  chosen_response_id: string | null;
+}
 
 async function main() {
   let failures = 0;

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -232,7 +232,13 @@ export function AgreementGroup({
 
   return (
     <TooltipProvider delayDuration={200}>
-      <div className="space-y-1.5">
+      {/*
+        `data-testid` é contrato de teste, não estilo: a asserção da #613 conta
+        quantas raízes de lista de cards existem no DOM após navegar (tem que ser
+        sempre 1). Contar por classe Tailwind quebraria no primeiro ajuste de
+        layout, silenciosamente e sempre para o lado do verde.
+      */}
+      <div className="space-y-1.5" data-testid="agreement-group">
         {allowEquivalence && groups.length > 1 && (
           <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1.5 text-[11px] leading-tight text-muted-foreground">
             <p className="min-w-0 flex-1">

--- a/frontend/src/components/compare/CompareFieldReview.tsx
+++ b/frontend/src/components/compare/CompareFieldReview.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { AgreementGroup, type FieldEquivalencePair } from "./AgreementGroup";
+import { MultiOptionReview } from "./MultiOptionReview";
+import { DivergenceActionsPanel } from "./DivergenceActionsPanel";
+import { UnansweredNotice } from "./UnansweredNotice";
+import { CompareFieldScope } from "./compare-field-scope";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2 } from "lucide-react";
+import {
+  readOnlyTitle,
+  type PendingVerdict,
+  type VerdictOrigin,
+} from "./compare-types";
+import type { VerdictInfo } from "@/lib/compare-reviews";
+import type { PydanticField } from "@/lib/types";
+
+export interface ComparisonResponse {
+  id: string;
+  respondent_type: "humano" | "llm";
+  respondent_name: string;
+  respondent_id: string | null;
+  answer: unknown;
+  justification?: string;
+  is_latest: boolean;
+  isFieldStale: boolean;
+  schemaVersion?: string | null;
+}
+
+// Affordances de equivalência agrupadas: o painel carrega uma config estruturada
+// em vez de dois booleanos soltos (`allowEquivalence`, `canManageAnyPair`) e os
+// repassa ao AgreementGroup.
+export interface EquivalenceConfig {
+  allow: boolean;
+  canManageAnyPair: boolean;
+}
+
+interface CompareFieldReviewProps {
+  readOnly: boolean;
+  projectId: string;
+  documentId: string;
+  documentTitle: string;
+  fieldName: string;
+  fieldDescription: string;
+  fields: PydanticField[];
+  isMulti: boolean;
+  displayOptions: string[];
+  responses: ComparisonResponse[];
+  existingVerdict: VerdictInfo | null;
+  pendingVerdict: PendingVerdict | null;
+  isDivergent: boolean;
+  isSavingVerdict: boolean;
+  onVerdict: (verdict: string, chosenResponseId?: string) => void;
+  onPrepareVerdict: (pending: PendingVerdict) => void;
+  onMarkReviewed: () => void;
+  comment: string;
+  onCommentChange: (value: string) => void;
+  equivalence: EquivalenceConfig;
+  equivalences: FieldEquivalencePair[];
+  onConfirmEquivalent: (
+    origin: VerdictOrigin,
+    responseIds: string[],
+    gabaritoId: string,
+    verdictDisplay: string,
+  ) => Promise<void>;
+  onUnmarkEquivalencePair: (pairId: string) => Promise<void>;
+  currentUserId: string;
+}
+
+/**
+ * Tudo que pertence a UM campo divergente: os cards de resposta (ou a grade de
+ * um campo multi), o aviso de quem não respondeu e as ações da divergência.
+ *
+ * Existe como componente próprio para que a identidade do campo seja UMA
+ * fronteira de montagem, não três keys irmãs coincidentes — que era o desenho
+ * anterior, em que `AgreementGroup`, `DivergenceActionsPanel` e
+ * `MultiOptionReview` ficavam keyados pela mesma string em posições distintas
+ * do mesmo pai. Duas consequências, e a segunda é a que importa para a #613:
+ *
+ * 1. a troca de campo passa a ser uma única deleção de subárvore, então um
+ *    resíduo de DOM (o defeito da #613, cuja causa no reconciler segue em
+ *    investigação) seria um painel inteiro e coerente, nunca meia tela de cards
+ *    do campo antigo intercalada com as ações do campo atual;
+ * 2. o `CompareFieldScope` montado aqui carimba a origem de toda decisão criada
+ *    nesta subárvore. Como uma subárvore fantasma não re-renderiza, ela nunca
+ *    passa a ver o campo novo — e o rascunho que ela produz é recusado na
+ *    fronteira de escrita em vez de gravar no campo errado.
+ *
+ * Fica DE FORA da fronteira, deliberadamente, tudo que não é do campo: o
+ * cabeçalho, os ProgressDots, o rodapé de confirmação e o container de scroll —
+ * assim a troca de campo não zera o `scrollTop` nem rouba o foco.
+ */
+export function CompareFieldReview({
+  readOnly,
+  projectId,
+  documentId,
+  documentTitle,
+  fieldName,
+  fieldDescription,
+  fields,
+  isMulti,
+  displayOptions,
+  responses,
+  existingVerdict,
+  pendingVerdict,
+  isDivergent,
+  isSavingVerdict,
+  onVerdict,
+  onPrepareVerdict,
+  onMarkReviewed,
+  comment,
+  onCommentChange,
+  equivalence,
+  equivalences,
+  onConfirmEquivalent,
+  onUnmarkEquivalencePair,
+  currentUserId,
+}: CompareFieldReviewProps) {
+  return (
+    <CompareFieldScope documentId={documentId} fieldName={fieldName}>
+      {isMulti ? (
+        <MultiOptionReview
+          readOnly={readOnly}
+          options={displayOptions}
+          responses={responses}
+          existingVerdict={existingVerdict}
+          isSubmitting={isSavingVerdict}
+          onSubmit={(verdictJson) => onVerdict(verdictJson)}
+        />
+      ) : (
+        <AgreementGroup
+          readOnly={readOnly}
+          responses={responses.map((r) => ({
+            id: r.id,
+            respondent_type: r.respondent_type,
+            respondent_name: r.respondent_name,
+            answer: r.answer,
+            justification: r.justification,
+            is_latest: r.is_latest,
+            isFieldStale: r.isFieldStale,
+            schemaVersion: r.schemaVersion,
+          }))}
+          existingVerdict={existingVerdict}
+          pendingVerdict={pendingVerdict}
+          onVote={(displayAnswer, chosenResponseId) =>
+            onPrepareVerdict({
+              kind: "response",
+              verdict: displayAnswer,
+              chosenResponseId,
+              // Origem literal das props deste render — e não do container —,
+              // que é o que faz um clique em card fantasma carregar o campo
+              // fantasma em vez de herdar o campo atual (#613).
+              origin: { documentId, fieldName },
+            })
+          }
+          allowEquivalence={equivalence.allow}
+          equivalences={equivalences}
+          onConfirmEquivalent={(responseIds, gabaritoId, verdictDisplay) =>
+            onConfirmEquivalent(
+              { documentId, fieldName },
+              responseIds,
+              gabaritoId,
+              verdictDisplay,
+            )
+          }
+          onUnmarkPair={onUnmarkEquivalencePair}
+          currentUserId={currentUserId}
+          canManageAnyPair={equivalence.canManageAnyPair}
+        />
+      )}
+
+      <UnansweredNotice responses={responses} />
+
+      {isDivergent ? (
+        <DivergenceActionsPanel
+          readOnly={readOnly}
+          projectId={projectId}
+          documentTitle={documentTitle}
+          fieldDescription={fieldDescription}
+          fields={fields}
+          isMulti={isMulti}
+          existingVerdict={existingVerdict}
+          pendingVerdict={pendingVerdict}
+          onPrepareVerdict={onPrepareVerdict}
+          comment={comment}
+          onCommentChange={onCommentChange}
+        />
+      ) : (
+        <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-green-500/20 bg-green-500/5 px-3 py-2 text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <CheckCircle2 className="size-3.5 text-green-600" />
+            Concordante: todos os respondentes concordam.
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 text-xs"
+            onClick={onMarkReviewed}
+            disabled={readOnly}
+            title={readOnlyTitle(readOnly)}
+          >
+            Marcar doc como revisado
+          </Button>
+        </div>
+      )}
+    </CompareFieldScope>
+  );
+}

--- a/frontend/src/components/compare/CompareFieldReview.tsx
+++ b/frontend/src/components/compare/CompareFieldReview.tsx
@@ -90,6 +90,17 @@ interface CompareFieldReviewProps {
  * cabeçalho, os ProgressDots, o rodapé de confirmação e o container de scroll —
  * assim a troca de campo não zera o `scrollTop` nem rouba o foco.
  */
+// Cognitive 22 vs. limiar 15, com cyclomatic 3 (dois ternários): a pontuação
+// vem do encaminhamento de props, que o fallow conta como fiação. É o mesmo
+// débito JSX inerente já rastreado na #580 para ComparePage/CompareMainView.
+//
+// A medição é explícita, não suposta: extrair este componente levou o
+// ComparisonPanel de cognitive 55 para 53, então a extração NÃO reduz a
+// complexidade total — realoca. Ela fica mesmo assim porque a razão de existir é
+// de correção, não de métrica: é a fronteira única de montagem por campo que
+// sustenta o escopo de origem do veredito (#613). Descer a ≤15 exigiria
+// fragmentar o encaminhamento em componentes sem significado próprio.
+// fallow-ignore-next-line complexity
 export function CompareFieldReview({
   readOnly,
   projectId,
@@ -128,44 +139,18 @@ export function CompareFieldReview({
           onSubmit={(verdictJson) => onVerdict(verdictJson)}
         />
       ) : (
-        <AgreementGroup
+        <SingleAnswerGroup
           readOnly={readOnly}
-          responses={responses.map((r) => ({
-            id: r.id,
-            respondent_type: r.respondent_type,
-            respondent_name: r.respondent_name,
-            answer: r.answer,
-            justification: r.justification,
-            is_latest: r.is_latest,
-            isFieldStale: r.isFieldStale,
-            schemaVersion: r.schemaVersion,
-          }))}
+          origin={{ documentId, fieldName }}
+          responses={responses}
           existingVerdict={existingVerdict}
           pendingVerdict={pendingVerdict}
-          onVote={(displayAnswer, chosenResponseId) =>
-            onPrepareVerdict({
-              kind: "response",
-              verdict: displayAnswer,
-              chosenResponseId,
-              // Origem literal das props deste render — e não do container —,
-              // que é o que faz um clique em card fantasma carregar o campo
-              // fantasma em vez de herdar o campo atual (#613).
-              origin: { documentId, fieldName },
-            })
-          }
-          allowEquivalence={equivalence.allow}
+          onPrepareVerdict={onPrepareVerdict}
+          equivalence={equivalence}
           equivalences={equivalences}
-          onConfirmEquivalent={(responseIds, gabaritoId, verdictDisplay) =>
-            onConfirmEquivalent(
-              { documentId, fieldName },
-              responseIds,
-              gabaritoId,
-              verdictDisplay,
-            )
-          }
-          onUnmarkPair={onUnmarkEquivalencePair}
+          onConfirmEquivalent={onConfirmEquivalent}
+          onUnmarkEquivalencePair={onUnmarkEquivalencePair}
           currentUserId={currentUserId}
-          canManageAnyPair={equivalence.canManageAnyPair}
         />
       )}
 
@@ -186,23 +171,103 @@ export function CompareFieldReview({
           onCommentChange={onCommentChange}
         />
       ) : (
-        <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-green-500/20 bg-green-500/5 px-3 py-2 text-xs text-muted-foreground">
-          <div className="flex items-center gap-1.5">
-            <CheckCircle2 className="size-3.5 text-green-600" />
-            Concordante: todos os respondentes concordam.
-          </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-6 text-xs"
-            onClick={onMarkReviewed}
-            disabled={readOnly}
-            title={readOnlyTitle(readOnly)}
-          >
-            Marcar doc como revisado
-          </Button>
-        </div>
+        <ConcordantNotice readOnly={readOnly} onMarkReviewed={onMarkReviewed} />
       )}
     </CompareFieldScope>
+  );
+}
+
+/**
+ * Cards de resposta de um campo NÃO-multi. Separado do `CompareFieldReview`
+ * porque é aqui que mora a adaptação entre a forma das respostas do painel e a
+ * do `AgreementGroup`, e o carimbo de origem nos dois callbacks de escrita.
+ */
+function SingleAnswerGroup({
+  readOnly,
+  origin,
+  responses,
+  existingVerdict,
+  pendingVerdict,
+  onPrepareVerdict,
+  equivalence,
+  equivalences,
+  onConfirmEquivalent,
+  onUnmarkEquivalencePair,
+  currentUserId,
+}: {
+  readOnly: boolean;
+  origin: VerdictOrigin;
+  responses: ComparisonResponse[];
+  existingVerdict: VerdictInfo | null;
+  pendingVerdict: PendingVerdict | null;
+  onPrepareVerdict: (pending: PendingVerdict) => void;
+  equivalence: EquivalenceConfig;
+  equivalences: FieldEquivalencePair[];
+  onConfirmEquivalent: CompareFieldReviewProps["onConfirmEquivalent"];
+  onUnmarkEquivalencePair: (pairId: string) => Promise<void>;
+  currentUserId: string;
+}) {
+  return (
+    <AgreementGroup
+      readOnly={readOnly}
+      responses={responses.map((r) => ({
+        id: r.id,
+        respondent_type: r.respondent_type,
+        respondent_name: r.respondent_name,
+        answer: r.answer,
+        justification: r.justification,
+        is_latest: r.is_latest,
+        isFieldStale: r.isFieldStale,
+        schemaVersion: r.schemaVersion,
+      }))}
+      existingVerdict={existingVerdict}
+      pendingVerdict={pendingVerdict}
+      // `origin` vem das props deste render — e não do container. É o que faz um
+      // clique em card fantasma carregar o campo FANTASMA, que a fronteira de
+      // escrita recusa, em vez de herdar o campo atual e gravar nele (#613).
+      onVote={(displayAnswer, chosenResponseId) =>
+        onPrepareVerdict({
+          kind: "response",
+          verdict: displayAnswer,
+          chosenResponseId,
+          origin,
+        })
+      }
+      allowEquivalence={equivalence.allow}
+      equivalences={equivalences}
+      onConfirmEquivalent={(responseIds, gabaritoId, verdictDisplay) =>
+        onConfirmEquivalent(origin, responseIds, gabaritoId, verdictDisplay)
+      }
+      onUnmarkPair={onUnmarkEquivalencePair}
+      currentUserId={currentUserId}
+      canManageAnyPair={equivalence.canManageAnyPair}
+    />
+  );
+}
+
+function ConcordantNotice({
+  readOnly,
+  onMarkReviewed,
+}: {
+  readOnly: boolean;
+  onMarkReviewed: () => void;
+}) {
+  return (
+    <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-green-500/20 bg-green-500/5 px-3 py-2 text-xs text-muted-foreground">
+      <div className="flex items-center gap-1.5">
+        <CheckCircle2 className="size-3.5 text-green-600" />
+        Concordante: todos os respondentes concordam.
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 text-xs"
+        onClick={onMarkReviewed}
+        disabled={readOnly}
+        title={readOnlyTitle(readOnly)}
+      >
+        Marcar doc como revisado
+      </Button>
+    </div>
   );
 }

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -18,6 +18,7 @@ import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import type { DocCoverage } from "@/app/(app)/projects/[id]/analyze/compare/page";
 import {
+  COMPARE_ORIGIN_MISMATCH_MESSAGE,
   verdictOriginMatches,
   type CompareDocument,
   type CompareResponse,
@@ -270,23 +271,19 @@ export function ComparePage({
       // é onde a revisora consegue relacionar o aviso ao que acabou de fazer. A
       // mensagem diz o que fazer (recarregar), porque com conteúdo desmontado na
       // tela nenhum clique naquela região vai funcionar (#613).
-      if (
-        !currentDoc ||
-        !verdictOriginMatches(next.origin, currentDoc.id, currentFieldName)
-      ) {
+      if (!currentOrigin || !verdictOriginMatches(next.origin, currentOrigin)) {
         console.error("compare: rascunho de outro campo recusado", {
           origin: next.origin,
-          atual: { documentId: currentDoc?.id, fieldName: currentFieldName },
+          atual: currentOrigin,
         });
-        toast.error(
-          "Essa resposta pertence a outro campo e não pode ser registrada aqui. Recarregue a página — a tela está exibindo conteúdo desatualizado.",
-          { id: "compare-origin-mismatch" },
-        );
+        toast.error(COMPARE_ORIGIN_MISMATCH_MESSAGE, {
+          id: "compare-origin-mismatch",
+        });
         return;
       }
       setPendingVerdict(next);
     },
-    [currentDoc, currentFieldName],
+    [currentOrigin],
   );
 
   // Único entrypoint para todo submit via handleVerdict: confirmação de

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { FullscreenNav } from "../coding/FullscreenNav";
 import { CompareNav } from "./CompareNav";
@@ -17,11 +17,13 @@ import { useUrlState } from "@/hooks/useUrlState";
 import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import type { DocCoverage } from "@/app/(app)/projects/[id]/analyze/compare/page";
-import type {
-  CompareDocument,
-  CompareResponse,
-  EquivalencePairWire,
-  PendingVerdict,
+import {
+  verdictOriginMatches,
+  type CompareDocument,
+  type CompareResponse,
+  type EquivalencePairWire,
+  type PendingVerdict,
+  type VerdictOrigin,
 } from "./compare-types";
 
 interface ComparePageProps {
@@ -215,6 +217,18 @@ export function ComparePage({
     setPendingVerdict(null);
   }
 
+  // Origem do campo EXIBIDO. Usada pelos caminhos de escrita que não passam por
+  // um rascunho (campo multi e os atalhos `a`/`s` de multi), que por construção
+  // só existem no render corrente. Os caminhos com rascunho usam a origem
+  // carimbada no próprio rascunho — ver `confirmPendingVerdict`.
+  const currentOrigin = useMemo<VerdictOrigin | null>(
+    () =>
+      currentDoc && currentFieldName
+        ? { documentId: currentDoc.id, fieldName: currentFieldName }
+        : null,
+    [currentDoc, currentFieldName],
+  );
+
   const {
     handleVerdict,
     handleConfirmEquivalent,
@@ -243,22 +257,52 @@ export function ComparePage({
       // O bloqueio de somente-leitura vive nos controles (`disabled`), no
       // teclado (`useCompareKeyboard`) e no backstop de escrita
       // (`useCompareVerdicts`) — aqui não se repete.
-      if (verdictSaveInFlightRef.current) return;
+      if (verdictSaveInFlightRef.current) {
+        // Antes este `return` era mudo, e um save lento (até os 15s do watchdog
+        // de #430) deixava a revisora clicando sem nenhum efeito visível.
+        toast.info(
+          "Salvando o veredito anterior — aguarde para escolher outra resposta.",
+          { id: "compare-save-inflight" },
+        );
+        return;
+      }
+      // Recusa PRIMÁRIA de rascunho vindo de outro campo: acontece no clique, que
+      // é onde a revisora consegue relacionar o aviso ao que acabou de fazer. A
+      // mensagem diz o que fazer (recarregar), porque com conteúdo desmontado na
+      // tela nenhum clique naquela região vai funcionar (#613).
+      if (
+        !currentDoc ||
+        !verdictOriginMatches(next.origin, currentDoc.id, currentFieldName)
+      ) {
+        console.error("compare: rascunho de outro campo recusado", {
+          origin: next.origin,
+          atual: { documentId: currentDoc?.id, fieldName: currentFieldName },
+        });
+        toast.error(
+          "Essa resposta pertence a outro campo e não pode ser registrada aqui. Recarregue a página — a tela está exibindo conteúdo desatualizado.",
+          { id: "compare-origin-mismatch" },
+        );
+        return;
+      }
       setPendingVerdict(next);
     },
-    [],
+    [currentDoc, currentFieldName],
   );
 
   // Único entrypoint para todo submit via handleVerdict: confirmação de
   // rascunho, campo multi e atalhos especiais. A ref torna um segundo save
   // impossível mesmo antes do rerender que desabilita os controles.
   const submitVerdictSingleFlight = useCallback(
-    async (verdict: string, chosenResponseId?: string) => {
+    async (
+      origin: VerdictOrigin,
+      verdict: string,
+      chosenResponseId?: string,
+    ) => {
       if (verdictSaveInFlightRef.current) return false;
       verdictSaveInFlightRef.current = true;
       setIsSavingVerdict(true);
       try {
-        return await handleVerdict(verdict, chosenResponseId);
+        return await handleVerdict(origin, verdict, chosenResponseId);
       } finally {
         verdictSaveInFlightRef.current = false;
         setIsSavingVerdict(false);
@@ -273,7 +317,11 @@ export function ComparePage({
   // rascunho é MANTIDO: a usuária reconfirma sem re-selecionar.
   const confirmPendingVerdict = useCallback(async () => {
     if (!pendingVerdict) return;
+    // A origem viaja com o rascunho: a confirmação grava no campo em que a
+    // decisão foi TOMADA, não no que estiver em tela agora. `useCompareVerdicts`
+    // recusa se os dois divergirem.
     const saved = await submitVerdictSingleFlight(
+      pendingVerdict.origin,
       pendingVerdict.verdict,
       pendingVerdict.kind === "response"
         ? pendingVerdict.chosenResponseId
@@ -360,8 +408,11 @@ export function ComparePage({
   // recebe os dois no array de deps do seu único effect, então um arrow inline
   // religaria o listener de `keydown` a cada render do container.
   const handleSpecialVerdict = useCallback(
-    (verdict: "ambiguo" | "pular") => void submitVerdictSingleFlight(verdict),
-    [submitVerdictSingleFlight],
+    (verdict: "ambiguo" | "pular") => {
+      if (!currentOrigin) return;
+      void submitVerdictSingleFlight(currentOrigin, verdict);
+    },
+    [currentOrigin, submitVerdictSingleFlight],
   );
   const handleConfirmPending = useCallback(
     () => void confirmPendingVerdict(),
@@ -375,6 +426,7 @@ export function ComparePage({
     isCurrentFieldDivergent,
     currentField,
     answerGroups,
+    origin: currentOrigin,
     onToggleFullscreen: toggleFullscreen,
     onExitFullscreen: exitFullscreen,
     onNextField: nextField,
@@ -555,8 +607,14 @@ export function ComparePage({
             ? { complete: true, hasNextDoc, onNextDoc: nextDoc }
             : { complete: false },
           onFieldNavigate: navigateField,
+          // Caminho do campo multi: não passa por rascunho, então a origem é a
+          // do campo exibido. `currentOrigin` é não-nulo aqui — o early-return
+          // acima já descartou o caso sem doc/campo.
           onVerdict: (verdict, chosenResponseId) =>
-            void submitVerdictSingleFlight(verdict, chosenResponseId),
+            void (
+              currentOrigin &&
+              submitVerdictSingleFlight(currentOrigin, verdict, chosenResponseId)
+            ),
           pendingVerdict,
           onPrepareVerdict: preparePendingVerdict,
           onConfirmPendingVerdict: handleConfirmPending,

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useMemo, useRef } from "react";
 import { ProgressDots } from "../coding/ProgressDots";
-import { AgreementGroup, type FieldEquivalencePair } from "./AgreementGroup";
-import { MultiOptionReview } from "./MultiOptionReview";
-import { DivergenceActionsPanel } from "./DivergenceActionsPanel";
-import { UnansweredNotice } from "./UnansweredNotice";
+import type { FieldEquivalencePair } from "./AgreementGroup";
+import {
+  CompareFieldReview,
+  type ComparisonResponse,
+  type EquivalenceConfig,
+} from "./CompareFieldReview";
 import { KeyboardHints } from "./KeyboardHints";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -22,22 +24,10 @@ import { FieldHeaderLabel } from "@/components/shared/FieldHeaderLabel";
 import type { VerdictInfo } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import {
-  readOnlyTitle,
   pendingVerdictLabel,
   type PendingVerdict,
+  type VerdictOrigin,
 } from "./compare-types";
-
-interface ComparisonResponse {
-  id: string;
-  respondent_type: "humano" | "llm";
-  respondent_name: string;
-  respondent_id: string | null;
-  answer: unknown;
-  justification?: string;
-  is_latest: boolean;
-  isFieldStale: boolean;
-  schemaVersion?: string | null;
-}
 
 // Conclusão do documento + navegação da fila. Discriminated union: `hasNextDoc`
 // e `onNextDoc` só fazem sentido depois que a revisão do documento terminou, então
@@ -48,14 +38,6 @@ interface ComparisonResponse {
 type DocStatus =
   | { complete: false }
   | { complete: true; hasNextDoc: boolean; onNextDoc: () => void };
-
-// Affordances de equivalência agrupadas: o painel carrega uma config estruturada
-// em vez de dois booleanos soltos (`allowEquivalence`, `canManageAnyPair`) e os
-// repassa ao AgreementGroup.
-interface EquivalenceConfig {
-  allow: boolean;
-  canManageAnyPair: boolean;
-}
 
 interface ComparisonPanelProps {
   readOnly: boolean;
@@ -90,6 +72,7 @@ interface ComparisonPanelProps {
   equivalence: EquivalenceConfig;
   equivalences: FieldEquivalencePair[];
   onConfirmEquivalent: (
+    origin: VerdictOrigin,
     responseIds: string[],
     gabaritoId: string,
     verdictDisplay: string,
@@ -231,86 +214,41 @@ export function ComparisonPanel({
         </div>
       </div>
 
+      {/*
+        O container de scroll NÃO é keyado: preservá-lo entre campos é o que
+        mantém o `scrollTop` da lista. Quem carrega a identidade do campo é o
+        `CompareFieldReview` abaixo — fronteira ÚNICA de montagem, em vez das
+        três keys irmãs coincidentes que existiam aqui (uma por slot). Ver o
+        cabeçalho de CompareFieldReview para o porquê (#613).
+      */}
       <div className="flex-1 overflow-y-auto px-4 py-2">
-        {isMulti ? (
-          <MultiOptionReview
-            key={`${documentId}|${fieldName}|${readOnly}`}
-            readOnly={readOnly}
-            options={displayOptions}
-            responses={responses}
-            existingVerdict={existingVerdict}
-            isSubmitting={isSavingVerdict}
-            onSubmit={(verdictJson) => onVerdict(verdictJson)}
-          />
-        ) : (
-          <AgreementGroup
-            key={`${documentId}|${fieldName}|${readOnly}`}
-            readOnly={readOnly}
-            responses={responses.map((r) => ({
-              id: r.id,
-              respondent_type: r.respondent_type,
-              respondent_name: r.respondent_name,
-              answer: r.answer,
-              justification: r.justification,
-              is_latest: r.is_latest,
-              isFieldStale: r.isFieldStale,
-              schemaVersion: r.schemaVersion,
-            }))}
-            existingVerdict={existingVerdict}
-            pendingVerdict={pendingVerdict}
-            onVote={(displayAnswer, chosenResponseId) =>
-              onPrepareVerdict({
-                kind: "response",
-                verdict: displayAnswer,
-                chosenResponseId,
-              })
-            }
-            allowEquivalence={equivalence.allow}
-            equivalences={equivalences}
-            onConfirmEquivalent={onConfirmEquivalent}
-            onUnmarkPair={onUnmarkEquivalencePair}
-            currentUserId={currentUserId}
-            canManageAnyPair={equivalence.canManageAnyPair}
-          />
-        )}
-
-        <UnansweredNotice responses={responses} />
-
-        {isDivergent ? (
-          <DivergenceActionsPanel
-            key={`${documentId}|${fieldName}|${readOnly}`}
-            readOnly={readOnly}
-            projectId={projectId}
-            documentId={documentId}
-            documentTitle={documentTitle}
-            fieldName={fieldName}
-            fieldDescription={fieldDescription}
-            fields={fields}
-            isMulti={isMulti}
-            existingVerdict={existingVerdict}
-            pendingVerdict={pendingVerdict}
-            onPrepareVerdict={onPrepareVerdict}
-            comment={comment}
-            onCommentChange={onCommentChange}
-          />
-        ) : (
-          <div className="mt-2 flex items-center justify-between gap-2 rounded-md border border-green-500/20 bg-green-500/5 px-3 py-2 text-xs text-muted-foreground">
-            <div className="flex items-center gap-1.5">
-              <CheckCircle2 className="size-3.5 text-green-600" />
-              Concordante: todos os respondentes concordam.
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="h-6 text-xs"
-              onClick={onMarkReviewed}
-              disabled={readOnly}
-              title={readOnlyTitle(readOnly)}
-            >
-              Marcar doc como revisado
-            </Button>
-          </div>
-        )}
+        <CompareFieldReview
+          key={`${documentId}|${fieldName}|${readOnly}`}
+          readOnly={readOnly}
+          projectId={projectId}
+          documentId={documentId}
+          documentTitle={documentTitle}
+          fieldName={fieldName}
+          fieldDescription={fieldDescription}
+          fields={fields}
+          isMulti={isMulti}
+          displayOptions={displayOptions}
+          responses={responses}
+          existingVerdict={existingVerdict}
+          pendingVerdict={pendingVerdict}
+          isDivergent={isDivergent}
+          isSavingVerdict={isSavingVerdict}
+          onVerdict={onVerdict}
+          onPrepareVerdict={onPrepareVerdict}
+          onMarkReviewed={onMarkReviewed}
+          comment={comment}
+          onCommentChange={onCommentChange}
+          equivalence={equivalence}
+          equivalences={equivalences}
+          onConfirmEquivalent={onConfirmEquivalent}
+          onUnmarkEquivalencePair={onUnmarkEquivalencePair}
+          currentUserId={currentUserId}
+        />
       </div>
 
       {isDivergent && !isMulti && (!docStatus.complete || pendingVerdict) && (

--- a/frontend/src/components/compare/DivergenceActionsPanel.tsx
+++ b/frontend/src/components/compare/DivergenceActionsPanel.tsx
@@ -12,13 +12,12 @@ import { formatVerdictDisplay } from "@/lib/verdict-display";
 import type { VerdictInfo } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import { readOnlyTitle, type PendingVerdict } from "./compare-types";
+import { useVerdictOrigin } from "./compare-field-scope";
 
 interface DivergenceActionsPanelProps {
   readOnly: boolean;
   projectId: string;
-  documentId: string;
   documentTitle: string;
-  fieldName: string;
   fieldDescription: string;
   fields: PydanticField[];
   isMulti: boolean;
@@ -35,9 +34,7 @@ interface DivergenceActionsPanelProps {
 export function DivergenceActionsPanel({
   readOnly,
   projectId,
-  documentId,
   documentTitle,
-  fieldName,
   fieldDescription,
   fields,
   isMulti,
@@ -47,6 +44,11 @@ export function DivergenceActionsPanel({
   comment,
   onCommentChange,
 }: DivergenceActionsPanelProps) {
+  // Documento e campo vêm do escopo, não de props: é a MESMA origem que carimba
+  // os rascunhos criados aqui e a que endereça a nota e a sugestão de schema,
+  // então não há como o painel anotar um campo e decidir sobre outro (#613).
+  const origin = useVerdictOrigin();
+  const { documentId, fieldName } = origin;
   const [suggestOpen, setSuggestOpen] = useState(false);
   const writeTitle = readOnlyTitle(readOnly);
   const suggestionTitle = readOnlyTitle(
@@ -68,7 +70,11 @@ export function DivergenceActionsPanel({
                 "border-brand bg-brand/10 text-brand",
             )}
             onClick={() =>
-              onPrepareVerdict({ kind: "ambiguous", verdict: "ambiguo" })
+              onPrepareVerdict({
+                kind: "ambiguous",
+                verdict: "ambiguo",
+                origin,
+              })
             }
             disabled={readOnly}
             title={writeTitle}
@@ -85,7 +91,7 @@ export function DivergenceActionsPanel({
                 "border-brand bg-brand/10 text-brand",
             )}
             onClick={() =>
-              onPrepareVerdict({ kind: "skip", verdict: "pular" })
+              onPrepareVerdict({ kind: "skip", verdict: "pular", origin })
             }
             disabled={readOnly}
             title={writeTitle}
@@ -122,6 +128,7 @@ export function DivergenceActionsPanel({
               onPrepareVerdict({
                 kind: "custom",
                 verdict: value,
+                origin,
               })
             }
           />

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -471,12 +471,24 @@ describe("ComparePage — árvore real (smoke)", () => {
     expect(screen.queryByText("Indeferido")).toBeNull();
   });
 
+  // Deliberadamente pelo MOUSE, e não pelo teclado: o teclado sempre leu
+  // `answerGroups` frescos e por isso nunca foi o vetor da #613 (ver o
+  // comentário em `useCompareKeyboard`). Um teste de teclado aqui afirmaria uma
+  // propriedade que já valia ANTES da correção — verde tanto no código são
+  // quanto no doente, que é a definição de teste que não testa nada.
   it("veredito confirmado depois de navegar grava no campo novo, com valor do campo novo", async () => {
     const user = userEvent.setup();
     renderReal();
 
     await user.keyboard("n");
-    await user.keyboard("1{Enter}");
+
+    // O primeiro card na tela: posição natural do clique, e exatamente onde
+    // ficava o card fantasma do campo anterior.
+    const card = screen.getByRole("button", {
+      name: /Selecionar esta resposta para confirmar: Sim/i,
+    });
+    await user.click(card);
+    await user.click(screen.getByRole("button", { name: /^Confirmar$/ }));
 
     expect(submitVerdict).toHaveBeenCalledTimes(1);
     const call = vi.mocked(submitVerdict).mock.calls[0][0] as {
@@ -484,7 +496,9 @@ describe("ComparePage — árvore real (smoke)", () => {
       verdict: string;
     };
     expect(call.fieldName).toBe("campoB");
-    expect(["Sim", "Não"]).toContain(call.verdict);
+    // Valor do conjunto de campoB. Como os conjuntos são disjuntos, "Deferido"
+    // aqui seria prova de campo trocado.
+    expect(call.verdict).toBe("Sim");
   });
 
   it("'Descartar' no painel real limpa a seleção sem salvar", async () => {

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -450,6 +450,43 @@ describe("ComparePage — árvore real (smoke)", () => {
     expectNoCompareWrites();
   });
 
+  // Defesa em profundidade da #613, na árvore real. A propriedade que faz estas
+  // asserções valerem alguma coisa é o fixture ter conjuntos de resposta
+  // DISJUNTOS por campo (campoA: Deferido/Indeferido; campoB: Sim/Não): assim
+  // "gravou valor de outro campo" é inequívoco, sem depender de qual card foi
+  // clicado. É a mesma propriedade que o fixture E2E preserva de propósito.
+  it("após navegar, a tela mostra só os cards do campo atual", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    expect(screen.getAllByTestId("agreement-group")).toHaveLength(1);
+    expect(screen.getByText("Deferido")).not.toBeNull();
+
+    await user.keyboard("n");
+
+    // Critério de aceitação 1 da #613: uma raiz, sempre.
+    expect(screen.getAllByTestId("agreement-group")).toHaveLength(1);
+    expect(screen.getByText("Sim")).not.toBeNull();
+    expect(screen.queryByText("Deferido")).toBeNull();
+    expect(screen.queryByText("Indeferido")).toBeNull();
+  });
+
+  it("veredito confirmado depois de navegar grava no campo novo, com valor do campo novo", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    await user.keyboard("n");
+    await user.keyboard("1{Enter}");
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(submitVerdict).mock.calls[0][0] as {
+      fieldName: string;
+      verdict: string;
+    };
+    expect(call.fieldName).toBe("campoB");
+    expect(["Sim", "Não"]).toContain(call.verdict);
+  });
+
   it("'Descartar' no painel real limpa a seleção sem salvar", async () => {
     const user = userEvent.setup();
     renderReal();

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -9,6 +9,10 @@ import {
   fireEvent,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+// Import só de TIPO (apagado na compilação, então não colide com o `vi.mock`
+// da view): serve para o harness derivar as assinaturas reais em vez de
+// redigitá-las — ver `MockComparisonPanel` abaixo.
+import type { ComparisonPanel } from "@/components/compare/ComparisonPanel";
 
 // Mocks dos Server Actions e do toast (efeitos colaterais fora do escopo do
 // teste de lógica do container).
@@ -40,23 +44,28 @@ vi.mock("next/navigation", () => ({
 // Mock das views: expõem só os controles necessários para dirigir a lógica do
 // container. NÃO testam o render dos filhos reais (CompareNav/ComparisonPanel/
 // DocumentReader), que este PR não altera e têm contrato garantido por tsc.
+//
+// As assinaturas de callback são DERIVADAS das props reais do `ComparisonPanel`
+// em vez de redigitadas: uma cópia à mão diverge em silêncio quando o contrato
+// muda, e foi o que aconteceu ao acrescentar a origem do veredito (#613) — o
+// harness continuou chamando `onConfirmEquivalent` com a aridade antiga, os
+// argumentos escorregaram uma posição e só o teste em execução denunciou.
+type RealPanelProps = Parameters<typeof ComparisonPanel>[0];
+
 interface MockComparisonPanel {
+  documentId: string;
   fieldName: string;
   fieldIndex: number;
   comment: string;
   onCommentChange: (v: string) => void;
   onFieldNavigate: (i: number) => void;
-  onVerdict: (verdict: string, chosenResponseId?: string) => void;
+  onVerdict: RealPanelProps["onVerdict"];
   pendingVerdict: PendingVerdict | null;
-  onPrepareVerdict: (pending: PendingVerdict) => void;
+  onPrepareVerdict: RealPanelProps["onPrepareVerdict"];
   onConfirmPendingVerdict: () => void;
   onDiscardPendingVerdict: () => void;
   isSavingVerdict: boolean;
-  onConfirmEquivalent: (
-    responseIds: string[],
-    gabaritoId: string,
-    verdictDisplay: string,
-  ) => Promise<void>;
+  onConfirmEquivalent: RealPanelProps["onConfirmEquivalent"];
   onMarkReviewed: () => void;
 }
 
@@ -96,6 +105,13 @@ vi.mock("@/components/compare/CompareWorkspace", () => ({
             kind: "response",
             verdict: "Deferido",
             chosenResponseId: "r1",
+            // Espelha o painel real: a origem sai das props do render corrente
+            // (CompareFieldReview), não de uma constante — é isso que o
+            // container valida antes de aceitar o rascunho.
+            origin: {
+              documentId: comparisonPanel.documentId,
+              fieldName: comparisonPanel.fieldName,
+            },
           })
         }
       >
@@ -108,6 +124,10 @@ vi.mock("@/components/compare/CompareWorkspace", () => ({
             kind: "response",
             verdict: "Indeferido",
             chosenResponseId: "r2",
+            origin: {
+              documentId: comparisonPanel.documentId,
+              fieldName: comparisonPanel.fieldName,
+            },
           })
         }
       >
@@ -130,6 +150,10 @@ vi.mock("@/components/compare/CompareWorkspace", () => ({
         data-testid="confirm-equiv"
         onClick={() =>
           void comparisonPanel.onConfirmEquivalent(
+            {
+              documentId: comparisonPanel.documentId,
+              fieldName: comparisonPanel.fieldName,
+            },
             ["r1", "r2"],
             "r1",
             "Equivalentes",
@@ -357,7 +381,11 @@ describe("ComparePage — comentário (fix no-derived-state)", () => {
 });
 
 describe("ComparePage — navegação e filtro", () => {
-  it("trocar o filtro reseta o índice de campo para o primeiro", async () => {
+  // O campo atual é rastreado por NOME (#613). Consequência direta: um ciclo de
+  // filtro devolve a revisora ao campo em que ela estava, em vez de jogá-la no
+  // primeiro — o nome fixado continua presente na lista completa. Antes, com
+  // índice, `changeFilter` zerava a posição.
+  it("ciclo de filtro (todos → campoB → todos) devolve ao campo em que estava", async () => {
     const user = userEvent.setup();
     render(<ComparePage {...makeProps()} />);
 
@@ -365,7 +393,16 @@ describe("ComparePage — navegação e filtro", () => {
     expect(text("field-name")).toBe("campoB");
 
     await user.click(screen.getByTestId("set-filter-all"));
+    expect(text("field-name")).toBe("campoB");
+  });
+
+  it("filtrar por um campo que não é o atual move para o campo filtrado", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
     expect(text("field-name")).toBe("campoA");
+    await user.click(screen.getByTestId("set-filter-b"));
+    expect(text("field-name")).toBe("campoB");
   });
 
   it("filtrar por um campo estreita a fila e o avanço fica preso nele", async () => {
@@ -392,7 +429,11 @@ describe("ComparePage — navegação e filtro", () => {
     expect(text("field-name")).toBe("campoA");
   });
 
-  it("clampa o índice de campo quando divergentFields encolhe (não vira undefined)", async () => {
+  it("o campo atual NÃO se desloca quando um campo ANTERIOR sai da fila", async () => {
+    // Regressão literal do caso real da #613: a revisora resolveu q4 por
+    // equivalência, avançou para q8, e o revalidate seguinte devolveu a lista
+    // sem q4 — com índice, ela passou a ver (e a gravar em) q14 sem ter clicado
+    // em nada. Com o pin por nome, o campo exibido não muda.
     const user = userEvent.setup();
     const fieldsABC: PydanticField[] = [
       ...fields,
@@ -405,13 +446,40 @@ describe("ComparePage — navegação e filtro", () => {
     };
     const { rerender } = render(<ComparePage {...base} />);
 
-    // Navega até o último campo (campoC) → fieldIndex interno = 2.
+    await user.keyboard("n");
+    expect(text("field-name")).toBe("campoB");
+
+    // campoA (ANTERIOR ao atual) sai da fila; com índice, campoB viraria campoC.
+    rerender(
+      <ComparePage
+        {...base}
+        divergentFields={{ d1: ["campoB", "campoC"], d2: ["campoA"] }}
+      />,
+    );
+
+    expect(text("field-name")).toBe("campoB");
+  });
+
+  it("o campo atual sai da fila → volta ao primeiro campo pendente", async () => {
+    const user = userEvent.setup();
+    const fieldsABC: PydanticField[] = [
+      ...fields,
+      { name: "campoC", type: "text", options: null, description: "Campo C", hash: "hC" },
+    ];
+    const base = {
+      ...makeProps(),
+      fields: fieldsABC,
+      divergentFields: { d1: ["campoA", "campoB", "campoC"], d2: ["campoA"] },
+    };
+    const { rerender } = render(<ComparePage {...base} />);
+
+    // Navega até o último campo (campoC).
     await user.keyboard("n");
     await user.keyboard("n");
     expect(text("field-name")).toBe("campoC");
 
     // Servidor revalida e o doc passa a ter só 2 campos divergentes; o filtro e
-    // o doc não mudaram, então fieldIndex (=2) fica fora de range.
+    // o doc não mudaram, e o campo FIXADO deixou de existir.
     rerender(
       <ComparePage
         {...base}
@@ -419,8 +487,9 @@ describe("ComparePage — navegação e filtro", () => {
       />,
     );
 
-    // Sem o clamp, docFields[2] seria undefined; com clamp cai no último válido.
-    expect(text("field-name")).toBe("campoB");
+    // Cai no primeiro pendente — mesmo idioma da re-pinagem de documento
+    // ("voltando ao topo") — e nunca em `undefined`.
+    expect(text("field-name")).toBe("campoA");
   });
 });
 

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -117,6 +117,27 @@ vi.mock("@/components/compare/CompareWorkspace", () => ({
       >
         prepare verdict
       </button>
+      {/*
+        Simula o clique num card FANTASMA: o rascunho chega carimbado com um
+        campo que não é o exibido. É o que uma subárvore sobrevivente no DOM
+        produz por construção, já que ela não re-renderiza (#613).
+      */}
+      <button
+        data-testid="prepare-verdict-campo-fantasma"
+        onClick={() =>
+          comparisonPanel.onPrepareVerdict({
+            kind: "response",
+            verdict: "ALFA-do-campo-antigo",
+            chosenResponseId: "r-fantasma",
+            origin: {
+              documentId: comparisonPanel.documentId,
+              fieldName: "campo_ja_desmontado",
+            },
+          })
+        }
+      >
+        prepare verdict fantasma
+      </button>
       <button
         data-testid="prepare-verdict-2"
         onClick={() =>
@@ -924,6 +945,44 @@ describe("ComparePage — vereditos e equivalências (useCompareVerdicts)", () =
 // Antes deste PR, nenhum teste deste arquivo exercitava isCoordinator: true —
 // a bar do toggle e a diferenciação da mensagem de estado vazio ficavam sem
 // cobertura direta.
+describe("ComparePage — rascunho vindo de outro campo (#613)", () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("não vira rascunho, não grava e avisa o que fazer", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.click(screen.getByTestId("prepare-verdict-campo-fantasma"));
+
+    // O rascunho nem chega a existir: sem ele, não há o que confirmar, e o
+    // valor do campo antigo não tem por onde alcançar o campo atual.
+    expect(text("pending-verdict")).toBe("");
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringContaining("pertence a outro campo"),
+      expect.objectContaining({ id: "compare-origin-mismatch" }),
+    );
+
+    await user.click(screen.getByTestId("confirm-verdict"));
+    expect(submitVerdict).not.toHaveBeenCalled();
+  });
+
+  it("um rascunho legítimo continua sendo aceito depois da recusa", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.click(screen.getByTestId("prepare-verdict-campo-fantasma"));
+    await user.click(screen.getByTestId("prepare-verdict"));
+
+    expect(text("pending-verdict")).toBe("Deferido");
+  });
+});
+
 describe("ComparePage — toggle de fila (só coordenador)", () => {
   function emptyProps(overrides: Partial<ReturnType<typeof makeProps>> = {}) {
     return {

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -481,7 +481,7 @@ describe("ComparePage — navegação e filtro", () => {
     expect(text("field-name")).toBe("campoB");
   });
 
-  it("o campo atual sai da fila → volta ao primeiro campo pendente", async () => {
+  it("o campo atual sai da fila → volta ao primeiro campo da fila", async () => {
     const user = userEvent.setup();
     const fieldsABC: PydanticField[] = [
       ...fields,
@@ -508,8 +508,10 @@ describe("ComparePage — navegação e filtro", () => {
       />,
     );
 
-    // Cai no primeiro pendente — mesmo idioma da re-pinagem de documento
-    // ("voltando ao topo") — e nunca em `undefined`.
+    // Cai no primeiro campo DA FILA — mesmo idioma da re-pinagem de documento
+    // ("voltando ao topo") — e nunca em `undefined`. Note que "primeiro da fila"
+    // não é sinônimo de "pendente": campoA pode já ter veredito nesta sessão e
+    // só sair da lista no revalidate seguinte. O aviso ao usuário diz o mesmo.
     expect(text("field-name")).toBe("campoA");
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
@@ -19,6 +19,9 @@ import { panelProps, panelResponse } from "./compare-test-helpers";
 
 afterEach(cleanup);
 
+/** Casa com o (documentId, fieldName) do painel montado abaixo. */
+const PANEL_ORIGIN = { documentId: "d1", fieldName: "data_parecer" };
+
 const FIELD: PydanticField = {
   name: "data_parecer",
   type: "date",
@@ -96,6 +99,7 @@ describe("ComparisonPanel — confirmação pendente", () => {
         kind: "response",
         verdict: "2021-05-10",
         chosenResponseId: "r-llm",
+        origin: PANEL_ORIGIN,
       },
       onConfirmPendingVerdict,
     });
@@ -113,6 +117,7 @@ describe("ComparisonPanel — confirmação pendente", () => {
         kind: "response",
         verdict: "2021-05-10",
         chosenResponseId: "r-llm",
+        origin: PANEL_ORIGIN,
       },
     });
 
@@ -133,6 +138,7 @@ describe("ComparisonPanel — confirmação pendente", () => {
         kind: "response",
         verdict: "2021-05-10",
         chosenResponseId: "r-llm",
+        origin: PANEL_ORIGIN,
       },
       isSavingVerdict: true,
     });

--- a/frontend/src/components/compare/__tests__/compare-queue-change.test.ts
+++ b/frontend/src/components/compare/__tests__/compare-queue-change.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { queueChangeNotice } from "../compare-queue-change";
+
+// Aviso de mudança de composição da fila de campos divergentes (#613). O valor
+// destes testes está nas SUPRESSÕES: um aviso que dispara na troca de parecer,
+// na troca de filtro ou a cada equivalência confirmada é um aviso que a revisora
+// aprende a ignorar — e aí não avisa nada quando importa.
+const base = {
+  previousFields: ["q1", "q2", "q3"],
+  currentFields: ["q1", "q2", "q3"],
+  previousFieldName: "q2",
+  previousDocId: "d1",
+  currentDocId: "d1",
+  previousFilter: "all",
+  currentFilter: "all",
+  reviewedFields: undefined,
+};
+
+describe("queueChangeNotice — quando avisa", () => {
+  it("a fila encolheu e o campo exibido sobreviveu → aviso de composição", () => {
+    const notice = queueChangeNotice({
+      ...base,
+      currentFields: ["q1", "q2"],
+    });
+
+    expect(notice?.id).toBe("compare-queue-changed");
+    expect(notice?.message).toContain("3 → 2 campos");
+  });
+
+  it("o campo exibido saiu da fila → aviso específico", () => {
+    const notice = queueChangeNotice({
+      ...base,
+      currentFields: ["q1", "q3"],
+    });
+
+    expect(notice?.id).toBe("compare-field-left-queue");
+  });
+
+  it("a fila cresceu (snapshot de um par deixou de casar) → aviso", () => {
+    const notice = queueChangeNotice({
+      ...base,
+      currentFields: ["q1", "q2", "q3", "q4"],
+    });
+
+    expect(notice?.id).toBe("compare-queue-changed");
+    expect(notice?.message).toContain("3 → 4 campos");
+  });
+});
+
+describe("queueChangeNotice — supressões", () => {
+  it("primeira montagem não é mudança", () => {
+    expect(
+      queueChangeNotice({ ...base, previousFields: null }),
+    ).toBeNull();
+  });
+
+  it("fila idêntica não avisa", () => {
+    expect(queueChangeNotice(base)).toBeNull();
+  });
+
+  it("(1) trocar de parecer não é mudança de fila", () => {
+    expect(
+      queueChangeNotice({
+        ...base,
+        currentDocId: "d2",
+        currentFields: ["qA", "qB"],
+      }),
+    ).toBeNull();
+  });
+
+  it("(2) trocar de filtro não é mudança de fila", () => {
+    expect(
+      queueChangeNotice({
+        ...base,
+        currentFilter: "q2",
+        currentFields: ["q2"],
+      }),
+    ).toBeNull();
+  });
+
+  it("(3) o campo saiu porque ELA acabou de resolvê-lo → silêncio", () => {
+    // É o caso de longe mais comum: confirmar uma equivalência funde grupos e
+    // tira o campo da fila. Sem esta supressão, toda equivalência avisaria.
+    expect(
+      queueChangeNotice({
+        ...base,
+        currentFields: ["q1", "q3"],
+        reviewedFields: { q2: { verdict: "x" } },
+      }),
+    ).toBeNull();
+  });
+
+  it("mas um campo que ela NÃO resolveu, saindo junto, ainda avisa", () => {
+    const notice = queueChangeNotice({
+      ...base,
+      currentFields: ["q1"],
+      reviewedFields: { q2: { verdict: "x" } },
+    });
+
+    // q3 saiu sem veredito dela — a fila mudou por outra causa.
+    expect(notice).not.toBeNull();
+  });
+
+  it("reordenação sem mudança de conjunto ainda conta como mudança", () => {
+    // A ordem vem do schema Pydantic; se ela mudou, a numeração "Campo N/M" que
+    // a revisora está lendo mudou de significado.
+    const notice = queueChangeNotice({
+      ...base,
+      currentFields: ["q3", "q2", "q1"],
+    });
+
+    expect(notice?.id).toBe("compare-queue-changed");
+  });
+});

--- a/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
+++ b/frontend/src/components/compare/__tests__/useCompareVerdicts.test.ts
@@ -42,6 +42,8 @@ const mockConfirmEquivalent = vi.mocked(confirmEquivalentVerdict);
 const mockUnmarkPair = vi.mocked(unmarkEquivalencePair);
 
 const DOC = doc("doc1", "Doc 1", "texto");
+/** Origem que CASA com (currentDoc, currentFieldName) do `setup` abaixo. */
+const ORIGIN = { documentId: "doc1", fieldName: "q1" };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -97,8 +99,9 @@ describe("modo somente leitura", () => {
     const { result, recordReview, goNextField } = setup(true);
 
     await act(async () => {
-      await result.current.handleVerdict("concordo", "r1");
+      await result.current.handleVerdict(ORIGIN, "concordo", "r1");
       await result.current.handleConfirmEquivalent(
+        ORIGIN,
         ["r1", "r2"],
         "r1",
         "fundida",
@@ -114,7 +117,87 @@ describe("modo somente leitura", () => {
     expect(recordReview).not.toHaveBeenCalled();
     expect(goNextField).not.toHaveBeenCalled();
     expect(toastSuccess).not.toHaveBeenCalled();
-    expect(toastError).not.toHaveBeenCalled();
+    // As duas ESCRITAS de veredito passaram a avisar em vez de recusar em
+    // silêncio (#613): os controles já nascem `disabled` em somente-leitura, e
+    // um deles ter chamado o handler mesmo assim é um bug que queremos ver.
+    // `handleMarkReviewed`/`handleUnmarkPair` seguem silenciosos.
+    expect(toastError).toHaveBeenCalledTimes(2);
+    expect(toastError).toHaveBeenCalledWith(
+      "Modo somente leitura: nenhuma decisão é registrada.",
+      expect.objectContaining({ id: "compare-write-blocked-read-only" }),
+    );
+  });
+});
+
+// Defesa em profundidade da #613: mesmo com os cards do campo anterior ainda no
+// DOM, uma decisão tomada num campo não pode ser gravada em outro. O guard vive
+// aqui — a fronteira de escrita — e não só no container, porque é aqui que os
+// dois vetores (veredito regular e equivalência) se encontram.
+describe("origem divergente do campo atual", () => {
+  const OUTRO_CAMPO = { documentId: "doc1", fieldName: "q_anterior" };
+  let consoleError: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("handleVerdict recusa antes da Server Action e devolve false", async () => {
+    const { result, recordReview, goNextField } = setup();
+    let returned: boolean | undefined;
+
+    await act(async () => {
+      returned = await result.current.handleVerdict(
+        OUTRO_CAMPO,
+        "ALFA-opcao-1",
+        "r1",
+      );
+    });
+
+    expect(returned).toBe(false);
+    expect(mockSubmitVerdict).not.toHaveBeenCalled();
+    expect(recordReview).not.toHaveBeenCalled();
+    expect(goNextField).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("pertence a outro campo"),
+      expect.objectContaining({ id: "compare-write-blocked-origin-mismatch" }),
+    );
+  });
+
+  it("handleConfirmEquivalent recusa antes da Server Action", async () => {
+    const { result, recordReview, goNextField } = setup();
+
+    await act(async () => {
+      await result.current.handleConfirmEquivalent(
+        OUTRO_CAMPO,
+        ["r1", "r2"],
+        "r1",
+        "fundida",
+      );
+    });
+
+    expect(mockConfirmEquivalent).not.toHaveBeenCalled();
+    expect(recordReview).not.toHaveBeenCalled();
+    expect(goNextField).not.toHaveBeenCalled();
+    expect(toastError).toHaveBeenCalledWith(
+      expect.stringContaining("pertence a outro campo"),
+      expect.objectContaining({ id: "compare-write-blocked-origin-mismatch" }),
+    );
+  });
+
+  it("documento divergente com o MESMO nome de campo também é recusado", async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleVerdict(
+        { documentId: "outro-doc", fieldName: "q1" },
+        "concordo",
+        "r1",
+      );
+    });
+
+    expect(mockSubmitVerdict).not.toHaveBeenCalled();
   });
 });
 
@@ -124,7 +207,7 @@ describe("handleVerdict", () => {
     const { result, recordReview, goNextField } = setup();
 
     await act(async () => {
-      await result.current.handleVerdict("concordo", "r1");
+      await result.current.handleVerdict(ORIGIN, "concordo", "r1");
     });
 
     expectNoOptimisticWrite(recordReview, goNextField, "falhou");
@@ -135,7 +218,7 @@ describe("handleVerdict", () => {
     const { result, recordReview, goNextField } = setup();
 
     await act(async () => {
-      await result.current.handleVerdict("concordo", "r1");
+      await result.current.handleVerdict(ORIGIN, "concordo", "r1");
     });
 
     expectOptimisticWrite(recordReview, goNextField, "doc1", "q1", {
@@ -152,7 +235,12 @@ describe("handleConfirmEquivalent — o caminho da issue #366", () => {
     const { result, recordReview, goNextField } = setup();
 
     await act(async () => {
-      await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
+      await result.current.handleConfirmEquivalent(
+        ORIGIN,
+        ["r1", "r2"],
+        "r1",
+        "fundida",
+      );
     });
 
     expectNoOptimisticWrite(recordReview, goNextField, "não foi");
@@ -163,7 +251,12 @@ describe("handleConfirmEquivalent — o caminho da issue #366", () => {
     const { result, recordReview, goNextField } = setup();
 
     await act(async () => {
-      await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
+      await result.current.handleConfirmEquivalent(
+        ORIGIN,
+        ["r1", "r2"],
+        "r1",
+        "fundida",
+      );
     });
 
     expectOptimisticWrite(recordReview, goNextField, "doc1", "q1", {
@@ -229,7 +322,7 @@ describe("rejeição da Server Action (fora do try dela) → toast.error, sem es
     const { result, recordReview, goNextField } = setup();
 
     await act(async () => {
-      await result.current.handleVerdict("concordo", "r1");
+      await result.current.handleVerdict(ORIGIN, "concordo", "r1");
     });
 
     expect(recordReview).not.toHaveBeenCalled();
@@ -243,7 +336,12 @@ describe("rejeição da Server Action (fora do try dela) → toast.error, sem es
     const { result, recordReview, goNextField } = setup();
 
     await act(async () => {
-      await result.current.handleConfirmEquivalent(["r1", "r2"], "r1", "fundida");
+      await result.current.handleConfirmEquivalent(
+        ORIGIN,
+        ["r1", "r2"],
+        "r1",
+        "fundida",
+      );
     });
 
     expect(recordReview).not.toHaveBeenCalled();

--- a/frontend/src/components/compare/compare-field-scope.tsx
+++ b/frontend/src/components/compare/compare-field-scope.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { createContext, useContext, useMemo } from "react";
+import type { VerdictOrigin } from "./compare-types";
+
+const CompareFieldScopeContext = createContext<VerdictOrigin | null>(null);
+
+/**
+ * Provê o par (documento, campo) a toda a subárvore que exibe e decide sobre um
+ * campo divergente. Montado por `CompareFieldReview`, que é keyed por essa mesma
+ * identidade.
+ *
+ * A garantia que isto carrega: um fiber desmontado nunca re-renderiza, então uma
+ * subárvore que sobreviva no DOM (issue #613) continua enxergando a origem do
+ * campo em que foi montada — nunca a do campo atual. Um clique nela produz um
+ * rascunho carimbado com o campo velho, que a fronteira de escrita recusa. Sem
+ * isto, o campo de destino era resolvido pelo container no render CORRENTE, e o
+ * clique fantasma gravava silenciosamente no campo errado.
+ *
+ * Por que contexto e não uma prop encadeada até o `AnswerCard`: a prop obrigaria
+ * cada componente novo dentro do painel a lembrar de recebê-la e repassá-la, e o
+ * esquecimento seria invisível. O contexto é herdado por construção.
+ */
+export function CompareFieldScope({
+  documentId,
+  fieldName,
+  children,
+}: {
+  documentId: string;
+  fieldName: string;
+  children: React.ReactNode;
+}) {
+  const origin = useMemo(
+    () => ({ documentId, fieldName }),
+    [documentId, fieldName],
+  );
+  return (
+    <CompareFieldScopeContext.Provider value={origin}>
+      {children}
+    </CompareFieldScopeContext.Provider>
+  );
+}
+
+/**
+ * Origem do campo em que este render está. Lança fora do escopo: construir uma
+ * decisão de comparação sem saber a que campo ela pertence é erro de
+ * programação, não um estado a tratar com fallback.
+ */
+export function useVerdictOrigin(): VerdictOrigin {
+  const origin = useContext(CompareFieldScopeContext);
+  if (!origin) {
+    throw new Error(
+      "useVerdictOrigin exige um <CompareFieldScope> acima na árvore.",
+    );
+  }
+  return origin;
+}

--- a/frontend/src/components/compare/compare-queue-change.ts
+++ b/frontend/src/components/compare/compare-queue-change.ts
@@ -1,0 +1,86 @@
+/**
+ * Decide se — e o que — avisar quando a fila de campos divergentes de um parecer
+ * muda de composição sob a revisora.
+ *
+ * `computeDivergentFieldNames` roda no servidor a cada `revalidatePath`: a lista
+ * encolhe quando uma equivalência funde grupos e cresce quando o snapshot de um
+ * par deixa de casar. Com o campo atual fixado por nome (#613) a revisora não é
+ * mais deslocada, mas a fila mudar em silêncio continua desorientador — foi o
+ * que tornou o bug difícil de relatar ("tem coisa que foi respondida e ainda
+ * continua").
+ *
+ * Puro e fora do hook de propósito: as três supressões abaixo são o que separa
+ * um aviso útil de um toast que a revisora aprende a ignorar, e cada uma merece
+ * teste próprio sem montar componente.
+ */
+
+export interface QueueChangeInput {
+  /** Campos da fila no render anterior; `null` na primeira montagem. */
+  previousFields: readonly string[] | null;
+  currentFields: readonly string[];
+  /** Campo EXIBIDO no render anterior — não o pin já re-resolvido. */
+  previousFieldName: string | undefined;
+  previousDocId: string | undefined;
+  currentDocId: string | undefined;
+  previousFilter: string;
+  currentFilter: string;
+  /** Vereditos locais do doc atual, para reconhecer a ação da própria revisora. */
+  reviewedFields: Readonly<Record<string, unknown>> | undefined;
+}
+
+export interface QueueChangeNotice {
+  /** `id` fixo do toast: uma rajada de revalidates colapsa num aviso só. */
+  id: "compare-field-left-queue" | "compare-queue-changed";
+  message: string;
+}
+
+export function queueChangeNotice(
+  input: QueueChangeInput,
+): QueueChangeNotice | null {
+  const {
+    previousFields,
+    currentFields,
+    previousFieldName,
+    previousDocId,
+    currentDocId,
+    previousFilter,
+    currentFilter,
+    reviewedFields,
+  } = input;
+
+  if (previousFields === null) return null; // primeira montagem: não há "mudou"
+  if (previousDocId !== currentDocId) return null; // (1) troca de parecer
+  if (previousFilter !== currentFilter) return null; // (2) troca de filtro
+  if (sameOrder(previousFields, currentFields)) return null;
+
+  const stillPresent = new Set(currentFields);
+  const departed = previousFields.filter((fn) => !stillPresent.has(fn));
+
+  // (3) consequência da própria ação dela: confirmar uma equivalência funde
+  // grupos e tira o campo da fila. `recordReview` já gravou o veredito local
+  // nesse ponto, então "todo campo que saiu já tem veredito" identifica
+  // exatamente esse caso — que é, de longe, o mais comum.
+  if (
+    departed.length > 0 &&
+    departed.every((fn) => reviewedFields?.[fn] !== undefined)
+  ) {
+    return null;
+  }
+
+  if (previousFieldName !== undefined && departed.includes(previousFieldName)) {
+    return {
+      id: "compare-field-left-queue",
+      message:
+        "O campo que você estava revisando saiu da fila de divergências — voltando ao primeiro campo pendente.",
+    };
+  }
+
+  return {
+    id: "compare-queue-changed",
+    message: `A fila de divergências deste parecer mudou (${previousFields.length} → ${currentFields.length} campos). Você continua no campo atual.`,
+  };
+}
+
+function sameOrder(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}

--- a/frontend/src/components/compare/compare-queue-change.ts
+++ b/frontend/src/components/compare/compare-queue-change.ts
@@ -70,8 +70,12 @@ export function queueChangeNotice(
   if (previousFieldName !== undefined && departed.includes(previousFieldName)) {
     return {
       id: "compare-field-left-queue",
+      // "primeiro campo da fila", não "primeiro campo pendente": a re-pinagem
+      // aponta para `docFields[0]`, que é o primeiro campo DIVERGENTE do parecer
+      // — e ele pode já ter veredito dado nesta sessão, já que o campo só sai da
+      // fila no revalidate seguinte. Prometer "pendente" seria falso na tela.
       message:
-        "O campo que você estava revisando saiu da fila de divergências — voltando ao primeiro campo pendente.",
+        "O campo que você estava revisando saiu da fila de divergências — voltando ao primeiro campo da fila.",
     };
   }
 

--- a/frontend/src/components/compare/compare-types.ts
+++ b/frontend/src/components/compare/compare-types.ts
@@ -57,11 +57,43 @@ export function readOnlyTitle(
   return readOnly ? COMPARE_READ_ONLY_REASON : activeTitle;
 }
 
-export type PendingVerdict =
+/**
+ * Documento/campo em que uma decisão foi TOMADA — que não é necessariamente o
+ * campo em que ela seria gravada. Os dois divergem quando a tela exibe conteúdo
+ * de um campo que o React já deveria ter desmontado (issue #613: o DOM do
+ * `AgreementGroup` do campo anterior sobrevivia à troca de campo, e clicar num
+ * card fantasma gravava o valor dele no campo atual).
+ *
+ * A origem é lida do `CompareFieldScope` (`compare-field-scope.tsx`), montado
+ * junto com os cards: uma subárvore fantasma nunca re-renderiza, logo o valor
+ * de contexto que ela enxerga é, por construção, o do campo em que foi montada.
+ * É isso — e não um guard adicional — que impede a escrita cruzada.
+ */
+export interface VerdictOrigin {
+  documentId: string;
+  fieldName: string;
+}
+
+/**
+ * Interseção (e não uma propriedade opcional em cada variante) para que o
+ * compilador enumere todos os sítios que constroem um rascunho: adicionar uma
+ * variante nova sem origem passa a não compilar.
+ */
+export type PendingVerdict = (
   | { kind: "response"; verdict: string; chosenResponseId: string }
   | { kind: "ambiguous"; verdict: "ambiguo" }
   | { kind: "skip"; verdict: "pular" }
-  | { kind: "custom"; verdict: string };
+  | { kind: "custom"; verdict: string }
+) & { origin: VerdictOrigin };
+
+/** Origem e destino descrevem o mesmo par (documento, campo)? */
+export function verdictOriginMatches(
+  origin: VerdictOrigin,
+  documentId: string,
+  fieldName: string,
+): boolean {
+  return origin.documentId === documentId && origin.fieldName === fieldName;
+}
 
 export function pendingVerdictLabel(pending: PendingVerdict): string {
   switch (pending.kind) {

--- a/frontend/src/components/compare/compare-types.ts
+++ b/frontend/src/components/compare/compare-types.ts
@@ -86,14 +86,30 @@ export type PendingVerdict = (
   | { kind: "custom"; verdict: string }
 ) & { origin: VerdictOrigin };
 
-/** Origem e destino descrevem o mesmo par (documento, campo)? */
+/**
+ * Origem e destino descrevem o mesmo par (documento, campo)?
+ *
+ * Os dois lados são `VerdictOrigin` — e não um struct contra `(documentId,
+ * fieldName)` soltos — porque a assinatura assimétrica convidava a trocar a
+ * ordem das duas strings sem o compilador reclamar, exatamente no ponto que
+ * decide se uma escrita cruzada é aceita.
+ */
 export function verdictOriginMatches(
-  origin: VerdictOrigin,
-  documentId: string,
-  fieldName: string,
+  a: VerdictOrigin,
+  b: VerdictOrigin,
 ): boolean {
-  return origin.documentId === documentId && origin.fieldName === fieldName;
+  return a.documentId === b.documentId && a.fieldName === b.fieldName;
 }
+
+/**
+ * Texto único da recusa por origem divergente. Vive aqui, ao lado de
+ * `verdictOriginMatches`, porque as duas camadas que recusam (a primária no
+ * clique, em `ComparePage`, e o backstop de escrita em `useCompareVerdicts`)
+ * são defesa em profundidade deliberada: duas cópias da mesma frase divergiriam
+ * na primeira vez que alguém reescrevesse uma delas.
+ */
+export const COMPARE_ORIGIN_MISMATCH_MESSAGE =
+  "Essa resposta pertence a outro campo e não pode ser registrada aqui. Recarregue a página — a tela está exibindo conteúdo desatualizado.";
 
 export function pendingVerdictLabel(pending: PendingVerdict): string {
   switch (pending.kind) {

--- a/frontend/src/components/compare/useCompareKeyboard.ts
+++ b/frontend/src/components/compare/useCompareKeyboard.ts
@@ -2,7 +2,11 @@
 
 import { useEffect } from "react";
 import type { PydanticField } from "@/lib/types";
-import type { FieldResponse, PendingVerdict } from "./compare-types";
+import type {
+  FieldResponse,
+  PendingVerdict,
+  VerdictOrigin,
+} from "./compare-types";
 
 interface UseCompareKeyboardParams {
   readOnly: boolean;
@@ -11,6 +15,12 @@ interface UseCompareKeyboardParams {
   isCurrentFieldDivergent: boolean;
   currentField: PydanticField | undefined;
   answerGroups: FieldResponse[][];
+  // Campo a que pertencem as decisões tomadas pelo teclado. `null` quando não há
+  // doc/campo resolvido — os atalhos de decisão então não fazem nada, em vez de
+  // produzir um rascunho sem dono. O teclado sempre lê `answerGroups` frescos, e
+  // por isso NÃO era o vetor da #613; carimbar a origem aqui é o que mantém os
+  // dois caminhos (mouse e teclado) sob a mesma regra.
+  origin: VerdictOrigin | null;
   onToggleFullscreen: () => void;
   onExitFullscreen: () => void;
   onNextField: () => void;
@@ -38,6 +48,7 @@ export function useCompareKeyboard({
   isCurrentFieldDivergent,
   currentField,
   answerGroups,
+  origin,
   onToggleFullscreen,
   onExitFullscreen,
   onNextField,
@@ -77,8 +88,9 @@ export function useCompareKeyboard({
 
       // `n`/`p` e fullscreen são navegação/leitura e continuam ativos. Todos
       // os atalhos abaixo preparam ou persistem uma decisão e, portanto,
-      // param aqui durante a impersonação master (issue #428).
-      if (readOnly || !isCurrentFieldDivergent) return;
+      // param aqui durante a impersonação master (issue #428) e quando não há
+      // campo a que atribuir a decisão.
+      if (readOnly || !isCurrentFieldDivergent || !origin) return;
 
       const isMultiField =
         currentField?.type === "multi" && currentField.options?.length;
@@ -108,12 +120,15 @@ export function useCompareKeyboard({
           kind: "response",
           verdict: displayAnswer,
           chosenResponseId: group[0].id,
+          origin,
         });
         return;
       }
 
-      if (e.key === "a") onPrepareVerdict({ kind: "ambiguous", verdict: "ambiguo" });
-      if (e.key === "s") onPrepareVerdict({ kind: "skip", verdict: "pular" });
+      if (e.key === "a")
+        onPrepareVerdict({ kind: "ambiguous", verdict: "ambiguo", origin });
+      if (e.key === "s")
+        onPrepareVerdict({ kind: "skip", verdict: "pular", origin });
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
@@ -124,6 +139,7 @@ export function useCompareKeyboard({
     isCurrentDocComplete,
     isCurrentFieldDivergent,
     isFullscreen,
+    origin,
     hasPendingVerdict,
     onConfirmPendingVerdict,
     onExitFullscreen,

--- a/frontend/src/components/compare/useCompareNavigation.ts
+++ b/frontend/src/components/compare/useCompareNavigation.ts
@@ -5,7 +5,7 @@ import { toast } from "sonner";
 import { isDocComplete } from "@/lib/compare-assignment-status";
 import { findNextPendingDocIndex } from "@/lib/compare-queue-navigation";
 import { pinnedIndex } from "@/hooks/usePinnedDoc";
-import { queueChangeNotice } from "./compare-queue-change";
+import { useQueueChangeNotice } from "./useQueueChangeNotice";
 import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import type { CompareDocument } from "./compare-types";
@@ -156,11 +156,17 @@ export function useCompareNavigation({
   const currentFieldName = docFields[fieldIndex];
 
   // Re-pinagem quando o nome fixado não resolve: pin `null` (primeiro render) ou
-  // o campo saiu da lista. Nos dois casos `fieldIndex` caiu para o fallback 0 e
-  // o campo exibido deixou de ser o pinado. Ajuste condicional de estado durante
-  // o render (padrão "adjusting state when a prop changes" dos docs do React),
-  // não effect — `set-state-in-effect` proíbe o setState síncrono em effect, e é
-  // o mesmo idioma já usado para o doc logo acima.
+  // o campo saiu da lista. Ajuste condicional de estado durante o render (padrão
+  // "adjusting state when a prop changes" dos docs do React), não effect —
+  // `set-state-in-effect` proíbe o setState síncrono em effect, e é o mesmo
+  // idioma já usado para o doc logo acima.
+  //
+  // O que esta linha compra NÃO é o campo exibido: `pinnedIndex` já cai em 0, então
+  // `currentFieldName` seria idêntico sem ela. Ela existe para impedir
+  // RESSURREIÇÃO — a fila também CRESCE (quando o snapshot de um par deixa de
+  // casar), e um pin órfão que voltasse a aparecer teleportaria a revisora para
+  // um campo que ela não escolheu, sem clique. Descartar o pin morto no mesmo
+  // render em que ele deixa de resolver fecha essa janela.
   if (docFields.length > 0 && docFields[fieldIndex] !== pinnedFieldName) {
     setPinnedFieldName(docFields[0]);
   }
@@ -168,37 +174,17 @@ export function useCompareNavigation({
   const currentField = fields.find((f) => f.name === currentFieldName);
   const isCurrentFieldDivergent = divergentSet.has(currentFieldName);
 
-  // Avisa quando a COMPOSIÇÃO da fila de campos muda sob a revisora. A decisão
-  // (inclusive as três supressões que impedem o aviso de virar ruído) mora em
-  // `queueChangeNotice`, puro e testado à parte; aqui fica só o rastreio do
-  // render anterior e o efeito colateral.
-  const prevQueueRef = useRef<{
-    fields: readonly string[] | null;
-    fieldName: string | undefined;
-    docId: string | undefined;
-    filter: string;
-  }>({ fields: null, fieldName: undefined, docId: undefined, filter });
+  // Avisa quando a COMPOSIÇÃO da fila de campos muda sob a revisora. Tanto a
+  // decisão (com as três supressões que impedem o aviso de virar ruído) quanto o
+  // rastreio do render anterior moram em `compare-queue-change`.
   const currentDocId = currentDoc?.id;
-  useEffect(() => {
-    const prev = prevQueueRef.current;
-    prevQueueRef.current = {
-      fields: docFields,
-      fieldName: currentFieldName,
-      docId: currentDocId,
-      filter,
-    };
-    const notice = queueChangeNotice({
-      previousFields: prev.fields,
-      currentFields: docFields,
-      previousFieldName: prev.fieldName,
-      previousDocId: prev.docId,
-      currentDocId,
-      previousFilter: prev.filter,
-      currentFilter: filter,
-      reviewedFields: currentDocId ? localReviews[currentDocId] : undefined,
-    });
-    if (notice) toast.info(notice.message, { id: notice.id });
-  }, [docFields, filter, currentDocId, currentFieldName, localReviews]);
+  useQueueChangeNotice({
+    currentFields: docFields,
+    currentFieldName,
+    currentDocId,
+    currentFilter: filter,
+    reviewedFields: currentDocId ? localReviews[currentDocId] : undefined,
+  });
 
   const reviewedDocsCount = useMemo(
     () =>

--- a/frontend/src/components/compare/useCompareNavigation.ts
+++ b/frontend/src/components/compare/useCompareNavigation.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { isDocComplete } from "@/lib/compare-assignment-status";
 import { findNextPendingDocIndex } from "@/lib/compare-queue-navigation";
-import { pinnedDocIndex } from "@/hooks/usePinnedDoc";
+import { pinnedIndex } from "@/hooks/usePinnedDoc";
 import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import type { CompareDocument } from "./compare-types";
@@ -61,7 +61,9 @@ export function useCompareNavigation({
   const [pinnedDocId, setPinnedDocId] = useState<string | null>(
     () => documents[0]?.id ?? null,
   );
-  const [fieldIndex, setFieldIndex] = useState(0);
+  // `null` = "nenhum campo escolhido ainda neste recorte"; o guard de render
+  // abaixo resolve para o primeiro campo da lista.
+  const [pinnedFieldName, setPinnedFieldName] = useState<string | null>(null);
   const [filter, setFilter] = useState("all");
 
   // O parecer atual é derivado de `pinnedDocId` (o doc exibido, atualizado a
@@ -72,7 +74,7 @@ export function useCompareNavigation({
   // `documents[0]`.
   const docIndex = useMemo(
     () =>
-      pinnedDocIndex(
+      pinnedIndex(
         documents.map((d) => d.id),
         pinnedDocId,
       ),
@@ -130,19 +132,96 @@ export function useCompareNavigation({
     [allDocDivergent],
   );
 
-  const docFields =
-    filter === "all"
-      ? allDocDivergent
-      : allDocDivergent.filter((fn) => fn === filter);
-  // `fieldIndex` pode ficar fora de range se `docFields` encolher sob o usuário
-  // (ex.: um revalidate reduziu os campos divergentes do doc fixado) sem que o
-  // filtro ou o doc — os únicos pontos que resetam `fieldIndex` — mudem. Clampa
-  // na leitura para `currentFieldName` nunca cair em `undefined` havendo campos.
-  const clampedFieldIndex =
-    docFields.length > 0 ? Math.min(fieldIndex, docFields.length - 1) : 0;
-  const currentFieldName = docFields[clampedFieldIndex];
+  // Memoizado porque alimenta as deps dos callbacks de navegação abaixo: o ramo
+  // filtrado produziria array novo a cada render e tiraria a identidade estável
+  // de que o effect de teclado (`useCompareKeyboard`) depende.
+  const docFields = useMemo(
+    () =>
+      filter === "all"
+        ? allDocDivergent
+        : allDocDivergent.filter((fn) => fn === filter),
+    [allDocDivergent, filter],
+  );
+
+  // O campo atual é derivado do NOME fixado, não de um índice — mesmo motivo do
+  // `pinnedDocId` acima, e mesma primitiva. `allDocDivergent` é recomputado no
+  // servidor a cada `revalidatePath` (`computeDivergentFieldNames`): a lista
+  // encolhe quando uma equivalência funde grupos e cresce quando o snapshot de
+  // um par deixa de casar. Com índice, esse encolhimento deslocava a revisora
+  // para OUTRO campo em silêncio, sem clique e sem passar por `guardNavigation`
+  // — o segundo defeito provado da #613 (caso real: confirmar equivalência em
+  // q4 fez o índice apontar de q8 para q14).
+  const fieldIndex = pinnedIndex(docFields, pinnedFieldName);
+  const currentFieldName = docFields[fieldIndex];
+
+  // Re-pinagem quando o nome fixado não resolve: pin `null` (primeiro render) ou
+  // o campo saiu da lista. Nos dois casos `fieldIndex` caiu para o fallback 0 e
+  // o campo exibido deixou de ser o pinado. Ajuste condicional de estado durante
+  // o render (padrão "adjusting state when a prop changes" dos docs do React),
+  // não effect — `set-state-in-effect` proíbe o setState síncrono em effect, e é
+  // o mesmo idioma já usado para o doc logo acima.
+  if (docFields.length > 0 && docFields[fieldIndex] !== pinnedFieldName) {
+    setPinnedFieldName(docFields[0]);
+  }
+
   const currentField = fields.find((f) => f.name === currentFieldName);
   const isCurrentFieldDivergent = divergentSet.has(currentFieldName);
+
+  // Avisa quando a COMPOSIÇÃO da fila de campos muda sob a revisora. Com o pin
+  // por nome ela não é mais deslocada, mas a fila mudar em silêncio (o
+  // denominador de "Campo 2/6" virar 5, ou o campo em que ela estava sumir) é
+  // desorientador — e foi o que tornou a #613 difícil de relatar.
+  //
+  // As três supressões abaixo são o que separa um aviso útil de um toast que se
+  // aprende a ignorar; sem elas ele dispararia a cada confirmação de
+  // equivalência e a cada troca de parecer.
+  const queueSignatureRef = useRef<string | null>(null);
+  const prevQueueDocIdRef = useRef<string | undefined>(undefined);
+  const prevQueueFilterRef = useRef(filter);
+  const prevFieldNameRef = useRef<string | undefined>(undefined);
+  const currentDocId = currentDoc?.id;
+  useEffect(() => {
+    const signature = docFields.join("|");
+    const prevSignature = queueSignatureRef.current;
+    const prevDocId = prevQueueDocIdRef.current;
+    const prevFilter = prevQueueFilterRef.current;
+    const prevFieldName = prevFieldNameRef.current;
+    queueSignatureRef.current = signature;
+    prevQueueDocIdRef.current = currentDocId;
+    prevQueueFilterRef.current = filter;
+    prevFieldNameRef.current = currentFieldName;
+
+    if (prevSignature === null) return; // primeira montagem: não há "mudou"
+    if (prevSignature === signature) return;
+    if (prevDocId !== currentDocId) return; // (1) troca de parecer
+    if (prevFilter !== filter) return; // (2) troca de filtro
+
+    const stillPresent = new Set(docFields);
+    const departed = prevSignature
+      .split("|")
+      .filter((fn) => fn.length > 0 && !stillPresent.has(fn));
+    // (3) consequência da própria ação dela: confirmar uma equivalência funde
+    // grupos e tira o campo da fila. Como `recordReview` já gravou o veredito
+    // local, "todo campo que saiu já tem veredito" identifica exatamente esse
+    // caso — e é o mais comum de todos.
+    const docReviews = currentDocId ? localReviews[currentDocId] : undefined;
+    if (departed.length > 0 && departed.every((fn) => !!docReviews?.[fn])) {
+      return;
+    }
+
+    if (prevFieldName && departed.includes(prevFieldName)) {
+      toast.info(
+        "O campo que você estava revisando saiu da fila de divergências — voltando ao primeiro campo pendente.",
+        { id: "compare-field-left-queue" },
+      );
+      return;
+    }
+    // `id` fixo: uma sequência de `revalidatePath` colapsa num aviso só.
+    toast.info(
+      `A fila de divergências deste parecer mudou (${prevSignature.split("|").filter((fn) => fn.length > 0).length} → ${docFields.length} campos). Você continua no campo atual.`,
+      { id: "compare-queue-changed" },
+    );
+  }, [docFields, filter, currentDocId, currentFieldName, localReviews]);
 
   const reviewedDocsCount = useMemo(
     () =>
@@ -179,10 +258,14 @@ export function useCompareNavigation({
 
   const hasNextDoc = nextPendingDocIndex >= 0;
 
+  // Trocar de parecer começa do primeiro campo do novo doc: `null` é resolvido
+  // pelo guard de render. Explícito (e não deixado para a re-pinagem automática)
+  // porque um doc novo pode ter um campo divergente de MESMO NOME, e herdar a
+  // posição nesse caso seria uma continuidade acidental, não uma decisão.
   const handleNextDoc = useCallback(() => {
     if (nextPendingDocIndex >= 0) {
       setPinnedDocId(documents[nextPendingDocIndex].id);
-      setFieldIndex(0);
+      setPinnedFieldName(null);
     }
   }, [nextPendingDocIndex, documents]);
 
@@ -191,29 +274,44 @@ export function useCompareNavigation({
       if (documents.length === 0) return;
       const clamped = Math.max(0, Math.min(newIndex, documents.length - 1));
       setPinnedDocId(documents[clamped].id);
-      setFieldIndex(0);
+      setPinnedFieldName(null);
     },
     [documents],
   );
 
-  // Parte do índice CLAMPADO (não do `idx` cru do estado): se o estado ficou
-  // fora de range por um encolhimento de `docFields`, navegar a partir do índice
-  // exibido evita ficar preso num índice morto.
-  const docFieldsLength = docFields.length;
-  const goNextField = useCallback(() => {
-    setFieldIndex(
-      clampedFieldIndex < docFieldsLength - 1
-        ? clampedFieldIndex + 1
-        : clampedFieldIndex,
-    );
-  }, [clampedFieldIndex, docFieldsLength]);
-  const goPrevField = useCallback(() => {
-    setFieldIndex(clampedFieldIndex > 0 ? clampedFieldIndex - 1 : clampedFieldIndex);
-  }, [clampedFieldIndex]);
+  // A API de borda continua por ÍNDICE (ProgressDots navega por posição e o
+  // painel exibe "Campo N/M"); a tradução índice → nome vive aqui, para que o
+  // estado interno seja sempre o nome.
+  const setFieldIndex = useCallback(
+    (index: number) => {
+      if (docFields.length === 0) return;
+      const clamped = Math.max(0, Math.min(index, docFields.length - 1));
+      setPinnedFieldName(docFields[clamped]);
+    },
+    [docFields],
+  );
 
+  // Fixa o NOME do vizinho, não a posição dele: é esta linha que fecha o caso
+  // real da #613 — o avanço automático após confirmar uma equivalência
+  // (`handleConfirmEquivalent` → `goNextField`) deixa de deslocar quando o
+  // refresh seguinte chega com a lista já sem o campo fundido.
+  const goNextField = useCallback(() => {
+    if (fieldIndex < docFields.length - 1) {
+      setPinnedFieldName(docFields[fieldIndex + 1]);
+    }
+  }, [docFields, fieldIndex]);
+  const goPrevField = useCallback(() => {
+    if (fieldIndex > 0) setPinnedFieldName(docFields[fieldIndex - 1]);
+  }, [docFields, fieldIndex]);
+
+  // O pin NÃO é resetado aqui: o guard de render já resolve os dois sentidos, e
+  // resolvê-los por omissão dá o comportamento melhor nos dois. Ao filtrar por
+  // um campo único, o nome fixado sai do recorte e a re-pinagem aponta para o
+  // campo filtrado; ao voltar para "all", o nome continua presente na lista
+  // completa e a revisora permanece onde estava — antes, o reset de índice a
+  // jogava de volta no campo 1.
   const changeFilter = useCallback((value: string) => {
     setFilter(value);
-    setFieldIndex(0);
   }, []);
 
   return {
@@ -221,7 +319,7 @@ export function useCompareNavigation({
     currentDoc,
     allDocDivergent,
     docFields,
-    fieldIndex: clampedFieldIndex,
+    fieldIndex,
     setFieldIndex,
     filter,
     changeFilter,

--- a/frontend/src/components/compare/useCompareNavigation.ts
+++ b/frontend/src/components/compare/useCompareNavigation.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { isDocComplete } from "@/lib/compare-assignment-status";
 import { findNextPendingDocIndex } from "@/lib/compare-queue-navigation";
 import { pinnedIndex } from "@/hooks/usePinnedDoc";
+import { queueChangeNotice } from "./compare-queue-change";
 import type { ReviewsByDoc } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
 import type { CompareDocument } from "./compare-types";
@@ -167,60 +168,36 @@ export function useCompareNavigation({
   const currentField = fields.find((f) => f.name === currentFieldName);
   const isCurrentFieldDivergent = divergentSet.has(currentFieldName);
 
-  // Avisa quando a COMPOSIÇÃO da fila de campos muda sob a revisora. Com o pin
-  // por nome ela não é mais deslocada, mas a fila mudar em silêncio (o
-  // denominador de "Campo 2/6" virar 5, ou o campo em que ela estava sumir) é
-  // desorientador — e foi o que tornou a #613 difícil de relatar.
-  //
-  // As três supressões abaixo são o que separa um aviso útil de um toast que se
-  // aprende a ignorar; sem elas ele dispararia a cada confirmação de
-  // equivalência e a cada troca de parecer.
-  const queueSignatureRef = useRef<string | null>(null);
-  const prevQueueDocIdRef = useRef<string | undefined>(undefined);
-  const prevQueueFilterRef = useRef(filter);
-  const prevFieldNameRef = useRef<string | undefined>(undefined);
+  // Avisa quando a COMPOSIÇÃO da fila de campos muda sob a revisora. A decisão
+  // (inclusive as três supressões que impedem o aviso de virar ruído) mora em
+  // `queueChangeNotice`, puro e testado à parte; aqui fica só o rastreio do
+  // render anterior e o efeito colateral.
+  const prevQueueRef = useRef<{
+    fields: readonly string[] | null;
+    fieldName: string | undefined;
+    docId: string | undefined;
+    filter: string;
+  }>({ fields: null, fieldName: undefined, docId: undefined, filter });
   const currentDocId = currentDoc?.id;
   useEffect(() => {
-    const signature = docFields.join("|");
-    const prevSignature = queueSignatureRef.current;
-    const prevDocId = prevQueueDocIdRef.current;
-    const prevFilter = prevQueueFilterRef.current;
-    const prevFieldName = prevFieldNameRef.current;
-    queueSignatureRef.current = signature;
-    prevQueueDocIdRef.current = currentDocId;
-    prevQueueFilterRef.current = filter;
-    prevFieldNameRef.current = currentFieldName;
-
-    if (prevSignature === null) return; // primeira montagem: não há "mudou"
-    if (prevSignature === signature) return;
-    if (prevDocId !== currentDocId) return; // (1) troca de parecer
-    if (prevFilter !== filter) return; // (2) troca de filtro
-
-    const stillPresent = new Set(docFields);
-    const departed = prevSignature
-      .split("|")
-      .filter((fn) => fn.length > 0 && !stillPresent.has(fn));
-    // (3) consequência da própria ação dela: confirmar uma equivalência funde
-    // grupos e tira o campo da fila. Como `recordReview` já gravou o veredito
-    // local, "todo campo que saiu já tem veredito" identifica exatamente esse
-    // caso — e é o mais comum de todos.
-    const docReviews = currentDocId ? localReviews[currentDocId] : undefined;
-    if (departed.length > 0 && departed.every((fn) => !!docReviews?.[fn])) {
-      return;
-    }
-
-    if (prevFieldName && departed.includes(prevFieldName)) {
-      toast.info(
-        "O campo que você estava revisando saiu da fila de divergências — voltando ao primeiro campo pendente.",
-        { id: "compare-field-left-queue" },
-      );
-      return;
-    }
-    // `id` fixo: uma sequência de `revalidatePath` colapsa num aviso só.
-    toast.info(
-      `A fila de divergências deste parecer mudou (${prevSignature.split("|").filter((fn) => fn.length > 0).length} → ${docFields.length} campos). Você continua no campo atual.`,
-      { id: "compare-queue-changed" },
-    );
+    const prev = prevQueueRef.current;
+    prevQueueRef.current = {
+      fields: docFields,
+      fieldName: currentFieldName,
+      docId: currentDocId,
+      filter,
+    };
+    const notice = queueChangeNotice({
+      previousFields: prev.fields,
+      currentFields: docFields,
+      previousFieldName: prev.fieldName,
+      previousDocId: prev.docId,
+      currentDocId,
+      previousFilter: prev.filter,
+      currentFilter: filter,
+      reviewedFields: currentDocId ? localReviews[currentDocId] : undefined,
+    });
+    if (notice) toast.info(notice.message, { id: notice.id });
   }, [docFields, filter, currentDocId, currentFieldName, localReviews]);
 
   const reviewedDocsCount = useMemo(

--- a/frontend/src/components/compare/useCompareVerdicts.ts
+++ b/frontend/src/components/compare/useCompareVerdicts.ts
@@ -13,6 +13,7 @@ import {
 } from "@/actions/equivalences";
 import type { ReviewsByDoc, VerdictInfo } from "@/lib/compare-reviews";
 import {
+  COMPARE_ORIGIN_MISMATCH_MESSAGE,
   verdictOriginMatches,
   type CompareDocument,
   type FieldResponse,
@@ -143,8 +144,9 @@ const COMPARE_WRITE_BLOCK_MESSAGE: Record<CompareWriteBlockReason, string> = {
   "no-field": "Nenhum campo selecionado — recarregue a página.",
   "not-divergent":
     "Este campo não está mais divergente e não aceita veredito. Recarregue a página.",
-  "origin-mismatch":
-    "Essa resposta pertence a outro campo e não pode ser registrada aqui. Recarregue a página — a tela está exibindo conteúdo desatualizado.",
+  // Mesma frase da recusa primária no clique (`ComparePage`): as duas camadas
+  // são defesa em profundidade da MESMA condição, então compartilham o texto.
+  "origin-mismatch": COMPARE_ORIGIN_MISMATCH_MESSAGE,
 };
 
 /**
@@ -164,7 +166,12 @@ function compareWriteGate(
   if (currentDoc === undefined) return { ok: false, reason: "no-doc" };
   if (currentFieldName.length === 0) return { ok: false, reason: "no-field" };
   if (!isCurrentFieldDivergent) return { ok: false, reason: "not-divergent" };
-  if (!verdictOriginMatches(origin, currentDoc.id, currentFieldName)) {
+  if (
+    !verdictOriginMatches(origin, {
+      documentId: currentDoc.id,
+      fieldName: currentFieldName,
+    })
+  ) {
     return { ok: false, reason: "origin-mismatch" };
   }
   return { ok: true, doc: currentDoc };

--- a/frontend/src/components/compare/useCompareVerdicts.ts
+++ b/frontend/src/components/compare/useCompareVerdicts.ts
@@ -12,7 +12,12 @@ import {
   unmarkEquivalencePair,
 } from "@/actions/equivalences";
 import type { ReviewsByDoc, VerdictInfo } from "@/lib/compare-reviews";
-import type { CompareDocument, FieldResponse } from "./compare-types";
+import {
+  verdictOriginMatches,
+  type CompareDocument,
+  type FieldResponse,
+  type VerdictOrigin,
+} from "./compare-types";
 
 interface UseCompareVerdictsParams {
   readOnly: boolean;
@@ -29,8 +34,15 @@ interface UseCompareVerdictsParams {
 }
 
 export interface CompareVerdicts {
-  handleVerdict: (verdict: string, chosenResponseId?: string) => Promise<boolean>;
+  // `origin` em primeira posição e obrigatório nas duas escritas: a fronteira
+  // não confia no chamador para ter resolvido o campo certo (#613).
+  handleVerdict: (
+    origin: VerdictOrigin,
+    verdict: string,
+    chosenResponseId?: string,
+  ) => Promise<boolean>;
   handleConfirmEquivalent: (
+    origin: VerdictOrigin,
     responseIds: string[],
     gabaritoId: string,
     verdictDisplay: string,
@@ -105,18 +117,74 @@ function buildSnapshot(fieldResponses: FieldResponse[]): ResponseSnapshotEntry[]
     }));
 }
 
-function canSubmitCompareVerdict(
+type CompareWriteBlockReason =
+  | "read-only"
+  | "no-doc"
+  | "no-field"
+  | "not-divergent"
+  | "origin-mismatch";
+
+/**
+ * Resultado do gate de escrita. Discriminado (e não um booleano) porque as
+ * cinco razões de recusa levam a mensagens diferentes: colapsá-las num `false`
+ * era exatamente o que fazia `handleVerdict` retornar sem dizer nada à revisora
+ * (#613, "ruídos adjacentes"). O `doc` viaja no ramo `ok` para preservar o
+ * estreitamento de tipo que o antigo type guard dava.
+ */
+type CompareWriteGate =
+  | { ok: true; doc: CompareDocument }
+  | { ok: false; reason: CompareWriteBlockReason };
+
+const COMPARE_WRITE_BLOCK_MESSAGE: Record<CompareWriteBlockReason, string> = {
+  // Os controles já nascem `disabled` em somente-leitura; chegar aqui significa
+  // que um deles escapou do gate visual — a mensagem é o sinal desse bug.
+  "read-only": "Modo somente leitura: nenhuma decisão é registrada.",
+  "no-doc": "Nenhum parecer selecionado — recarregue a página.",
+  "no-field": "Nenhum campo selecionado — recarregue a página.",
+  "not-divergent":
+    "Este campo não está mais divergente e não aceita veredito. Recarregue a página.",
+  "origin-mismatch":
+    "Essa resposta pertence a outro campo e não pode ser registrada aqui. Recarregue a página — a tela está exibindo conteúdo desatualizado.",
+};
+
+/**
+ * Fronteira de escrita da Comparação. Valida a ORIGEM recebida (o campo em que
+ * a decisão foi tomada) contra o campo atual, em vez de simplesmente confiar no
+ * campo do render corrente — que era o buraco pelo qual um clique em card
+ * fantasma gravava no campo seguinte (#613).
+ */
+function compareWriteGate(
   readOnly: boolean,
   currentDoc: CompareDocument | undefined,
   currentFieldName: string,
   isCurrentFieldDivergent: boolean,
-): currentDoc is CompareDocument {
-  return (
-    !readOnly &&
-    currentDoc !== undefined &&
-    currentFieldName.length > 0 &&
-    isCurrentFieldDivergent
-  );
+  origin: VerdictOrigin,
+): CompareWriteGate {
+  if (readOnly) return { ok: false, reason: "read-only" };
+  if (currentDoc === undefined) return { ok: false, reason: "no-doc" };
+  if (currentFieldName.length === 0) return { ok: false, reason: "no-field" };
+  if (!isCurrentFieldDivergent) return { ok: false, reason: "not-divergent" };
+  if (!verdictOriginMatches(origin, currentDoc.id, currentFieldName)) {
+    return { ok: false, reason: "origin-mismatch" };
+  }
+  return { ok: true, doc: currentDoc };
+}
+
+/** Recusa com mensagem visível; devolve `false` para o `return` do chamador. */
+function rejectCompareWrite(
+  reason: CompareWriteBlockReason,
+  context: Record<string, unknown>,
+): false {
+  // `console.error` (e não warn) porque `origin-mismatch` só é alcançável se a
+  // tela exibir conteúdo de um campo desmontado: se aparecer em produção, é um
+  // vetor novo e queremos vê-lo.
+  console.error("compare: escrita recusada", { reason, ...context });
+  toast.error(COMPARE_WRITE_BLOCK_MESSAGE[reason], {
+    // `id` fixo: cliques repetidos no mesmo card fantasma atualizam o mesmo
+    // toast em vez de empilhar uma pilha de avisos idênticos.
+    id: `compare-write-blocked-${reason}`,
+  });
+  return false;
 }
 
 /**
@@ -145,17 +213,26 @@ export function useCompareVerdicts({
   goNextField,
 }: UseCompareVerdictsParams): CompareVerdicts {
   const handleVerdict = useCallback(
-    async (verdict: string, chosenResponseId?: string) => {
-      if (
-        !canSubmitCompareVerdict(
-          readOnly,
-          currentDoc,
+    async (
+      origin: VerdictOrigin,
+      verdict: string,
+      chosenResponseId?: string,
+    ) => {
+      const gate = compareWriteGate(
+        readOnly,
+        currentDoc,
+        currentFieldName,
+        isCurrentFieldDivergent,
+        origin,
+      );
+      if (!gate.ok) {
+        return rejectCompareWrite(gate.reason, {
+          origin,
           currentFieldName,
-          isCurrentFieldDivergent,
-        )
-      ) {
-        return false;
+          verdict,
+        });
       }
+      const currentDocument = gate.doc;
 
       const verdictComment = comment || undefined;
       const info: VerdictInfo = {
@@ -166,7 +243,7 @@ export function useCompareVerdicts({
       const saved = await actionSucceeded(
         submitVerdict({
           projectId,
-          documentId: currentDoc.id,
+          documentId: currentDocument.id,
           fieldName: currentFieldName,
           verdict,
           chosenResponseId,
@@ -176,7 +253,7 @@ export function useCompareVerdicts({
         "Failed to submit compare verdict",
         {
           projectId,
-          documentId: currentDoc.id,
+          documentId: currentDocument.id,
           fieldName: currentFieldName,
           verdict,
           chosenResponseId,
@@ -188,14 +265,14 @@ export function useCompareVerdicts({
       // Escrita otimista só após o sucesso: `recordReview` grava em `overrides`
       // (estado da sessão, não auto-revertido). Gravar antes deixaria o campo
       // exibido como revisado mesmo quando o save falha, até um reload.
-      recordReview(currentDoc.id, currentFieldName, info);
+      recordReview(currentDocument.id, currentFieldName, info);
 
       toast.success("Veredito salvo!");
 
       // Usa `info` recém-emitido sobre o estado atual (que o setState ainda não
       // refletiu neste closure) para decidir se o documento fechou.
       const nextDocReviews = {
-        ...localReviews[currentDoc.id],
+        ...localReviews[currentDocument.id],
         [currentFieldName]: info,
       };
       const allFieldsReviewed = allDocDivergent.every(
@@ -225,23 +302,33 @@ export function useCompareVerdicts({
 
   const handleConfirmEquivalent = useCallback(
     async (
+      origin: VerdictOrigin,
       responseIds: string[],
       gabaritoId: string,
       verdictDisplay: string,
     ) => {
-      if (
-        !canSubmitCompareVerdict(
-          readOnly,
-          currentDoc,
+      // O mesmo gate do veredito regular: o botão "Confirmar N respostas como
+      // equivalentes" também vive na subárvore de cards e, num painel fantasma,
+      // gravaria a equivalência (em `response_equivalences`, não só em
+      // `reviews`) contra o campo errado.
+      const gate = compareWriteGate(
+        readOnly,
+        currentDoc,
+        currentFieldName,
+        isCurrentFieldDivergent,
+        origin,
+      );
+      if (!gate.ok) {
+        rejectCompareWrite(gate.reason, {
+          origin,
           currentFieldName,
-          isCurrentFieldDivergent,
-        )
-      ) {
+          responseIds,
+        });
         return;
       }
 
       const verdictComment = comment || undefined;
-      const docId = currentDoc.id;
+      const docId = gate.doc.id;
       const fieldName = currentFieldName;
       const info: VerdictInfo = {
         verdict: verdictDisplay,

--- a/frontend/src/components/compare/useQueueChangeNotice.ts
+++ b/frontend/src/components/compare/useQueueChangeNotice.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import {
+  queueChangeNotice,
+  type QueueChangeInput,
+} from "./compare-queue-change";
+
+/** A metade "agora" do input: o hook guarda a metade "antes" sozinho. */
+export type QueueChangeCurrent = Pick<
+  QueueChangeInput,
+  "currentFields" | "currentDocId" | "currentFilter" | "reviewedFields"
+> & { currentFieldName: string | undefined };
+
+/**
+ * Rastreia a fila do render anterior e emite o aviso quando ela muda de
+ * composição.
+ *
+ * Mora aqui, e não dentro de `useCompareNavigation`, por medição: aquele hook já
+ * estava acima do limiar de complexidade do fallow antes da #613 (cognitive 21
+ * em `origin/main`, severidade moderate) e embutir o ref + effect o levava a 25,
+ * cruzando para HIGH. E mora aqui, e não em `compare-queue-change.ts`, para que
+ * a decisão continue sendo um módulo PURO — testável sem React nem sonner no
+ * ambiente, que é o que aquele arquivo declara no próprio cabeçalho.
+ *
+ * O ref é atualizado no topo do effect, antes de decidir: assim uma rajada de
+ * revalidates compara sempre contra o render imediatamente anterior, e não
+ * contra o último que gerou aviso.
+ */
+export function useQueueChangeNotice({
+  currentFields,
+  currentFieldName,
+  currentDocId,
+  currentFilter,
+  reviewedFields,
+}: QueueChangeCurrent): void {
+  const prevRef = useRef<{
+    fields: readonly string[] | null;
+    fieldName: string | undefined;
+    docId: string | undefined;
+    filter: string;
+  }>({
+    fields: null,
+    fieldName: undefined,
+    docId: undefined,
+    filter: currentFilter,
+  });
+
+  useEffect(() => {
+    const prev = prevRef.current;
+    prevRef.current = {
+      fields: currentFields,
+      fieldName: currentFieldName,
+      docId: currentDocId,
+      filter: currentFilter,
+    };
+    const notice = queueChangeNotice({
+      previousFields: prev.fields,
+      currentFields,
+      previousFieldName: prev.fieldName,
+      previousDocId: prev.docId,
+      currentDocId,
+      previousFilter: prev.filter,
+      currentFilter,
+      reviewedFields,
+    });
+    if (notice) toast.info(notice.message, { id: notice.id });
+  }, [
+    currentFields,
+    currentFieldName,
+    currentDocId,
+    currentFilter,
+    reviewedFields,
+  ]);
+}

--- a/frontend/src/components/stats/useDocGroupNavigation.ts
+++ b/frontend/src/components/stats/useDocGroupNavigation.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { pinnedDocIndex } from "@/hooks/usePinnedDoc";
+import { pinnedIndex } from "@/hooks/usePinnedDoc";
 import type { ReviewComment } from "./comment-card-utils";
 
 interface DocGroup {
@@ -29,11 +29,11 @@ export function useDocGroupNavigation(
 
   // Fixa o documento atual por id (não por índice): `comments` é reordenado
   // pelo servidor a cada resolve/reopen (buildOrderedComments), o que pode
-  // mudar qual doc ocupa a posição N — pinnedDocIndex recalcula o índice a
+  // mudar qual doc ocupa a posição N — pinnedIndex recalcula o índice a
   // cada render em vez de confiar num índice preso desde o mount.
   const [currentDocId, setCurrentDocId] = useState(initialDocId);
   const docIds = useMemo(() => docGroups.map((g) => g.docId), [docGroups]);
-  const docIndex = pinnedDocIndex(docIds, currentDocId);
+  const docIndex = pinnedIndex(docIds, currentDocId);
   const currentGroup = docGroups[docIndex];
 
   const setDocIndex = (updater: number | ((prev: number) => number)) => {

--- a/frontend/src/hooks/__tests__/usePinnedDoc.test.ts
+++ b/frontend/src/hooks/__tests__/usePinnedDoc.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { renderHook, act, cleanup, waitFor } from "@testing-library/react";
-import { pinnedDocIndex, usePinnedDocNavigation } from "../usePinnedDoc";
+import { pinnedIndex, usePinnedDocNavigation } from "../usePinnedDoc";
 
 beforeEach(() => {
   sessionStorage.clear();
@@ -84,20 +84,20 @@ describe("usePinnedDocNavigation", () => {
   });
 });
 
-describe("pinnedDocIndex", () => {
+describe("pinnedIndex", () => {
   it("retorna o índice do id fixado quando presente", () => {
-    expect(pinnedDocIndex(["a", "b", "c"], "b")).toBe(1);
+    expect(pinnedIndex(["a", "b", "c"], "b")).toBe(1);
   });
 
   it("cai para 0 quando o id fixado não está na lista", () => {
-    expect(pinnedDocIndex(["a", "b"], "x")).toBe(0);
+    expect(pinnedIndex(["a", "b"], "x")).toBe(0);
   });
 
   it("cai para 0 com pin null", () => {
-    expect(pinnedDocIndex(["a", "b"], null)).toBe(0);
+    expect(pinnedIndex(["a", "b"], null)).toBe(0);
   });
 
   it("cai para 0 com lista vazia", () => {
-    expect(pinnedDocIndex([], "a")).toBe(0);
+    expect(pinnedIndex([], "a")).toBe(0);
   });
 });

--- a/frontend/src/hooks/usePinnedDoc.ts
+++ b/frontend/src/hooks/usePinnedDoc.ts
@@ -68,12 +68,17 @@ function usePinnedDoc(
 }
 
 /**
- * Índice do doc fixado numa lista de ids, com fallback ao topo: quando o pin
- * é `null` ou não está na lista (inclui lista vazia), retorna 0 — a posição
- * exibida por padrão. Derivação compartilhada pelos consumidores de seleção
- * fixada (Comparação, Auto-revisão, Arbitragem) para não triplicar o memo.
+ * Índice do item fixado numa lista de identificadores, com fallback ao topo:
+ * quando o pin é `null` ou não está na lista (inclui lista vazia), retorna 0 —
+ * a posição exibida por padrão. Derivação compartilhada por todos os
+ * consumidores de seleção fixada (Comparação, Auto-revisão, Arbitragem) para
+ * não triplicar o memo.
+ *
+ * Genérica quanto ao que é fixado: os identificadores são ids de documento na
+ * maioria dos casos e NOMES DE CAMPO na navegação de campos da Comparação
+ * (#613) — daí o nome não mencionar documento.
  */
-export function pinnedDocIndex(
+export function pinnedIndex(
   ids: readonly string[],
   pinnedId: string | null,
 ): number {
@@ -97,7 +102,7 @@ export function usePinnedDocNavigation(
   const [pinnedDocId, setPinnedDocId] = usePinnedDoc(storageKey, {
     validIds: validDocIds,
   });
-  const docIndex = pinnedDocIndex(validDocIds, pinnedDocId);
+  const docIndex = pinnedIndex(validDocIds, pinnedDocId);
   const navigateToIndex = useCallback(
     (requestedIndex: number) => {
       const lastIndex = validDocIds.length - 1;

--- a/frontend/src/lib/__tests__/playwright-pre-push-env.test.ts
+++ b/frontend/src/lib/__tests__/playwright-pre-push-env.test.ts
@@ -17,7 +17,7 @@ const completeRequiredEnv = Object.fromEntries(
 );
 
 describe("assertRequiredPrePushEnv", () => {
-  it("deriva as dez variáveis obrigatórias dos exemplos canônicos", () => {
+  it("deriva as onze variáveis obrigatórias dos exemplos canônicos", () => {
     expect(requiredPrePushEnv).toEqual(
       [
         "NEXT_PUBLIC_SUPABASE_URL",
@@ -31,6 +31,9 @@ describe("assertRequiredPrePushEnv", () => {
         "E2E_LOTTERY_PROJECT_ID",
         // coding-save.smoke.spec.ts — projeto dedicado do smoke de salvamento
         "E2E_CODING_PROJECT_ID",
+        // compare-field-switch.smoke.spec.ts — projeto dedicado do smoke de
+        // troca de campo na Comparação (#613)
+        "E2E_COMPARE_PROJECT_ID",
       ].sort(),
     );
   });


### PR DESCRIPTION
Primeiro dos dois PRs planejados para a #613. Este **para a corrupção de dado**; a causa do DOM órfão e a regressão E2E permanente ficam para o PR B, que não segura este.

## Por que dá para separar

A issue trata como um só defeito o que são dois. Um card fantasma na tela é exibição — confuso, não corrompe. Um clique nesse card virar `verdict` do campo atual é escrita, e é o que corrompeu 5 de 1.016 reviews. O segundo só existia porque `onVote` não carregava origem: subia `{verdict, chosenResponseId}` e quem resolvia `field_name` era o container no render **corrente**. **O buraco é a ausência de origem, não a presença do fantasma** — por isso a correção não depende de descobrir o que o reconciler está fazendo.

## O que muda

**1. A identidade do campo vira ambiente da subárvore.** `CompareFieldReview` (extraído do `ComparisonPanel`) monta um `CompareFieldScope` junto com os cards. Como um fiber desmontado nunca re-renderiza, uma subárvore que sobreviva no DOM só enxerga a origem em que foi montada — o rascunho que ela produz vem carimbado com o campo velho e é recusado. A escrita cruzada deixa de ser representável, em vez de ser barrada por um `if`.

A extração também troca as três `key` irmãs coincidentes (um slot cada) por **uma** fronteira de montagem, deixando de fora o cabeçalho e o container de scroll — `scrollTop` e foco preservados.

**2. O campo atual é fixado por nome, não por índice.** `useCompareNavigation` já rastreava o *documento* por ID exatamente por este motivo; faltava o campo. Fecha o caso real medido na issue: confirmar equivalência em `q4` fazia o índice apontar de `q8` para `q14` quando o revalidate chegava com a lista encurtada — sem clique e sem passar por `guardNavigation`.

**3. Cobertura maior que a da issue.** A validação de origem está na fronteira de escrita, então pega também dois vetores que a issue não lista: o campo **multi** (não passa por rascunho) e a **confirmação de equivalência** (também clicável num painel fantasma, e escreve em `response_equivalences`, não só em `reviews`).

**4. Aviso de mudança de fila** com as três supressões que o impedem de virar ruído — troca de parecer, troca de filtro e, a mais importante, o campo ter saído porque a revisora acabou de resolvê-lo (o caso mais comum de todos).

**5. As duas ações silenciosas** passam a dar feedback: `canSubmitCompareVerdict` colapsava quatro razões num booleano, e `preparePendingVerdict` engolia cliques por até 15 s durante um save.

## Verificação

Tier 1 (write path de `reviews`) — label `revisão: integral`.

**Prova do vermelho da navegação:** rodei os testes novos contra a implementação por índice (`HEAD~` com o import corrigido, para não contaminar o resultado com o rename de `pinnedIndex`): falham exatamente 3, incluindo a regressão literal do caso real, e passam os outros 31.

**Mutação:**

| Mutação | Resultado |
|---|---|
| `verdictOriginMatches` → `true` | 4 testes falham (fronteira de escrita **e** container) |
| gate ausente em `handleConfirmEquivalent` | 1 teste falha |

A primeira rodada dessa mutação matou só os testes da fronteira de escrita — a recusa em `preparePendingVerdict`, que é a que a revisora vê no clique, **não tinha teste**. O segundo commit fecha essa lacuna; foi a mutação que a encontrou, não a leitura.

**Gates:** tsc 0 erros · vitest 2011/2011 · lint e lint:types 0 erros · react-doctor 0 erros · fallow verde · semgrep verde · e2e smoke verde.

## Dois pontos para a revisão

**Contratos que mudam de comportamento**, ambos com teste reescrito de propósito (não adaptado para passar):

- ciclo de filtro (todos → campo → todos) agora **devolve ao campo em que estava**, em vez de jogar no primeiro;
- quando o campo fixado sai da fila, cai no **primeiro pendente** (idioma da re-pinagem de documento), onde antes o clamp caía no último válido.

**Uma supressão de gate, com a medição no comentário.** `CompareFieldReview` fica em cognitive 22 (limiar 15) com cyclomatic 3 — pontuação de encaminhamento de props, o débito JSX já rastreado na #580. Registrei no código que a extração **não** reduz complexidade total (`ComparisonPanel` foi de 55 para 53, mais 22 do componente novo): ela realoca, e existe por correção. Não quis deixar isso implícito.

## Correção de premissa (pós-revisão)

O corpo acima trata as violações como resíduo já existente. Conferindo os `created_at`, **as três foram gravadas em 27/07/2026, com o defeito ainda ativo em produção** — inclusive uma às 21:19, depois deste PR aberto. Uma delas é cross-**documento**: veredito `"Zolgensma®"` (valor de `q3_medicamento` de OUTRO parecer) gravado em `q4_doenca_paciente`. A correção cobre esse vetor, porque `VerdictOrigin` carrega `documentId`. Reparo do dado na #623.

Refs #613, #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ED9EV4G9NYi1xivvQFL3h2
