### PR TITLE
feat(codificação): rascunho local de respostas e estado de envio explícito (#608, PR 1/3)

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -47,10 +47,11 @@ export default async function CodePage({
   const access = requireResolvedProjectAccess(
     await getProjectAccessContext(id, user),
   );
-  const { queueUserId, isImpersonating } = resolveProjectQueueIdentity(
-    access,
-    sp.viewAsUser,
-  );
+  // `ownMemberUserId` é quem ESCREVE; `queueUserId` é só a fila exibida. O
+  // rascunho local se chaveia pelo primeiro — chavear pelo observado faria o
+  // master, sob impersonação, depositar trabalho no slot da pesquisadora.
+  const { ownMemberUserId, queueUserId, isImpersonating } =
+    resolveProjectQueueIdentity(access, sp.viewAsUser);
   const roundParam = sp.round ?? CURRENT_FILTER_VALUE;
 
   const supabase = await createSupabaseServer();
@@ -257,6 +258,7 @@ export default async function CodePage({
     <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Carregando…</div>}>
       <CodingPage
         projectId={id}
+        userId={ownMemberUserId}
         documents={filteredDocuments}
         codedAtByDoc={codedAtByDoc}
         fields={fields}

--- a/frontend/src/components/coding/AssignedCodingView.tsx
+++ b/frontend/src/components/coding/AssignedCodingView.tsx
@@ -58,7 +58,6 @@ export function AssignedCodingView({
   readOnly,
   onReorder,
   outOfScope,
-  unsent,
   allDone,
   onExploreMore,
   hasAssignments,
@@ -118,7 +117,6 @@ export function AssignedCodingView({
             readOnly={readOnly}
             onReorder={onReorder}
             outOfScope={outOfScope}
-            unsent={unsent}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/frontend/src/components/coding/AssignedCodingView.tsx
+++ b/frontend/src/components/coding/AssignedCodingView.tsx
@@ -58,6 +58,7 @@ export function AssignedCodingView({
   readOnly,
   onReorder,
   outOfScope,
+  unsent,
   allDone,
   onExploreMore,
   hasAssignments,
@@ -117,6 +118,7 @@ export function AssignedCodingView({
             readOnly={readOnly}
             onReorder={onReorder}
             outOfScope={outOfScope}
+            unsent={unsent}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/frontend/src/components/coding/BrowseCodingView.tsx
+++ b/frontend/src/components/coding/BrowseCodingView.tsx
@@ -65,8 +65,6 @@ export function BrowseCodingView({
   onSubmit,
   onDraftChange,
   outOfScope,
-  unsent,
-  restoredDraft,
   restoreNonce = 0,
 }: BrowseCodingViewProps) {
   if (browseError) {
@@ -123,8 +121,6 @@ export function BrowseCodingView({
       onSubmit={onSubmit}
       onDraftChange={onDraftChange}
       outOfScope={outOfScope}
-      unsent={unsent}
-      restoredDraft={restoredDraft}
     />
   );
 }

--- a/frontend/src/components/coding/BrowseCodingView.tsx
+++ b/frontend/src/components/coding/BrowseCodingView.tsx
@@ -31,6 +31,10 @@ interface BrowseCodingViewProps {
   onSubmit: (draft: CodingDraft) => void;
   onDraftChange: (draft: CodingDraft) => void;
   outOfScope?: OutOfScopeConfig;
+  /** Alterações não enviadas neste documento (#608). */
+  unsent?: boolean;
+  restoredDraft?: CodingDraft | null;
+  restoreNonce?: number;
 }
 
 /** Estado centralizado de falha + ação de retry do modo Explorar (lista e doc
@@ -74,6 +78,9 @@ export function BrowseCodingView({
   onSubmit,
   onDraftChange,
   outOfScope,
+  unsent,
+  restoredDraft,
+  restoreNonce = 0,
 }: BrowseCodingViewProps) {
   if (browseError) {
     return (
@@ -114,7 +121,9 @@ export function BrowseCodingView({
   }
   return (
     <BrowseDocCoder
-      key={browseDocId}
+      // O nonce força o remount ao retomar um rascunho: é assim que o conteúdo
+      // recuperado entra no seed sem setState em effect.
+      key={`${browseDocId}:${restoreNonce}`}
       doc={browseDoc}
       fields={fields}
       submitting={submitting}
@@ -127,6 +136,8 @@ export function BrowseCodingView({
       onSubmit={onSubmit}
       onDraftChange={onDraftChange}
       outOfScope={outOfScope}
+      unsent={unsent}
+      restoredDraft={restoredDraft}
     />
   );
 }

--- a/frontend/src/components/coding/BrowseCodingView.tsx
+++ b/frontend/src/components/coding/BrowseCodingView.tsx
@@ -2,13 +2,13 @@
 
 import { Button } from "@/components/ui/button";
 import { DocumentPicker } from "./DocumentPicker";
-import { BrowseDocCoder, type CodingDraft } from "./BrowseDocCoder";
+import { type ForwardedCodingProps, BrowseDocCoder, type CodingDraft } from "./BrowseDocCoder";
 import type { OutOfScopeConfig } from "./QuestionsPanel";
 import type { CodingDocument } from "@/hooks/useDocumentForCoding";
 import type { BrowseDocument } from "@/actions/documents";
 import type { PydanticField } from "@/lib/types";
 
-interface BrowseCodingViewProps {
+interface BrowseCodingViewProps extends ForwardedCodingProps {
   browseLoading: boolean;
   browseError: boolean;
   browseDocId: string | null;
@@ -20,20 +20,7 @@ interface BrowseCodingViewProps {
   onRetry: () => void;
   /** Retry do fetch do doc selecionado (conteúdo falhou ao carregar). */
   onRetryDoc: () => void;
-  fields: PydanticField[];
-  submitting: boolean;
-  readOnly: boolean;
-  isFullscreen: boolean;
-  title: string;
-  responseCount: number;
-  onToggleFullscreen: () => void;
-  onReorder: (newOrder: string[]) => void;
-  onSubmit: (draft: CodingDraft) => void;
-  onDraftChange: (draft: CodingDraft) => void;
-  outOfScope?: OutOfScopeConfig;
-  /** Alterações não enviadas neste documento (#608). */
-  unsent?: boolean;
-  restoredDraft?: CodingDraft | null;
+  /** Nonce que força o remount do coder ao retomar um rascunho local (#608). */
   restoreNonce?: number;
 }
 

--- a/frontend/src/components/coding/BrowseDocCoder.tsx
+++ b/frontend/src/components/coding/BrowseDocCoder.tsx
@@ -41,12 +41,6 @@ export interface ForwardedCodingProps {
   /** Reporta o rascunho atual para cima (autosave-on-exit + dirty tracking). */
   onDraftChange: (draft: CodingDraft) => void;
   outOfScope?: OutOfScopeConfig;
-  /** Alterações não enviadas neste documento (#608). */
-  unsent?: boolean;
-  /** Rascunho local retomado pela pesquisadora. Entra pelo SEED, e o componente
-   *  é remontado por `key` quando ele muda — empurrar o valor por prop exigiria
-   *  setState em effect, e este componente é construído sem estado derivado. */
-  restoredDraft?: CodingDraft | null;
 }
 
 interface BrowseDocCoderProps extends ForwardedCodingProps {
@@ -78,13 +72,11 @@ export function BrowseDocCoder({
   onSubmit,
   onDraftChange,
   outOfScope,
-  unsent,
-  restoredDraft,
 }: BrowseDocCoderProps) {
   const [answers, setAnswers] = useState<Record<string, unknown>>(
-    () => restoredDraft?.answers ?? doc.initialAnswers,
+    () => doc.initialAnswers,
   );
-  const [notes, setNotes] = useState(() => restoredDraft?.notes ?? doc.initialNotes);
+  const [notes, setNotes] = useState(() => doc.initialNotes);
 
   // Espelho do rascunho corrente. Lê/escreve sempre o valor atual (não a
   // closure), então edições no mesmo tick não se sobrescrevem e os callbacks
@@ -152,7 +144,6 @@ export function BrowseDocCoder({
             readOnly={readOnly}
             onReorder={onReorder}
             outOfScope={outOfScope}
-            unsent={unsent}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/frontend/src/components/coding/BrowseDocCoder.tsx
+++ b/frontend/src/components/coding/BrowseDocCoder.tsx
@@ -39,6 +39,12 @@ interface BrowseDocCoderProps {
   /** Reporta o rascunho atual para cima (autosave-on-exit + dirty tracking). */
   onDraftChange: (draft: CodingDraft) => void;
   outOfScope?: OutOfScopeConfig;
+  /** Alterações não enviadas neste documento (#608). */
+  unsent?: boolean;
+  /** Rascunho local retomado pela pesquisadora. Entra pelo SEED, e o componente
+   *  é remontado por `key` quando ele muda — empurrar o valor por prop exigiria
+   *  setState em effect, e este componente é construído sem estado derivado. */
+  restoredDraft?: CodingDraft | null;
 }
 
 /**
@@ -65,11 +71,13 @@ export function BrowseDocCoder({
   onSubmit,
   onDraftChange,
   outOfScope,
+  unsent,
+  restoredDraft,
 }: BrowseDocCoderProps) {
   const [answers, setAnswers] = useState<Record<string, unknown>>(
-    () => doc.initialAnswers,
+    () => restoredDraft?.answers ?? doc.initialAnswers,
   );
-  const [notes, setNotes] = useState(() => doc.initialNotes);
+  const [notes, setNotes] = useState(() => restoredDraft?.notes ?? doc.initialNotes);
 
   // Espelho do rascunho corrente. Lê/escreve sempre o valor atual (não a
   // closure), então edições no mesmo tick não se sobrescrevem e os callbacks
@@ -137,6 +145,7 @@ export function BrowseDocCoder({
             readOnly={readOnly}
             onReorder={onReorder}
             outOfScope={outOfScope}
+            unsent={unsent}
           />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/frontend/src/components/coding/BrowseDocCoder.tsx
+++ b/frontend/src/components/coding/BrowseDocCoder.tsx
@@ -22,9 +22,11 @@ export interface CodingDraft {
   notes: string;
 }
 
-interface BrowseDocCoderProps {
-  /** Documento já carregado (texto + respostas/notas iniciais). */
-  doc: CodingDocument;
+// Props que o container repassa INALTERADAS ao coder. Declaradas uma vez e
+// reusadas por `BrowseCodingView`, que apenas as encaminha: manter as duas
+// listas à mão fazia as assinaturas divergirem a cada campo novo, e era
+// duplicação real (o gate do fallow a flagrou).
+export interface ForwardedCodingProps {
   fields: PydanticField[];
   submitting: boolean;
   readOnly: boolean;
@@ -45,6 +47,11 @@ interface BrowseDocCoderProps {
    *  é remontado por `key` quando ele muda — empurrar o valor por prop exigiria
    *  setState em effect, e este componente é construído sem estado derivado. */
   restoredDraft?: CodingDraft | null;
+}
+
+interface BrowseDocCoderProps extends ForwardedCodingProps {
+  /** Documento já carregado (texto + respostas/notas iniciais). */
+  doc: CodingDocument;
 }
 
 /**

--- a/frontend/src/components/coding/CodingDraftBanner.tsx
+++ b/frontend/src/components/coding/CodingDraftBanner.tsx
@@ -123,3 +123,23 @@ export function CodingDraftUnavailableBanner({ visible }: { visible: boolean }) 
     </div>
   );
 }
+
+// Indicador permanente de "há alterações não enviadas" (#608). Fica aqui, junto
+// das outras superfícies do rascunho local, e não inline no `QuestionsPanel`:
+// esse painel já é grande e o JSX condicional a mais o empurrava sobre o limiar
+// de complexidade do gate.
+//
+// O sinal que o alimenta vem da sujeira em memória, nunca do storage — ver
+// `useDirtyDocs`.
+export function UnsentChangesBadge({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+  return (
+    <span
+      role="status"
+      className="flex items-center gap-1.5 whitespace-nowrap rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200"
+    >
+      <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />
+      Alterações não enviadas
+    </span>
+  );
+}

--- a/frontend/src/components/coding/CodingDraftBanner.tsx
+++ b/frontend/src/components/coding/CodingDraftBanner.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { AlertTriangle, FileClock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CODING_DRAFT_NOTES_KEY, type CodingDraftRecovery } from "@/lib/coding-draft";
@@ -39,7 +40,8 @@ interface CodingDraftBannerProps {
   fields: PydanticField[];
   onRestore: () => void;
   onDiscard: () => void;
-  /** Injetável para o teste não depender do relógio real. */
+  /** Instante de referência da idade do rascunho. Injetável para o teste não
+   *  depender do relógio real; omitido, é capturado no mount. */
   now?: number;
 }
 
@@ -48,8 +50,14 @@ export function CodingDraftBanner({
   fields,
   onRestore,
   onDiscard,
-  now = Date.now(),
+  now,
 }: CodingDraftBannerProps) {
+  // `Date.now()` no corpo do componente é impuro no render. A idade exibida é
+  // uma ordem de grandeza ("há 2 horas"), não um cronômetro: capturar o instante
+  // no mount, num inicializador lazy, dá o mesmo texto sem a impureza.
+  const [mountedAt] = useState(() => Date.now());
+  const reference = now ?? mountedAt;
+
   if (recovery.kind !== "resumable" && recovery.kind !== "diverged") return null;
 
   const overwritten =
@@ -64,7 +72,7 @@ export function CodingDraftBanner({
         <FileClock className="size-4 shrink-0 text-amber-600" aria-hidden />
         <span className="flex-1">
           Você tem alterações não enviadas neste documento, salvas neste navegador{" "}
-          {humanizeAge(recovery.updatedAt, now)}.
+          {humanizeAge(recovery.updatedAt, reference)}.
         </span>
         <Button size="sm" variant="default" onClick={onRestore}>
           Retomar rascunho

--- a/frontend/src/components/coding/CodingDraftBanner.tsx
+++ b/frontend/src/components/coding/CodingDraftBanner.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { AlertTriangle, FileClock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CODING_DRAFT_NOTES_KEY, type CodingDraftRecovery } from "@/lib/coding-draft";
+import type { PydanticField } from "@/lib/types";
+
+// Faixa de recuperação do rascunho local (#608).
+//
+// É uma faixa, e não um toast, de propósito: o requisito é que a oferta continue
+// disponível até ser resolvida. Um toast some sozinho, e um rascunho que a
+// pesquisadora não viu passar é indistinguível de rascunho nenhum.
+//
+// O formulário abaixo dela mostra os valores DO SERVIDOR. Nada é aplicado até
+// que "Retomar" seja clicado — é o que separa esta feature do auto-save que ela
+// substitui, que gravava sem pedir e sem avisar.
+
+function fieldLabel(name: string, fields: PydanticField[]): string {
+  if (name === CODING_DRAFT_NOTES_KEY) return "Notas e sugestões";
+  const field = fields.find((f) => f.name === name);
+  return field?.description?.trim() || name;
+}
+
+// "há N minutos/horas/dias". O instante exato não ajuda a decidir; a ordem de
+// grandeza sim — um rascunho de dez minutos atrás é a sessão interrompida, um de
+// duas semanas provavelmente já foi superado.
+function humanizeAge(updatedAt: number, now: number): string {
+  const minutes = Math.floor(Math.max(0, now - updatedAt) / 60_000);
+  if (minutes < 1) return "agora há pouco";
+  if (minutes < 60) return `há ${minutes} minuto${minutes === 1 ? "" : "s"}`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `há ${hours} hora${hours === 1 ? "" : "s"}`;
+  const days = Math.floor(hours / 24);
+  return `há ${days} dia${days === 1 ? "" : "s"}`;
+}
+
+interface CodingDraftBannerProps {
+  recovery: CodingDraftRecovery;
+  fields: PydanticField[];
+  onRestore: () => void;
+  onDiscard: () => void;
+  /** Injetável para o teste não depender do relógio real. */
+  now?: number;
+}
+
+export function CodingDraftBanner({
+  recovery,
+  fields,
+  onRestore,
+  onDiscard,
+  now = Date.now(),
+}: CodingDraftBannerProps) {
+  if (recovery.kind !== "resumable" && recovery.kind !== "diverged") return null;
+
+  const overwritten =
+    recovery.kind === "diverged" ? recovery.overwrittenFields : [];
+
+  return (
+    <div
+      role="status"
+      className="flex flex-col gap-2 border-b bg-amber-50 px-4 py-2.5 text-sm dark:bg-amber-950/30"
+    >
+      <div className="flex items-center gap-2">
+        <FileClock className="size-4 shrink-0 text-amber-600" aria-hidden />
+        <span className="flex-1">
+          Você tem alterações não enviadas neste documento, salvas neste navegador{" "}
+          {humanizeAge(recovery.updatedAt, now)}.
+        </span>
+        <Button size="sm" variant="default" onClick={onRestore}>
+          Retomar rascunho
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onDiscard}>
+          Descartar
+        </Button>
+      </div>
+
+      {overwritten.length > 0 && (
+        // Só o que retomar de fato sobrescreve — ver `overwrittenFields`, que é
+        // a interseção e não tudo que o servidor mudou.
+        <div className="flex items-start gap-2 text-amber-800 dark:text-amber-200">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+          <span>
+            Este documento foi salvo depois que o rascunho foi criado. Retomar
+            substitui{" "}
+            {overwritten.length === 1
+              ? "a resposta de "
+              : `as respostas de ${overwritten.length} perguntas: `}
+            <strong>
+              {overwritten.map((name) => fieldLabel(name, fields)).join(", ")}
+            </strong>
+            .
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Aviso separado, e permanente enquanto durar: o rascunho local não está
+// funcionando neste navegador. Distinto do indicador de "não enviado", que vem
+// da sujeira em memória — a tela precisa poder dizer "há trabalho pendente" E
+// "não consegui guardá-lo aqui" ao mesmo tempo.
+export function CodingDraftUnavailableBanner({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-2 border-b bg-destructive/10 px-4 py-2 text-sm"
+    >
+      <AlertTriangle className="size-4 shrink-0 text-destructive" aria-hidden />
+      <span>
+        Não foi possível guardar uma cópia local das suas respostas neste
+        navegador. Envie o documento antes de fechar a aba.
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/coding/CodingDraftBanner.tsx
+++ b/frontend/src/components/coding/CodingDraftBanner.tsx
@@ -108,6 +108,12 @@ export function CodingDraftBanner({
 // funcionando neste navegador. Distinto do indicador de "não enviado", que vem
 // da sujeira em memória — a tela precisa poder dizer "há trabalho pendente" E
 // "não consegui guardá-lo aqui" ao mesmo tempo.
+//
+// Cobre duas causas com a mesma consequência: o storage não responde (janela
+// anônima, quota estourada) ou o slot pertence a outra aba / a um formato que
+// este build não sabe ler. Um texto só porque a ação da pesquisadora é a mesma
+// nos dois casos — enviar antes de fechar; distinguir a causa na tela seria
+// precisão que não muda decisão nenhuma.
 export function CodingDraftUnavailableBanner({ visible }: { visible: boolean }) {
   if (!visible) return null;
   return (

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useMemo, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { applyFieldOrder } from "@/lib/field-order";
 import { sortByRecent } from "@/lib/coding-sort";
 import { useUrlState } from "@/hooks/useUrlState";
@@ -241,6 +241,18 @@ function CodingPageInner({
     [setParams],
   );
 
+  // Rede local (#608). Instanciado ANTES dos hooks de modo porque eles precisam
+  // do `recordDraft`; em troca, o documento aberto — que só é conhecido depois —
+  // entra por `openDocument`, num effect mais abaixo.
+  const drafts = useCodingDrafts({
+    projectId,
+    userId,
+    // Sob impersonação ou rodada anterior a tela é read-only: guardar rascunho
+    // ali depositaria trabalho num slot que ninguém vai enviar.
+    enabled: !readOnly,
+    fields,
+  });
+
   const assigned = useAssignedCoding({
     projectId,
     documents,
@@ -254,6 +266,9 @@ function CodingPageInner({
     markDirty,
     markClean,
     isDirty,
+    recordDraft: drafts.recordDraft,
+    restoreDraft: drafts.restoreDraft,
+    submitConfirmed: drafts.submitConfirmed,
     updateDocParam,
     setParams,
   });
@@ -267,6 +282,8 @@ function CodingPageInner({
     markDirty,
     markClean,
     isDirty,
+    recordDraft: drafts.recordDraft,
+    submitConfirmed: drafts.submitConfirmed,
     updateDocParam,
   });
 
@@ -299,6 +316,64 @@ function CodingPageInner({
     [mode, getAssignedPayload, getBrowsePayload],
   );
   useAutosaveOnExit({ activeDocId, getIsDirty, getPayload });
+
+  // --- Rascunho local (#608) ---
+  // O baseline do documento aberto é o que o SERVIDOR entregou, nunca o que está
+  // na tela: é contra ele que se decide se o rascunho ainda vale e o que ele
+  // sobrescreveria. Em Explorar o conteúdo vem do fetch do doc; em Atribuídos,
+  // das props do RSC.
+  const remoteSnapshot: CodingSnapshot | null = useMemo(() => {
+    if (!activeDocId) return null;
+    if (mode === "assigned") {
+      return {
+        answers: existingAnswers[activeDocId] ?? {},
+        notes:
+          typeof existingJustifications[activeDocId]?._notes === "string"
+            ? (existingJustifications[activeDocId]._notes as string)
+            : "",
+      };
+    }
+    const doc = browse.browseDoc;
+    if (!doc || doc.document.id !== activeDocId) return null;
+    return { answers: doc.initialAnswers, notes: doc.initialNotes };
+  }, [activeDocId, mode, existingAnswers, existingJustifications, browse.browseDoc]);
+
+  const openDocument = drafts.openDocument;
+  useEffect(() => {
+    // Em Explorar o baseline só existe depois do fetch; abrir antes classificaria
+    // o rascunho contra um documento vazio e anunciaria como sobrescrita tudo o
+    // que o servidor já tinha.
+    if (mode === "browse" && activeDocId && !remoteSnapshot) return;
+    openDocument(activeDocId, remoteSnapshot);
+  }, [openDocument, activeDocId, mode, remoteSnapshot]);
+
+  // Indicador de "não enviado": vem da sujeira em memória, não do storage — ver
+  // o comentário em `useDirtyDocs`.
+  const activeDocUnsent = useIsDocDirty(dirtyDocs, activeDocId);
+
+  // "Retomar" no modo Explorar entra por REMOUNT do filho keyed, e não por
+  // setState: `BrowseDocCoder` é construído sem estado derivado e sem setState em
+  // effect, e empurrar valor para dentro dele quebraria essa propriedade.
+  const [browseRestoreNonce, setBrowseRestoreNonce] = useState(0);
+  const [browseRestored, setBrowseRestored] = useState<CodingSnapshot | null>(null);
+  const restoreDraft = drafts.restoreDraft;
+  const handleRestoreDraft = useCallback(() => {
+    if (mode === "assigned") {
+      assigned.handleRestoreDraft();
+      return;
+    }
+    if (!browse.browseDocId) return;
+    const restored = restoreDraft(browse.browseDocId);
+    if (!restored) return;
+    setBrowseRestored(restored);
+    setBrowseRestoreNonce((n) => n + 1);
+    markDirty(browse.browseDocId);
+  }, [mode, assigned, browse.browseDocId, restoreDraft, markDirty]);
+
+  const discardDraft = drafts.discardDraft;
+  const handleDiscardDraft = useCallback(() => {
+    if (activeDocId) discardDraft(activeDocId);
+  }, [activeDocId, discardDraft]);
 
   if (fields.length === 0) {
     return <CodingEmptyStates kind="no-fields" />;
@@ -397,6 +472,24 @@ function CodingPageInner({
         />
       )}
 
+      {/* Faixas do rascunho local (#608), abaixo do header e acima das duas
+          views: a oferta de recuperação e o aviso de que a cópia local não está
+          funcionando. Nenhuma das duas se aplica em fullscreen, onde o header
+          também não aparece. */}
+      {!isFullscreen && (
+        <>
+          <CodingDraftBanner
+            recovery={drafts.recovery}
+            fields={fields}
+            onRestore={handleRestoreDraft}
+            onDiscard={handleDiscardDraft}
+          />
+          <CodingDraftUnavailableBanner
+            visible={!drafts.storageAvailable && activeDocUnsent}
+          />
+        </>
+      )}
+
       {mode === "assigned" && (
         <AssignedCodingView
           doc={assigned.currentDoc}
@@ -416,6 +509,7 @@ function CodingPageInner({
           readOnly={readOnly}
           onReorder={handleReorder}
           outOfScope={assignedOutOfScope}
+          unsent={activeDocUnsent}
           allDone={assigned.allDone}
           onExploreMore={handleExploreMore}
           hasAssignments={hasAssignments}
@@ -445,6 +539,9 @@ function CodingPageInner({
           onSubmit={(draft) => void browse.handleBrowseSubmit(draft)}
           onDraftChange={browse.handleDraftChange}
           outOfScope={browseOutOfScope}
+          unsent={activeDocUnsent}
+          restoredDraft={browseRestored}
+          restoreNonce={browseRestoreNonce}
         />
       )}
     </div>

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -7,13 +7,13 @@ import { useUrlState } from "@/hooks/useUrlState";
 import { useFieldOrder } from "@/hooks/useFieldOrder";
 import { useAutosaveOnExit } from "@/hooks/useAutosaveOnExit";
 import { useFullscreen } from "@/hooks/useFullscreen";
-import { useDirtyDocs, useIsDocDirty } from "@/hooks/useDirtyDocs";
+import { useDirtyDocs } from "@/hooks/useDirtyDocs";
 import { useCodingDrafts } from "@/hooks/useCodingDrafts";
+import { useCodingDraftWiring } from "./useCodingDraftWiring";
 import {
   CodingDraftBanner,
   CodingDraftUnavailableBanner,
 } from "./CodingDraftBanner";
-import type { CodingSnapshot } from "@/lib/coding-draft";
 import { CodingHeader, type DocSection } from "./CodingHeader";
 import { CodingEmptyStates } from "./CodingEmptyStates";
 import { AssignedCodingView } from "./AssignedCodingView";
@@ -317,63 +317,24 @@ function CodingPageInner({
   );
   useAutosaveOnExit({ activeDocId, getIsDirty, getPayload });
 
-  // --- Rascunho local (#608) ---
-  // O baseline do documento aberto é o que o SERVIDOR entregou, nunca o que está
-  // na tela: é contra ele que se decide se o rascunho ainda vale e o que ele
-  // sobrescreveria. Em Explorar o conteúdo vem do fetch do doc; em Atribuídos,
-  // das props do RSC.
-  const remoteSnapshot: CodingSnapshot | null = useMemo(() => {
-    if (!activeDocId) return null;
-    if (mode === "assigned") {
-      return {
-        answers: existingAnswers[activeDocId] ?? {},
-        notes:
-          typeof existingJustifications[activeDocId]?._notes === "string"
-            ? (existingJustifications[activeDocId]._notes as string)
-            : "",
-      };
-    }
-    const doc = browse.browseDoc;
-    if (!doc || doc.document.id !== activeDocId) return null;
-    return { answers: doc.initialAnswers, notes: doc.initialNotes };
-  }, [activeDocId, mode, existingAnswers, existingJustifications, browse.browseDoc]);
-
-  const openDocument = drafts.openDocument;
-  useEffect(() => {
-    // Em Explorar o baseline só existe depois do fetch; abrir antes classificaria
-    // o rascunho contra um documento vazio e anunciaria como sobrescrita tudo o
-    // que o servidor já tinha.
-    if (mode === "browse" && activeDocId && !remoteSnapshot) return;
-    openDocument(activeDocId, remoteSnapshot);
-  }, [openDocument, activeDocId, mode, remoteSnapshot]);
-
-  // Indicador de "não enviado": vem da sujeira em memória, não do storage — ver
-  // o comentário em `useDirtyDocs`.
-  const activeDocUnsent = useIsDocDirty(dirtyDocs, activeDocId);
-
-  // "Retomar" no modo Explorar entra por REMOUNT do filho keyed, e não por
-  // setState: `BrowseDocCoder` é construído sem estado derivado e sem setState em
-  // effect, e empurrar valor para dentro dele quebraria essa propriedade.
-  const [browseRestoreNonce, setBrowseRestoreNonce] = useState(0);
-  const [browseRestored, setBrowseRestored] = useState<CodingSnapshot | null>(null);
-  const restoreDraft = drafts.restoreDraft;
-  const handleRestoreDraft = useCallback(() => {
-    if (mode === "assigned") {
-      assigned.handleRestoreDraft();
-      return;
-    }
-    if (!browse.browseDocId) return;
-    const restored = restoreDraft(browse.browseDocId);
-    if (!restored) return;
-    setBrowseRestored(restored);
-    setBrowseRestoreNonce((n) => n + 1);
-    markDirty(browse.browseDocId);
-  }, [mode, assigned, browse.browseDocId, restoreDraft, markDirty]);
-
-  const discardDraft = drafts.discardDraft;
-  const handleDiscardDraft = useCallback(() => {
-    if (activeDocId) discardDraft(activeDocId);
-  }, [activeDocId, discardDraft]);
+  const {
+    activeDocUnsent,
+    handleRestoreDraft,
+    handleDiscardDraft,
+    browseRestored,
+    browseRestoreNonce,
+  } = useCodingDraftWiring({
+    mode,
+    activeDocId,
+    drafts,
+    dirtyDocs,
+    markDirty,
+    restoreAssignedDraft: assigned.handleRestoreDraft,
+    browseDocId: browse.browseDocId,
+    browseDoc: browse.browseDoc,
+    existingAnswers,
+    existingJustifications,
+  });
 
   if (fields.length === 0) {
     return <CodingEmptyStates kind="no-fields" />;

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -7,7 +7,13 @@ import { useUrlState } from "@/hooks/useUrlState";
 import { useFieldOrder } from "@/hooks/useFieldOrder";
 import { useAutosaveOnExit } from "@/hooks/useAutosaveOnExit";
 import { useFullscreen } from "@/hooks/useFullscreen";
-import { useDirtyDocs } from "@/hooks/useDirtyDocs";
+import { useDirtyDocs, useIsDocDirty } from "@/hooks/useDirtyDocs";
+import { useCodingDrafts } from "@/hooks/useCodingDrafts";
+import {
+  CodingDraftBanner,
+  CodingDraftUnavailableBanner,
+} from "./CodingDraftBanner";
+import type { CodingSnapshot } from "@/lib/coding-draft";
 import { CodingHeader, type DocSection } from "./CodingHeader";
 import { CodingEmptyStates } from "./CodingEmptyStates";
 import { AssignedCodingView } from "./AssignedCodingView";
@@ -142,6 +148,10 @@ function buildHeaderDocSection(
 
 interface CodingPageProps {
   projectId: string;
+  /** Membro DONO das escritas (`ownMemberUserId`), não o observado sob
+   *  impersonação: é a identidade do slot do rascunho local. Ver
+   *  `CodingDraftScope` em `lib/coding-draft.ts`. */
+  userId: string;
   documents: AssignedDoc[];
   codedAtByDoc?: Record<string, string>;
   fields: PydanticField[];
@@ -171,6 +181,7 @@ export function CodingPage(props: CodingPageProps) {
 
 function CodingPageInner({
   projectId,
+  userId,
   documents,
   codedAtByDoc = EMPTY_CODED_AT,
   fields,
@@ -217,8 +228,11 @@ function CodingPageInner({
     [fields, fieldOrder],
   );
 
-  // Dirty tracking via ref (sem re-render) — compartilhado entre os modos.
-  const { markDirty, markClean, isDirty } = useDirtyDocs();
+  // Sujeira compartilhada entre os modos. O store é imperativo para os handlers
+  // e reativo para a tela (ver `useDirtyDocs`): o indicador de "não enviado" sai
+  // DAQUI, nunca do resultado da persistência local.
+  const dirtyDocs = useDirtyDocs();
+  const { markDirty, markClean, isDirty } = dirtyDocs;
 
   const updateDocParam = useCallback(
     (docId: string | null) => {

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -13,6 +13,7 @@ import { useCodingDraftWiring } from "./useCodingDraftWiring";
 import {
   CodingDraftBanner,
   CodingDraftUnavailableBanner,
+  UnsentChangesBadge,
 } from "./CodingDraftBanner";
 import { CodingHeader, type DocSection } from "./CodingHeader";
 import { CodingEmptyStates } from "./CodingEmptyStates";
@@ -321,7 +322,7 @@ function CodingPageInner({
     activeDocUnsent,
     handleRestoreDraft,
     handleDiscardDraft,
-    browseRestored,
+    browseDocForCoder,
     browseRestoreNonce,
   } = useCodingDraftWiring({
     mode,
@@ -439,6 +440,16 @@ function CodingPageInner({
           também não aparece. */}
       {!isFullscreen && (
         <>
+          {/* Um único indicador para os dois modos, junto das faixas do
+              rascunho: permanente enquanto houver pendência, some quando o envio
+              é confirmado. Fica aqui — e não dentro do painel de perguntas —
+              porque o sinal é da PÁGINA (o documento aberto), e porque duplicá-lo
+              por modo obrigava cada view a repassá-lo. */}
+          {activeDocUnsent && (
+            <div className="flex items-center gap-2 border-b px-4 py-1.5">
+              <UnsentChangesBadge visible />
+            </div>
+          )}
           <CodingDraftBanner
             recovery={drafts.recovery}
             fields={fields}
@@ -470,7 +481,6 @@ function CodingPageInner({
           readOnly={readOnly}
           onReorder={handleReorder}
           outOfScope={assignedOutOfScope}
-          unsent={activeDocUnsent}
           allDone={assigned.allDone}
           onExploreMore={handleExploreMore}
           hasAssignments={hasAssignments}
@@ -485,7 +495,7 @@ function CodingPageInner({
           browseDocId={browse.browseDocId}
           browseDocuments={browse.browseDocuments}
           browseDocLoading={browse.browseDocLoading}
-          browseDoc={browse.browseDoc}
+          browseDoc={browseDocForCoder}
           onSelect={browse.handleBrowseSelect}
           onRetry={browse.retryBrowse}
           onRetryDoc={browse.retryBrowseDoc}
@@ -500,8 +510,6 @@ function CodingPageInner({
           onSubmit={(draft) => void browse.handleBrowseSubmit(draft)}
           onDraftChange={browse.handleDraftChange}
           outOfScope={browseOutOfScope}
-          unsent={activeDocUnsent}
-          restoredDraft={browseRestored}
           restoreNonce={browseRestoreNonce}
         />
       )}

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -31,13 +31,9 @@ export interface QuestionsPanelProps {
   onReorder?: (newOrder: string[]) => void;
   /** Presente = renderiza a pergunta "Documento fora do escopo?" primeiro. */
   outOfScope?: OutOfScopeConfig;
-  /** Há alterações ainda não enviadas neste documento (#608). Vem da sujeira em
-   *  memória, não do rascunho local: a tela precisa dizer a verdade mesmo quando
-   *  a cópia local não pôde ser gravada. */
-  unsent?: boolean;
 }
 
-export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false, onReorder, outOfScope, unsent = false }: QuestionsPanelProps) {
+export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false, onReorder, outOfScope }: QuestionsPanelProps) {
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const { outOfScopeState, setOutOfScopeState, outOfScopeBlocked } = useOutOfScopeState(outOfScope);
@@ -110,22 +106,10 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
 
   return (
     <div className="flex h-full flex-col bg-card">
-      <div className="flex items-center justify-between gap-2 border-b px-4 py-2.5 shrink-0">
+      <div className="border-b px-4 py-2.5 shrink-0">
         <p className="text-xs font-medium text-muted-foreground">
           Perguntas ({answeredRequiredCount}/{requiredFields.length} obrigatórias respondidas)
         </p>
-        {/* Indicador permanente enquanto houver pendência — não um toast, que
-            some. É o que responde "isto está salvo?" sem a pesquisadora ter de
-            adivinhar, e some sozinho quando o envio é confirmado. */}
-        {unsent && (
-          <span
-            role="status"
-            className="flex items-center gap-1.5 whitespace-nowrap rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200"
-          >
-            <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />
-            Alterações não enviadas
-          </span>
-        )}
       </div>
 
       <div

--- a/frontend/src/components/coding/QuestionsPanel.tsx
+++ b/frontend/src/components/coding/QuestionsPanel.tsx
@@ -31,9 +31,13 @@ export interface QuestionsPanelProps {
   onReorder?: (newOrder: string[]) => void;
   /** Presente = renderiza a pergunta "Documento fora do escopo?" primeiro. */
   outOfScope?: OutOfScopeConfig;
+  /** Há alterações ainda não enviadas neste documento (#608). Vem da sujeira em
+   *  memória, não do rascunho local: a tela precisa dizer a verdade mesmo quando
+   *  a cópia local não pôde ser gravada. */
+  unsent?: boolean;
 }
 
-export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false, onReorder, outOfScope }: QuestionsPanelProps) {
+export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting = false, notes = "", onNotesChange, readOnly = false, onReorder, outOfScope, unsent = false }: QuestionsPanelProps) {
   const questionRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const { outOfScopeState, setOutOfScopeState, outOfScopeBlocked } = useOutOfScopeState(outOfScope);
@@ -106,10 +110,22 @@ export function QuestionsPanel({ fields, answers, onAnswer, onSubmit, submitting
 
   return (
     <div className="flex h-full flex-col bg-card">
-      <div className="border-b px-4 py-2.5 shrink-0">
+      <div className="flex items-center justify-between gap-2 border-b px-4 py-2.5 shrink-0">
         <p className="text-xs font-medium text-muted-foreground">
           Perguntas ({answeredRequiredCount}/{requiredFields.length} obrigatórias respondidas)
         </p>
+        {/* Indicador permanente enquanto houver pendência — não um toast, que
+            some. É o que responde "isto está salvo?" sem a pesquisadora ter de
+            adivinhar, e some sozinho quando o envio é confirmado. */}
+        {unsent && (
+          <span
+            role="status"
+            className="flex items-center gap-1.5 whitespace-nowrap rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 dark:bg-amber-950 dark:text-amber-200"
+          >
+            <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />
+            Alterações não enviadas
+          </span>
+        )}
       </div>
 
       <div

--- a/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
@@ -121,6 +121,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
   it("sem documentos atribuídos: mostra o empty-state 'no-doc'", async () => {
     render(
       <CodingPage
+        userId="user-teste"
         projectId="p1"
         documents={[]}
         fields={FIELDS}
@@ -139,6 +140,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
 
     render(
       <CodingPage
+        userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}
         fields={FIELDS}
@@ -165,6 +167,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
   it("documento normal: renderiza o doc certo com as respostas existentes", async () => {
     render(
       <CodingPage
+        userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1"), assignedDoc("a2")]}
         fields={FIELDS}
@@ -182,6 +185,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
   it("fora do escopo habilitado no projeto: config chega ao QuestionsPanel com status normal", async () => {
     render(
       <CodingPage
+        userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}
         fields={FIELDS}
@@ -206,6 +210,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
   it("fora do escopo com pendência do próprio usuário: status pending_mine com o motivo", async () => {
     render(
       <CodingPage
+        userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}
         fields={FIELDS}

--- a/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
@@ -193,7 +193,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     saveResponse.mockResolvedValue({ success: true });
 
     render(
-      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -220,7 +220,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     saveResponse.mockResolvedValue({ success: true });
 
     render(
-      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     expect((await screen.findByTestId("count-d1")).textContent).toBe("0");
@@ -244,7 +244,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     );
 
     render(
-      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -279,6 +279,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
 
     render(
       <CodingPage
+        userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}
         fields={FIELDS}
@@ -299,7 +300,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     getDocumentForCoding.mockResolvedValue(codingResult("d1", null));
 
     render(
-      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -340,7 +341,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     );
 
     render(
-      <CodingPage projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));

--- a/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
@@ -1,0 +1,320 @@
+// @vitest-environment jsdom
+//
+// Os critérios de aceitação do #608 no nível da TELA — os que nenhum teste de
+// unidade cobre porque dependem da composição container + hooks + storage:
+//
+//   (2) fechar a aba com alterações pendentes não perde trabalho;
+//   (4) a tela diz, a qualquer momento, se há alterações não enviadas;
+//       e o rascunho é OFERECIDO, nunca aplicado em silêncio.
+//
+// Diferente das outras suítes de `CodingPage`, o `QuestionsPanel` NÃO é
+// mockado por um stub mínimo: o indicador de "não enviado" mora nele, e um stub
+// tornaria vácua justamente a asserção do critério 4.
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import type { PydanticField, Document } from "@/lib/types";
+
+const { saveResponse, getDocumentsForBrowse, urlParams } = vi.hoisted(() => ({
+  saveResponse: vi.fn(),
+  getDocumentsForBrowse: vi.fn(),
+  urlParams: { current: {} as Record<string, string | null> },
+}));
+
+vi.mock("@/actions/responses", () => ({ saveResponse }));
+vi.mock("@/actions/documents", () => ({
+  getDocumentsForBrowse,
+  getDocumentForCoding: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+vi.mock("@/hooks/useUrlState", async () => {
+  const React = await import("react");
+  return {
+    useUrlState: () => {
+      const [, force] = React.useState(0);
+      return {
+        get: (k: string) => urlParams.current[k] ?? null,
+        set: (updates: Record<string, string | null>) => {
+          urlParams.current = { ...urlParams.current, ...updates };
+          force((n) => n + 1);
+        },
+      };
+    },
+  };
+});
+vi.mock("@/hooks/useFieldOrder", () => ({
+  useFieldOrder: () => ({ fieldOrder: [], handleReorder: vi.fn() }),
+}));
+// O auto-save de servidor segue existindo nesta etapa (ele sai no PR seguinte);
+// aqui é neutralizado para que o que se observa seja só a rede local.
+vi.mock("@/hooks/useAutosaveOnExit", () => ({ useAutosaveOnExit: () => {} }));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => <div />,
+}));
+vi.mock("@/components/coding/DocumentReader", () => ({
+  DocumentReader: () => <div data-testid="doc-reader" />,
+}));
+vi.mock("@/components/coding/DocumentPicker", () => ({
+  DocumentPicker: () => <div data-testid="picker" />,
+}));
+vi.mock("@/components/coding/CodingHeader", () => ({
+  CodingHeader: ({ mode }: { mode: string }) => <div data-testid="hdr-mode">{mode}</div>,
+}));
+vi.mock("@/components/coding/FullscreenNav", () => ({
+  FullscreenNav: () => <div data-testid="fsnav" />,
+}));
+
+import { CodingPage } from "@/components/coding/CodingPage";
+import { codingDraftStorageKey, parseCodingDraft } from "@/lib/coding-draft";
+
+const USER = "user-teste";
+const PROJECT = "p1";
+const DOC = "d1";
+const KEY = codingDraftStorageKey({
+  userId: USER,
+  projectId: PROJECT,
+  documentId: DOC,
+});
+
+const FIELDS: PydanticField[] = [
+  { name: "q1", type: "text", options: null, description: "Qual o medicamento?" },
+];
+
+function assignedDoc(id: string): Document {
+  return {
+    id,
+    project_id: PROJECT,
+    external_id: `ext-${id}`,
+    title: `Assigned ${id}`,
+    text: `texto-${id}`,
+    metadata: null,
+    created_at: "2026-01-01",
+    excluded_at: null,
+    excluded_reason: null,
+    excluded_by: null,
+    exclusion_pending_at: null,
+  };
+}
+
+function renderPage(existingAnswers: Record<string, Record<string, unknown>> = {}) {
+  return render(
+    <CodingPage
+      userId={USER}
+      projectId={PROJECT}
+      documents={[assignedDoc(DOC)]}
+      fields={FIELDS}
+      existingAnswers={existingAnswers}
+      hasAssignments
+    />,
+  );
+}
+
+function plantDraft(draftAnswers: Record<string, unknown>, base = {}) {
+  window.localStorage.setItem(
+    KEY,
+    JSON.stringify({
+      formatVersion: 1,
+      writeToken: "tok-plantado",
+      userId: USER,
+      projectId: PROJECT,
+      documentId: DOC,
+      updatedAt: Date.now() - 5 * 60_000,
+      base: { answers: base, notes: "" },
+      draft: { answers: draftAnswers, notes: "" },
+    }),
+  );
+}
+
+const storedDraft = () => parseCodingDraft(window.localStorage.getItem(KEY));
+
+// O campo de resposta não tem `label` associado no `FieldRenderer`; é o
+// primeiro textbox do painel (o segundo é a caixa de notas).
+const answerInput = () => screen.getAllByRole("textbox")[0];
+
+const typeAnswer = async (user: ReturnType<typeof userEvent.setup>, text: string) => {
+  await user.type(answerInput(), text);
+};
+
+beforeEach(() => {
+  urlParams.current = {};
+  window.localStorage.clear();
+  Element.prototype.scrollTo = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+  getDocumentsForBrowse.mockResolvedValue([]);
+  saveResponse.mockResolvedValue({ success: true });
+});
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  // `restoreAllMocks`, e não só `clearAllMocks`: o teste de quota substitui a
+  // IMPLEMENTAÇÃO de `Storage.prototype.setItem` por um spy que lança, e
+  // `clearAllMocks` zera as chamadas sem desfazer a substituição. Sem isto, um
+  // único teste derrubava os sete seguintes com `QuotaExceededError`.
+  vi.restoreAllMocks();
+});
+
+describe("critério 4 — a tela diz se há alterações não enviadas", () => {
+  it("o indicador não aparece antes de editar", () => {
+    renderPage();
+    expect(screen.queryByText(/alterações não enviadas/i)).toBeNull();
+  });
+
+  // Mutação vermelha: derivar o indicador de qualquer coisa que não seja a
+  // sujeira em memória (por exemplo, do que foi persistido no localStorage).
+  it("aparece ao editar e some quando o envio é confirmado", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await typeAnswer(user, "Zolgensma");
+    expect(await screen.findByText(/alterações não enviadas/i)).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: /enviar/i }));
+    await waitFor(() =>
+      expect(screen.queryByText(/alterações não enviadas/i)).toBeNull(),
+    );
+  });
+
+  // A razão de o indicador NÃO sair do storage: aqui o localStorage está
+  // quebrado e a tela ainda precisa dizer a verdade sobre o trabalho pendente.
+  // Mutação vermelha: derivar `unsent` de `drafts`/`storageAvailable`.
+  it("com o localStorage indisponível, ainda avisa que há trabalho pendente", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("cheio", "QuotaExceededError");
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await typeAnswer(user, "Zolgensma");
+    expect(await screen.findByText(/alterações não enviadas/i)).toBeTruthy();
+    // E avisa, além disso, que a cópia local não pôde ser guardada.
+    expect(
+      await screen.findByText(/não foi possível guardar uma cópia local/i),
+    ).toBeTruthy();
+  });
+});
+
+describe("critério 2 — fechar a aba não perde trabalho", () => {
+  // A prova de que a rede local existe: o conteúdo digitado sobrevive ao
+  // `pagehide` sem nenhuma escrita no servidor. Mutação vermelha: remover o
+  // flush de `pagehide`/`visibilitychange` do hook de rascunho.
+  it("o que foi digitado é persistido localmente ao esconder a aba", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await typeAnswer(user, "Zolgensma");
+    window.dispatchEvent(new Event("pagehide"));
+
+    await waitFor(() => expect(storedDraft()?.draft.answers).toEqual({ q1: "Zolgensma" }));
+    // E nada foi para o servidor: a gravação continua sendo ação explícita.
+    expect(saveResponse).not.toHaveBeenCalled();
+  });
+});
+
+describe("recuperação — oferecer, nunca aplicar em silêncio", () => {
+  // O teste que fixa a decisão de desenho mais importante da issue. Mutação
+  // vermelha: semear o reducer com o rascunho no `useState`/`useReducer` inicial
+  // — o formulário abriria já preenchido, que é exatamente o comportamento
+  // "grava sem pedir e sem avisar" que esta issue remove.
+  it("com rascunho no slot, o formulário monta com os valores DO SERVIDOR", async () => {
+    plantDraft({ q1: "do rascunho" });
+    renderPage({ [DOC]: { q1: "do servidor" } });
+
+    await waitFor(() => expect(answerInput()).toBeTruthy());
+    expect(answerInput()).toHaveProperty("value", "do servidor");
+    // Mas a existência do rascunho é anunciada.
+    expect(screen.getByText(/alterações não enviadas neste documento/i)).toBeTruthy();
+  });
+
+  it("`Retomar` aplica o rascunho e acende o indicador de não enviado", async () => {
+    const user = userEvent.setup();
+    plantDraft({ q1: "do rascunho" });
+    renderPage({ [DOC]: { q1: "do servidor" } });
+
+    await user.click(await screen.findByRole("button", { name: /retomar rascunho/i }));
+
+    expect(answerInput()).toHaveProperty("value", "do rascunho");
+    expect(screen.getByText(/alterações não enviadas/i)).toBeTruthy();
+  });
+
+  // Mutação vermelha: `discardDraft` que só esconde a faixa sem apagar o slot —
+  // a oferta voltaria na próxima abertura e a decisão da pesquisadora seria
+  // silenciosamente ignorada.
+  it("`Descartar` apaga o slot", async () => {
+    const user = userEvent.setup();
+    plantDraft({ q1: "do rascunho" });
+    renderPage({ [DOC]: { q1: "do servidor" } });
+
+    await user.click(await screen.findByRole("button", { name: /descartar/i }));
+
+    expect(storedDraft()).toBeNull();
+    expect(
+      screen.queryByText(/alterações não enviadas neste documento/i),
+    ).toBeNull();
+  });
+
+  it("rascunho que apenas repete o servidor não é oferecido", async () => {
+    plantDraft({ q1: "igual" });
+    renderPage({ [DOC]: { q1: "igual" } });
+
+    await waitFor(() => expect(storedDraft()).toBeNull());
+    expect(
+      screen.queryByText(/alterações não enviadas neste documento/i),
+    ).toBeNull();
+  });
+
+  it("anuncia o que seria sobrescrito quando o servidor andou depois do rascunho", async () => {
+    plantDraft({ q1: "do rascunho" }, { q1: "antigo" });
+    renderPage({ [DOC]: { q1: "servidor-novo" } });
+
+    expect(await screen.findByText(/foi salvo depois/i)).toBeTruthy();
+    // Nomeia a pergunta pelo RÓTULO, não pelo nome interno do campo (`q1`). A
+    // busca é escopada ao `<strong>` da faixa porque o mesmo texto também é o
+    // enunciado da pergunta no formulário.
+    const emphasized = screen.getByText(
+      (_, el) => el?.tagName === "STRONG" && el.textContent === "Qual o medicamento?",
+    );
+    expect(emphasized).toBeTruthy();
+  });
+});
+
+describe("envio confirmado", () => {
+  // Mutação vermelha: preservar o rascunho quando `missingRequired > 0`. A
+  // escrita aconteceu; manter o envelope deixaria o indicador aceso sobre
+  // trabalho que FOI enviado, e a oferta voltaria depois.
+  it("descarta o rascunho mesmo quando o documento segue pendente", async () => {
+    saveResponse.mockResolvedValue({ success: true, missingRequired: 1 });
+    const user = userEvent.setup();
+    renderPage();
+
+    await typeAnswer(user, "Zolgensma");
+    window.dispatchEvent(new Event("pagehide"));
+    await waitFor(() => expect(storedDraft()).not.toBeNull());
+
+    await user.click(screen.getByRole("button", { name: /enviar/i }));
+    await waitFor(() => expect(storedDraft()).toBeNull());
+  });
+
+  // Mutação vermelha: apagar o rascunho no `finally` em vez de no ramo de
+  // sucesso. É o caso para o qual a feature inteira existe.
+  it("falha no envio mantém o rascunho E a sujeira", async () => {
+    saveResponse.mockResolvedValue({ success: false, error: "falhou" });
+    const user = userEvent.setup();
+    renderPage();
+
+    await typeAnswer(user, "Zolgensma");
+    window.dispatchEvent(new Event("pagehide"));
+
+    await user.click(screen.getByRole("button", { name: /enviar/i }));
+
+    await waitFor(() => expect(saveResponse).toHaveBeenCalled());
+    expect(storedDraft()?.draft.answers).toEqual({ q1: "Zolgensma" });
+    expect(screen.getByText(/alterações não enviadas/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
@@ -200,19 +200,24 @@ describe("critério 4 — a tela diz se há alterações não enviadas", () => {
   });
 });
 
-describe("critério 2 — fechar a aba não perde trabalho", () => {
-  // A prova de que a rede local existe: o conteúdo digitado sobrevive ao
-  // `pagehide` sem nenhuma escrita no servidor. Mutação vermelha: remover o
-  // flush de `pagehide`/`visibilitychange` do hook de rascunho.
-  it("o que foi digitado é persistido localmente ao esconder a aba", async () => {
+describe("critério 2 — o que foi digitado sobrevive fora do servidor", () => {
+  // Esta suíte roda com timers REAIS (userEvent precisa deles), então o debounce
+  // de 300ms já disparou quando as asserções rodam. Consequência medida: este
+  // teste continua passando mesmo sem o `pagehide` — ele prova a existência da
+  // rede local, NÃO o flush de saída.
+  //
+  // Os três gatilhos de flush (`pagehide`, `visibilitychange:hidden`, unmount)
+  // são provados em `useCodingDrafts.test.ts`, com fake timers, cada um com a
+  // mutação que o derruba. Aqui, alegar o contrário seria uma asserção vácua.
+  it("o que foi digitado é persistido localmente, sem ir ao servidor", async () => {
     const user = userEvent.setup();
     renderPage();
 
     await typeAnswer(user, "Zolgensma");
-    window.dispatchEvent(new Event("pagehide"));
 
     await waitFor(() => expect(storedDraft()?.draft.answers).toEqual({ q1: "Zolgensma" }));
-    // E nada foi para o servidor: a gravação continua sendo ação explícita.
+    // Nenhuma escrita implícita: a gravação no servidor segue sendo ação
+    // explícita da pesquisadora (critério 1).
     expect(saveResponse).not.toHaveBeenCalled();
   });
 });
@@ -294,7 +299,6 @@ describe("envio confirmado", () => {
     renderPage();
 
     await typeAnswer(user, "Zolgensma");
-    window.dispatchEvent(new Event("pagehide"));
     await waitFor(() => expect(storedDraft()).not.toBeNull());
 
     await user.click(screen.getByRole("button", { name: /enviar/i }));
@@ -309,7 +313,7 @@ describe("envio confirmado", () => {
     renderPage();
 
     await typeAnswer(user, "Zolgensma");
-    window.dispatchEvent(new Event("pagehide"));
+    await waitFor(() => expect(storedDraft()).not.toBeNull());
 
     await user.click(screen.getByRole("button", { name: /enviar/i }));
 

--- a/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
@@ -64,8 +64,27 @@ vi.mock("@/components/coding/DocumentReader", () => ({
 vi.mock("@/components/coding/DocumentPicker", () => ({
   DocumentPicker: () => <div data-testid="picker" />,
 }));
+// O header é stub, mas expõe a navegação entre documentos atribuídos: é ela que
+// dispara o autosave de navegação, e o efeito desse autosave sobre o rascunho
+// local é o que a suíte "autosave de navegação" abaixo verifica.
 vi.mock("@/components/coding/CodingHeader", () => ({
-  CodingHeader: ({ mode }: { mode: string }) => <div data-testid="hdr-mode">{mode}</div>,
+  CodingHeader: ({
+    mode,
+    doc,
+  }: {
+    mode: string;
+    doc?: { index: number; onNavigate: (index: number) => void };
+  }) => (
+    <div>
+      <div data-testid="hdr-mode">{mode}</div>
+      {doc && (
+        <>
+          <button onClick={() => doc.onNavigate(doc.index + 1)}>ir-proximo</button>
+          <button onClick={() => doc.onNavigate(doc.index - 1)}>ir-anterior</button>
+        </>
+      )}
+    </div>
+  ),
 }));
 vi.mock("@/components/coding/FullscreenNav", () => ({
   FullscreenNav: () => <div data-testid="fsnav" />,
@@ -103,12 +122,15 @@ function assignedDoc(id: string): Document {
   };
 }
 
-function renderPage(existingAnswers: Record<string, Record<string, unknown>> = {}) {
+function renderPage(
+  existingAnswers: Record<string, Record<string, unknown>> = {},
+  documents: Document[] = [assignedDoc(DOC)],
+) {
   return render(
     <CodingPage
       userId={USER}
       projectId={PROJECT}
-      documents={[assignedDoc(DOC)]}
+      documents={documents}
       fields={FIELDS}
       existingAnswers={existingAnswers}
       hasAssignments
@@ -320,5 +342,57 @@ describe("envio confirmado", () => {
     await waitFor(() => expect(saveResponse).toHaveBeenCalled());
     expect(storedDraft()?.draft.answers).toEqual({ q1: "Zolgensma" });
     expect(screen.getByText(/alterações não enviadas/i)).toBeTruthy();
+  });
+});
+
+// O autosave de navegação é uma escrita CONFIRMADA como qualquer outra: a
+// resposta foi ao servidor. Enquanto ele existir (sai no PR seguinte), tem de
+// produzir os mesmos dois efeitos do Enviar — limpar a sujeira e reassentar o
+// baseline do rascunho local. Sem o segundo, o envelope sobrevivia à navegação
+// e a volta ao documento oferecia "alterações não enviadas" sobre trabalho já
+// enviado; pior, o `base` stale fazia a oferta seguinte se anunciar como
+// `diverged`, acusando "salvo depois" contra a nossa própria escrita.
+describe("autosave de navegação — escrita confirmada também rebaseia", () => {
+  const OUTRO = "d2";
+  const twoDocs = () => [assignedDoc(DOC), assignedDoc(OUTRO)];
+
+  // Mutação vermelha: passar só `markClean` no `onSaved` do `autosaveDirtyDoc`
+  // (isto é, salvar sem `submitConfirmed`) — a faixa reaparece ao voltar.
+  it("navegar para outro documento e voltar não oferece o que já foi salvo", async () => {
+    const user = userEvent.setup();
+    renderPage({}, twoDocs());
+
+    await typeAnswer(user, "Zolgensma");
+    await waitFor(() => expect(storedDraft()).not.toBeNull());
+
+    await user.click(screen.getByRole("button", { name: "ir-proximo" }));
+    // O autosave salvou de verdade: é isso que torna a oferta uma mentira.
+    await waitFor(() => expect(saveResponse).toHaveBeenCalled());
+    // E o slot foi liberado junto, em vez de sobreviver à navegação.
+    await waitFor(() => expect(storedDraft()).toBeNull());
+
+    await user.click(screen.getByRole("button", { name: "ir-anterior" }));
+
+    // As props do RSC não revalidaram (`existingAnswers` segue vazio): é
+    // justamente por isso que a classificação não pode depender delas contra um
+    // envelope que devia ter sido descartado no autosave.
+    expect(screen.queryByText(/alterações não enviadas neste documento/i)).toBeNull();
+    expect(screen.queryByText(/foi salvo depois/i)).toBeNull();
+  });
+
+  // O outro lado da mesma regra: autosave que FALHA não é escrita confirmada, e
+  // aí o rascunho tem de sobreviver — é o único registro do trabalho.
+  it("autosave que falha preserva o rascunho para a volta", async () => {
+    saveResponse.mockResolvedValue({ success: false, error: "falhou" });
+    const user = userEvent.setup();
+    renderPage({}, twoDocs());
+
+    await typeAnswer(user, "Zolgensma");
+    await waitFor(() => expect(storedDraft()).not.toBeNull());
+
+    await user.click(screen.getByRole("button", { name: "ir-proximo" }));
+    await waitFor(() => expect(saveResponse).toHaveBeenCalled());
+
+    expect(storedDraft()?.draft.answers).toEqual({ q1: "Zolgensma" });
   });
 });

--- a/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
@@ -49,6 +49,9 @@ function setup(overrides?: {
     markDirty: vi.fn((id: string) => dirty.add(id)),
     markClean: vi.fn((id: string) => dirty.delete(id)),
     isDirty: (id: string | null | undefined) => !!id && dirty.has(id),
+    recordDraft: vi.fn(),
+    restoreDraft: vi.fn(() => null),
+    submitConfirmed: vi.fn(),
     updateDocParam: vi.fn(),
     setParams: vi.fn(),
   };

--- a/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
@@ -73,6 +73,8 @@ function setup(docParam: string | null, dirty = new Set<string>()) {
     markDirty: vi.fn((id: string) => dirty.add(id)),
     markClean: vi.fn((id: string) => dirty.delete(id)),
     isDirty: (id: string | null | undefined) => !!id && dirty.has(id),
+    recordDraft: vi.fn(),
+    submitConfirmed: vi.fn(),
     updateDocParam: vi.fn(),
   };
   return { view: renderHook(() => useBrowseCoding(params)), params, dirty };

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -25,7 +25,11 @@ type AssignedAction =
   | { type: "answer"; docId: string; field: string; value: unknown; fields: PydanticField[] }
   | { type: "notes"; docId: string; notes: string }
   | { type: "index"; index: number }
-  | { type: "allDone"; value: boolean };
+  | { type: "allDone"; value: boolean }
+  // Aplicação EXPLÍCITA de um rascunho local (#608). Nunca entra pelo seed do
+  // reducer: semear a partir do rascunho seria aplicá-lo em silêncio, e o
+  // requisito é o oposto — a faixa oferece, a pesquisadora decide.
+  | { type: "restoreDraft"; docId: string; answers: Record<string, unknown>; notes: string };
 
 function reducer(state: AssignedState, action: AssignedAction): AssignedState {
   switch (action.type) {
@@ -60,6 +64,12 @@ function reducer(state: AssignedState, action: AssignedAction): AssignedState {
       return { ...state, docIndex: action.index, allDone: false };
     case "allDone":
       return { ...state, allDone: action.value };
+    case "restoreDraft":
+      return {
+        ...state,
+        allAnswers: { ...state.allAnswers, [action.docId]: action.answers },
+        allNotes: { ...state.allNotes, [action.docId]: action.notes },
+      };
   }
 }
 
@@ -92,6 +102,8 @@ interface UseAssignedCodingParams {
   /** Rede local do #608: registra a edição corrente para o rascunho em
    *  localStorage. O baseline é do hook de rascunho, não daqui. */
   recordDraft: (docId: string, draft: CodingSnapshot) => void;
+  /** Devolve o rascunho oferecido para aplicação explícita. */
+  restoreDraft: (docId: string) => CodingSnapshot | null;
   /** Chamado quando o servidor confirmou a ESCRITA, inclusive com obrigatória
    *  em aberto — ver `submitConfirmed`. */
   submitConfirmed: (docId: string, saved: CodingSnapshot) => void;
@@ -126,6 +138,7 @@ export function useAssignedCoding({
   markClean,
   isDirty,
   recordDraft,
+  restoreDraft,
   submitConfirmed,
   updateDocParam,
   setParams,
@@ -188,6 +201,23 @@ export function useAssignedCoding({
     },
     [currentDoc?.id, markDirty],
   );
+
+  // Aplica o rascunho oferecido pela faixa. Marca sujo porque o conteúdo passa a
+  // divergir do servidor — é justamente o que o indicador de "não enviado" e o
+  // aviso de saída precisam enxergar.
+  const handleRestoreDraft = useCallback(() => {
+    const id = currentDoc?.id;
+    if (!id) return;
+    const restored = restoreDraft(id);
+    if (!restored) return;
+    dispatch({
+      type: "restoreDraft",
+      docId: id,
+      answers: restored.answers,
+      notes: restored.notes,
+    });
+    markDirty(id);
+  }, [currentDoc?.id, restoreDraft, markDirty]);
 
   const handleSubmit = useCallback(async () => {
     if (!currentDoc || Object.keys(docAnswers).length === 0) return;
@@ -344,6 +374,7 @@ export function useAssignedCoding({
     handleAnswer,
     handleNotesChange,
     handleSubmit,
+    handleRestoreDraft,
     handleDocNavigate,
     handleSortChange,
     resetAllDone,

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -276,6 +276,20 @@ export function useAssignedCoding({
     setSubmitting,
   ]);
 
+  // Os dois efeitos de uma escrita confirmada, num lugar só: a sujeira sai e o
+  // baseline do rascunho local passa a ser o que foi gravado. O autosave é tão
+  // "escrita confirmada" quanto o Enviar — sem o rebase aqui, navegar para o
+  // próximo documento e voltar reabria a faixa de recuperação sobre trabalho que
+  // JÁ tinha ido ao servidor, acusando "salvo depois" contra a nossa própria
+  // escrita.
+  const handleAutosaved = useCallback(
+    (docId: string, saved: CodingSnapshot) => {
+      markClean(docId);
+      submitConfirmed(docId, saved);
+    },
+    [markClean, submitConfirmed],
+  );
+
   const handleDocNavigate = useCallback(
     (newIndex: number) => {
       if (currentDoc && isDirty(currentDoc.id)) {
@@ -284,7 +298,7 @@ export function useAssignedCoding({
           docId: currentDoc.id,
           answers: docAnswers,
           notes: docNotes,
-          markClean,
+          onSaved: handleAutosaved,
         });
       }
       const clampedIndex = Math.max(
@@ -302,7 +316,7 @@ export function useAssignedCoding({
       sortedDocuments,
       updateDocParam,
       isDirty,
-      markClean,
+      handleAutosaved,
     ],
   );
 
@@ -318,7 +332,7 @@ export function useAssignedCoding({
           docId: currentDoc.id,
           answers: docAnswers,
           notes: docNotes,
-          markClean,
+          onSaved: handleAutosaved,
         });
       }
       const nextDocs =
@@ -345,7 +359,7 @@ export function useAssignedCoding({
       documents,
       codedAtByDoc,
       isDirty,
-      markClean,
+      handleAutosaved,
       setParams,
     ],
   );

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useReducer, useRef } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { sortByRecent } from "@/lib/coding-sort";
 import {
   autosaveDirtyDoc,
@@ -8,6 +8,7 @@ import {
 } from "@/lib/coding-autosave";
 import { clearHiddenConditionalAnswers } from "@/lib/conditional";
 import { notifySaved } from "@/lib/coding-save-feedback";
+import type { CodingSnapshot } from "@/lib/coding-draft";
 import { toast } from "sonner";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
 import type { CodingSortMode } from "./CodingPage";
@@ -88,6 +89,12 @@ interface UseAssignedCodingParams {
   markDirty: (docId: string) => void;
   markClean: (docId: string) => void;
   isDirty: (docId: string | null | undefined) => boolean;
+  /** Rede local do #608: registra a edição corrente para o rascunho em
+   *  localStorage. O baseline é do hook de rascunho, não daqui. */
+  recordDraft: (docId: string, draft: CodingSnapshot) => void;
+  /** Chamado quando o servidor confirmou a ESCRITA, inclusive com obrigatória
+   *  em aberto — ver `submitConfirmed`. */
+  submitConfirmed: (docId: string, saved: CodingSnapshot) => void;
   updateDocParam: (docId: string | null) => void;
   setParams: (
     updates: Record<string, string | null>,
@@ -118,6 +125,8 @@ export function useAssignedCoding({
   markDirty,
   markClean,
   isDirty,
+  recordDraft,
+  submitConfirmed,
   updateDocParam,
   setParams,
 }: UseAssignedCodingParams) {
@@ -145,6 +154,18 @@ export function useAssignedCoding({
   // próximo doc; sem o guard, teclas digitadas durante o save editariam o doc já
   // salvo com o snapshot antigo e seriam descartadas na navegação.
   const savingRef = useRef(false);
+
+  // O rascunho local é registrado a partir do estado já reduzido, não de dentro
+  // dos handlers: `handleAnswer` despacha e não vê o resultado, e recompor o
+  // valor novo no call site duplicaria `clearHiddenConditionalAnswers` — a
+  // limpeza de condicionais órfãs (#252) que o reducer faz. O guard de sujeira é
+  // o que impede que abrir um documento limpo registre o conteúdo do servidor
+  // como se fosse edição (o que apagaria um rascunho ainda não retomado).
+  const docId = currentDoc?.id;
+  useEffect(() => {
+    if (!docId || !isDirty(docId)) return;
+    recordDraft(docId, { answers: docAnswers, notes: docNotes });
+  }, [docId, docAnswers, docNotes, isDirty, recordDraft]);
 
   const handleAnswer = useCallback(
     (fieldName: string, value: unknown) => {
@@ -182,6 +203,10 @@ export function useAssignedCoding({
         return;
       }
       markClean(currentDoc.id);
+      // A escrita aconteceu: o rascunho local virou redundante e o baseline
+      // passa a ser o que foi gravado. Vem ANTES do early-return abaixo de
+      // propósito — um envio que deixou obrigatória em aberto também gravou.
+      submitConfirmed(currentDoc.id, { answers: docAnswers, notes: docNotes });
       notifySaved(result.missingRequired);
       // Save com obrigatórias em aberto mantém o pesquisador NO documento:
       // avançar tiraria a tela de baixo do aviso que acabou de pedir para
@@ -217,6 +242,7 @@ export function useAssignedCoding({
     sortedDocuments,
     updateDocParam,
     markClean,
+    submitConfirmed,
     setSubmitting,
   ]);
 

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -7,6 +7,7 @@ import { useDocumentForCoding } from "@/hooks/useDocumentForCoding";
 import { saveCodingResponse } from "@/lib/coding-autosave";
 import { notifySaved } from "@/lib/coding-save-feedback";
 import { type CodingDraft } from "./BrowseDocCoder";
+import type { CodingSnapshot } from "@/lib/coding-draft";
 import type { AutosavePayload } from "@/hooks/useAutosaveOnExit";
 import type { AssignedDoc } from "@/lib/types";
 
@@ -19,6 +20,8 @@ interface UseBrowseCodingParams {
   setSubmitting: (value: boolean) => void;
   markDirty: (docId: string) => void;
   markClean: (docId: string) => void;
+  recordDraft: (docId: string, draft: CodingSnapshot) => void;
+  submitConfirmed: (docId: string, saved: CodingSnapshot) => void;
   isDirty: (docId: string | null | undefined) => boolean;
   updateDocParam: (docId: string | null) => void;
 }
@@ -43,6 +46,8 @@ export function useBrowseCoding({
   setSubmitting,
   markDirty,
   markClean,
+  recordDraft,
+  submitConfirmed,
   isDirty,
   updateDocParam,
 }: UseBrowseCodingParams) {
@@ -104,7 +109,12 @@ export function useBrowseCoding({
   const handleDraftChange = useCallback(
     (draft: CodingDraft) => {
       browseDraftRef.current = draft;
-      if (browseDocId) markDirty(browseDocId);
+      if (browseDocId) {
+        markDirty(browseDocId);
+        // Diferente do modo Atribuídos, aqui o conteúdo novo chega pronto no
+        // callback (o estado vive no filho keyed), então o registro é direto.
+        recordDraft(browseDocId, draft);
+      }
     },
     [browseDocId, markDirty],
   );
@@ -121,6 +131,7 @@ export function useBrowseCoding({
         });
         if (result.success) {
           markClean(browseDocId);
+          submitConfirmed(browseDocId, { answers, notes });
           notifySaved(result.missingRequired);
           markResponded(browseDocId);
           browseDraftRef.current = null;

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -116,7 +116,7 @@ export function useBrowseCoding({
         recordDraft(browseDocId, draft);
       }
     },
-    [browseDocId, markDirty],
+    [browseDocId, markDirty, recordDraft],
   );
 
   const handleBrowseSubmit = useCallback(
@@ -165,6 +165,7 @@ export function useBrowseCoding({
       browseDocId,
       projectId,
       markClean,
+      submitConfirmed,
       markResponded,
       invalidateBrowseDoc,
       updateDocParam,
@@ -195,6 +196,13 @@ export function useBrowseCoding({
           return;
         }
         markClean(docId);
+        // Mesma regra do autosave de navegação em Atribuídos: a escrita
+        // aconteceu, então o baseline do rascunho local passa a ser o que foi
+        // gravado. Aqui o `invalidateBrowseDoc` abaixo tornaria o slot
+        // `redundant` na reabertura de qualquer forma — mas depender do refetch
+        // para não mentir seria acidente, e o caminho de erro (save falho, que
+        // retorna antes) não teria essa rede.
+        submitConfirmed(docId, { answers, notes });
         markResponded(docId);
         saved = true;
       } finally {
@@ -213,6 +221,7 @@ export function useBrowseCoding({
     updateDocParam,
     isDirty,
     markClean,
+    submitConfirmed,
     markResponded,
     invalidateBrowseDoc,
     setSubmitting,

--- a/frontend/src/components/coding/useCodingDraftWiring.ts
+++ b/frontend/src/components/coding/useCodingDraftWiring.ts
@@ -91,11 +91,24 @@ export function useCodingDraftWiring({
     if (activeDocId) discardDraft(activeDocId);
   }, [activeDocId, discardDraft]);
 
+  // O rascunho retomado entra no Explorar como o documento INICIAL, e não como
+  // uma prop de seed do coder: `BrowseDocCoder` é construído sem estado derivado
+  // e sem setState em effect, e o remount por `key` já é o mecanismo de aplicação.
+  // Resolver aqui mantém aquele componente sem nenhuma decisão nova.
+  const browseDocForCoder = useMemo(() => {
+    if (!browseDoc || !browseRestored) return browseDoc;
+    return {
+      ...browseDoc,
+      initialAnswers: browseRestored.answers,
+      initialNotes: browseRestored.notes,
+    };
+  }, [browseDoc, browseRestored]);
+
   return {
     activeDocUnsent,
     handleRestoreDraft,
     handleDiscardDraft,
-    browseRestored,
+    browseDocForCoder,
     browseRestoreNonce,
   };
 }

--- a/frontend/src/components/coding/useCodingDraftWiring.ts
+++ b/frontend/src/components/coding/useCodingDraftWiring.ts
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useIsDocDirty, type DirtyDocsStore } from "@/hooks/useDirtyDocs";
+import type { CodingDraftsApi } from "@/hooks/useCodingDrafts";
+import type { CodingSnapshot } from "@/lib/coding-draft";
+import type { CodingDocument } from "@/hooks/useDocumentForCoding";
+
+// Fiação entre o rascunho local (#608) e os dois modos de codificação. Vive
+// fora do `CodingPage` porque lá já é o container mais longo da tela, e porque a
+// regra de qual snapshot é o baseline se lê melhor isolada.
+
+interface UseCodingDraftWiringParams {
+  mode: "assigned" | "browse";
+  activeDocId: string | null;
+  drafts: CodingDraftsApi;
+  dirtyDocs: DirtyDocsStore;
+  markDirty: (docId: string) => void;
+  /** Aplica o rascunho no reducer do modo Atribuídos. */
+  restoreAssignedDraft: () => void;
+  browseDocId: string | null;
+  browseDoc: CodingDocument | null | undefined;
+  existingAnswers: Record<string, Record<string, unknown>>;
+  existingJustifications: Record<string, Record<string, unknown>>;
+}
+
+export function useCodingDraftWiring({
+  mode,
+  activeDocId,
+  drafts,
+  dirtyDocs,
+  markDirty,
+  restoreAssignedDraft,
+  browseDocId,
+  browseDoc,
+  existingAnswers,
+  existingJustifications,
+}: UseCodingDraftWiringParams) {
+  // O baseline do documento aberto é o que o SERVIDOR entregou, nunca o que está
+  // na tela: é contra ele que se decide se o rascunho ainda vale e o que ele
+  // sobrescreveria. Em Explorar o conteúdo vem do fetch do doc; em Atribuídos,
+  // das props do RSC.
+  const remoteSnapshot: CodingSnapshot | null = useMemo(() => {
+    if (!activeDocId) return null;
+    if (mode === "assigned") {
+      const notes = existingJustifications[activeDocId]?._notes;
+      return {
+        answers: existingAnswers[activeDocId] ?? {},
+        notes: typeof notes === "string" ? notes : "",
+      };
+    }
+    if (!browseDoc || browseDoc.document.id !== activeDocId) return null;
+    return { answers: browseDoc.initialAnswers, notes: browseDoc.initialNotes };
+  }, [activeDocId, mode, existingAnswers, existingJustifications, browseDoc]);
+
+  const openDocument = drafts.openDocument;
+  useEffect(() => {
+    // Em Explorar o baseline só existe depois do fetch; abrir antes classificaria
+    // o rascunho contra um documento vazio e anunciaria como sobrescrita tudo o
+    // que o servidor já tinha.
+    if (mode === "browse" && activeDocId && !remoteSnapshot) return;
+    openDocument(activeDocId, remoteSnapshot);
+  }, [openDocument, activeDocId, mode, remoteSnapshot]);
+
+  // Indicador de "não enviado": vem da sujeira em memória, não do storage — ver
+  // o comentário em `useDirtyDocs`.
+  const activeDocUnsent = useIsDocDirty(dirtyDocs, activeDocId);
+
+  // "Retomar" no modo Explorar entra por REMOUNT do filho keyed, e não por
+  // setState: `BrowseDocCoder` é construído sem estado derivado e sem setState em
+  // effect, e empurrar valor para dentro dele quebraria essa propriedade.
+  const [browseRestoreNonce, setBrowseRestoreNonce] = useState(0);
+  const [browseRestored, setBrowseRestored] = useState<CodingSnapshot | null>(null);
+
+  const restoreDraft = drafts.restoreDraft;
+  const handleRestoreDraft = useCallback(() => {
+    if (mode === "assigned") {
+      restoreAssignedDraft();
+      return;
+    }
+    if (!browseDocId) return;
+    const restored = restoreDraft(browseDocId);
+    if (!restored) return;
+    setBrowseRestored(restored);
+    setBrowseRestoreNonce((n) => n + 1);
+    markDirty(browseDocId);
+  }, [mode, restoreAssignedDraft, browseDocId, restoreDraft, markDirty]);
+
+  const discardDraft = drafts.discardDraft;
+  const handleDiscardDraft = useCallback(() => {
+    if (activeDocId) discardDraft(activeDocId);
+  }, [activeDocId, discardDraft]);
+
+  return {
+    activeDocUnsent,
+    handleRestoreDraft,
+    handleDiscardDraft,
+    browseRestored,
+    browseRestoreNonce,
+  };
+}

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -1,0 +1,444 @@
+// @vitest-environment jsdom
+//
+// I/O e política do rascunho local de respostas (#608). O que se fixa aqui é
+// aquilo de que a promessa "fechar a aba não perde trabalho" depende: o debounce
+// e seus flushes, o compare-and-swap entre abas, o GC que impede a quota de
+// degradar em silêncio, e o descarte no envio confirmado. A classificação pura
+// é coberta por `lib/__tests__/coding-draft.test.ts`.
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCodingDrafts, type UseCodingDraftsParams } from "../useCodingDrafts";
+import {
+  CODING_DRAFT_FORMAT_VERSION,
+  codingDraftStorageKey,
+  parseCodingDraft,
+  type CodingSnapshot,
+} from "@/lib/coding-draft";
+import type { PydanticField } from "@/lib/types";
+
+const FIELDS: PydanticField[] = [
+  { name: "q1", type: "text", options: null, description: "" },
+  { name: "q2", type: "text", options: null, description: "" },
+];
+
+const USER = "user-1";
+const PROJECT = "project-1";
+const DOC = "doc-1";
+const KEY = codingDraftStorageKey({ userId: USER, projectId: PROJECT, documentId: DOC });
+
+const EMPTY: CodingSnapshot = { answers: {}, notes: "" };
+const snap = (answers: Record<string, unknown>, notes = ""): CodingSnapshot => ({
+  answers,
+  notes,
+});
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function render(over: Partial<UseCodingDraftsParams> = {}) {
+  const params: UseCodingDraftsParams = {
+    projectId: PROJECT,
+    userId: USER,
+    enabled: true,
+    openDocId: DOC,
+    remote: EMPTY,
+    fields: FIELDS,
+    ...over,
+  };
+  const view = renderHook((p: UseCodingDraftsParams) => useCodingDrafts(p), {
+    initialProps: params,
+  });
+  // O hook só age pós-hidratação; sem este flush nada do effect rodou ainda.
+  act(() => {
+    vi.advanceTimersByTime(0);
+  });
+  return view;
+}
+
+const flushDebounce = () => {
+  act(() => {
+    vi.advanceTimersByTime(300);
+  });
+};
+
+const stored = (key = KEY) => parseCodingDraft(window.localStorage.getItem(key));
+
+function plant(
+  over: Partial<{
+    key: string;
+    userId: string;
+    projectId: string;
+    documentId: string;
+    writeToken: string;
+    updatedAt: number;
+    base: CodingSnapshot;
+    draft: CodingSnapshot;
+    formatVersion: number;
+  }> = {},
+) {
+  const userId = over.userId ?? USER;
+  const projectId = over.projectId ?? PROJECT;
+  const documentId = over.documentId ?? DOC;
+  const envelope = {
+    formatVersion: over.formatVersion ?? CODING_DRAFT_FORMAT_VERSION,
+    writeToken: over.writeToken ?? "tok-plantado",
+    userId,
+    projectId,
+    documentId,
+    updatedAt: over.updatedAt ?? Date.now(),
+    base: over.base ?? EMPTY,
+    draft: over.draft ?? snap({ q1: "do rascunho" }),
+  };
+  const key = over.key ?? codingDraftStorageKey({ userId, projectId, documentId });
+  window.localStorage.setItem(key, JSON.stringify(envelope));
+  return key;
+}
+
+describe("gravação e debounce", () => {
+  it("não grava antes do debounce e grava depois", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    expect(stored()).toBeNull();
+    flushDebounce();
+    expect(stored()?.draft.answers).toEqual({ q1: "a" });
+  });
+
+  // Mutação vermelha: escrever a cada chamada em vez de reagendar. O debounce é
+  // indexado pelo token justamente para que um timer atrasado não grave conteúdo
+  // velho por cima do novo.
+  it("edições sucessivas deixam um único envelope, com o conteúdo mais recente", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" }), EMPTY));
+    flushDebounce();
+    expect(stored()?.draft.answers).toEqual({ q1: "ab" });
+    expect(window.localStorage.length).toBe(1);
+  });
+
+  it("grava as notas junto das respostas", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({}, "minha nota"), EMPTY));
+    flushDebounce();
+    expect(stored()?.draft.notes).toBe("minha nota");
+  });
+
+  // Voltar ao baseline é ausência de rascunho, não rascunho vazio. Mutação
+  // vermelha: gravar sempre — a faixa passaria a oferecer, na abertura seguinte,
+  // um rascunho idêntico ao que o servidor já tem.
+  it("desfazer até o baseline apaga o slot", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    flushDebounce();
+    expect(stored()).not.toBeNull();
+    act(() => result.current.recordDraft(DOC, EMPTY, EMPTY));
+    flushDebounce();
+    expect(stored()).toBeNull();
+  });
+
+  it("o envelope carrega a identidade do escopo", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    flushDebounce();
+    expect(stored()).toMatchObject({ userId: USER, projectId: PROJECT, documentId: DOC });
+  });
+
+  // Sob impersonação a tela é read-only; gravar ali depositaria trabalho num
+  // slot que ninguém vai enviar. Mutação vermelha: ignorar `enabled`.
+  it("com `enabled: false` não escreve nada", () => {
+    const { result } = render({ enabled: false });
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    flushDebounce();
+    expect(window.localStorage.length).toBe(0);
+  });
+});
+
+describe("flush — os gatilhos de que depende 'fechar a aba não perde trabalho'", () => {
+  it.each([
+    ["pagehide", () => window.dispatchEvent(new Event("pagehide"))],
+    ["beforeunload", () => window.dispatchEvent(new Event("beforeunload"))],
+  ])("%s persiste antes do debounce", (_label, fire) => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    expect(stored()).toBeNull();
+    act(() => {
+      fire();
+    });
+    expect(stored()?.draft.answers).toEqual({ q1: "a" });
+  });
+
+  it("visibilitychange com a aba oculta persiste; visível não", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(stored()).toBeNull();
+
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(stored()?.draft.answers).toEqual({ q1: "a" });
+  });
+
+  it("unmount antes do debounce persiste", () => {
+    const { result, unmount } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => {
+      unmount();
+    });
+    expect(stored()?.draft.answers).toEqual({ q1: "a" });
+  });
+});
+
+describe("recuperação — oferecer, nunca aplicar em silêncio", () => {
+  it("oferece o rascunho plantado ao abrir o documento", () => {
+    plant({ draft: snap({ q1: "do rascunho" }) });
+    const { result } = render();
+    expect(result.current.recovery).toMatchObject({
+      kind: "resumable",
+      changedFields: ["q1"],
+    });
+  });
+
+  // Mutação vermelha: aplicar o conteúdo no `recovery` sem passar por
+  // `restoreDraft`. Oferecer e aplicar são coisas diferentes — é o requisito
+  // central da issue.
+  it("`restoreDraft` é o que devolve o conteúdo, e ele sobrevive no slot", () => {
+    plant({ draft: snap({ q1: "do rascunho" }) });
+    const { result } = render();
+    let applied: CodingSnapshot | null = null;
+    act(() => {
+      applied = result.current.restoreDraft(DOC);
+    });
+    expect(applied).toEqual(snap({ q1: "do rascunho" }));
+    // Retomar não é enviar: o trabalho segue não-enviado e o envelope fica.
+    expect(stored()).not.toBeNull();
+    expect(result.current.recovery.kind).toBe("none");
+  });
+
+  it("`discardDraft` apaga o slot e a oferta não volta", () => {
+    plant();
+    const { result } = render();
+    expect(result.current.recovery.kind).toBe("resumable");
+    act(() => result.current.discardDraft(DOC));
+    expect(stored()).toBeNull();
+    expect(result.current.recovery.kind).toBe("none");
+  });
+
+  it("rascunho que repete o servidor não é oferecido e é limpo do slot", () => {
+    plant({ draft: snap({ q1: "igual" }) });
+    const { result } = render({ remote: snap({ q1: "igual" }) });
+    expect(result.current.recovery.kind).toBe("none");
+    expect(stored()).toBeNull();
+  });
+
+  it("servidor que andou desde o rascunho é oferecido como `diverged`", () => {
+    plant({ base: snap({ q1: "antigo" }), draft: snap({ q1: "rascunho" }) });
+    const { result } = render({ remote: snap({ q1: "servidor-novo" }) });
+    expect(result.current.recovery).toMatchObject({
+      kind: "diverged",
+      overwrittenFields: ["q1"],
+    });
+  });
+
+  // Mutação vermelha: remover a checagem de escopo em `readSlot`. Aplicar as
+  // respostas de um documento em outro é dado de pesquisa fabricado em silêncio.
+  it("envelope cuja identidade discorda da chave não é oferecido", () => {
+    plant({ key: KEY, documentId: "outro-doc" });
+    const { result } = render();
+    expect(result.current.recovery.kind).toBe("none");
+  });
+
+  it("sem documento aberto não há oferta", () => {
+    plant();
+    const { result } = render({ openDocId: null });
+    expect(result.current.recovery.kind).toBe("none");
+  });
+});
+
+describe("envio confirmado", () => {
+  // O teste que fixa a decisão de desenho: `success: true` significa que a
+  // escrita aconteceu, mesmo com obrigatória em aberto. Mutação vermelha:
+  // preservar o rascunho quando o documento segue pendente — o indicador de
+  // "não enviado" ficaria aceso sobre trabalho que FOI enviado.
+  it("descarta o rascunho mesmo quando o documento segue pendente", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    flushDebounce();
+    expect(stored()).not.toBeNull();
+
+    act(() => result.current.submitConfirmed(DOC, snap({ q1: "a" })));
+    expect(stored()).toBeNull();
+  });
+
+  // Mutação vermelha: não rebasear (`dropSlot(docId)` sem o snapshot salvo).
+  // Sem o rebase, a próxima tecla nasce com o `base` do seed stale do RSC e
+  // reabrir o documento acusaria "o documento foi salvo depois" contra uma
+  // escrita nossa.
+  it("rebaseia o baseline no que foi gravado", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    flushDebounce();
+    act(() => result.current.submitConfirmed(DOC, snap({ q1: "a" })));
+
+    // Continuar digitando depois do envio: o novo rascunho parte do que foi
+    // gravado, então voltar ao valor enviado limpa o slot em vez de virar diff.
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), snap({ q1: "a" })));
+    flushDebounce();
+    expect(stored()).toBeNull();
+
+    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" }), snap({ q1: "a" })));
+    flushDebounce();
+    expect(stored()?.base.answers).toEqual({ q1: "a" });
+  });
+});
+
+describe("compare-and-swap entre abas", () => {
+  // A decisão da chave por documento, provada. Mutação vermelha: uma chave por
+  // projeto — a segunda aba ficaria `blocked` permanentemente contra a primeira,
+  // perdendo a rede de proteção inteira num fluxo corriqueiro.
+  it("duas abas em documentos diferentes não se bloqueiam", () => {
+    const a = render({ openDocId: "doc-a", remote: EMPTY });
+    const b = render({ openDocId: "doc-b", remote: EMPTY });
+
+    act(() => a.result.current.recordDraft("doc-a", snap({ q1: "de A" }), EMPTY));
+    act(() => b.result.current.recordDraft("doc-b", snap({ q1: "de B" }), EMPTY));
+    flushDebounce();
+
+    const keyA = codingDraftStorageKey({ userId: USER, projectId: PROJECT, documentId: "doc-a" });
+    const keyB = codingDraftStorageKey({ userId: USER, projectId: PROJECT, documentId: "doc-b" });
+    expect(stored(keyA)?.draft.answers).toEqual({ q1: "de A" });
+    expect(stored(keyB)?.draft.answers).toEqual({ q1: "de B" });
+  });
+
+  // Mutação vermelha: remover o compare-and-swap. Duas abas no MESMO documento
+  // são conflito de verdade, e a segunda não pode apagar o envelope da primeira.
+  it("envelope de formato maior não é sobrescrito", () => {
+    plant({ formatVersion: CODING_DRAFT_FORMAT_VERSION + 1 });
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" }), EMPTY));
+    flushDebounce();
+    const rawStored = JSON.parse(window.localStorage.getItem(KEY) ?? "{}");
+    expect(rawStored.formatVersion).toBe(CODING_DRAFT_FORMAT_VERSION + 1);
+  });
+
+  it("slot tomado por outro token não é sobrescrito", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" }), EMPTY));
+    flushDebounce();
+    // Outra aba assume o slot entre duas escritas nossas.
+    plant({ writeToken: "de-outra-aba", draft: snap({ q1: "da outra aba" }) });
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu 2" }), EMPTY));
+    flushDebounce();
+    expect(stored()?.draft.answers).toEqual({ q1: "da outra aba" });
+  });
+});
+
+describe("GC — a peça que impede a quota de degradar em silêncio", () => {
+  const otherDocKey = (docId: string, userId = USER) =>
+    codingDraftStorageKey({ userId, projectId: PROJECT, documentId: docId });
+
+  it("apaga rascunho além do TTL", () => {
+    const velho = otherDocKey("doc-velho");
+    plant({ documentId: "doc-velho", updatedAt: Date.now() - 31 * 24 * 60 * 60 * 1000 });
+    render();
+    expect(window.localStorage.getItem(velho)).toBeNull();
+  });
+
+  it("preserva rascunho dentro do TTL", () => {
+    plant({ documentId: "doc-recente", updatedAt: Date.now() - 1000 });
+    render();
+    expect(window.localStorage.getItem(otherDocKey("doc-recente"))).not.toBeNull();
+  });
+
+  // Mutação vermelha: varrer sem o prefixo do usuário. Numa máquina
+  // compartilhada isso apaga o trabalho de um colega.
+  it("nunca toca no slot de outro usuário, mesmo expirado", () => {
+    plant({
+      userId: "outro-user",
+      documentId: "doc-x",
+      updatedAt: Date.now() - 99 * 24 * 60 * 60 * 1000,
+    });
+    render();
+    expect(window.localStorage.getItem(otherDocKey("doc-x", "outro-user"))).not.toBeNull();
+  });
+
+  // Mutação vermelha: tratar `newer-format` como lixo. É de uma aba que sabe
+  // mais — apagá-lo destrói trabalho que não temos como recuperar.
+  it("nunca apaga envelope de formato maior", () => {
+    plant({
+      documentId: "doc-novo",
+      formatVersion: CODING_DRAFT_FORMAT_VERSION + 1,
+      updatedAt: Date.now() - 99 * 24 * 60 * 60 * 1000,
+    });
+    render();
+    expect(window.localStorage.getItem(otherDocKey("doc-novo"))).not.toBeNull();
+  });
+
+  // Mutação vermelha: não excluir `keepKey` da varredura — o GC apagaria o
+  // rascunho do documento que está aberto na tela.
+  it("nunca evicta o documento aberto, mesmo expirado", () => {
+    plant({ documentId: DOC, updatedAt: Date.now() - 99 * 24 * 60 * 60 * 1000 });
+    render();
+    expect(window.localStorage.getItem(KEY)).not.toBeNull();
+  });
+
+  it("conta o envelope ilegível descartado em vez de sumir com ele calado", () => {
+    window.localStorage.setItem(otherDocKey("doc-lixo"), JSON.stringify({ formatVersion: 0 }));
+    const { result } = render();
+    expect(result.current.staleDiscardedCount).toBeGreaterThan(0);
+    expect(window.localStorage.getItem(otherDocKey("doc-lixo"))).toBeNull();
+  });
+
+  it("apaga envelope cuja identidade embutida discorda da chave", () => {
+    const key = otherDocKey("doc-mentiroso");
+    plant({ key, documentId: "outro-completamente" });
+    render();
+    expect(window.localStorage.getItem(key)).toBeNull();
+  });
+});
+
+describe("indisponibilidade do storage", () => {
+  // Mutação vermelha: engolir a exceção e continuar reportando disponível. A
+  // tela precisa poder avisar que a cópia local caiu — o indicador de "não
+  // enviado" vem da sujeira em memória, não daqui, e os dois sinais são
+  // distintos de propósito.
+  it("quota estourada não lança e reporta `storageAvailable: false`", () => {
+    const { result } = render();
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("cheio", "QuotaExceededError");
+    });
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    flushDebounce();
+    expect(result.current.storageAvailable).toBe(false);
+  });
+
+  // Mutação vermelha: avançar `persistedToken` mesmo em falha. A aba passaria a
+  // colidir com o próprio lixo e nunca mais gravaria na sessão.
+  it("depois de uma falha transitória, a próxima edição volta a gravar", () => {
+    const { result } = render();
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
+      throw new DOMException("cheio", "QuotaExceededError");
+    });
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    flushDebounce();
+    expect(stored()).toBeNull();
+
+    setItem.mockRestore();
+    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" }), EMPTY));
+    flushDebounce();
+    expect(stored()?.draft.answers).toEqual({ q1: "ab" });
+    expect(result.current.storageAvailable).toBe(true);
+  });
+});

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -43,22 +43,27 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function render(over: Partial<UseCodingDraftsParams> = {}) {
+// `openDocument` é o que estabelece o baseline e classifica o slot; no app ele é
+// chamado de um effect do `CodingPage`, aqui é chamado explicitamente.
+function render(
+  over: Partial<UseCodingDraftsParams> & {
+    openDocId?: string | null;
+    remote?: CodingSnapshot | null;
+  } = {},
+) {
+  const { openDocId = DOC, remote = EMPTY, ...rest } = over;
   const params: UseCodingDraftsParams = {
     projectId: PROJECT,
     userId: USER,
     enabled: true,
-    openDocId: DOC,
-    remote: EMPTY,
     fields: FIELDS,
-    ...over,
+    ...rest,
   };
   const view = renderHook((p: UseCodingDraftsParams) => useCodingDrafts(p), {
     initialProps: params,
   });
-  // O hook só age pós-hidratação; sem este flush nada do effect rodou ainda.
   act(() => {
-    vi.advanceTimersByTime(0);
+    view.result.current.openDocument(openDocId, remote);
   });
   return view;
 }
@@ -148,6 +153,16 @@ describe("gravação e debounce", () => {
     act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(stored()).toMatchObject({ userId: USER, projectId: PROJECT, documentId: DOC });
+  });
+
+  // O baseline é estabelecido ao abrir o documento, e o hook é seu dono único.
+  // Mutação vermelha: cair para um baseline vazio quando não há registro — o
+  // formulário inteiro seria gravado como se fosse edição da pesquisadora.
+  it("não grava rascunho de documento que nunca foi aberto", () => {
+    const { result } = render();
+    act(() => result.current.recordDraft("doc-nunca-aberto", snap({ q1: "a" })));
+    flushDebounce();
+    expect(window.localStorage.length).toBe(0);
   });
 
   // Sob impersonação a tela é read-only; gravar ali depositaria trabalho num

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -76,6 +76,9 @@ const flushDebounce = () => {
 
 const stored = (key = KEY) => parseCodingDraft(window.localStorage.getItem(key));
 
+// Planta um envelope no localStorage. Os defaults vivem na desestruturação, e
+// não em `??` por campo: além de mais curto, é o que mantém o helper abaixo do
+// limiar de complexidade do gate.
 function plant(
   over: Partial<{
     key: string;
@@ -89,21 +92,31 @@ function plant(
     formatVersion: number;
   }> = {},
 ) {
-  const userId = over.userId ?? USER;
-  const projectId = over.projectId ?? PROJECT;
-  const documentId = over.documentId ?? DOC;
-  const envelope = {
-    formatVersion: over.formatVersion ?? CODING_DRAFT_FORMAT_VERSION,
-    writeToken: over.writeToken ?? "tok-plantado",
-    userId,
-    projectId,
-    documentId,
-    updatedAt: over.updatedAt ?? Date.now(),
-    base: over.base ?? EMPTY,
-    draft: over.draft ?? snap({ q1: "do rascunho" }),
-  };
-  const key = over.key ?? codingDraftStorageKey({ userId, projectId, documentId });
-  window.localStorage.setItem(key, JSON.stringify(envelope));
+  const {
+    userId = USER,
+    projectId = PROJECT,
+    documentId = DOC,
+    writeToken = "tok-plantado",
+    updatedAt = Date.now(),
+    base = EMPTY,
+    draft = snap({ q1: "do rascunho" }),
+    formatVersion = CODING_DRAFT_FORMAT_VERSION,
+    key = codingDraftStorageKey({ userId, projectId, documentId }),
+  } = over;
+
+  window.localStorage.setItem(
+    key,
+    JSON.stringify({
+      formatVersion,
+      writeToken,
+      userId,
+      projectId,
+      documentId,
+      updatedAt,
+      base,
+      draft,
+    }),
+  );
   return key;
 }
 

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -189,15 +189,17 @@ describe("gravação e debounce", () => {
 });
 
 describe("flush — os gatilhos de que depende 'fechar a aba não perde trabalho'", () => {
-  it.each([
-    ["pagehide", () => window.dispatchEvent(new Event("pagehide"))],
-    ["beforeunload", () => window.dispatchEvent(new Event("beforeunload"))],
-  ])("%s persiste antes do debounce", (_label, fire) => {
+  // `pagehide` dispara em TODO descarregamento da página, inclusive nos que um
+  // `beforeunload` pegaria — por isso este hook não registra o segundo: ele não
+  // acrescentaria cobertura e tiraria a página do back/forward cache no Firefox
+  // e no Safari. O `beforeunload` de `useAutosaveOnExit` é outro caso: lá ele
+  // serve ao aviso nativo do navegador, que só existe por meio dele.
+  it("pagehide persiste antes do debounce", () => {
     const { result } = render();
     act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     expect(stored()).toBeNull();
     act(() => {
-      fire();
+      window.dispatchEvent(new Event("pagehide"));
     });
     expect(stored()?.draft.answers).toEqual({ q1: "a" });
   });
@@ -371,6 +373,21 @@ describe("compare-and-swap entre abas", () => {
     flushDebounce();
     expect(stored()?.draft.answers).toEqual({ q1: "da outra aba" });
   });
+
+  // Mutação vermelha: reportar `storageAvailable: false` só no caso
+  // `unavailable`, deixando o `blocked` calado. Esta aba não está mantendo cópia
+  // local nenhuma — não avisar é a mesma mentira que o indicador de "não
+  // enviado" existe para eliminar, só que sobre a outra metade da promessa.
+  it("slot tomado por outra aba avisa que a cópia local não está funcionando", () => {
+    const { result } = render();
+    expect(result.current.storageAvailable).toBe(true);
+
+    plant({ writeToken: "de-outra-aba", draft: snap({ q1: "da outra aba" }) });
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" })));
+    act(() => flushDebounce());
+
+    expect(result.current.storageAvailable).toBe(false);
+  });
 });
 
 describe("GC — a peça que impede a quota de degradar em silêncio", () => {
@@ -422,10 +439,12 @@ describe("GC — a peça que impede a quota de degradar em silêncio", () => {
     expect(window.localStorage.getItem(KEY)).not.toBeNull();
   });
 
-  it("conta o envelope ilegível descartado em vez de sumir com ele calado", () => {
+  // Formato antigo não é recuperável por este build: ocupa quota e não pode ser
+  // aplicado. Sai como qualquer outro lixo — o que NÃO pode sair é o de formato
+  // MAIOR, coberto pelo caso acima.
+  it("apaga envelope de formato antigo", () => {
     window.localStorage.setItem(otherDocKey("doc-lixo"), JSON.stringify({ formatVersion: 0 }));
-    const { result } = render();
-    expect(result.current.staleDiscardedCount).toBeGreaterThan(0);
+    render();
     expect(window.localStorage.getItem(otherDocKey("doc-lixo"))).toBeNull();
   });
 

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -105,7 +105,7 @@ function plant(
 describe("gravação e debounce", () => {
   it("não grava antes do debounce e grava depois", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     expect(stored()).toBeNull();
     flushDebounce();
     expect(stored()?.draft.answers).toEqual({ q1: "a" });
@@ -116,8 +116,8 @@ describe("gravação e debounce", () => {
   // velho por cima do novo.
   it("edições sucessivas deixam um único envelope, com o conteúdo mais recente", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
-    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" })));
     flushDebounce();
     expect(stored()?.draft.answers).toEqual({ q1: "ab" });
     expect(window.localStorage.length).toBe(1);
@@ -125,7 +125,7 @@ describe("gravação e debounce", () => {
 
   it("grava as notas junto das respostas", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({}, "minha nota"), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({}, "minha nota")));
     flushDebounce();
     expect(stored()?.draft.notes).toBe("minha nota");
   });
@@ -135,17 +135,17 @@ describe("gravação e debounce", () => {
   // um rascunho idêntico ao que o servidor já tem.
   it("desfazer até o baseline apaga o slot", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(stored()).not.toBeNull();
-    act(() => result.current.recordDraft(DOC, EMPTY, EMPTY));
+    act(() => result.current.recordDraft(DOC, EMPTY));
     flushDebounce();
     expect(stored()).toBeNull();
   });
 
   it("o envelope carrega a identidade do escopo", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(stored()).toMatchObject({ userId: USER, projectId: PROJECT, documentId: DOC });
   });
@@ -154,7 +154,7 @@ describe("gravação e debounce", () => {
   // slot que ninguém vai enviar. Mutação vermelha: ignorar `enabled`.
   it("com `enabled: false` não escreve nada", () => {
     const { result } = render({ enabled: false });
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(window.localStorage.length).toBe(0);
   });
@@ -166,7 +166,7 @@ describe("flush — os gatilhos de que depende 'fechar a aba não perde trabalho
     ["beforeunload", () => window.dispatchEvent(new Event("beforeunload"))],
   ])("%s persiste antes do debounce", (_label, fire) => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     expect(stored()).toBeNull();
     act(() => {
       fire();
@@ -176,7 +176,7 @@ describe("flush — os gatilhos de que depende 'fechar a aba não perde trabalho
 
   it("visibilitychange com a aba oculta persiste; visível não", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
 
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
     act(() => {
@@ -193,7 +193,7 @@ describe("flush — os gatilhos de que depende 'fechar a aba não perde trabalho
 
   it("unmount antes do debounce persiste", () => {
     const { result, unmount } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     act(() => {
       unmount();
     });
@@ -274,7 +274,7 @@ describe("envio confirmado", () => {
   // "não enviado" ficaria aceso sobre trabalho que FOI enviado.
   it("descarta o rascunho mesmo quando o documento segue pendente", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(stored()).not.toBeNull();
 
@@ -288,17 +288,17 @@ describe("envio confirmado", () => {
   // escrita nossa.
   it("rebaseia o baseline no que foi gravado", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     act(() => result.current.submitConfirmed(DOC, snap({ q1: "a" })));
 
     // Continuar digitando depois do envio: o novo rascunho parte do que foi
     // gravado, então voltar ao valor enviado limpa o slot em vez de virar diff.
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), snap({ q1: "a" })));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(stored()).toBeNull();
 
-    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" }), snap({ q1: "a" })));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" })));
     flushDebounce();
     expect(stored()?.base.answers).toEqual({ q1: "a" });
   });
@@ -312,8 +312,8 @@ describe("compare-and-swap entre abas", () => {
     const a = render({ openDocId: "doc-a", remote: EMPTY });
     const b = render({ openDocId: "doc-b", remote: EMPTY });
 
-    act(() => a.result.current.recordDraft("doc-a", snap({ q1: "de A" }), EMPTY));
-    act(() => b.result.current.recordDraft("doc-b", snap({ q1: "de B" }), EMPTY));
+    act(() => a.result.current.recordDraft("doc-a", snap({ q1: "de A" })));
+    act(() => b.result.current.recordDraft("doc-b", snap({ q1: "de B" })));
     flushDebounce();
 
     const keyA = codingDraftStorageKey({ userId: USER, projectId: PROJECT, documentId: "doc-a" });
@@ -327,7 +327,7 @@ describe("compare-and-swap entre abas", () => {
   it("envelope de formato maior não é sobrescrito", () => {
     plant({ formatVersion: CODING_DRAFT_FORMAT_VERSION + 1 });
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" })));
     flushDebounce();
     const rawStored = JSON.parse(window.localStorage.getItem(KEY) ?? "{}");
     expect(rawStored.formatVersion).toBe(CODING_DRAFT_FORMAT_VERSION + 1);
@@ -335,11 +335,11 @@ describe("compare-and-swap entre abas", () => {
 
   it("slot tomado por outro token não é sobrescrito", () => {
     const { result } = render();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" })));
     flushDebounce();
     // Outra aba assume o slot entre duas escritas nossas.
     plant({ writeToken: "de-outra-aba", draft: snap({ q1: "da outra aba" }) });
-    act(() => result.current.recordDraft(DOC, snap({ q1: "meu 2" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu 2" })));
     flushDebounce();
     expect(stored()?.draft.answers).toEqual({ q1: "da outra aba" });
   });
@@ -419,7 +419,7 @@ describe("indisponibilidade do storage", () => {
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new DOMException("cheio", "QuotaExceededError");
     });
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(result.current.storageAvailable).toBe(false);
   });
@@ -431,12 +431,12 @@ describe("indisponibilidade do storage", () => {
     const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementationOnce(() => {
       throw new DOMException("cheio", "QuotaExceededError");
     });
-    act(() => result.current.recordDraft(DOC, snap({ q1: "a" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "a" })));
     flushDebounce();
     expect(stored()).toBeNull();
 
     setItem.mockRestore();
-    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" }), EMPTY));
+    act(() => result.current.recordDraft(DOC, snap({ q1: "ab" })));
     flushDebounce();
     expect(stored()?.draft.answers).toEqual({ q1: "ab" });
     expect(result.current.storageAvailable).toBe(true);

--- a/frontend/src/hooks/__tests__/useDirtyDocs.test.ts
+++ b/frontend/src/hooks/__tests__/useDirtyDocs.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// O conjunto de documentos não enviados virou um external store no #608, porque
+// a tela passou a EXIBIR "há alterações não enviadas". O que se fixa aqui é que
+// a leitura reativa funciona sem que a API imperativa (lida em tempo de evento
+// por guards e handlers) mude de comportamento.
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useDirtyDocs, useDirtyDocsCount, useIsDocDirty } from "../useDirtyDocs";
+
+afterEach(cleanup);
+
+describe("API imperativa — inalterada", () => {
+  it("marca, consulta e limpa", () => {
+    const { result } = renderHook(() => useDirtyDocs());
+    expect(result.current.isDirty("doc-1")).toBe(false);
+    act(() => result.current.markDirty("doc-1"));
+    expect(result.current.isDirty("doc-1")).toBe(true);
+    act(() => result.current.markClean("doc-1"));
+    expect(result.current.isDirty("doc-1")).toBe(false);
+  });
+
+  it("id nulo nunca é sujo", () => {
+    const { result } = renderHook(() => useDirtyDocs());
+    expect(result.current.isDirty(null)).toBe(false);
+    expect(result.current.isDirty(undefined)).toBe(false);
+  });
+
+  it("a identidade do store é estável entre renders", () => {
+    const { result, rerender } = renderHook(() => useDirtyDocs());
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});
+
+describe("leitura reativa — o indicador de não enviado", () => {
+  // Mutação vermelha: manter `useDirtyDocs` só-ref (sem `emit`/`subscribe`). O
+  // componente nunca re-renderizaria e o indicador ficaria preso no estado do
+  // primeiro render — o critério "a tela diz, a qualquer momento, se há
+  // alterações não enviadas" seria falso.
+  it("`useIsDocDirty` re-renderiza quando o documento fica sujo e quando limpa", () => {
+    const { result } = renderHook(() => {
+      const store = useDirtyDocs();
+      return { store, dirty: useIsDocDirty(store, "doc-1") };
+    });
+
+    expect(result.current.dirty).toBe(false);
+    act(() => result.current.store.markDirty("doc-1"));
+    expect(result.current.dirty).toBe(true);
+    act(() => result.current.store.markClean("doc-1"));
+    expect(result.current.dirty).toBe(false);
+  });
+
+  it("não reage à sujeira de outro documento", () => {
+    const { result } = renderHook(() => {
+      const store = useDirtyDocs();
+      return { store, dirty: useIsDocDirty(store, "doc-1") };
+    });
+    act(() => result.current.store.markDirty("doc-2"));
+    expect(result.current.dirty).toBe(false);
+  });
+
+  // O aviso de saída vale para a fila inteira: navegar para longe com outro
+  // documento pendente também perde trabalho.
+  it("`useDirtyDocsCount` acompanha o total", () => {
+    const { result } = renderHook(() => {
+      const store = useDirtyDocs();
+      return { store, count: useDirtyDocsCount(store) };
+    });
+
+    expect(result.current.count).toBe(0);
+    act(() => result.current.store.markDirty("doc-1"));
+    act(() => result.current.store.markDirty("doc-2"));
+    expect(result.current.count).toBe(2);
+    act(() => result.current.store.markClean("doc-1"));
+    expect(result.current.count).toBe(1);
+  });
+
+  // Mutação vermelha: notificar incondicionalmente em `markDirty`/`markClean`.
+  // Cada tecla chama `markDirty` no documento já sujo; sem a guarda, toda tecla
+  // vira um re-render da tela de codificação inteira.
+  it("marcar de novo o que já está sujo não notifica", () => {
+    const { result } = renderHook(() => useDirtyDocs());
+    act(() => result.current.markDirty("doc-1"));
+    const afterFirst = result.current.getVersion();
+    act(() => result.current.markDirty("doc-1"));
+    expect(result.current.getVersion()).toBe(afterFirst);
+  });
+
+  it("limpar o que já está limpo não notifica", () => {
+    const { result } = renderHook(() => useDirtyDocs());
+    const initial = result.current.getVersion();
+    act(() => result.current.markClean("doc-inexistente"));
+    expect(result.current.getVersion()).toBe(initial);
+  });
+
+  it("desinscrever para de notificar", () => {
+    const { result } = renderHook(() => useDirtyDocs());
+    let calls = 0;
+    const unsubscribe = result.current.subscribe(() => {
+      calls += 1;
+    });
+    act(() => result.current.markDirty("doc-1"));
+    expect(calls).toBe(1);
+    unsubscribe();
+    act(() => result.current.markDirty("doc-2"));
+    expect(calls).toBe(1);
+  });
+});

--- a/frontend/src/hooks/__tests__/useDirtyDocs.test.ts
+++ b/frontend/src/hooks/__tests__/useDirtyDocs.test.ts
@@ -6,7 +6,7 @@
 // por guards e handlers) mude de comportamento.
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { useDirtyDocs, useDirtyDocsCount, useIsDocDirty } from "../useDirtyDocs";
+import { useDirtyDocs, useIsDocDirty } from "../useDirtyDocs";
 
 afterEach(cleanup);
 
@@ -59,22 +59,6 @@ describe("leitura reativa — o indicador de não enviado", () => {
     });
     act(() => result.current.store.markDirty("doc-2"));
     expect(result.current.dirty).toBe(false);
-  });
-
-  // O aviso de saída vale para a fila inteira: navegar para longe com outro
-  // documento pendente também perde trabalho.
-  it("`useDirtyDocsCount` acompanha o total", () => {
-    const { result } = renderHook(() => {
-      const store = useDirtyDocs();
-      return { store, count: useDirtyDocsCount(store) };
-    });
-
-    expect(result.current.count).toBe(0);
-    act(() => result.current.store.markDirty("doc-1"));
-    act(() => result.current.store.markDirty("doc-2"));
-    expect(result.current.count).toBe(2);
-    act(() => result.current.store.markClean("doc-1"));
-    expect(result.current.count).toBe(1);
   });
 
   // Mutação vermelha: notificar incondicionalmente em `markDirty`/`markClean`.

--- a/frontend/src/hooks/useAutosaveOnExit.ts
+++ b/frontend/src/hooks/useAutosaveOnExit.ts
@@ -36,6 +36,15 @@ interface UseAutosaveOnExitParams {
  * Os listeners são registrados uma vez só (`[endpoint]`); `activeDocId`,
  * `getIsDirty` e `getPayload` são lidos via refs sempre atualizados, evitando
  * re-registrar o listener a cada keystroke.
+ *
+ * Diferente dos autosaves de navegação, este caminho **não** rebaseia o
+ * baseline do rascunho local (#608) e nem poderia: o beacon é fire-and-forget
+ * por construção — a aba está sendo fechada e não existe resposta para
+ * confirmar a escrita. Não é um buraco: o envelope sobrevive no `localStorage`
+ * e, na reabertura, é classificado contra o que o servidor ENTÃO devolve; se o
+ * beacon chegou, rascunho e servidor coincidem e o slot é limpo como
+ * `redundant`. Se não chegou, a oferta de recuperação aparece — que é
+ * exatamente o desfecho desejado.
  */
 export function useAutosaveOnExit({
   activeDocId,

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -246,9 +246,17 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
   const stateRef = useRef<Map<string, DocDraftState>>(new Map());
   const timersRef = useRef<Map<string, number>>(new Map());
   const keyPartsRef = useRef({ projectId, userId, enabled });
-  keyPartsRef.current = { projectId, userId, enabled };
   const fieldsRef = useRef(params.fields);
-  fieldsRef.current = params.fields;
+  // A sincronização acontece num effect sem deps (roda após cada render), e não
+  // no corpo do componente: escrever em ref durante o render quebra o modelo
+  // concorrente do React e é erro de lint (`react-hooks/refs`). Mesmo padrão de
+  // `useAutosaveOnExit`. Os leitores destes refs são handlers e listeners, que
+  // rodam sempre depois do commit.
+  const fields = params.fields;
+  useEffect(() => {
+    keyPartsRef.current = { projectId, userId, enabled };
+    fieldsRef.current = fields;
+  });
 
   const [recovery, setRecovery] = useState<CodingDraftRecovery>({ kind: "none" });
   const [storageAvailable, setStorageAvailable] = useState(true);

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -54,9 +54,16 @@ interface DocDraftState {
 }
 
 export interface CodingDraftsApi {
-  // Registra a edição corrente. Idempotente: chamar com conteúdo igual ao
-  // baseline limpa o slot em vez de gravar rascunho vazio.
-  recordDraft(docId: string, draft: CodingSnapshot, base: CodingSnapshot): void;
+  // Registra a edição corrente. Idempotente: conteúdo igual ao baseline limpa o
+  // slot em vez de gravar rascunho vazio.
+  //
+  // O baseline NÃO é parâmetro. Ele é estabelecido na abertura do documento (a
+  // partir do que o servidor entregou) e rebaseado por `submitConfirmed`, e o
+  // hook é seu dono único. Quando o consumidor também o passava a cada tecla,
+  // havia duas fontes para o mesmo fato e a do consumidor sempre vencia — o que
+  // tornava o rebase pós-envio inobservável e deixava um `base` stale entrar no
+  // envelope. Sem o parâmetro, esse estado não é construível.
+  recordDraft(docId: string, draft: CodingSnapshot): void;
   // Devolve o conteúdo a aplicar e marca a oferta como resolvida. NÃO apaga o
   // envelope: retomar não é enviar, e o trabalho segue não-enviado.
   restoreDraft(docId: string): CodingSnapshot | null;
@@ -343,24 +350,24 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
   }, []);
 
   const recordDraft = useCallback(
-    (docId: string, draft: CodingSnapshot, base: CodingSnapshot) => {
+    (docId: string, draft: CodingSnapshot) => {
       if (!keyPartsRef.current.enabled) return;
+      const previous = stateRef.current.get(docId);
+      // Sem baseline registrado não há como decidir o que é edição. Isso só
+      // ocorre para um documento que nunca foi aberto — não há caminho de UI que
+      // edite um documento fechado —, e inventar um baseline vazio gravaria o
+      // formulário inteiro como se fosse rascunho.
+      if (!previous) return;
+
       // Voltar ao baseline não é "rascunho vazio", é ausência de rascunho: manter
       // o envelope faria a faixa oferecer, na próxima abertura, um rascunho
-      // idêntico ao servidor.
-      if (sameCodingSnapshot(draft, base, fieldsRef.current)) {
-        dropSlot(docId, base);
+      // idêntico ao que o servidor já tem.
+      if (sameCodingSnapshot(draft, previous.base, fieldsRef.current)) {
+        dropSlot(docId, previous.base);
         return;
       }
-      const previous = stateRef.current.get(docId);
       const token = makeId("cdraft");
-      stateRef.current.set(docId, {
-        base,
-        draft,
-        writeToken: token,
-        persistedToken: previous?.persistedToken ?? null,
-        blocked: previous?.blocked ?? false,
-      });
+      stateRef.current.set(docId, { ...previous, draft, writeToken: token });
       scheduleWrite(docId, token);
     },
     [dropSlot, scheduleWrite],
@@ -424,11 +431,24 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
     if (slot.staleFormat) setStaleDiscardedCount((n) => n + 1);
 
     const remote = remoteRef.current ?? { answers: {}, notes: "" };
+
+    // Abrir estabelece o baseline do documento — o hook é dono único dele a
+    // partir daqui. Preserva `persistedToken` de uma edição anterior nesta mesma
+    // sessão (ir e voltar entre documentos não pode fazer a aba perder a posse
+    // do próprio slot).
+    const previous = stateRef.current.get(openDocId);
+    stateRef.current.set(openDocId, {
+      base: remote,
+      draft: previous?.draft ?? null,
+      writeToken: previous?.writeToken ?? null,
+      persistedToken: previous?.persistedToken ?? null,
+      blocked: previous?.blocked ?? false,
+    });
+
     const classified = classifyCodingDraft(slot.envelope, remote, fieldsRef.current);
     if (classified.kind === "redundant" && slot.envelope) {
       // Repete o servidor: some do caminho em vez de virar ruído recorrente.
       deleteSlotIfTokenMatches(scope, slot.envelope.writeToken);
-      stateRef.current.delete(openDocId);
       setRecovery({ kind: "none" });
       return;
     }

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -176,7 +176,7 @@ interface GcResult {
 // toca em chave de outro usuário (numa máquina compartilhada isso seria apagar
 // trabalho alheio) nem em envelope de formato maior (é de uma aba que sabe
 // mais) nem no documento aberto.
-export function collectCodingDraftGarbage(
+function collectCodingDraftGarbage(
   userId: string,
   now: number,
   keepKey: string | null,

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -27,7 +27,6 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
 
   const [recovery, setRecovery] = useState<CodingDraftRecovery>({ kind: "none" });
   const [storageAvailable, setStorageAvailable] = useState(true);
-  const [staleDiscardedCount, setStaleDiscardedCount] = useState(0);
 
   // Sessão criada uma única vez, por inicializador lazy de `useState`: um
   // `ref.current ??= ...` no corpo do componente seria acesso a ref durante o
@@ -37,7 +36,6 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
     createCodingDraftSession({
       onRecovery: setRecovery,
       onStorageAvailable: setStorageAvailable,
-      onStaleDiscarded: (n) => setStaleDiscardedCount((current) => current + n),
     }),
   );
 
@@ -71,9 +69,14 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
     [session],
   );
 
-  // Flush garantido nos três gatilhos que o navegador oferece, mais o unmount.
-  // O `beforeunload` aqui só persiste; quem avisa a pesquisadora é o guard de
-  // navegação.
+  // Flush nos dois gatilhos de saída que o navegador oferece, mais o unmount.
+  //
+  // Deliberadamente SEM `beforeunload`: ele não acrescenta cobertura nenhuma
+  // aqui (`pagehide` dispara em todo descarregamento, inclusive nos que o
+  // `beforeunload` pega) e registrá-lo tira a página do back/forward cache no
+  // Firefox e no Safari — voltar para a fila deixaria de ser instantâneo em
+  // troca de nada. O `beforeunload` que existe em `useAutosaveOnExit` é outro
+  // caso: lá ele serve ao aviso nativo do navegador, que só existe por meio dele.
   useEffect(() => {
     const flush = () => session.flushAll();
     const onVisibility = () => {
@@ -81,11 +84,9 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
     };
     document.addEventListener("visibilitychange", onVisibility);
     window.addEventListener("pagehide", flush);
-    window.addEventListener("beforeunload", flush);
     return () => {
       document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener("pagehide", flush);
-      window.removeEventListener("beforeunload", flush);
       flush();
     };
   }, [session]);
@@ -98,6 +99,5 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
     submitConfirmed,
     recovery,
     storageAvailable,
-    staleDiscardedCount,
   };
 }

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -1,0 +1,485 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  CODING_DRAFT_FORMAT_VERSION,
+  classifyCodingDraft,
+  codingDraftStorageKey,
+  codingDraftUserPrefix,
+  envelopeMatchesScope,
+  readCodingDraft,
+  sameCodingSnapshot,
+  type CodingDraftEnvelope,
+  type CodingDraftRecovery,
+  type CodingDraftScope,
+  type CodingSnapshot,
+} from "@/lib/coding-draft";
+import { makeId } from "@/lib/utils";
+import type { PydanticField } from "@/lib/types";
+
+// I/O e política do rascunho local de respostas (#608). A camada pura vive em
+// `lib/coding-draft.ts`; aqui mora tudo que toca `window`.
+//
+// Instanciado UMA vez, em `CodingPage`, servindo os dois modos. Isso é seguro
+// porque o espaço de `docId` é particionado por construção: `useBrowseCoding`
+// devolve `browseDocId: null` para documento atribuído, então um mesmo id nunca
+// é editado pelos dois modos.
+//
+// O hook não é dono das respostas — Atribuídos as guarda num reducer e Explorar
+// num filho keyed. Ele é armazenamento + política, e recebe conteúdo por chamada.
+
+const DRAFT_DEBOUNCE_MS = 300;
+
+// Um slot por documento escala para centenas de chaves, e o padrão herdado de
+// `useSchemaDraft` (um slot por projeto) não tem GC, TTL nem teto — lá isso
+// nunca importou. Aqui importa, e as três coisas entram junto com a feature:
+// quota estourada degrada em silêncio, que é exatamente o modo de falha que
+// esta issue existe para eliminar.
+const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_DRAFTS_PER_USER = 100;
+
+interface DocDraftState {
+  // O que estava na tela quando este rascunho nasceu.
+  base: CodingSnapshot;
+  // Conteúdo pendente de escrita, ou `null` quando o documento está limpo.
+  draft: CodingSnapshot | null;
+  // Token do envelope que queremos gravar (rotaciona a cada edição).
+  writeToken: string | null;
+  // "O que esta aba gravou por último e ainda acredita ser dela". É SEMPRE por
+  // ele que se apaga — nunca pelo token submetido. Ver a armadilha em
+  // `useSchemaDraft.ts:369-376`: o debounce rotaciona o token durante o save, e
+  // apagar pelo token errado deixa o envelope órfão E zera `persistedToken`,
+  // envenenando toda escrita seguinte da sessão.
+  persistedToken: string | null;
+  // Slot tomado por uma aba que sabe mais (formato maior) ou por outro token.
+  blocked: boolean;
+}
+
+export interface CodingDraftsApi {
+  // Registra a edição corrente. Idempotente: chamar com conteúdo igual ao
+  // baseline limpa o slot em vez de gravar rascunho vazio.
+  recordDraft(docId: string, draft: CodingSnapshot, base: CodingSnapshot): void;
+  // Devolve o conteúdo a aplicar e marca a oferta como resolvida. NÃO apaga o
+  // envelope: retomar não é enviar, e o trabalho segue não-enviado.
+  restoreDraft(docId: string): CodingSnapshot | null;
+  discardDraft(docId: string): void;
+  // Chamado quando o servidor confirmou a ESCRITA (`success: true`), inclusive
+  // quando o documento segue pendente por obrigatória em aberto.
+  submitConfirmed(docId: string, saved: CodingSnapshot): void;
+  recovery: CodingDraftRecovery;
+  isHydrated: boolean;
+  storageAvailable: boolean;
+  staleDiscardedCount: number;
+}
+
+export interface UseCodingDraftsParams {
+  projectId: string;
+  // O membro DONO da escrita (`ownMemberUserId`), nunca o observado sob
+  // impersonação — ver o comentário de `CodingDraftScope`.
+  userId: string;
+  // `false` sob impersonação ou rodada anterior: a tela é read-only e gravar
+  // rascunho ali depositaria trabalho num slot que ninguém vai enviar.
+  enabled: boolean;
+  openDocId: string | null;
+  // O que o servidor entregou no render para o documento aberto.
+  remote: CodingSnapshot | null;
+  fields: PydanticField[];
+}
+
+type StorageWrite = "written" | "blocked" | "unavailable";
+
+function scopeFor(
+  params: { userId: string; projectId: string },
+  documentId: string,
+): CodingDraftScope {
+  return { userId: params.userId, projectId: params.projectId, documentId };
+}
+
+function readSlot(scope: CodingDraftScope): {
+  available: boolean;
+  envelope: CodingDraftEnvelope | null;
+  staleFormat: boolean;
+} {
+  if (typeof window === "undefined") {
+    return { available: false, envelope: null, staleFormat: false };
+  }
+  try {
+    const read = readCodingDraft(window.localStorage.getItem(codingDraftStorageKey(scope)));
+    if (read.kind === "draft") {
+      // Segunda barreira: a chave disse que é deste documento, o conteúdo
+      // precisa concordar. Discordância vira "sem rascunho", nunca aplicação
+      // cruzada — ver `envelopeMatchesScope`.
+      if (!envelopeMatchesScope(read.draft, scope)) {
+        return { available: true, envelope: null, staleFormat: true };
+      }
+      return { available: true, envelope: read.draft, staleFormat: false };
+    }
+    return { available: true, envelope: null, staleFormat: read.kind === "stale-format" };
+  } catch {
+    return { available: false, envelope: null, staleFormat: false };
+  }
+}
+
+function writeSlotIfTokenMatches(
+  scope: CodingDraftScope,
+  envelope: CodingDraftEnvelope,
+  expectedToken: string | null,
+): StorageWrite {
+  if (typeof window === "undefined") return "unavailable";
+  try {
+    const key = codingDraftStorageKey(scope);
+    const stored = readCodingDraft(window.localStorage.getItem(key));
+    // Envelope que este build não sabe ler pertence a uma aba mais nova;
+    // sobrescrevê-lo apagaria trabalho irrecuperável.
+    if (stored.kind === "newer-format") return "blocked";
+    const storedToken = stored.kind === "draft" ? stored.draft.writeToken : null;
+    if (storedToken !== expectedToken) return "blocked";
+    window.localStorage.setItem(key, JSON.stringify(envelope));
+    return "written";
+  } catch {
+    return "unavailable";
+  }
+}
+
+function deleteSlotIfTokenMatches(
+  scope: CodingDraftScope,
+  writeToken: string | null,
+): boolean {
+  if (!writeToken || typeof window === "undefined") return false;
+  try {
+    const key = codingDraftStorageKey(scope);
+    const stored = readCodingDraft(window.localStorage.getItem(key));
+    if (stored.kind !== "draft" || stored.draft.writeToken !== writeToken) return false;
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface GcResult {
+  removed: number;
+  staleDiscarded: number;
+}
+
+// Varredura escopada ao prefixo do PRÓPRIO usuário, uma vez por mount. Nunca
+// toca em chave de outro usuário (numa máquina compartilhada isso seria apagar
+// trabalho alheio) nem em envelope de formato maior (é de uma aba que sabe
+// mais) nem no documento aberto.
+export function collectCodingDraftGarbage(
+  userId: string,
+  now: number,
+  keepKey: string | null,
+): GcResult {
+  if (typeof window === "undefined") return { removed: 0, staleDiscarded: 0 };
+  const result: GcResult = { removed: 0, staleDiscarded: 0 };
+  try {
+    const prefix = codingDraftUserPrefix(userId);
+    const mine: Array<{ key: string; updatedAt: number }> = [];
+    const doomed: string[] = [];
+
+    for (let i = 0; i < window.localStorage.length; i += 1) {
+      const key = window.localStorage.key(i);
+      if (!key || !key.startsWith(prefix) || key === keepKey) continue;
+      const read = readCodingDraft(window.localStorage.getItem(key));
+      if (read.kind === "newer-format") continue;
+      if (read.kind !== "draft") {
+        doomed.push(key);
+        // "Havia trabalho aqui e não sei ler" é um fato que a pesquisadora
+        // precisa saber; some do slot, não do aviso.
+        if (read.kind === "stale-format") result.staleDiscarded += 1;
+        continue;
+      }
+      const embedded = codingDraftStorageKey({
+        userId: read.draft.userId,
+        projectId: read.draft.projectId,
+        documentId: read.draft.documentId,
+      });
+      if (key !== embedded) {
+        // Identidade embutida discorda da chave: não dá para saber a que
+        // documento o conteúdo pertence, e aplicar no errado seria pior.
+        doomed.push(key);
+        continue;
+      }
+      if (now - read.draft.updatedAt > DRAFT_TTL_MS) {
+        doomed.push(key);
+        continue;
+      }
+      mine.push({ key, updatedAt: read.draft.updatedAt });
+    }
+
+    // Teto: acima dele, sai o mais antigo primeiro.
+    const overflow = mine.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
+    if (overflow > 0) {
+      mine
+        .toSorted((a, b) => a.updatedAt - b.updatedAt)
+        .slice(0, overflow)
+        .forEach((entry) => doomed.push(entry.key));
+    }
+
+    for (const key of doomed) {
+      window.localStorage.removeItem(key);
+      result.removed += 1;
+    }
+  } catch {
+    // Storage indisponível: o GC é best-effort e nunca deve derrubar a tela.
+  }
+  return result;
+}
+
+export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi {
+  const { projectId, userId, enabled, openDocId } = params;
+
+  // Refs atualizados a cada render, para que os effects de flush possam ser
+  // registrados uma única vez e ainda ler o estado mais recente — mesmo padrão
+  // que `useAutosaveOnExit` usa.
+  const stateRef = useRef<Map<string, DocDraftState>>(new Map());
+  const timersRef = useRef<Map<string, number>>(new Map());
+  const keyPartsRef = useRef({ projectId, userId, enabled });
+  keyPartsRef.current = { projectId, userId, enabled };
+  const remoteRef = useRef(params.remote);
+  remoteRef.current = params.remote;
+  const fieldsRef = useRef(params.fields);
+  fieldsRef.current = params.fields;
+
+  const [recovery, setRecovery] = useState<CodingDraftRecovery>({ kind: "none" });
+  const [storageAvailable, setStorageAvailable] = useState(true);
+  const [staleDiscardedCount, setStaleDiscardedCount] = useState(0);
+  // A tela de codificação não pode esperar hidratação atrás de um skeleton — ela
+  // mostra o texto do documento a partir do servidor. `isHydrated` protege só a
+  // faixa de recuperação, que é UI aditiva: um elemento que aparece, não uma
+  // página que troca.
+  const [isHydrated, setIsHydrated] = useState(false);
+  useEffect(() => setIsHydrated(true), []);
+
+  const persist = useCallback((docId: string, token: string) => {
+    const { projectId: pid, userId: uid, enabled: on } = keyPartsRef.current;
+    if (!on) return;
+    const state = stateRef.current.get(docId);
+    // Timer atrasado não grava conteúdo velho: o token precisa ainda ser o
+    // corrente. É por isso que o debounce é indexado pelo token, não por contador.
+    if (!state || !state.draft || state.writeToken !== token) return;
+
+    const scope = scopeFor({ projectId: pid, userId: uid }, docId);
+    const envelope: CodingDraftEnvelope = {
+      formatVersion: CODING_DRAFT_FORMAT_VERSION,
+      writeToken: token,
+      userId: uid,
+      projectId: pid,
+      documentId: docId,
+      updatedAt: Date.now(),
+      base: state.base,
+      draft: state.draft,
+    };
+
+    let outcome = writeSlotIfTokenMatches(scope, envelope, state.persistedToken);
+    if (outcome === "unavailable") {
+      // Evicção de emergência: quota estourada é recuperável se houver rascunho
+      // velho nosso ocupando espaço. Só depois de tentar é que se desiste.
+      const freed = collectCodingDraftGarbage(uid, Date.now(), codingDraftStorageKey(scope));
+      if (freed.removed > 0) {
+        outcome = writeSlotIfTokenMatches(scope, envelope, state.persistedToken);
+      }
+    }
+
+    if (outcome === "written") {
+      stateRef.current.set(docId, { ...state, persistedToken: token, blocked: false });
+      setStorageAvailable(true);
+      return;
+    }
+    // Falha NÃO avança `persistedToken`: a próxima edição tenta de novo. Avançá-lo
+    // faria a aba colidir com o próprio lixo e nunca mais gravar na sessão.
+    stateRef.current.set(docId, { ...state, blocked: outcome === "blocked" });
+    if (outcome === "unavailable") setStorageAvailable(false);
+  }, []);
+
+  const scheduleWrite = useCallback(
+    (docId: string, token: string) => {
+      const existing = timersRef.current.get(docId);
+      if (existing) window.clearTimeout(existing);
+      timersRef.current.set(
+        docId,
+        window.setTimeout(() => {
+          timersRef.current.delete(docId);
+          persist(docId, token);
+        }, DRAFT_DEBOUNCE_MS),
+      );
+    },
+    [persist],
+  );
+
+  const flushAll = useCallback(() => {
+    for (const [docId, timer] of timersRef.current) {
+      window.clearTimeout(timer);
+      const token = stateRef.current.get(docId)?.writeToken;
+      if (token) persist(docId, token);
+    }
+    timersRef.current.clear();
+  }, [persist]);
+
+  const dropSlot = useCallback((docId: string, nextBase?: CodingSnapshot) => {
+    const { projectId: pid, userId: uid } = keyPartsRef.current;
+    const state = stateRef.current.get(docId);
+    const timer = timersRef.current.get(docId);
+    if (timer) {
+      window.clearTimeout(timer);
+      timersRef.current.delete(docId);
+    }
+    const scope = scopeFor({ projectId: pid, userId: uid }, docId);
+    // Normalmente apaga-se pelo `persistedToken` — "o que esta aba gravou e
+    // ainda acredita ser dela". Mas um envelope apenas OFERECIDO (escrito numa
+    // sessão anterior, ainda não retomado) não tem estado em memória, e sem o
+    // fallback abaixo o botão "Descartar" não apagava nada: a faixa voltaria na
+    // abertura seguinte. Ler o token do slot é seguro porque
+    // `deleteSlotIfTokenMatches` só remove um envelope legível cujo token bate —
+    // um `newer-format`, de aba mais nova, continua intocado.
+    const token = state?.persistedToken ?? readSlot(scope).envelope?.writeToken ?? null;
+    deleteSlotIfTokenMatches(scope, token);
+    stateRef.current.set(docId, {
+      base: nextBase ?? state?.base ?? { answers: {}, notes: "" },
+      draft: null,
+      writeToken: null,
+      persistedToken: null,
+      blocked: false,
+    });
+  }, []);
+
+  const recordDraft = useCallback(
+    (docId: string, draft: CodingSnapshot, base: CodingSnapshot) => {
+      if (!keyPartsRef.current.enabled) return;
+      // Voltar ao baseline não é "rascunho vazio", é ausência de rascunho: manter
+      // o envelope faria a faixa oferecer, na próxima abertura, um rascunho
+      // idêntico ao servidor.
+      if (sameCodingSnapshot(draft, base, fieldsRef.current)) {
+        dropSlot(docId, base);
+        return;
+      }
+      const previous = stateRef.current.get(docId);
+      const token = makeId("cdraft");
+      stateRef.current.set(docId, {
+        base,
+        draft,
+        writeToken: token,
+        persistedToken: previous?.persistedToken ?? null,
+        blocked: previous?.blocked ?? false,
+      });
+      scheduleWrite(docId, token);
+    },
+    [dropSlot, scheduleWrite],
+  );
+
+  const restoreDraft = useCallback((docId: string): CodingSnapshot | null => {
+    const { projectId: pid, userId: uid } = keyPartsRef.current;
+    const slot = readSlot(scopeFor({ projectId: pid, userId: uid }, docId));
+    if (!slot.envelope) {
+      setRecovery({ kind: "none" });
+      return null;
+    }
+    // O envelope permanece no slot: retomar não é enviar. Assumimos a posse dele
+    // para que o compare-and-swap das próximas escritas case.
+    stateRef.current.set(docId, {
+      base: slot.envelope.base,
+      draft: slot.envelope.draft,
+      writeToken: slot.envelope.writeToken,
+      persistedToken: slot.envelope.writeToken,
+      blocked: false,
+    });
+    setRecovery({ kind: "none" });
+    return slot.envelope.draft;
+  }, []);
+
+  const discardDraft = useCallback(
+    (docId: string) => {
+      dropSlot(docId);
+      setRecovery({ kind: "none" });
+    },
+    [dropSlot],
+  );
+
+  const submitConfirmed = useCallback(
+    (docId: string, saved: CodingSnapshot) => {
+      // A escrita aconteceu: o rascunho virou redundante por definição, mesmo
+      // que o documento siga pendente por obrigatória em aberto. Manter deixaria
+      // o indicador de "não enviado" aceso sobre trabalho que FOI enviado.
+      //
+      // O baseline é rebaseado para o que foi gravado — sem isso, a próxima
+      // tecla criaria um rascunho cujo `base` é o seed stale do RSC, e reabrir o
+      // documento depois acusaria "o documento foi salvo depois" contra uma
+      // escrita nossa.
+      dropSlot(docId, saved);
+      setRecovery({ kind: "none" });
+    },
+    [dropSlot],
+  );
+
+  // Leitura e classificação ao abrir um documento. Roda pós-hidratação, fora do
+  // seed do reducer: semear o formulário a partir do rascunho SERIA aplicá-lo em
+  // silêncio, e a issue pede o contrário.
+  useEffect(() => {
+    if (!isHydrated || !enabled || !openDocId) {
+      setRecovery({ kind: "none" });
+      return;
+    }
+    const scope = scopeFor({ projectId, userId }, openDocId);
+    const slot = readSlot(scope);
+    setStorageAvailable(slot.available);
+    if (slot.staleFormat) setStaleDiscardedCount((n) => n + 1);
+
+    const remote = remoteRef.current ?? { answers: {}, notes: "" };
+    const classified = classifyCodingDraft(slot.envelope, remote, fieldsRef.current);
+    if (classified.kind === "redundant" && slot.envelope) {
+      // Repete o servidor: some do caminho em vez de virar ruído recorrente.
+      deleteSlotIfTokenMatches(scope, slot.envelope.writeToken);
+      stateRef.current.delete(openDocId);
+      setRecovery({ kind: "none" });
+      return;
+    }
+    if (classified.kind === "resumable" || classified.kind === "diverged") {
+      // Posse do slot é assumida só ao retomar; até lá, apenas oferecemos.
+      setRecovery(classified);
+      return;
+    }
+    setRecovery({ kind: "none" });
+  }, [isHydrated, enabled, openDocId, projectId, userId]);
+
+  // GC uma vez por mount, pós-hidratação.
+  useEffect(() => {
+    if (!isHydrated || !enabled) return;
+    const keep = openDocId
+      ? codingDraftStorageKey(scopeFor({ projectId, userId }, openDocId))
+      : null;
+    const result = collectCodingDraftGarbage(userId, Date.now(), keep);
+    if (result.staleDiscarded > 0) setStaleDiscardedCount((n) => n + result.staleDiscarded);
+    // Roda no mount; `openDocId` entra como valor inicial apenas — reagir a cada
+    // navegação transformaria o GC num custo por documento visitado.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated, enabled, userId, projectId]);
+
+  // Flush garantido nos três gatilhos que o navegador oferece, mais o unmount.
+  // O `beforeunload` aqui só persiste; quem avisa a pesquisadora é o guard de
+  // navegação.
+  useEffect(() => {
+    const flush = () => flushAll();
+    const onVisibility = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("pagehide", flush);
+    window.addEventListener("beforeunload", flush);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("pagehide", flush);
+      window.removeEventListener("beforeunload", flush);
+      flush();
+    };
+  }, [flushAll]);
+
+  return {
+    recordDraft,
+    restoreDraft,
+    discardDraft,
+    submitConfirmed,
+    recovery,
+    isHydrated,
+    storageAvailable,
+    staleDiscardedCount,
+  };
+}

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { CodingDraftRecovery, CodingSnapshot } from "@/lib/coding-draft";
 import {
   createCodingDraftSession,
@@ -29,15 +29,17 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
   const [storageAvailable, setStorageAvailable] = useState(true);
   const [staleDiscardedCount, setStaleDiscardedCount] = useState(0);
 
-  // Sessão criada uma única vez. Os callbacks são estáveis porque só usam os
-  // setters do React, cuja identidade é garantida.
-  const sessionRef = useRef<CodingDraftSession | null>(null);
-  sessionRef.current ??= createCodingDraftSession({
-    onRecovery: setRecovery,
-    onStorageAvailable: setStorageAvailable,
-    onStaleDiscarded: (n) => setStaleDiscardedCount((current) => current + n),
-  });
-  const session = sessionRef.current;
+  // Sessão criada uma única vez, por inicializador lazy de `useState`: um
+  // `ref.current ??= ...` no corpo do componente seria acesso a ref durante o
+  // render (erro de `react-hooks/refs`). Os callbacks são estáveis porque só
+  // usam os setters do React, cuja identidade é garantida.
+  const [session] = useState<CodingDraftSession>(() =>
+    createCodingDraftSession({
+      onRecovery: setRecovery,
+      onStorageAvailable: setStorageAvailable,
+      onStaleDiscarded: (n) => setStaleDiscardedCount((current) => current + n),
+    }),
+  );
 
   // A sessão recebe as chaves e o schema num effect sem deps (roda após cada
   // render), e não no corpo do componente: escrever durante o render quebra o

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -1,508 +1,79 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { CodingDraftRecovery, CodingSnapshot } from "@/lib/coding-draft";
 import {
-  CODING_DRAFT_FORMAT_VERSION,
-  classifyCodingDraft,
-  codingDraftStorageKey,
-  codingDraftUserPrefix,
-  envelopeMatchesScope,
-  readCodingDraft,
-  sameCodingSnapshot,
-  type CodingDraftEnvelope,
-  type CodingDraftRecovery,
-  type CodingDraftScope,
-  type CodingSnapshot,
-} from "@/lib/coding-draft";
-import { makeId } from "@/lib/utils";
-import type { PydanticField } from "@/lib/types";
+  createCodingDraftSession,
+  type CodingDraftSession,
+  type CodingDraftsApi,
+  type UseCodingDraftsParams,
+} from "@/lib/coding-draft-storage";
 
-// I/O e política do rascunho local de respostas (#608). A camada pura vive em
-// `lib/coding-draft.ts`; aqui mora tudo que toca `window`.
+export type { CodingDraftsApi, UseCodingDraftsParams };
+
+// Ciclo de vida React do rascunho local de respostas (#608). A máquina de
+// estados (debounce, posse do slot, GC, abertura) vive em
+// `createCodingDraftSession`, sem React; a lógica pura (envelope, classificação)
+// em `lib/coding-draft.ts`. Aqui fica só o que é do React: o estado que a faixa
+// de recuperação consome e os listeners de saída.
 //
-// Instanciado UMA vez, em `CodingPage`, servindo os dois modos. Isso é seguro
-// porque o espaço de `docId` é particionado por construção: `useBrowseCoding`
-// devolve `browseDocId: null` para documento atribuído, então um mesmo id nunca
-// é editado pelos dois modos.
+// Instanciado UMA vez, em `CodingPage`, servindo os dois modos. É seguro porque
+// o espaço de `docId` é particionado por construção: `useBrowseCoding` devolve
+// `browseDocId: null` para documento atribuído, então um mesmo id nunca é
+// editado pelos dois modos.
 //
 // O hook não é dono das respostas — Atribuídos as guarda num reducer e Explorar
 // num filho keyed. Ele é armazenamento + política, e recebe conteúdo por chamada.
-
-const DRAFT_DEBOUNCE_MS = 300;
-
-// Um slot por documento escala para centenas de chaves, e o padrão herdado de
-// `useSchemaDraft` (um slot por projeto) não tem GC, TTL nem teto — lá isso
-// nunca importou. Aqui importa, e as três coisas entram junto com a feature:
-// quota estourada degrada em silêncio, que é exatamente o modo de falha que
-// esta issue existe para eliminar.
-const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const MAX_DRAFTS_PER_USER = 100;
-
-interface DocDraftState {
-  // O que estava na tela quando este rascunho nasceu.
-  base: CodingSnapshot;
-  // Conteúdo pendente de escrita, ou `null` quando o documento está limpo.
-  draft: CodingSnapshot | null;
-  // Token do envelope que queremos gravar (rotaciona a cada edição).
-  writeToken: string | null;
-  // "O que esta aba gravou por último e ainda acredita ser dela". É SEMPRE por
-  // ele que se apaga — nunca pelo token submetido. Ver a armadilha em
-  // `useSchemaDraft.ts:369-376`: o debounce rotaciona o token durante o save, e
-  // apagar pelo token errado deixa o envelope órfão E zera `persistedToken`,
-  // envenenando toda escrita seguinte da sessão.
-  persistedToken: string | null;
-  // Slot tomado por uma aba que sabe mais (formato maior) ou por outro token.
-  blocked: boolean;
-}
-
-export interface CodingDraftsApi {
-  // Registra a edição corrente. Idempotente: conteúdo igual ao baseline limpa o
-  // slot em vez de gravar rascunho vazio.
-  //
-  // O baseline NÃO é parâmetro. Ele é estabelecido na abertura do documento (a
-  // partir do que o servidor entregou) e rebaseado por `submitConfirmed`, e o
-  // hook é seu dono único. Quando o consumidor também o passava a cada tecla,
-  // havia duas fontes para o mesmo fato e a do consumidor sempre vencia — o que
-  // tornava o rebase pós-envio inobservável e deixava um `base` stale entrar no
-  // envelope. Sem o parâmetro, esse estado não é construível.
-  recordDraft(docId: string, draft: CodingSnapshot): void;
-  // Devolve o conteúdo a aplicar e marca a oferta como resolvida. NÃO apaga o
-  // envelope: retomar não é enviar, e o trabalho segue não-enviado.
-  restoreDraft(docId: string): CodingSnapshot | null;
-  discardDraft(docId: string): void;
-  // Chamado quando o servidor confirmou a ESCRITA (`success: true`), inclusive
-  // quando o documento segue pendente por obrigatória em aberto.
-  submitConfirmed(docId: string, saved: CodingSnapshot): void;
-  // Abre um documento: estabelece o baseline a partir do que o servidor
-  // entregou e classifica o slot. Chamado de um effect pelo consumidor — e não
-  // recebido como parâmetro — porque o documento ativo só é conhecido DEPOIS dos
-  // hooks de modo, que por sua vez precisam do `recordDraft` daqui.
-  //
-  // Como a leitura do storage acontece só aqui, e effects não rodam no SSR, o
-  // primeiro render do cliente é idêntico ao do servidor por construção: nenhuma
-  // flag de hidratação é necessária.
-  openDocument(docId: string | null, remote: CodingSnapshot | null): void;
-  recovery: CodingDraftRecovery;
-  storageAvailable: boolean;
-  staleDiscardedCount: number;
-}
-
-export interface UseCodingDraftsParams {
-  projectId: string;
-  // O membro DONO da escrita (`ownMemberUserId`), nunca o observado sob
-  // impersonação — ver o comentário de `CodingDraftScope`.
-  userId: string;
-  // `false` sob impersonação ou rodada anterior: a tela é read-only e gravar
-  // rascunho ali depositaria trabalho num slot que ninguém vai enviar.
-  enabled: boolean;
-  fields: PydanticField[];
-}
-
-type StorageWrite = "written" | "blocked" | "unavailable";
-
-function scopeFor(
-  params: { userId: string; projectId: string },
-  documentId: string,
-): CodingDraftScope {
-  return { userId: params.userId, projectId: params.projectId, documentId };
-}
-
-function readSlot(scope: CodingDraftScope): {
-  available: boolean;
-  envelope: CodingDraftEnvelope | null;
-  staleFormat: boolean;
-} {
-  if (typeof window === "undefined") {
-    return { available: false, envelope: null, staleFormat: false };
-  }
-  try {
-    const read = readCodingDraft(window.localStorage.getItem(codingDraftStorageKey(scope)));
-    if (read.kind === "draft") {
-      // Segunda barreira: a chave disse que é deste documento, o conteúdo
-      // precisa concordar. Discordância vira "sem rascunho", nunca aplicação
-      // cruzada — ver `envelopeMatchesScope`.
-      if (!envelopeMatchesScope(read.draft, scope)) {
-        return { available: true, envelope: null, staleFormat: true };
-      }
-      return { available: true, envelope: read.draft, staleFormat: false };
-    }
-    return { available: true, envelope: null, staleFormat: read.kind === "stale-format" };
-  } catch {
-    return { available: false, envelope: null, staleFormat: false };
-  }
-}
-
-function writeSlotIfTokenMatches(
-  scope: CodingDraftScope,
-  envelope: CodingDraftEnvelope,
-  expectedToken: string | null,
-): StorageWrite {
-  if (typeof window === "undefined") return "unavailable";
-  try {
-    const key = codingDraftStorageKey(scope);
-    const stored = readCodingDraft(window.localStorage.getItem(key));
-    // Envelope que este build não sabe ler pertence a uma aba mais nova;
-    // sobrescrevê-lo apagaria trabalho irrecuperável.
-    if (stored.kind === "newer-format") return "blocked";
-    const storedToken = stored.kind === "draft" ? stored.draft.writeToken : null;
-    if (storedToken !== expectedToken) return "blocked";
-    window.localStorage.setItem(key, JSON.stringify(envelope));
-    return "written";
-  } catch {
-    return "unavailable";
-  }
-}
-
-function deleteSlotIfTokenMatches(
-  scope: CodingDraftScope,
-  writeToken: string | null,
-): boolean {
-  if (!writeToken || typeof window === "undefined") return false;
-  try {
-    const key = codingDraftStorageKey(scope);
-    const stored = readCodingDraft(window.localStorage.getItem(key));
-    if (stored.kind !== "draft" || stored.draft.writeToken !== writeToken) return false;
-    window.localStorage.removeItem(key);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-interface GcResult {
-  removed: number;
-  staleDiscarded: number;
-}
-
-// Varredura escopada ao prefixo do PRÓPRIO usuário, uma vez por mount. Nunca
-// toca em chave de outro usuário (numa máquina compartilhada isso seria apagar
-// trabalho alheio) nem em envelope de formato maior (é de uma aba que sabe
-// mais) nem no documento aberto.
-function collectCodingDraftGarbage(
-  userId: string,
-  now: number,
-  keepKey: string | null,
-): GcResult {
-  if (typeof window === "undefined") return { removed: 0, staleDiscarded: 0 };
-  const result: GcResult = { removed: 0, staleDiscarded: 0 };
-  try {
-    const prefix = codingDraftUserPrefix(userId);
-    const mine: Array<{ key: string; updatedAt: number }> = [];
-    const doomed: string[] = [];
-
-    for (let i = 0; i < window.localStorage.length; i += 1) {
-      const key = window.localStorage.key(i);
-      if (!key || !key.startsWith(prefix) || key === keepKey) continue;
-      const read = readCodingDraft(window.localStorage.getItem(key));
-      if (read.kind === "newer-format") continue;
-      if (read.kind !== "draft") {
-        doomed.push(key);
-        // "Havia trabalho aqui e não sei ler" é um fato que a pesquisadora
-        // precisa saber; some do slot, não do aviso.
-        if (read.kind === "stale-format") result.staleDiscarded += 1;
-        continue;
-      }
-      const embedded = codingDraftStorageKey({
-        userId: read.draft.userId,
-        projectId: read.draft.projectId,
-        documentId: read.draft.documentId,
-      });
-      if (key !== embedded) {
-        // Identidade embutida discorda da chave: não dá para saber a que
-        // documento o conteúdo pertence, e aplicar no errado seria pior.
-        doomed.push(key);
-        continue;
-      }
-      if (now - read.draft.updatedAt > DRAFT_TTL_MS) {
-        doomed.push(key);
-        continue;
-      }
-      mine.push({ key, updatedAt: read.draft.updatedAt });
-    }
-
-    // Teto: acima dele, sai o mais antigo primeiro.
-    const overflow = mine.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
-    if (overflow > 0) {
-      mine
-        .toSorted((a, b) => a.updatedAt - b.updatedAt)
-        .slice(0, overflow)
-        .forEach((entry) => doomed.push(entry.key));
-    }
-
-    for (const key of doomed) {
-      window.localStorage.removeItem(key);
-      result.removed += 1;
-    }
-  } catch {
-    // Storage indisponível: o GC é best-effort e nunca deve derrubar a tela.
-  }
-  return result;
-}
-
 export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi {
-  const { projectId, userId, enabled } = params;
-
-  // Refs atualizados a cada render, para que os effects de flush possam ser
-  // registrados uma única vez e ainda ler o estado mais recente — mesmo padrão
-  // que `useAutosaveOnExit` usa.
-  const stateRef = useRef<Map<string, DocDraftState>>(new Map());
-  const timersRef = useRef<Map<string, number>>(new Map());
-  const keyPartsRef = useRef({ projectId, userId, enabled });
-  const fieldsRef = useRef(params.fields);
-  // A sincronização acontece num effect sem deps (roda após cada render), e não
-  // no corpo do componente: escrever em ref durante o render quebra o modelo
-  // concorrente do React e é erro de lint (`react-hooks/refs`). Mesmo padrão de
-  // `useAutosaveOnExit`. Os leitores destes refs são handlers e listeners, que
-  // rodam sempre depois do commit.
-  const fields = params.fields;
-  useEffect(() => {
-    keyPartsRef.current = { projectId, userId, enabled };
-    fieldsRef.current = fields;
-  });
+  const { projectId, userId, enabled, fields } = params;
 
   const [recovery, setRecovery] = useState<CodingDraftRecovery>({ kind: "none" });
   const [storageAvailable, setStorageAvailable] = useState(true);
   const [staleDiscardedCount, setStaleDiscardedCount] = useState(0);
-  // Último documento aberto: o GC nunca evicta o slot dele.
-  const openDocIdRef = useRef<string | null>(null);
-  // Distingue "nunca abriu" de "abriu o documento null": sem isso, a primeira
-  // chamada com `null` cairia no guard de idempotência e o GC nunca rodaria.
-  const openedOnceRef = useRef(false);
 
-  const persist = useCallback((docId: string, token: string) => {
-    const { projectId: pid, userId: uid, enabled: on } = keyPartsRef.current;
-    if (!on) return;
-    const state = stateRef.current.get(docId);
-    // Timer atrasado não grava conteúdo velho: o token precisa ainda ser o
-    // corrente. É por isso que o debounce é indexado pelo token, não por contador.
-    if (!state || !state.draft || state.writeToken !== token) return;
+  // Sessão criada uma única vez. Os callbacks são estáveis porque só usam os
+  // setters do React, cuja identidade é garantida.
+  const sessionRef = useRef<CodingDraftSession | null>(null);
+  sessionRef.current ??= createCodingDraftSession({
+    onRecovery: setRecovery,
+    onStorageAvailable: setStorageAvailable,
+    onStaleDiscarded: (n) => setStaleDiscardedCount((current) => current + n),
+  });
+  const session = sessionRef.current;
 
-    const scope = scopeFor({ projectId: pid, userId: uid }, docId);
-    const envelope: CodingDraftEnvelope = {
-      formatVersion: CODING_DRAFT_FORMAT_VERSION,
-      writeToken: token,
-      userId: uid,
-      projectId: pid,
-      documentId: docId,
-      updatedAt: Date.now(),
-      base: state.base,
-      draft: state.draft,
-    };
-
-    let outcome = writeSlotIfTokenMatches(scope, envelope, state.persistedToken);
-    if (outcome === "unavailable") {
-      // Evicção de emergência: quota estourada é recuperável se houver rascunho
-      // velho nosso ocupando espaço. Só depois de tentar é que se desiste.
-      const freed = collectCodingDraftGarbage(uid, Date.now(), codingDraftStorageKey(scope));
-      if (freed.removed > 0) {
-        outcome = writeSlotIfTokenMatches(scope, envelope, state.persistedToken);
-      }
-    }
-
-    if (outcome === "written") {
-      stateRef.current.set(docId, { ...state, persistedToken: token, blocked: false });
-      setStorageAvailable(true);
-      return;
-    }
-    // Falha NÃO avança `persistedToken`: a próxima edição tenta de novo. Avançá-lo
-    // faria a aba colidir com o próprio lixo e nunca mais gravar na sessão.
-    stateRef.current.set(docId, { ...state, blocked: outcome === "blocked" });
-    if (outcome === "unavailable") setStorageAvailable(false);
-  }, []);
-
-  const scheduleWrite = useCallback(
-    (docId: string, token: string) => {
-      const existing = timersRef.current.get(docId);
-      if (existing) window.clearTimeout(existing);
-      timersRef.current.set(
-        docId,
-        window.setTimeout(() => {
-          timersRef.current.delete(docId);
-          persist(docId, token);
-        }, DRAFT_DEBOUNCE_MS),
-      );
-    },
-    [persist],
-  );
-
-  const flushAll = useCallback(() => {
-    for (const [docId, timer] of timersRef.current) {
-      window.clearTimeout(timer);
-      const token = stateRef.current.get(docId)?.writeToken;
-      if (token) persist(docId, token);
-    }
-    timersRef.current.clear();
-  }, [persist]);
-
-  const dropSlot = useCallback((docId: string, nextBase?: CodingSnapshot) => {
-    const { projectId: pid, userId: uid } = keyPartsRef.current;
-    const state = stateRef.current.get(docId);
-    const timer = timersRef.current.get(docId);
-    if (timer) {
-      window.clearTimeout(timer);
-      timersRef.current.delete(docId);
-    }
-    const scope = scopeFor({ projectId: pid, userId: uid }, docId);
-    // Normalmente apaga-se pelo `persistedToken` — "o que esta aba gravou e
-    // ainda acredita ser dela". Mas um envelope apenas OFERECIDO (escrito numa
-    // sessão anterior, ainda não retomado) não tem estado em memória, e sem o
-    // fallback abaixo o botão "Descartar" não apagava nada: a faixa voltaria na
-    // abertura seguinte. Ler o token do slot é seguro porque
-    // `deleteSlotIfTokenMatches` só remove um envelope legível cujo token bate —
-    // um `newer-format`, de aba mais nova, continua intocado.
-    const token = state?.persistedToken ?? readSlot(scope).envelope?.writeToken ?? null;
-    deleteSlotIfTokenMatches(scope, token);
-    stateRef.current.set(docId, {
-      base: nextBase ?? state?.base ?? { answers: {}, notes: "" },
-      draft: null,
-      writeToken: null,
-      persistedToken: null,
-      blocked: false,
-    });
-  }, []);
+  // A sessão recebe as chaves e o schema num effect sem deps (roda após cada
+  // render), e não no corpo do componente: escrever durante o render quebra o
+  // modelo concorrente do React e é erro de lint (`react-hooks/refs`). Quem lê
+  // esses valores são handlers e listeners, que rodam sempre após o commit.
+  useEffect(() => {
+    session.configure({ projectId, userId, enabled }, fields);
+  });
 
   const recordDraft = useCallback(
-    (docId: string, draft: CodingSnapshot) => {
-      if (!keyPartsRef.current.enabled) return;
-      const previous = stateRef.current.get(docId);
-      // Sem baseline registrado não há como decidir o que é edição. Isso só
-      // ocorre para um documento que nunca foi aberto — não há caminho de UI que
-      // edite um documento fechado —, e inventar um baseline vazio gravaria o
-      // formulário inteiro como se fosse rascunho.
-      if (!previous) return;
-
-      // Voltar ao baseline não é "rascunho vazio", é ausência de rascunho: manter
-      // o envelope faria a faixa oferecer, na próxima abertura, um rascunho
-      // idêntico ao que o servidor já tem.
-      if (sameCodingSnapshot(draft, previous.base, fieldsRef.current)) {
-        dropSlot(docId, previous.base);
-        return;
-      }
-      const token = makeId("cdraft");
-      stateRef.current.set(docId, { ...previous, draft, writeToken: token });
-      scheduleWrite(docId, token);
-    },
-    [dropSlot, scheduleWrite],
+    (docId: string, draft: CodingSnapshot) => session.recordDraft(docId, draft),
+    [session],
   );
-
-  const restoreDraft = useCallback((docId: string): CodingSnapshot | null => {
-    const { projectId: pid, userId: uid } = keyPartsRef.current;
-    const slot = readSlot(scopeFor({ projectId: pid, userId: uid }, docId));
-    if (!slot.envelope) {
-      setRecovery({ kind: "none" });
-      return null;
-    }
-    // O envelope permanece no slot: retomar não é enviar. Assumimos a posse dele
-    // para que o compare-and-swap das próximas escritas case.
-    stateRef.current.set(docId, {
-      base: slot.envelope.base,
-      draft: slot.envelope.draft,
-      writeToken: slot.envelope.writeToken,
-      persistedToken: slot.envelope.writeToken,
-      blocked: false,
-    });
-    setRecovery({ kind: "none" });
-    return slot.envelope.draft;
-  }, []);
-
+  const restoreDraft = useCallback(
+    (docId: string) => session.restoreDraft(docId),
+    [session],
+  );
   const discardDraft = useCallback(
-    (docId: string) => {
-      dropSlot(docId);
-      setRecovery({ kind: "none" });
-    },
-    [dropSlot],
+    (docId: string) => session.discardDraft(docId),
+    [session],
   );
-
   const submitConfirmed = useCallback(
-    (docId: string, saved: CodingSnapshot) => {
-      // A escrita aconteceu: o rascunho virou redundante por definição, mesmo
-      // que o documento siga pendente por obrigatória em aberto. Manter deixaria
-      // o indicador de "não enviado" aceso sobre trabalho que FOI enviado.
-      //
-      // O baseline é rebaseado para o que foi gravado — sem isso, a próxima
-      // tecla criaria um rascunho cujo `base` é o seed stale do RSC, e reabrir o
-      // documento depois acusaria "o documento foi salvo depois" contra uma
-      // escrita nossa.
-      dropSlot(docId, saved);
-      setRecovery({ kind: "none" });
-    },
-    [dropSlot],
+    (docId: string, saved: CodingSnapshot) => session.submitConfirmed(docId, saved),
+    [session],
   );
-
-  // Leitura e classificação ao abrir um documento. Fora do seed do reducer de
-  // propósito: semear o formulário a partir do rascunho SERIA aplicá-lo em
-  // silêncio, e a issue pede o contrário. Idempotente por documento — reabrir o
-  // mesmo id não reclassifica, senão cada revalidação do RSC ressuscitaria uma
-  // oferta que a pesquisadora acabou de descartar.
   const openDocument = useCallback(
-    (docId: string | null, remote: CodingSnapshot | null) => {
-      const { projectId: pid, userId: uid, enabled: on } = keyPartsRef.current;
-      if (openedOnceRef.current && openDocIdRef.current === docId) return;
-      const firstOpen = !openedOnceRef.current;
-      openedOnceRef.current = true;
-      openDocIdRef.current = docId;
-
-      // O GC roda na PRIMEIRA abertura, não num effect de mount: é aqui que se
-      // sabe qual slot preservar. Num effect de mount, `openDocument` ainda não
-      // teria sido chamado (o consumidor o chama do próprio effect, declarado
-      // depois), `keepKey` seria nulo, e o rascunho do documento na tela entraria
-      // na varredura — expirado ou acima do teto, seria apagado debaixo da
-      // pesquisadora.
-      if (firstOpen && on) {
-        const keep = docId
-          ? codingDraftStorageKey(scopeFor({ projectId: pid, userId: uid }, docId))
-          : null;
-        const collected = collectCodingDraftGarbage(uid, Date.now(), keep);
-        if (collected.staleDiscarded > 0) {
-          setStaleDiscardedCount((n) => n + collected.staleDiscarded);
-        }
-      }
-
-      if (!on || !docId) {
-        setRecovery({ kind: "none" });
-        return;
-      }
-
-      const scope = scopeFor({ projectId: pid, userId: uid }, docId);
-      const slot = readSlot(scope);
-      setStorageAvailable(slot.available);
-      if (slot.staleFormat) setStaleDiscardedCount((n) => n + 1);
-
-      const baseline = remote ?? { answers: {}, notes: "" };
-
-      // Abrir estabelece o baseline do documento — o hook é dono único dele a
-      // partir daqui. Preserva `persistedToken` de uma edição anterior nesta
-      // mesma sessão: ir e voltar entre documentos não pode fazer a aba perder a
-      // posse do próprio slot.
-      const previous = stateRef.current.get(docId);
-      stateRef.current.set(docId, {
-        base: previous?.draft ? previous.base : baseline,
-        draft: previous?.draft ?? null,
-        writeToken: previous?.writeToken ?? null,
-        persistedToken: previous?.persistedToken ?? null,
-        blocked: previous?.blocked ?? false,
-      });
-
-      const classified = classifyCodingDraft(slot.envelope, baseline, fieldsRef.current);
-      if (classified.kind === "redundant" && slot.envelope) {
-        // Repete o servidor: some do caminho em vez de virar ruído recorrente.
-        deleteSlotIfTokenMatches(scope, slot.envelope.writeToken);
-        setRecovery({ kind: "none" });
-        return;
-      }
-      // Posse do slot é assumida só ao retomar; até lá, apenas oferecemos.
-      setRecovery(
-        classified.kind === "resumable" || classified.kind === "diverged"
-          ? classified
-          : { kind: "none" },
-      );
-    },
-    [],
+    (docId: string | null, remote: CodingSnapshot | null) =>
+      session.openDocument(docId, remote),
+    [session],
   );
 
   // Flush garantido nos três gatilhos que o navegador oferece, mais o unmount.
   // O `beforeunload` aqui só persiste; quem avisa a pesquisadora é o guard de
   // navegação.
   useEffect(() => {
-    const flush = () => flushAll();
+    const flush = () => session.flushAll();
     const onVisibility = () => {
       if (document.visibilityState === "hidden") flush();
     };
@@ -515,7 +86,7 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
       window.removeEventListener("beforeunload", flush);
       flush();
     };
-  }, [flushAll]);
+  }, [session]);
 
   return {
     openDocument,

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -71,8 +71,16 @@ export interface CodingDraftsApi {
   // Chamado quando o servidor confirmou a ESCRITA (`success: true`), inclusive
   // quando o documento segue pendente por obrigatória em aberto.
   submitConfirmed(docId: string, saved: CodingSnapshot): void;
+  // Abre um documento: estabelece o baseline a partir do que o servidor
+  // entregou e classifica o slot. Chamado de um effect pelo consumidor — e não
+  // recebido como parâmetro — porque o documento ativo só é conhecido DEPOIS dos
+  // hooks de modo, que por sua vez precisam do `recordDraft` daqui.
+  //
+  // Como a leitura do storage acontece só aqui, e effects não rodam no SSR, o
+  // primeiro render do cliente é idêntico ao do servidor por construção: nenhuma
+  // flag de hidratação é necessária.
+  openDocument(docId: string | null, remote: CodingSnapshot | null): void;
   recovery: CodingDraftRecovery;
-  isHydrated: boolean;
   storageAvailable: boolean;
   staleDiscardedCount: number;
 }
@@ -85,9 +93,6 @@ export interface UseCodingDraftsParams {
   // `false` sob impersonação ou rodada anterior: a tela é read-only e gravar
   // rascunho ali depositaria trabalho num slot que ninguém vai enviar.
   enabled: boolean;
-  openDocId: string | null;
-  // O que o servidor entregou no render para o documento aberto.
-  remote: CodingSnapshot | null;
   fields: PydanticField[];
 }
 
@@ -233,7 +238,7 @@ export function collectCodingDraftGarbage(
 }
 
 export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi {
-  const { projectId, userId, enabled, openDocId } = params;
+  const { projectId, userId, enabled } = params;
 
   // Refs atualizados a cada render, para que os effects de flush possam ser
   // registrados uma única vez e ainda ler o estado mais recente — mesmo padrão
@@ -242,20 +247,17 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
   const timersRef = useRef<Map<string, number>>(new Map());
   const keyPartsRef = useRef({ projectId, userId, enabled });
   keyPartsRef.current = { projectId, userId, enabled };
-  const remoteRef = useRef(params.remote);
-  remoteRef.current = params.remote;
   const fieldsRef = useRef(params.fields);
   fieldsRef.current = params.fields;
 
   const [recovery, setRecovery] = useState<CodingDraftRecovery>({ kind: "none" });
   const [storageAvailable, setStorageAvailable] = useState(true);
   const [staleDiscardedCount, setStaleDiscardedCount] = useState(0);
-  // A tela de codificação não pode esperar hidratação atrás de um skeleton — ela
-  // mostra o texto do documento a partir do servidor. `isHydrated` protege só a
-  // faixa de recuperação, que é UI aditiva: um elemento que aparece, não uma
-  // página que troca.
-  const [isHydrated, setIsHydrated] = useState(false);
-  useEffect(() => setIsHydrated(true), []);
+  // Último documento aberto: o GC nunca evicta o slot dele.
+  const openDocIdRef = useRef<string | null>(null);
+  // Distingue "nunca abriu" de "abriu o documento null": sem isso, a primeira
+  // chamada com `null` cairia no guard de idempotência e o GC nunca rodaria.
+  const openedOnceRef = useRef(false);
 
   const persist = useCallback((docId: string, token: string) => {
     const { projectId: pid, userId: uid, enabled: on } = keyPartsRef.current;
@@ -417,61 +419,76 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
     [dropSlot],
   );
 
-  // Leitura e classificação ao abrir um documento. Roda pós-hidratação, fora do
-  // seed do reducer: semear o formulário a partir do rascunho SERIA aplicá-lo em
-  // silêncio, e a issue pede o contrário.
-  useEffect(() => {
-    if (!isHydrated || !enabled || !openDocId) {
-      setRecovery({ kind: "none" });
-      return;
-    }
-    const scope = scopeFor({ projectId, userId }, openDocId);
-    const slot = readSlot(scope);
-    setStorageAvailable(slot.available);
-    if (slot.staleFormat) setStaleDiscardedCount((n) => n + 1);
+  // Leitura e classificação ao abrir um documento. Fora do seed do reducer de
+  // propósito: semear o formulário a partir do rascunho SERIA aplicá-lo em
+  // silêncio, e a issue pede o contrário. Idempotente por documento — reabrir o
+  // mesmo id não reclassifica, senão cada revalidação do RSC ressuscitaria uma
+  // oferta que a pesquisadora acabou de descartar.
+  const openDocument = useCallback(
+    (docId: string | null, remote: CodingSnapshot | null) => {
+      const { projectId: pid, userId: uid, enabled: on } = keyPartsRef.current;
+      if (openedOnceRef.current && openDocIdRef.current === docId) return;
+      const firstOpen = !openedOnceRef.current;
+      openedOnceRef.current = true;
+      openDocIdRef.current = docId;
 
-    const remote = remoteRef.current ?? { answers: {}, notes: "" };
+      // O GC roda na PRIMEIRA abertura, não num effect de mount: é aqui que se
+      // sabe qual slot preservar. Num effect de mount, `openDocument` ainda não
+      // teria sido chamado (o consumidor o chama do próprio effect, declarado
+      // depois), `keepKey` seria nulo, e o rascunho do documento na tela entraria
+      // na varredura — expirado ou acima do teto, seria apagado debaixo da
+      // pesquisadora.
+      if (firstOpen && on) {
+        const keep = docId
+          ? codingDraftStorageKey(scopeFor({ projectId: pid, userId: uid }, docId))
+          : null;
+        const collected = collectCodingDraftGarbage(uid, Date.now(), keep);
+        if (collected.staleDiscarded > 0) {
+          setStaleDiscardedCount((n) => n + collected.staleDiscarded);
+        }
+      }
 
-    // Abrir estabelece o baseline do documento — o hook é dono único dele a
-    // partir daqui. Preserva `persistedToken` de uma edição anterior nesta mesma
-    // sessão (ir e voltar entre documentos não pode fazer a aba perder a posse
-    // do próprio slot).
-    const previous = stateRef.current.get(openDocId);
-    stateRef.current.set(openDocId, {
-      base: remote,
-      draft: previous?.draft ?? null,
-      writeToken: previous?.writeToken ?? null,
-      persistedToken: previous?.persistedToken ?? null,
-      blocked: previous?.blocked ?? false,
-    });
+      if (!on || !docId) {
+        setRecovery({ kind: "none" });
+        return;
+      }
 
-    const classified = classifyCodingDraft(slot.envelope, remote, fieldsRef.current);
-    if (classified.kind === "redundant" && slot.envelope) {
-      // Repete o servidor: some do caminho em vez de virar ruído recorrente.
-      deleteSlotIfTokenMatches(scope, slot.envelope.writeToken);
-      setRecovery({ kind: "none" });
-      return;
-    }
-    if (classified.kind === "resumable" || classified.kind === "diverged") {
+      const scope = scopeFor({ projectId: pid, userId: uid }, docId);
+      const slot = readSlot(scope);
+      setStorageAvailable(slot.available);
+      if (slot.staleFormat) setStaleDiscardedCount((n) => n + 1);
+
+      const baseline = remote ?? { answers: {}, notes: "" };
+
+      // Abrir estabelece o baseline do documento — o hook é dono único dele a
+      // partir daqui. Preserva `persistedToken` de uma edição anterior nesta
+      // mesma sessão: ir e voltar entre documentos não pode fazer a aba perder a
+      // posse do próprio slot.
+      const previous = stateRef.current.get(docId);
+      stateRef.current.set(docId, {
+        base: previous?.draft ? previous.base : baseline,
+        draft: previous?.draft ?? null,
+        writeToken: previous?.writeToken ?? null,
+        persistedToken: previous?.persistedToken ?? null,
+        blocked: previous?.blocked ?? false,
+      });
+
+      const classified = classifyCodingDraft(slot.envelope, baseline, fieldsRef.current);
+      if (classified.kind === "redundant" && slot.envelope) {
+        // Repete o servidor: some do caminho em vez de virar ruído recorrente.
+        deleteSlotIfTokenMatches(scope, slot.envelope.writeToken);
+        setRecovery({ kind: "none" });
+        return;
+      }
       // Posse do slot é assumida só ao retomar; até lá, apenas oferecemos.
-      setRecovery(classified);
-      return;
-    }
-    setRecovery({ kind: "none" });
-  }, [isHydrated, enabled, openDocId, projectId, userId]);
-
-  // GC uma vez por mount, pós-hidratação.
-  useEffect(() => {
-    if (!isHydrated || !enabled) return;
-    const keep = openDocId
-      ? codingDraftStorageKey(scopeFor({ projectId, userId }, openDocId))
-      : null;
-    const result = collectCodingDraftGarbage(userId, Date.now(), keep);
-    if (result.staleDiscarded > 0) setStaleDiscardedCount((n) => n + result.staleDiscarded);
-    // Roda no mount; `openDocId` entra como valor inicial apenas — reagir a cada
-    // navegação transformaria o GC num custo por documento visitado.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isHydrated, enabled, userId, projectId]);
+      setRecovery(
+        classified.kind === "resumable" || classified.kind === "diverged"
+          ? classified
+          : { kind: "none" },
+      );
+    },
+    [],
+  );
 
   // Flush garantido nos três gatilhos que o navegador oferece, mais o unmount.
   // O `beforeunload` aqui só persiste; quem avisa a pesquisadora é o guard de
@@ -493,12 +510,12 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
   }, [flushAll]);
 
   return {
+    openDocument,
     recordDraft,
     restoreDraft,
     discardDraft,
     submitConfirmed,
     recovery,
-    isHydrated,
     storageAvailable,
     staleDiscardedCount,
   };

--- a/frontend/src/hooks/useDirtyDocs.ts
+++ b/frontend/src/hooks/useDirtyDocs.ts
@@ -1,38 +1,111 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 
 /**
- * Rastreamento de documentos "sujos" (editados sem salvar) por id.
+ * Rastreamento de documentos "sujos" (editados sem enviar) por id.
  *
- * Usa `useRef` em vez de `useState`: marcar/limpar não precisa re-renderizar
- * (nada do conjunto é exibido na tela) — isso zera o `rerender-state-only-in-
- * handlers` que o `CodingPage` disparava com um `useState<Set>`. Como o valor
- * é um ref, `isDirty` é uma **função** lida em tempo de evento (handlers e o
- * unload do autosave-on-exit), nunca durante o render.
+ * O conjunto vive num `useRef` e as mutações não passam por `setState`: marcar
+ * e limpar acontecem em tempo de evento, e um `useState<Set>` aqui disparava o
+ * `rerender-state-only-in-handlers` no `CodingPage`. `isDirty` continua sendo
+ * uma **função** lida em tempo de evento, nunca durante o render — os callers
+ * imperativos (guards de navegação, handlers) seguem inalterados.
+ *
+ * O que mudou com o #608: a tela passou a precisar EXIBIR "há alterações não
+ * enviadas", e isso exige um sinal reativo. Em vez de duplicar o conjunto num
+ * estado paralelo — duas fontes para o mesmo fato, que divergem —, o ref ganhou
+ * um `subscribe` e um contador de versão, e a leitura reativa sai de
+ * `useSyncExternalStore` sobre esse contador. O estado passa a ser genuinamente
+ * renderizado, então o diagnóstico que motivou o ref não se aplica à leitura.
+ *
+ * Este é deliberadamente o sinal que alimenta o indicador de "não enviado", e
+ * NÃO o resultado da persistência local: sujeira é um fato da memória, gravar é
+ * best-effort. Com o localStorage bloqueado (janela anônima) ou a quota
+ * estourada, um indicador derivado do storage diria "tudo enviado" enquanto há
+ * edição pendente no reducer — exatamente a classe de mentira que o #608 existe
+ * para eliminar. Os dois sinais são distintos e ambos visíveis.
  */
-export function useDirtyDocs(): {
+export interface DirtyDocsStore {
   markDirty: (docId: string) => void;
   markClean: (docId: string) => void;
   isDirty: (docId: string | null | undefined) => boolean;
-} {
-  // `useRef(null)` + init lazy dentro dos callbacks (tempo de evento): não
-  // realoca o Set a cada render e nunca acessa o ref durante o render.
+  subscribe: (listener: () => void) => () => void;
+  getVersion: () => number;
+  getDirtyCount: () => number;
+}
+
+export function useDirtyDocs(): DirtyDocsStore {
   const ref = useRef<Set<string> | null>(null);
+  const listenersRef = useRef<Set<() => void> | null>(null);
+  // Snapshot primitivo. Devolver o próprio `Set` faria `useSyncExternalStore`
+  // comparar por identidade e re-renderizar em loop a cada mutação in-place.
+  const versionRef = useRef(0);
 
-  const markDirty = useCallback((docId: string) => {
-    (ref.current ??= new Set()).add(docId);
+  const emit = useCallback(() => {
+    versionRef.current += 1;
+    listenersRef.current?.forEach((listener) => listener());
   }, []);
 
-  const markClean = useCallback((docId: string) => {
-    (ref.current ??= new Set()).delete(docId);
-  }, []);
+  const markDirty = useCallback(
+    (docId: string) => {
+      const set = (ref.current ??= new Set());
+      if (set.has(docId)) return;
+      set.add(docId);
+      emit();
+    },
+    [emit],
+  );
+
+  const markClean = useCallback(
+    (docId: string) => {
+      const set = (ref.current ??= new Set());
+      if (!set.delete(docId)) return;
+      emit();
+    },
+    [emit],
+  );
 
   const isDirty = useCallback(
-    (docId: string | null | undefined) =>
-      !!docId && (ref.current ??= new Set()).has(docId),
+    (docId: string | null | undefined) => !!docId && (ref.current ??= new Set()).has(docId),
     [],
   );
 
-  return { markDirty, markClean, isDirty };
+  const subscribe = useCallback((listener: () => void) => {
+    const listeners = (listenersRef.current ??= new Set());
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  const getVersion = useCallback(() => versionRef.current, []);
+  const getDirtyCount = useCallback(() => ref.current?.size ?? 0, []);
+
+  return useMemo(
+    () => ({ markDirty, markClean, isDirty, subscribe, getVersion, getDirtyCount }),
+    [markDirty, markClean, isDirty, subscribe, getVersion, getDirtyCount],
+  );
+}
+
+// Leitura reativa por documento. `getVersion` é o snapshot; o predicado é
+// reavaliado a cada notificação.
+export function useIsDocDirty(
+  store: DirtyDocsStore,
+  docId: string | null | undefined,
+): boolean {
+  const version = useSyncExternalStore(
+    store.subscribe,
+    store.getVersion,
+    // No servidor não há sujeira: o valor inicial precisa casar com o primeiro
+    // render do cliente, senão o React acusa mismatch de hidratação.
+    () => 0,
+  );
+  return useMemo(() => store.isDirty(docId), [store, docId, version]);
+}
+
+// Quantos documentos têm alterações não enviadas — o sinal do aviso de saída,
+// que precisa valer para a fila inteira, não só para o documento aberto.
+export function useDirtyDocsCount(store: DirtyDocsStore): number {
+  const version = useSyncExternalStore(store.subscribe, store.getVersion, () => 0);
+  return useMemo(() => store.getDirtyCount(), [store, version]);
 }

--- a/frontend/src/hooks/useDirtyDocs.ts
+++ b/frontend/src/hooks/useDirtyDocs.ts
@@ -31,7 +31,6 @@ export interface DirtyDocsStore {
   isDirty: (docId: string | null | undefined) => boolean;
   subscribe: (listener: () => void) => () => void;
   getVersion: () => number;
-  getDirtyCount: () => number;
 }
 
 export function useDirtyDocs(): DirtyDocsStore {
@@ -79,11 +78,10 @@ export function useDirtyDocs(): DirtyDocsStore {
   }, []);
 
   const getVersion = useCallback(() => versionRef.current, []);
-  const getDirtyCount = useCallback(() => ref.current?.size ?? 0, []);
 
   return useMemo(
-    () => ({ markDirty, markClean, isDirty, subscribe, getVersion, getDirtyCount }),
-    [markDirty, markClean, isDirty, subscribe, getVersion, getDirtyCount],
+    () => ({ markDirty, markClean, isDirty, subscribe, getVersion }),
+    [markDirty, markClean, isDirty, subscribe, getVersion],
   );
 }
 
@@ -102,10 +100,4 @@ export function useIsDocDirty(
     // cliente, senão o React acusa mismatch de hidratação.
     () => false,
   );
-}
-
-// Quantos documentos têm alterações não enviadas — o sinal do aviso de saída,
-// que precisa valer para a fila inteira, não só para o documento aberto.
-export function useDirtyDocsCount(store: DirtyDocsStore): number {
-  return useSyncExternalStore(store.subscribe, store.getDirtyCount, () => 0);
 }

--- a/frontend/src/hooks/useDirtyDocs.ts
+++ b/frontend/src/hooks/useDirtyDocs.ts
@@ -87,25 +87,25 @@ export function useDirtyDocs(): DirtyDocsStore {
   );
 }
 
-// Leitura reativa por documento. `getVersion` é o snapshot; o predicado é
-// reavaliado a cada notificação.
+// Leitura reativa por documento. O snapshot é o próprio booleano — primitivo,
+// portanto estável por valor: devolver o `Set` faria o React comparar por
+// identidade e re-renderizar em loop, já que o conjunto é mutado in-place.
 export function useIsDocDirty(
   store: DirtyDocsStore,
   docId: string | null | undefined,
 ): boolean {
-  const version = useSyncExternalStore(
+  const getSnapshot = useCallback(() => store.isDirty(docId), [store, docId]);
+  return useSyncExternalStore(
     store.subscribe,
-    store.getVersion,
-    // No servidor não há sujeira: o valor inicial precisa casar com o primeiro
-    // render do cliente, senão o React acusa mismatch de hidratação.
-    () => 0,
+    getSnapshot,
+    // No servidor não há sujeira: o valor precisa casar com o primeiro render do
+    // cliente, senão o React acusa mismatch de hidratação.
+    () => false,
   );
-  return useMemo(() => store.isDirty(docId), [store, docId, version]);
 }
 
 // Quantos documentos têm alterações não enviadas — o sinal do aviso de saída,
 // que precisa valer para a fila inteira, não só para o documento aberto.
 export function useDirtyDocsCount(store: DirtyDocsStore): number {
-  const version = useSyncExternalStore(store.subscribe, store.getVersion, () => 0);
-  return useMemo(() => store.getDirtyCount(), [store, version]);
+  return useSyncExternalStore(store.subscribe, store.getDirtyCount, () => 0);
 }

--- a/frontend/src/lib/__tests__/coding-autosave.test.ts
+++ b/frontend/src/lib/__tests__/coding-autosave.test.ts
@@ -53,7 +53,7 @@ describe("autosaveDirtyDoc", () => {
     docId: "d1",
     answers: { q: "sim" },
     notes: "nota",
-    markClean: vi.fn(),
+    onSaved: vi.fn(),
   });
 
   it("não limpa a sujeira e usa a mensagem de navegação quando o transporte rejeita", async () => {
@@ -63,7 +63,7 @@ describe("autosaveDirtyDoc", () => {
     autosaveDirtyDoc(p);
     await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
 
-    expect(p.markClean).not.toHaveBeenCalled();
+    expect(p.onSaved).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(CODING_AUTOSAVE_TRANSPORT_ERROR);
     // A mensagem do save aguardado ("continuam nesta página") apontaria para o
     // documento que o pesquisador acabou de deixar.
@@ -80,18 +80,25 @@ describe("autosaveDirtyDoc", () => {
     autosaveDirtyDoc(p);
     await vi.waitFor(() => expect(toast.error).toHaveBeenCalled());
 
-    expect(p.markClean).not.toHaveBeenCalled();
+    expect(p.onSaved).not.toHaveBeenCalled();
     expect(toast.error).toHaveBeenCalledWith(
       "Documento removido do escopo do projeto",
     );
   });
 
-  it("limpa a sujeira e salva como autosave no sucesso", async () => {
+  it("notifica o sucesso com o snapshot GRAVADO e salva como autosave", async () => {
     mockSave.mockResolvedValue({ success: true });
     const p = params();
 
     autosaveDirtyDoc(p);
-    await vi.waitFor(() => expect(p.markClean).toHaveBeenCalledWith("d1"));
+    // O snapshot volta no callback para que o caller rebaseie o baseline do
+    // rascunho local sem recompor o que acabou de mandar ao servidor (#608).
+    await vi.waitFor(() =>
+      expect(p.onSaved).toHaveBeenCalledWith("d1", {
+        answers: { q: "sim" },
+        notes: "nota",
+      }),
+    );
 
     expect(mockSave).toHaveBeenCalledWith(
       "p1",
@@ -108,13 +115,13 @@ describe("autosaveDirtyDoc", () => {
     process.on("unhandledRejection", unhandled);
     const p = {
       ...params(),
-      markClean: vi.fn(() => {
-        throw new Error("markClean explodiu");
+      onSaved: vi.fn(() => {
+        throw new Error("onSaved explodiu");
       }),
     };
 
     autosaveDirtyDoc(p);
-    await vi.waitFor(() => expect(p.markClean).toHaveBeenCalled());
+    await vi.waitFor(() => expect(p.onSaved).toHaveBeenCalled());
     await new Promise((r) => setImmediate(r));
 
     process.off("unhandledRejection", unhandled);

--- a/frontend/src/lib/__tests__/coding-draft.test.ts
+++ b/frontend/src/lib/__tests__/coding-draft.test.ts
@@ -1,0 +1,290 @@
+// Camada pura do rascunho local de respostas (#608). O que se fixa aqui é a
+// leitura fail-closed do envelope e a classificação que decide o que a faixa de
+// recuperação oferece — as duas coisas de que depende a promessa "o rascunho é
+// oferecido, nunca aplicado em silêncio". O I/O (chave, compare-and-swap,
+// debounce, GC) é coberto por `useCodingDrafts.test.ts`.
+import { describe, it, expect } from "vitest";
+import {
+  CODING_DRAFT_FORMAT_VERSION,
+  CODING_DRAFT_NOTES_KEY,
+  classifyCodingDraft,
+  codingDraftStorageKey,
+  codingDraftUserPrefix,
+  diffCodingSnapshots,
+  envelopeMatchesScope,
+  readCodingDraft,
+  sameCodingSnapshot,
+  type CodingDraftEnvelope,
+  type CodingSnapshot,
+} from "@/lib/coding-draft";
+import type { PydanticField } from "@/lib/types";
+
+const field = (name: string, extra: Partial<PydanticField> = {}): PydanticField =>
+  ({ name, type: "text", options: null, description: "", ...extra }) as PydanticField;
+
+const FIELDS = [field("q1"), field("q2")];
+
+const snapshot = (
+  answers: Record<string, unknown>,
+  notes = "",
+): CodingSnapshot => ({ answers, notes });
+
+const SCOPE = { userId: "u-1", projectId: "p-1", documentId: "d-1" };
+
+const envelope = (over: Partial<CodingDraftEnvelope> = {}): CodingDraftEnvelope => ({
+  formatVersion: CODING_DRAFT_FORMAT_VERSION,
+  writeToken: "tok-1",
+  userId: "u-1",
+  projectId: "p-1",
+  documentId: "d-1",
+  updatedAt: 1_700_000_000_000,
+  base: snapshot({ q1: "a" }),
+  draft: snapshot({ q1: "a", q2: "b" }),
+  ...over,
+});
+
+const raw = (value: unknown): string => JSON.stringify(value);
+
+describe("codingDraftStorageKey — escopo da chave", () => {
+  // O usuário na chave é o que impede duas pesquisadoras que dividem a mesma
+  // máquina de verem o rascunho uma da outra: nada limpa o localStorage no
+  // logout. Mutação que fica vermelha: tirar `userId` da composição.
+  it("separa usuários no mesmo documento", () => {
+    const a = codingDraftStorageKey(SCOPE);
+    const b = codingDraftStorageKey({ ...SCOPE, userId: "u-2" });
+    expect(a).not.toBe(b);
+    expect(a).toContain("u-1");
+  });
+
+  it("separa documentos do mesmo projeto", () => {
+    expect(codingDraftStorageKey(SCOPE)).not.toBe(
+      codingDraftStorageKey({ ...SCOPE, documentId: "d-2" }),
+    );
+  });
+
+  // O GC varre por este prefixo; se ele não delimitasse o usuário, a varredura
+  // alcançaria o slot de um colega na mesma máquina.
+  it("o prefixo de varredura do GC contém o usuário e casa com a chave", () => {
+    expect(codingDraftStorageKey(SCOPE).startsWith(codingDraftUserPrefix("u-1"))).toBe(true);
+    expect(codingDraftStorageKey(SCOPE).startsWith(codingDraftUserPrefix("u-2"))).toBe(false);
+  });
+});
+
+describe("readCodingDraft — leitura fail-closed", () => {
+  it("lê um envelope válido", () => {
+    const read = readCodingDraft(raw(envelope()));
+    expect(read.kind).toBe("draft");
+  });
+
+  it("slot vazio é `empty`", () => {
+    expect(readCodingDraft(null).kind).toBe("empty");
+    expect(readCodingDraft("").kind).toBe("empty");
+  });
+
+  it("JSON quebrado é `empty`, não lança", () => {
+    expect(readCodingDraft("{nao-e-json").kind).toBe("empty");
+  });
+
+  // Mutação vermelha: trocar `z.strictObject` por `z.object`. Uma propriedade
+  // desconhecida significa que o envelope foi escrito por um contrato que não é
+  // este; aceitá-la parcialmente aplicaria dado de origem desconhecida.
+  it("propriedade desconhecida no envelope não vira `draft`", () => {
+    const read = readCodingDraft(raw({ ...envelope(), extra: 1 }));
+    expect(read.kind).toBe("stale-format");
+  });
+
+  // Mutação vermelha: devolver `stale-format` para formato maior. Um envelope
+  // de formato MAIOR foi escrito por um build que sabe mais — durante um deploy,
+  // a aba velha não pode assumir o slot da aba nova.
+  it("formato maior cede o slot (`newer-format`)", () => {
+    const read = readCodingDraft(raw({ formatVersion: CODING_DRAFT_FORMAT_VERSION + 1 }));
+    expect(read).toEqual({
+      kind: "newer-format",
+      formatVersion: CODING_DRAFT_FORMAT_VERSION + 1,
+    });
+  });
+
+  // Mutação vermelha: colapsar `stale-format` em `empty`. "Não havia rascunho" e
+  // "havia um que não consegui ler" são fatos diferentes — o segundo precisa ser
+  // contado para a pesquisadora, senão todo bump de formato apaga trabalho calado.
+  it("formato antigo é `stale-format`, distinto de `empty`", () => {
+    const read = readCodingDraft(raw({ formatVersion: 0, writeToken: "x" }));
+    expect(read).toEqual({ kind: "stale-format", formatVersion: 0 });
+  });
+
+  it("envelope do formato corrente porém corrompido é `stale-format`, não `empty`", () => {
+    const read = readCodingDraft(raw({ ...envelope(), writeToken: "" }));
+    expect(read.kind).toBe("stale-format");
+  });
+
+  it("rejeita `notes` ausente e `answers` em forma errada", () => {
+    expect(readCodingDraft(raw({ ...envelope(), draft: { answers: {} } })).kind).toBe(
+      "stale-format",
+    );
+    expect(
+      readCodingDraft(raw({ ...envelope(), draft: { answers: [], notes: "" } })).kind,
+    ).toBe("stale-format");
+  });
+
+  // A contrapartida do `z.record(z.string(), z.unknown())`: um valor que não
+  // casa com o tipo do campo no schema ATUAL ainda é um envelope legível. O
+  // schema pode ter mudado desde a escrita; quem filtra é `sanitizeStoredAnswers`
+  // na hora de aplicar. Mutação vermelha: tipar `answers` por campo.
+  it("aceita valor de qualquer forma em `answers` (o schema pode ter mudado)", () => {
+    const read = readCodingDraft(
+      raw(envelope({ draft: snapshot({ q1: { doenca: "x" }, q2: ["a", "b"] }) })),
+    );
+    expect(read.kind).toBe("draft");
+  });
+});
+
+describe("envelopeMatchesScope — o envelope certo no slot certo", () => {
+  // Mutação vermelha: remover a checagem. O separador da chave é `:` e três
+  // UUIDs se parecem; sem esta segunda barreira, um bug de parse aplicaria as
+  // respostas de um documento em outro — dado de pesquisa fabricado em silêncio.
+  it("recusa envelope cuja identidade embutida discorda da chave", () => {
+    expect(envelopeMatchesScope(envelope(), SCOPE)).toBe(true);
+    expect(envelopeMatchesScope(envelope({ documentId: "d-9" }), SCOPE)).toBe(false);
+    expect(envelopeMatchesScope(envelope({ userId: "u-9" }), SCOPE)).toBe(false);
+    expect(envelopeMatchesScope(envelope({ projectId: "p-9" }), SCOPE)).toBe(false);
+  });
+});
+
+describe("diffCodingSnapshots — o que difere", () => {
+  it("nomeia os campos que diferem", () => {
+    expect(
+      diffCodingSnapshots(snapshot({ q1: "a", q2: "x" }), snapshot({ q1: "a" }), FIELDS),
+    ).toEqual(["q2"]);
+  });
+
+  // Mutação vermelha: trocar `stableStringify` por `JSON.stringify`. Um grupo de
+  // subcampos que faz round-trip pelo jsonb volta com as chaves em outra ordem;
+  // contá-lo como edição faria a faixa oferecer um rascunho idêntico ao servidor.
+  it("reordenar chaves de um valor composto não conta como diferença", () => {
+    const a = snapshot({ q1: { cid: "G12", doenca: "AME" } });
+    const b = snapshot({ q1: { doenca: "AME", cid: "G12" } });
+    expect(diffCodingSnapshots(a, b, FIELDS)).toEqual([]);
+    expect(sameCodingSnapshot(a, b, FIELDS)).toBe(true);
+  });
+
+  // Mutação vermelha: iterar as chaves de `answers` em vez de `fields`. Um campo
+  // que saiu do schema não seria reescrito ao aplicar (`sanitizeStoredAnswers` o
+  // descarta), então contá-lo faria a faixa prometer uma mudança que não ocorre.
+  it("ignora campo que saiu do schema", () => {
+    expect(
+      diffCodingSnapshots(snapshot({ q1: "a", removido: "z" }), snapshot({ q1: "a" }), FIELDS),
+    ).toEqual([]);
+  });
+
+  it("as notas entram no diff sob a chave que o servidor já usa", () => {
+    expect(diffCodingSnapshots(snapshot({}, "nota"), snapshot({}, ""), FIELDS)).toEqual([
+      CODING_DRAFT_NOTES_KEY,
+    ]);
+  });
+
+  it("ausente e vazio são distintos; ausente e ausente são iguais", () => {
+    expect(diffCodingSnapshots(snapshot({ q1: "" }), snapshot({}), FIELDS)).toEqual(["q1"]);
+    expect(diffCodingSnapshots(snapshot({}), snapshot({}), FIELDS)).toEqual([]);
+  });
+});
+
+describe("classifyCodingDraft — o que a faixa oferece", () => {
+  const remote = snapshot({ q1: "a" });
+
+  it("sem envelope, não há nada a oferecer", () => {
+    expect(classifyCodingDraft(null, remote, FIELDS)).toEqual({ kind: "none" });
+  });
+
+  // Mutação vermelha: oferecer sempre que houver envelope. Uma faixa que aparece
+  // sem ter o que oferecer ensina a pesquisadora a ignorá-la — e ela deixa de
+  // funcionar no dia em que há trabalho de verdade no slot.
+  it("rascunho que repete o servidor é `redundant`", () => {
+    const r = classifyCodingDraft(
+      envelope({ base: snapshot({}), draft: snapshot({ q1: "a" }) }),
+      remote,
+      FIELDS,
+    );
+    expect(r.kind).toBe("redundant");
+  });
+
+  // Mutação vermelha: devolver sempre `diverged`. Avisar "o documento foi salvo
+  // depois" quando não foi é o mesmo ruído, com o agravante de sugerir perda.
+  it("servidor parado desde o rascunho é `resumable`", () => {
+    const r = classifyCodingDraft(
+      envelope({ base: snapshot({ q1: "a" }), draft: snapshot({ q1: "a", q2: "b" }) }),
+      remote,
+      FIELDS,
+    );
+    expect(r).toMatchObject({ kind: "resumable", changedFields: ["q2"] });
+  });
+
+  it("servidor que andou é `diverged`", () => {
+    const r = classifyCodingDraft(
+      envelope({ base: snapshot({ q1: "antigo" }), draft: snapshot({ q1: "rascunho" }) }),
+      remote,
+      FIELDS,
+    );
+    expect(r.kind).toBe("diverged");
+  });
+
+  // O teste que fixa a decisão de desenho mais fácil de errar, e o único que
+  // separa a interseção de "tudo que o servidor mudou". Mutação vermelha:
+  // `overwrittenFields: remoteMoved`.
+  //
+  // O cenário discriminante exige um campo em que o servidor andou E o rascunho
+  // já coincide com o valor novo — duas abas, ou a mesma pessoa que digitou o
+  // que já fora gravado. Ali retomar não perde nada, e anunciar perda empurra a
+  // pesquisadora a descartar trabalho bom. Cuidado ao editar: com `q2: "antigo"`
+  // no rascunho os dois cálculos dão o mesmo resultado e o teste vira vácuo.
+  it("`overwrittenFields` exclui o campo que o servidor mudou e o rascunho já concorda", () => {
+    const r = classifyCodingDraft(
+      envelope({
+        base: snapshot({ q1: "antigo", q2: "antigo" }),
+        draft: snapshot({ q1: "rascunho", q2: "coincide" }),
+      }),
+      snapshot({ q1: "antigo", q2: "coincide" }),
+      FIELDS,
+    );
+    if (r.kind !== "diverged") throw new Error("esperava diverged");
+    expect(r.changedFields).toEqual(["q1"]);
+    expect(r.overwrittenFields).toEqual([]);
+  });
+
+  // O caso complementar: aqui o rascunho de fato atropela a escrita do servidor,
+  // e o campo PRECISA ser anunciado.
+  it("`overwrittenFields` inclui o campo que o rascunho atropela", () => {
+    const r = classifyCodingDraft(
+      envelope({
+        base: snapshot({ q1: "antigo", q2: "antigo" }),
+        draft: snapshot({ q1: "rascunho", q2: "antigo" }),
+      }),
+      snapshot({ q1: "antigo", q2: "servidor-novo" }),
+      FIELDS,
+    );
+    if (r.kind !== "diverged") throw new Error("esperava diverged");
+    expect(r.changedFields.toSorted()).toEqual(["q1", "q2"]);
+    expect(r.overwrittenFields).toEqual(["q2"]);
+  });
+
+  it("carrega o conteúdo e o instante do rascunho para a faixa", () => {
+    const r = classifyCodingDraft(
+      envelope({ base: snapshot({ q1: "a" }), draft: snapshot({ q1: "a", q2: "b" }) }),
+      remote,
+      FIELDS,
+    );
+    if (r.kind !== "resumable") throw new Error("esperava resumable");
+    expect(r.draft.answers).toEqual({ q1: "a", q2: "b" });
+    expect(r.updatedAt).toBe(1_700_000_000_000);
+  });
+
+  // Um rascunho que só difere num campo removido do schema não tem o que
+  // acrescentar: aplicá-lo não mudaria nada de visível.
+  it("diferença apenas em campo removido do schema é `redundant`", () => {
+    const r = classifyCodingDraft(
+      envelope({ base: snapshot({ q1: "a" }), draft: snapshot({ q1: "a", removido: "z" }) }),
+      remote,
+      FIELDS,
+    );
+    expect(r.kind).toBe("redundant");
+  });
+});

--- a/frontend/src/lib/coding-autosave.ts
+++ b/frontend/src/lib/coding-autosave.ts
@@ -42,14 +42,27 @@ interface AutosaveDirtyDocParams {
   docId: string;
   answers: Record<string, unknown>;
   notes: string;
-  markClean: (docId: string) => void;
+  /**
+   * Único callback de sucesso, e não um par `markClean` + "rebaseia o rascunho":
+   * uma escrita confirmada produz DOIS efeitos que precisam acontecer juntos —
+   * limpar a sujeira e reassentar o baseline do rascunho local no que foi
+   * gravado. Com dois parâmetros, um call site podia passar só o primeiro, e foi
+   * exatamente o que aconteceu quando o rascunho local (#608) entrou: a
+   * navegação salvava, limpava a sujeira e deixava o envelope para trás, e
+   * reabrir o documento oferecia "alterações não enviadas" sobre trabalho já
+   * enviado. Com um callback só, esse estado não é construível.
+   *
+   * Recebe o snapshot GRAVADO para que o caller não precise recompor o que
+   * acabou de mandar ao servidor.
+   */
+  onSaved: (docId: string, saved: { answers: Record<string, unknown>; notes: string }) => void;
 }
 
 /**
  * Autosave fire-and-forget de um doc sujo ao navegar (trocar de doc ou de
- * ordenação no modo Atribuídos). Salva com `isAutoSave: true`, limpa a sujeira
- * no sucesso e mostra toast no erro. O caller é responsável pelo guard de
- * `isDirty` antes de chamar.
+ * ordenação no modo Atribuídos). Salva com `isAutoSave: true`, notifica o
+ * caller no sucesso (ver `onSaved`) e mostra toast no erro. O caller é
+ * responsável pelo guard de `isDirty` antes de chamar.
  *
  * O back do modo Explorar NÃO usa este helper: lá o save é aguardado (`await`)
  * para manter o rascunho intacto se falhar (#257) — semântica diferente.
@@ -59,7 +72,7 @@ export function autosaveDirtyDoc({
   docId,
   answers,
   notes,
-  markClean,
+  onSaved,
 }: AutosaveDirtyDocParams): void {
   void saveCodingResponse(
     projectId,
@@ -70,13 +83,13 @@ export function autosaveDirtyDoc({
   )
     .then((result) => {
       if (result.success) {
-        markClean(docId);
+        onSaved(docId, { answers, notes });
       } else {
         toast.error(result.error);
       }
     })
     // `saveCodingResponse` não rejeita — este `catch` cobre o que vem DEPOIS do
-    // save (`markClean` do caller, render do toast). Sem ele vira unhandled
+    // save (`onSaved` do caller, render do toast). Sem ele vira unhandled
     // rejection, e o `void` já satisfaz o `no-floating-promises`, então nenhum
     // gate reclamaria. O doc simplesmente segue sujo, que é o estado seguro.
     .catch(() => {});

--- a/frontend/src/lib/coding-draft-storage.ts
+++ b/frontend/src/lib/coding-draft-storage.ts
@@ -30,6 +30,16 @@ const DRAFT_DEBOUNCE_MS = 300;
 // nunca importou. Aqui importa, e as três coisas entram junto com a feature:
 // quota estourada degrada em silêncio, que é exatamente o modo de falha que
 // esta issue existe para eliminar.
+//
+// Duas limitações conhecidas e aceitas, registradas aqui para não se perderem
+// (ver #608). Primeiro, retenção: o envelope guarda RESPOSTAS de codificação em
+// claro no `localStorage` por até 30 dias, e nada o limpa no logout. A chave
+// isola usuários entre si, mas não protege contra quem tenha acesso ao mesmo
+// perfil de navegador — em máquina compartilhada, o isolamento real é o perfil,
+// não esta chave. Segundo, o teto é por USUÁRIO e não por projeto: uma sessão
+// longa num projeto pode evictar o rascunho mais antigo de outro projeto do
+// mesmo usuário. Ambas são aceitáveis enquanto o rascunho for uma rede de
+// segurança de curta duração; deixam de ser se ele virar armazenamento primário.
 const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_DRAFTS_PER_USER = 100;
 
@@ -47,6 +57,9 @@ interface DocDraftState {
   // envenenando toda escrita seguinte da sessão.
   persistedToken: string | null;
   // Slot tomado por uma aba que sabe mais (formato maior) ou por outro token.
+  // Para a pesquisadora a consequência é idêntica à do storage indisponível — a
+  // cópia local não está sendo mantida por ESTA aba —, então os dois casos
+  // alimentam o mesmo aviso; ver `persist`.
   blocked: boolean;
 }
 
@@ -78,8 +91,11 @@ export interface CodingDraftsApi {
   // flag de hidratação é necessária.
   openDocument(docId: string | null, remote: CodingSnapshot | null): void;
   recovery: CodingDraftRecovery;
+  // `false` quando esta aba não está conseguindo manter a cópia local — seja
+  // porque o storage não responde (janela anônima, quota estourada) ou porque o
+  // slot pertence a outra aba. Um sinal só: a conclusão para a pesquisadora é a
+  // mesma nos dois casos, e é ela que a faixa comunica.
   storageAvailable: boolean;
-  staleDiscardedCount: number;
 }
 
 export interface UseCodingDraftsParams {
@@ -102,28 +118,30 @@ function scopeFor(
   return { userId: params.userId, projectId: params.projectId, documentId };
 }
 
+// Devolve o que há de aplicável no slot. Um envelope ilegível, de formato
+// antigo ou cuja identidade embutida discorde da chave é indistinguível de slot
+// vazio PARA QUEM VAI OFERECER: em todos esses casos não há conteúdo que se
+// possa aplicar com segurança. Quem trata cada caso de forma diferente é o CAS
+// (`writeSlotIfTokenMatches`, que cede o slot ao `newer-format`) e o GC
+// (`classifyForGc`) — ali a distinção muda a decisão, aqui não mudaria.
 function readSlot(scope: CodingDraftScope): {
   available: boolean;
   envelope: CodingDraftEnvelope | null;
-  staleFormat: boolean;
 } {
   if (typeof window === "undefined") {
-    return { available: false, envelope: null, staleFormat: false };
+    return { available: false, envelope: null };
   }
   try {
     const read = readCodingDraft(window.localStorage.getItem(codingDraftStorageKey(scope)));
-    if (read.kind === "draft") {
-      // Segunda barreira: a chave disse que é deste documento, o conteúdo
-      // precisa concordar. Discordância vira "sem rascunho", nunca aplicação
-      // cruzada — ver `envelopeMatchesScope`.
-      if (!envelopeMatchesScope(read.draft, scope)) {
-        return { available: true, envelope: null, staleFormat: true };
-      }
-      return { available: true, envelope: read.draft, staleFormat: false };
+    // Segunda barreira: a chave disse que é deste documento, o conteúdo precisa
+    // concordar. Discordância vira "sem rascunho", nunca aplicação cruzada — ver
+    // `envelopeMatchesScope`.
+    if (read.kind === "draft" && envelopeMatchesScope(read.draft, scope)) {
+      return { available: true, envelope: read.draft };
     }
-    return { available: true, envelope: null, staleFormat: read.kind === "stale-format" };
+    return { available: true, envelope: null };
   } catch {
-    return { available: false, envelope: null, staleFormat: false };
+    return { available: false, envelope: null };
   }
 }
 
@@ -166,7 +184,6 @@ function deleteSlotIfTokenMatches(
 
 interface GcResult {
   removed: number;
-  staleDiscarded: number;
 }
 
 // Varredura escopada ao prefixo do PRÓPRIO usuário, uma vez por mount. Nunca
@@ -175,16 +192,15 @@ interface GcResult {
 // mais) nem no documento aberto.
 // Destino de uma chave na varredura do GC. Separado do loop porque é a regra
 // que precisa ser lida com atenção: cada `keep` aqui protege trabalho de alguém.
-type GcVerdict = "keep" | "drop" | "drop-stale";
+type GcVerdict = "keep" | "drop";
 
 function classifyForGc(key: string, now: number): GcVerdict {
   const read = readCodingDraft(window.localStorage.getItem(key));
   // Envelope de formato maior é de uma aba que sabe mais: apagá-lo destruiria
   // trabalho que não temos como recuperar.
   if (read.kind === "newer-format") return "keep";
-  // "Havia trabalho aqui e não sei ler" é um fato que a pesquisadora precisa
-  // saber; some do slot, não do aviso.
-  if (read.kind === "stale-format") return "drop-stale";
+  // Ilegível ou de formato antigo: não há como aplicar o conteúdo, e mantê-lo
+  // ocuparia quota para sempre — sai do slot como qualquer outro lixo.
   if (read.kind !== "draft") return "drop";
 
   const embedded = codingDraftStorageKey({
@@ -205,11 +221,10 @@ function sweepOwnKeys(
   userId: string,
   now: number,
   keepKey: string | null,
-): { survivors: Array<{ key: string; updatedAt: number }>; doomed: string[]; staleDiscarded: number } {
+): { survivors: Array<{ key: string; updatedAt: number }>; doomed: string[] } {
   const prefix = codingDraftUserPrefix(userId);
   const survivors: Array<{ key: string; updatedAt: number }> = [];
   const doomed: string[] = [];
-  let staleDiscarded = 0;
 
   for (let i = 0; i < window.localStorage.length; i += 1) {
     const key = window.localStorage.key(i);
@@ -224,10 +239,9 @@ function sweepOwnKeys(
       if (envelope) survivors.push({ key, updatedAt: envelope.updatedAt });
       continue;
     }
-    if (verdict === "drop-stale") staleDiscarded += 1;
     doomed.push(key);
   }
-  return { survivors, doomed, staleDiscarded };
+  return { survivors, doomed };
 }
 
 function collectCodingDraftGarbage(
@@ -235,11 +249,10 @@ function collectCodingDraftGarbage(
   now: number,
   keepKey: string | null,
 ): GcResult {
-  if (typeof window === "undefined") return { removed: 0, staleDiscarded: 0 };
-  const result: GcResult = { removed: 0, staleDiscarded: 0 };
+  if (typeof window === "undefined") return { removed: 0 };
+  const result: GcResult = { removed: 0 };
   try {
-    const { survivors, doomed, staleDiscarded } = sweepOwnKeys(userId, now, keepKey);
-    result.staleDiscarded = staleDiscarded;
+    const { survivors, doomed } = sweepOwnKeys(userId, now, keepKey);
 
     // Teto: acima dele, sai o mais antigo primeiro.
     const overflow = survivors.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
@@ -274,7 +287,6 @@ function collectCodingDraftGarbage(
 export interface CodingDraftSessionCallbacks {
   onRecovery(recovery: CodingDraftRecovery): void;
   onStorageAvailable(available: boolean): void;
-  onStaleDiscarded(count: number): void;
 }
 
 export interface CodingDraftSession {
@@ -348,7 +360,12 @@ function persist(
   // Falha NÃO avança `persistedToken`: a próxima edição tenta de novo. Avançá-lo
   // faria a aba colidir com o próprio lixo e nunca mais gravar na sessão.
   st.states.set(docId, { ...state, blocked: outcome === "blocked" });
-  if (outcome === "unavailable") cb.onStorageAvailable(false);
+  // `blocked` avisa junto com `unavailable`, e não em silêncio: o slot pertence
+  // a outra aba (ou a um formato que este build não sabe ler), então ESTA aba
+  // não está mantendo cópia local nenhuma. Reportar só a quota deixaria a
+  // segunda aba aberta no mesmo documento sem rede e sem aviso — a mesma classe
+  // de mentira que o indicador de "não enviado" existe para eliminar.
+  cb.onStorageAvailable(false);
 }
 
 function scheduleWrite(
@@ -419,16 +436,11 @@ function recordDraftIn(
 // ponto que se sabe qual slot preservar: antes disso `keepKey` seria nulo e o
 // rascunho do documento na tela entraria na varredura — expirado ou acima do
 // teto, seria apagado debaixo da pesquisadora.
-function runFirstOpenGc(
-  st: SessionState,
-  cb: CodingDraftSessionCallbacks,
-  docId: string | null,
-): void {
+function runFirstOpenGc(st: SessionState, docId: string | null): void {
   const { projectId, userId, enabled } = st.keyParts;
   if (!enabled) return;
   const keep = docId ? codingDraftStorageKey(scopeFor({ projectId, userId }, docId)) : null;
-  const collected = collectCodingDraftGarbage(userId, Date.now(), keep);
-  if (collected.staleDiscarded > 0) cb.onStaleDiscarded(collected.staleDiscarded);
+  collectCodingDraftGarbage(userId, Date.now(), keep);
 }
 
 // Abrir estabelece o baseline do documento — a sessão é dona única dele a partir
@@ -465,7 +477,7 @@ function openDocumentIn(
   st.openedOnce = true;
   st.openDocId = docId;
 
-  if (firstOpen) runFirstOpenGc(st, cb, docId);
+  if (firstOpen) runFirstOpenGc(st, docId);
 
   if (!enabled || !docId) {
     cb.onRecovery({ kind: "none" });
@@ -475,7 +487,6 @@ function openDocumentIn(
   const scope = scopeFor({ projectId, userId }, docId);
   const slot = readSlot(scope);
   cb.onStorageAvailable(slot.available);
-  if (slot.staleFormat) cb.onStaleDiscarded(1);
 
   const baseline = remote ?? EMPTY_SNAPSHOT;
   seedBaseline(st, docId, baseline);

--- a/frontend/src/lib/coding-draft-storage.ts
+++ b/frontend/src/lib/coding-draft-storage.ts
@@ -5,6 +5,7 @@ import {
   codingDraftUserPrefix,
   envelopeMatchesScope,
   readCodingDraft,
+  parseCodingDraft,
   sameCodingSnapshot,
   type CodingDraftEnvelope,
   type CodingDraftRecovery,
@@ -172,6 +173,63 @@ interface GcResult {
 // toca em chave de outro usuário (numa máquina compartilhada isso seria apagar
 // trabalho alheio) nem em envelope de formato maior (é de uma aba que sabe
 // mais) nem no documento aberto.
+// Destino de uma chave na varredura do GC. Separado do loop porque é a regra
+// que precisa ser lida com atenção: cada `keep` aqui protege trabalho de alguém.
+type GcVerdict = "keep" | "drop" | "drop-stale";
+
+function classifyForGc(key: string, now: number): GcVerdict {
+  const read = readCodingDraft(window.localStorage.getItem(key));
+  // Envelope de formato maior é de uma aba que sabe mais: apagá-lo destruiria
+  // trabalho que não temos como recuperar.
+  if (read.kind === "newer-format") return "keep";
+  // "Havia trabalho aqui e não sei ler" é um fato que a pesquisadora precisa
+  // saber; some do slot, não do aviso.
+  if (read.kind === "stale-format") return "drop-stale";
+  if (read.kind !== "draft") return "drop";
+
+  const embedded = codingDraftStorageKey({
+    userId: read.draft.userId,
+    projectId: read.draft.projectId,
+    documentId: read.draft.documentId,
+  });
+  // Identidade embutida discorda da chave: não dá para saber a que documento o
+  // conteúdo pertence, e aplicar no errado seria pior do que descartar.
+  if (key !== embedded) return "drop";
+  return now - read.draft.updatedAt > DRAFT_TTL_MS ? "drop" : "keep";
+}
+
+// Varredura: separa os slots do usuário em sobreviventes e condenados. Fica
+// fora de `collectCodingDraftGarbage` para que a coleta (decidir) e o descarte
+// (agir) sejam legíveis um de cada vez.
+function sweepOwnKeys(
+  userId: string,
+  now: number,
+  keepKey: string | null,
+): { survivors: Array<{ key: string; updatedAt: number }>; doomed: string[]; staleDiscarded: number } {
+  const prefix = codingDraftUserPrefix(userId);
+  const survivors: Array<{ key: string; updatedAt: number }> = [];
+  const doomed: string[] = [];
+  let staleDiscarded = 0;
+
+  for (let i = 0; i < window.localStorage.length; i += 1) {
+    const key = window.localStorage.key(i);
+    // Fora do prefixo do próprio usuário, o GC não toca: numa máquina
+    // compartilhada isso seria apagar trabalho de um colega. E o documento
+    // aberto na tela nunca é evictado.
+    if (!key || !key.startsWith(prefix) || key === keepKey) continue;
+
+    const verdict = classifyForGc(key, now);
+    if (verdict === "keep") {
+      const envelope = parseCodingDraft(window.localStorage.getItem(key));
+      if (envelope) survivors.push({ key, updatedAt: envelope.updatedAt });
+      continue;
+    }
+    if (verdict === "drop-stale") staleDiscarded += 1;
+    doomed.push(key);
+  }
+  return { survivors, doomed, staleDiscarded };
+}
+
 function collectCodingDraftGarbage(
   userId: string,
   now: number,
@@ -180,44 +238,13 @@ function collectCodingDraftGarbage(
   if (typeof window === "undefined") return { removed: 0, staleDiscarded: 0 };
   const result: GcResult = { removed: 0, staleDiscarded: 0 };
   try {
-    const prefix = codingDraftUserPrefix(userId);
-    const mine: Array<{ key: string; updatedAt: number }> = [];
-    const doomed: string[] = [];
-
-    for (let i = 0; i < window.localStorage.length; i += 1) {
-      const key = window.localStorage.key(i);
-      if (!key || !key.startsWith(prefix) || key === keepKey) continue;
-      const read = readCodingDraft(window.localStorage.getItem(key));
-      if (read.kind === "newer-format") continue;
-      if (read.kind !== "draft") {
-        doomed.push(key);
-        // "Havia trabalho aqui e não sei ler" é um fato que a pesquisadora
-        // precisa saber; some do slot, não do aviso.
-        if (read.kind === "stale-format") result.staleDiscarded += 1;
-        continue;
-      }
-      const embedded = codingDraftStorageKey({
-        userId: read.draft.userId,
-        projectId: read.draft.projectId,
-        documentId: read.draft.documentId,
-      });
-      if (key !== embedded) {
-        // Identidade embutida discorda da chave: não dá para saber a que
-        // documento o conteúdo pertence, e aplicar no errado seria pior.
-        doomed.push(key);
-        continue;
-      }
-      if (now - read.draft.updatedAt > DRAFT_TTL_MS) {
-        doomed.push(key);
-        continue;
-      }
-      mine.push({ key, updatedAt: read.draft.updatedAt });
-    }
+    const { survivors, doomed, staleDiscarded } = sweepOwnKeys(userId, now, keepKey);
+    result.staleDiscarded = staleDiscarded;
 
     // Teto: acima dele, sai o mais antigo primeiro.
-    const overflow = mine.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
+    const overflow = survivors.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
     if (overflow > 0) {
-      mine
+      survivors
         .toSorted((a, b) => a.updatedAt - b.updatedAt)
         .slice(0, overflow)
         .forEach((entry) => doomed.push(entry.key));
@@ -264,6 +291,8 @@ export interface CodingDraftSession {
 // vivem no topo do módulo em vez de fechadas dentro da factory: uma factory com
 // tudo dentro virava uma função de ~230 linhas, e o gate de complexidade a
 // barrava. Como efeito colateral, cada operação fica legível isoladamente.
+const EMPTY_SNAPSHOT: CodingSnapshot = { answers: {}, notes: "" };
+
 interface SessionState {
   states: Map<string, DocDraftState>;
   timers: Map<string, number>;
@@ -357,13 +386,7 @@ function dropSlot(st: SessionState, docId: string, nextBase?: CodingSnapshot): v
   // nova, continua intocado.
   const token = state?.persistedToken ?? readSlot(scope).envelope?.writeToken ?? null;
   deleteSlotIfTokenMatches(scope, token);
-  st.states.set(docId, {
-    base: nextBase ?? state?.base ?? { answers: {}, notes: "" },
-    draft: null,
-    writeToken: null,
-    persistedToken: null,
-    blocked: false,
-  });
+  st.states.set(docId, emptyDocState(nextBase ?? state?.base ?? EMPTY_SNAPSHOT));
 }
 
 function recordDraftIn(
@@ -392,6 +415,42 @@ function recordDraftIn(
   scheduleWrite(st, cb, docId, token);
 }
 
+// GC da primeira abertura. Roda aqui, e não num efeito de mount, porque é neste
+// ponto que se sabe qual slot preservar: antes disso `keepKey` seria nulo e o
+// rascunho do documento na tela entraria na varredura — expirado ou acima do
+// teto, seria apagado debaixo da pesquisadora.
+function runFirstOpenGc(
+  st: SessionState,
+  cb: CodingDraftSessionCallbacks,
+  docId: string | null,
+): void {
+  const { projectId, userId, enabled } = st.keyParts;
+  if (!enabled) return;
+  const keep = docId ? codingDraftStorageKey(scopeFor({ projectId, userId }, docId)) : null;
+  const collected = collectCodingDraftGarbage(userId, Date.now(), keep);
+  if (collected.staleDiscarded > 0) cb.onStaleDiscarded(collected.staleDiscarded);
+}
+
+// Abrir estabelece o baseline do documento — a sessão é dona única dele a partir
+// daqui. Preserva o estado de uma edição anterior nesta mesma sessão: ir e
+// voltar entre documentos não pode fazer a aba perder a posse do próprio slot,
+// nem trocar o baseline de um rascunho vivo.
+function emptyDocState(base: CodingSnapshot): DocDraftState {
+  return { base, draft: null, writeToken: null, persistedToken: null, blocked: false };
+}
+
+function seedBaseline(st: SessionState, docId: string, baseline: CodingSnapshot): void {
+  // Um único default (`?? emptyDocState`) em vez de um por propriedade: o
+  // espalhamento preserva a posse do slot e o rascunho vivo sem repetir a
+  // decisão cinco vezes. Só o baseline é condicional — trocá-lo debaixo de um
+  // rascunho em andamento faria a faixa acusar sobrescrita que não existe.
+  const previous = st.states.get(docId) ?? emptyDocState(baseline);
+  st.states.set(docId, {
+    ...previous,
+    base: previous.draft ? previous.base : baseline,
+  });
+}
+
 function openDocumentIn(
   st: SessionState,
   cb: CodingDraftSessionCallbacks,
@@ -399,22 +458,14 @@ function openDocumentIn(
   remote: CodingSnapshot | null,
 ): void {
   const { projectId, userId, enabled } = st.keyParts;
+  // Idempotente por documento: reabrir o mesmo id não reclassifica, senão cada
+  // revalidação do RSC ressuscitaria uma oferta recém-descartada.
   if (st.openedOnce && st.openDocId === docId) return;
   const firstOpen = !st.openedOnce;
   st.openedOnce = true;
   st.openDocId = docId;
 
-  // O GC roda na PRIMEIRA abertura, não num efeito de mount: é aqui que se sabe
-  // qual slot preservar. Antes disso `openDocument` ainda não foi chamado,
-  // `keepKey` seria nulo, e o rascunho do documento na tela entraria na
-  // varredura — expirado ou acima do teto, seria apagado debaixo da pesquisadora.
-  if (firstOpen && enabled) {
-    const keep = docId
-      ? codingDraftStorageKey(scopeFor({ projectId, userId }, docId))
-      : null;
-    const collected = collectCodingDraftGarbage(userId, Date.now(), keep);
-    if (collected.staleDiscarded > 0) cb.onStaleDiscarded(collected.staleDiscarded);
-  }
+  if (firstOpen) runFirstOpenGc(st, cb, docId);
 
   if (!enabled || !docId) {
     cb.onRecovery({ kind: "none" });
@@ -426,34 +477,30 @@ function openDocumentIn(
   cb.onStorageAvailable(slot.available);
   if (slot.staleFormat) cb.onStaleDiscarded(1);
 
-  const baseline = remote ?? { answers: {}, notes: "" };
+  const baseline = remote ?? EMPTY_SNAPSHOT;
+  seedBaseline(st, docId, baseline);
 
-  // Abrir estabelece o baseline do documento — a sessão é dona única dele a
-  // partir daqui. Preserva `persistedToken` de uma edição anterior nesta mesma
-  // sessão: ir e voltar entre documentos não pode fazer a aba perder a posse do
-  // próprio slot.
-  const previous = st.states.get(docId);
-  st.states.set(docId, {
-    base: previous?.draft ? previous.base : baseline,
-    draft: previous?.draft ?? null,
-    writeToken: previous?.writeToken ?? null,
-    persistedToken: previous?.persistedToken ?? null,
-    blocked: previous?.blocked ?? false,
-  });
+  offerOrClean(cb, scope, slot.envelope, baseline, st.fields);
+}
 
-  const classified = classifyCodingDraft(slot.envelope, baseline, st.fields);
-  if (classified.kind === "redundant" && slot.envelope) {
+// Decide o que a faixa mostra para o slot lido. Posse do slot é assumida só ao
+// retomar; até aqui, apenas oferecemos.
+function offerOrClean(
+  cb: CodingDraftSessionCallbacks,
+  scope: CodingDraftScope,
+  envelope: CodingDraftEnvelope | null,
+  baseline: CodingSnapshot,
+  fields: PydanticField[],
+): void {
+  const classified = classifyCodingDraft(envelope, baseline, fields);
+  if (classified.kind === "redundant" && envelope) {
     // Repete o servidor: some do caminho em vez de virar ruído recorrente.
-    deleteSlotIfTokenMatches(scope, slot.envelope.writeToken);
+    deleteSlotIfTokenMatches(scope, envelope.writeToken);
     cb.onRecovery({ kind: "none" });
     return;
   }
-  // Posse do slot é assumida só ao retomar; até lá, apenas oferecemos.
-  cb.onRecovery(
-    classified.kind === "resumable" || classified.kind === "diverged"
-      ? classified
-      : { kind: "none" },
-  );
+  const offered = classified.kind === "resumable" || classified.kind === "diverged";
+  cb.onRecovery(offered ? classified : { kind: "none" });
 }
 
 export function createCodingDraftSession(

--- a/frontend/src/lib/coding-draft-storage.ts
+++ b/frontend/src/lib/coding-draft-storage.ts
@@ -1,0 +1,522 @@
+import {
+  CODING_DRAFT_FORMAT_VERSION,
+  classifyCodingDraft,
+  codingDraftStorageKey,
+  codingDraftUserPrefix,
+  envelopeMatchesScope,
+  readCodingDraft,
+  sameCodingSnapshot,
+  type CodingDraftEnvelope,
+  type CodingDraftRecovery,
+  type CodingDraftScope,
+  type CodingSnapshot,
+} from "@/lib/coding-draft";
+import { makeId } from "@/lib/utils";
+import type { PydanticField } from "@/lib/types";
+
+// Acesso ao localStorage para o rascunho local de respostas (#608): leitura,
+// compare-and-swap, remoção e coleta de lixo. Sem React e sem estado próprio —
+// cada função recebe o escopo e devolve um resultado tipado, e nenhuma delas
+// lança (storage indisponível vira `unavailable`, nunca exceção na tela).
+//
+// A camada acima (`useCodingDrafts`) cuida do ciclo de vida React; a de baixo
+// (`lib/coding-draft.ts`) é pura e não conhece `window`.
+
+const DRAFT_DEBOUNCE_MS = 300;
+
+// Um slot por documento escala para centenas de chaves, e o padrão herdado de
+// `useSchemaDraft` (um slot por projeto) não tem GC, TTL nem teto — lá isso
+// nunca importou. Aqui importa, e as três coisas entram junto com a feature:
+// quota estourada degrada em silêncio, que é exatamente o modo de falha que
+// esta issue existe para eliminar.
+const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_DRAFTS_PER_USER = 100;
+
+interface DocDraftState {
+  // O que estava na tela quando este rascunho nasceu.
+  base: CodingSnapshot;
+  // Conteúdo pendente de escrita, ou `null` quando o documento está limpo.
+  draft: CodingSnapshot | null;
+  // Token do envelope que queremos gravar (rotaciona a cada edição).
+  writeToken: string | null;
+  // "O que esta aba gravou por último e ainda acredita ser dela". É SEMPRE por
+  // ele que se apaga — nunca pelo token submetido. Ver a armadilha em
+  // `useSchemaDraft.ts:369-376`: o debounce rotaciona o token durante o save, e
+  // apagar pelo token errado deixa o envelope órfão E zera `persistedToken`,
+  // envenenando toda escrita seguinte da sessão.
+  persistedToken: string | null;
+  // Slot tomado por uma aba que sabe mais (formato maior) ou por outro token.
+  blocked: boolean;
+}
+
+export interface CodingDraftsApi {
+  // Registra a edição corrente. Idempotente: conteúdo igual ao baseline limpa o
+  // slot em vez de gravar rascunho vazio.
+  //
+  // O baseline NÃO é parâmetro. Ele é estabelecido na abertura do documento (a
+  // partir do que o servidor entregou) e rebaseado por `submitConfirmed`, e o
+  // hook é seu dono único. Quando o consumidor também o passava a cada tecla,
+  // havia duas fontes para o mesmo fato e a do consumidor sempre vencia — o que
+  // tornava o rebase pós-envio inobservável e deixava um `base` stale entrar no
+  // envelope. Sem o parâmetro, esse estado não é construível.
+  recordDraft(docId: string, draft: CodingSnapshot): void;
+  // Devolve o conteúdo a aplicar e marca a oferta como resolvida. NÃO apaga o
+  // envelope: retomar não é enviar, e o trabalho segue não-enviado.
+  restoreDraft(docId: string): CodingSnapshot | null;
+  discardDraft(docId: string): void;
+  // Chamado quando o servidor confirmou a ESCRITA (`success: true`), inclusive
+  // quando o documento segue pendente por obrigatória em aberto.
+  submitConfirmed(docId: string, saved: CodingSnapshot): void;
+  // Abre um documento: estabelece o baseline a partir do que o servidor
+  // entregou e classifica o slot. Chamado de um effect pelo consumidor — e não
+  // recebido como parâmetro — porque o documento ativo só é conhecido DEPOIS dos
+  // hooks de modo, que por sua vez precisam do `recordDraft` daqui.
+  //
+  // Como a leitura do storage acontece só aqui, e effects não rodam no SSR, o
+  // primeiro render do cliente é idêntico ao do servidor por construção: nenhuma
+  // flag de hidratação é necessária.
+  openDocument(docId: string | null, remote: CodingSnapshot | null): void;
+  recovery: CodingDraftRecovery;
+  storageAvailable: boolean;
+  staleDiscardedCount: number;
+}
+
+export interface UseCodingDraftsParams {
+  projectId: string;
+  // O membro DONO da escrita (`ownMemberUserId`), nunca o observado sob
+  // impersonação — ver o comentário de `CodingDraftScope`.
+  userId: string;
+  // `false` sob impersonação ou rodada anterior: a tela é read-only e gravar
+  // rascunho ali depositaria trabalho num slot que ninguém vai enviar.
+  enabled: boolean;
+  fields: PydanticField[];
+}
+
+type StorageWrite = "written" | "blocked" | "unavailable";
+
+function scopeFor(
+  params: { userId: string; projectId: string },
+  documentId: string,
+): CodingDraftScope {
+  return { userId: params.userId, projectId: params.projectId, documentId };
+}
+
+function readSlot(scope: CodingDraftScope): {
+  available: boolean;
+  envelope: CodingDraftEnvelope | null;
+  staleFormat: boolean;
+} {
+  if (typeof window === "undefined") {
+    return { available: false, envelope: null, staleFormat: false };
+  }
+  try {
+    const read = readCodingDraft(window.localStorage.getItem(codingDraftStorageKey(scope)));
+    if (read.kind === "draft") {
+      // Segunda barreira: a chave disse que é deste documento, o conteúdo
+      // precisa concordar. Discordância vira "sem rascunho", nunca aplicação
+      // cruzada — ver `envelopeMatchesScope`.
+      if (!envelopeMatchesScope(read.draft, scope)) {
+        return { available: true, envelope: null, staleFormat: true };
+      }
+      return { available: true, envelope: read.draft, staleFormat: false };
+    }
+    return { available: true, envelope: null, staleFormat: read.kind === "stale-format" };
+  } catch {
+    return { available: false, envelope: null, staleFormat: false };
+  }
+}
+
+function writeSlotIfTokenMatches(
+  scope: CodingDraftScope,
+  envelope: CodingDraftEnvelope,
+  expectedToken: string | null,
+): StorageWrite {
+  if (typeof window === "undefined") return "unavailable";
+  try {
+    const key = codingDraftStorageKey(scope);
+    const stored = readCodingDraft(window.localStorage.getItem(key));
+    // Envelope que este build não sabe ler pertence a uma aba mais nova;
+    // sobrescrevê-lo apagaria trabalho irrecuperável.
+    if (stored.kind === "newer-format") return "blocked";
+    const storedToken = stored.kind === "draft" ? stored.draft.writeToken : null;
+    if (storedToken !== expectedToken) return "blocked";
+    window.localStorage.setItem(key, JSON.stringify(envelope));
+    return "written";
+  } catch {
+    return "unavailable";
+  }
+}
+
+function deleteSlotIfTokenMatches(
+  scope: CodingDraftScope,
+  writeToken: string | null,
+): boolean {
+  if (!writeToken || typeof window === "undefined") return false;
+  try {
+    const key = codingDraftStorageKey(scope);
+    const stored = readCodingDraft(window.localStorage.getItem(key));
+    if (stored.kind !== "draft" || stored.draft.writeToken !== writeToken) return false;
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+interface GcResult {
+  removed: number;
+  staleDiscarded: number;
+}
+
+// Varredura escopada ao prefixo do PRÓPRIO usuário, uma vez por mount. Nunca
+// toca em chave de outro usuário (numa máquina compartilhada isso seria apagar
+// trabalho alheio) nem em envelope de formato maior (é de uma aba que sabe
+// mais) nem no documento aberto.
+function collectCodingDraftGarbage(
+  userId: string,
+  now: number,
+  keepKey: string | null,
+): GcResult {
+  if (typeof window === "undefined") return { removed: 0, staleDiscarded: 0 };
+  const result: GcResult = { removed: 0, staleDiscarded: 0 };
+  try {
+    const prefix = codingDraftUserPrefix(userId);
+    const mine: Array<{ key: string; updatedAt: number }> = [];
+    const doomed: string[] = [];
+
+    for (let i = 0; i < window.localStorage.length; i += 1) {
+      const key = window.localStorage.key(i);
+      if (!key || !key.startsWith(prefix) || key === keepKey) continue;
+      const read = readCodingDraft(window.localStorage.getItem(key));
+      if (read.kind === "newer-format") continue;
+      if (read.kind !== "draft") {
+        doomed.push(key);
+        // "Havia trabalho aqui e não sei ler" é um fato que a pesquisadora
+        // precisa saber; some do slot, não do aviso.
+        if (read.kind === "stale-format") result.staleDiscarded += 1;
+        continue;
+      }
+      const embedded = codingDraftStorageKey({
+        userId: read.draft.userId,
+        projectId: read.draft.projectId,
+        documentId: read.draft.documentId,
+      });
+      if (key !== embedded) {
+        // Identidade embutida discorda da chave: não dá para saber a que
+        // documento o conteúdo pertence, e aplicar no errado seria pior.
+        doomed.push(key);
+        continue;
+      }
+      if (now - read.draft.updatedAt > DRAFT_TTL_MS) {
+        doomed.push(key);
+        continue;
+      }
+      mine.push({ key, updatedAt: read.draft.updatedAt });
+    }
+
+    // Teto: acima dele, sai o mais antigo primeiro.
+    const overflow = mine.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
+    if (overflow > 0) {
+      mine
+        .toSorted((a, b) => a.updatedAt - b.updatedAt)
+        .slice(0, overflow)
+        .forEach((entry) => doomed.push(entry.key));
+    }
+
+    for (const key of doomed) {
+      window.localStorage.removeItem(key);
+      result.removed += 1;
+    }
+  } catch {
+    // Storage indisponível: o GC é best-effort e nunca deve derrubar a tela.
+  }
+  return result;
+}
+
+
+// Sessão de rascunho: a máquina de estados por documento (debounce, posse do
+// slot, descarte, abertura) fora do React.
+//
+// Extraída do hook porque ali ela era uma função de ~290 linhas com 20 hooks: o
+// gate de complexidade a barrou, e a decomposição é a correção certa — nada aqui
+// depende de render, só de eventos. O React fica com o que é dele (o estado que
+// a faixa consome e os listeners de saída), e esta camada vira testável sem
+// montar componente.
+//
+// Os `on*` são callbacks de notificação: a sessão não conhece `setState`.
+export interface CodingDraftSessionCallbacks {
+  onRecovery(recovery: CodingDraftRecovery): void;
+  onStorageAvailable(available: boolean): void;
+  onStaleDiscarded(count: number): void;
+}
+
+export interface CodingDraftSession {
+  configure(keyParts: { projectId: string; userId: string; enabled: boolean }, fields: PydanticField[]): void;
+  recordDraft(docId: string, draft: CodingSnapshot): void;
+  restoreDraft(docId: string): CodingSnapshot | null;
+  discardDraft(docId: string): void;
+  submitConfirmed(docId: string, saved: CodingSnapshot): void;
+  openDocument(docId: string | null, remote: CodingSnapshot | null): void;
+  flushAll(): void;
+}
+
+// Estado mutável de uma sessão. Passado explicitamente às funções abaixo, que
+// vivem no topo do módulo em vez de fechadas dentro da factory: uma factory com
+// tudo dentro virava uma função de ~230 linhas, e o gate de complexidade a
+// barrava. Como efeito colateral, cada operação fica legível isoladamente.
+interface SessionState {
+  states: Map<string, DocDraftState>;
+  timers: Map<string, number>;
+  keyParts: { projectId: string; userId: string; enabled: boolean };
+  fields: PydanticField[];
+  // Último documento aberto: o GC nunca evicta o slot dele.
+  openDocId: string | null;
+  // Distingue "nunca abriu" de "abriu o documento null": sem isto, a primeira
+  // chamada com `null` cairia no guard de idempotência e o GC nunca rodaria.
+  openedOnce: boolean;
+}
+
+function persist(
+  st: SessionState,
+  cb: CodingDraftSessionCallbacks,
+  docId: string,
+  token: string,
+): void {
+  const { projectId, userId, enabled } = st.keyParts;
+  if (!enabled) return;
+  const state = st.states.get(docId);
+  // Timer atrasado não grava conteúdo velho: o token precisa ainda ser o
+  // corrente. É por isso que o debounce é indexado pelo token, não por contador.
+  if (!state?.draft || state.writeToken !== token) return;
+
+  const scope = scopeFor({ projectId, userId }, docId);
+  const envelope: CodingDraftEnvelope = {
+    formatVersion: CODING_DRAFT_FORMAT_VERSION,
+    writeToken: token,
+    userId,
+    projectId,
+    documentId: docId,
+    updatedAt: Date.now(),
+    base: state.base,
+    draft: state.draft,
+  };
+
+  let outcome = writeSlotIfTokenMatches(scope, envelope, state.persistedToken);
+  if (outcome === "unavailable") {
+    // Evicção de emergência: quota estourada é recuperável se houver rascunho
+    // velho nosso ocupando espaço. Só depois de tentar é que se desiste.
+    const freed = collectCodingDraftGarbage(userId, Date.now(), codingDraftStorageKey(scope));
+    if (freed.removed > 0) {
+      outcome = writeSlotIfTokenMatches(scope, envelope, state.persistedToken);
+    }
+  }
+
+  if (outcome === "written") {
+    st.states.set(docId, { ...state, persistedToken: token, blocked: false });
+    cb.onStorageAvailable(true);
+    return;
+  }
+  // Falha NÃO avança `persistedToken`: a próxima edição tenta de novo. Avançá-lo
+  // faria a aba colidir com o próprio lixo e nunca mais gravar na sessão.
+  st.states.set(docId, { ...state, blocked: outcome === "blocked" });
+  if (outcome === "unavailable") cb.onStorageAvailable(false);
+}
+
+function scheduleWrite(
+  st: SessionState,
+  cb: CodingDraftSessionCallbacks,
+  docId: string,
+  token: string,
+): void {
+  const existing = st.timers.get(docId);
+  if (existing) window.clearTimeout(existing);
+  st.timers.set(
+    docId,
+    window.setTimeout(() => {
+      st.timers.delete(docId);
+      persist(st, cb, docId, token);
+    }, DRAFT_DEBOUNCE_MS),
+  );
+}
+
+function dropSlot(st: SessionState, docId: string, nextBase?: CodingSnapshot): void {
+  const { projectId, userId } = st.keyParts;
+  const state = st.states.get(docId);
+  const timer = st.timers.get(docId);
+  if (timer) {
+    window.clearTimeout(timer);
+    st.timers.delete(docId);
+  }
+  const scope = scopeFor({ projectId, userId }, docId);
+  // Normalmente apaga-se pelo `persistedToken` — "o que esta aba gravou e ainda
+  // acredita ser dela". Mas um envelope apenas OFERECIDO (escrito numa sessão
+  // anterior, ainda não retomado) não tem estado em memória, e sem o fallback
+  // abaixo o botão "Descartar" não apagava nada: a faixa voltaria na abertura
+  // seguinte. Ler o token do slot é seguro porque `deleteSlotIfTokenMatches` só
+  // remove um envelope legível cujo token bate — um `newer-format`, de aba mais
+  // nova, continua intocado.
+  const token = state?.persistedToken ?? readSlot(scope).envelope?.writeToken ?? null;
+  deleteSlotIfTokenMatches(scope, token);
+  st.states.set(docId, {
+    base: nextBase ?? state?.base ?? { answers: {}, notes: "" },
+    draft: null,
+    writeToken: null,
+    persistedToken: null,
+    blocked: false,
+  });
+}
+
+function recordDraftIn(
+  st: SessionState,
+  cb: CodingDraftSessionCallbacks,
+  docId: string,
+  draft: CodingSnapshot,
+): void {
+  if (!st.keyParts.enabled) return;
+  const previous = st.states.get(docId);
+  // Sem baseline registrado não há como decidir o que é edição. Isso só ocorre
+  // para um documento que nunca foi aberto — não há caminho de UI que edite um
+  // documento fechado —, e inventar um baseline vazio gravaria o formulário
+  // inteiro como se fosse rascunho.
+  if (!previous) return;
+
+  // Voltar ao baseline não é "rascunho vazio", é ausência de rascunho: manter o
+  // envelope faria a faixa oferecer, na próxima abertura, um rascunho idêntico
+  // ao que o servidor já tem.
+  if (sameCodingSnapshot(draft, previous.base, st.fields)) {
+    dropSlot(st, docId, previous.base);
+    return;
+  }
+  const token = makeId("cdraft");
+  st.states.set(docId, { ...previous, draft, writeToken: token });
+  scheduleWrite(st, cb, docId, token);
+}
+
+function openDocumentIn(
+  st: SessionState,
+  cb: CodingDraftSessionCallbacks,
+  docId: string | null,
+  remote: CodingSnapshot | null,
+): void {
+  const { projectId, userId, enabled } = st.keyParts;
+  if (st.openedOnce && st.openDocId === docId) return;
+  const firstOpen = !st.openedOnce;
+  st.openedOnce = true;
+  st.openDocId = docId;
+
+  // O GC roda na PRIMEIRA abertura, não num efeito de mount: é aqui que se sabe
+  // qual slot preservar. Antes disso `openDocument` ainda não foi chamado,
+  // `keepKey` seria nulo, e o rascunho do documento na tela entraria na
+  // varredura — expirado ou acima do teto, seria apagado debaixo da pesquisadora.
+  if (firstOpen && enabled) {
+    const keep = docId
+      ? codingDraftStorageKey(scopeFor({ projectId, userId }, docId))
+      : null;
+    const collected = collectCodingDraftGarbage(userId, Date.now(), keep);
+    if (collected.staleDiscarded > 0) cb.onStaleDiscarded(collected.staleDiscarded);
+  }
+
+  if (!enabled || !docId) {
+    cb.onRecovery({ kind: "none" });
+    return;
+  }
+
+  const scope = scopeFor({ projectId, userId }, docId);
+  const slot = readSlot(scope);
+  cb.onStorageAvailable(slot.available);
+  if (slot.staleFormat) cb.onStaleDiscarded(1);
+
+  const baseline = remote ?? { answers: {}, notes: "" };
+
+  // Abrir estabelece o baseline do documento — a sessão é dona única dele a
+  // partir daqui. Preserva `persistedToken` de uma edição anterior nesta mesma
+  // sessão: ir e voltar entre documentos não pode fazer a aba perder a posse do
+  // próprio slot.
+  const previous = st.states.get(docId);
+  st.states.set(docId, {
+    base: previous?.draft ? previous.base : baseline,
+    draft: previous?.draft ?? null,
+    writeToken: previous?.writeToken ?? null,
+    persistedToken: previous?.persistedToken ?? null,
+    blocked: previous?.blocked ?? false,
+  });
+
+  const classified = classifyCodingDraft(slot.envelope, baseline, st.fields);
+  if (classified.kind === "redundant" && slot.envelope) {
+    // Repete o servidor: some do caminho em vez de virar ruído recorrente.
+    deleteSlotIfTokenMatches(scope, slot.envelope.writeToken);
+    cb.onRecovery({ kind: "none" });
+    return;
+  }
+  // Posse do slot é assumida só ao retomar; até lá, apenas oferecemos.
+  cb.onRecovery(
+    classified.kind === "resumable" || classified.kind === "diverged"
+      ? classified
+      : { kind: "none" },
+  );
+}
+
+export function createCodingDraftSession(
+  cb: CodingDraftSessionCallbacks,
+): CodingDraftSession {
+  const st: SessionState = {
+    states: new Map(),
+    timers: new Map(),
+    keyParts: { projectId: "", userId: "", enabled: false },
+    fields: [],
+    openDocId: null,
+    openedOnce: false,
+  };
+
+  return {
+    configure(keyParts, fields) {
+      st.keyParts = keyParts;
+      st.fields = fields;
+    },
+    recordDraft: (docId, draft) => recordDraftIn(st, cb, docId, draft),
+    openDocument: (docId, remote) => openDocumentIn(st, cb, docId, remote),
+    discardDraft(docId) {
+      dropSlot(st, docId);
+      cb.onRecovery({ kind: "none" });
+    },
+    submitConfirmed(docId, saved) {
+      // A escrita aconteceu: o rascunho virou redundante por definição, mesmo
+      // que o documento siga pendente por obrigatória em aberto. Manter deixaria
+      // o indicador de "não enviado" aceso sobre trabalho que FOI enviado.
+      //
+      // O baseline é rebaseado para o que foi gravado — sem isso, a próxima
+      // tecla criaria um rascunho cujo `base` é o seed stale do RSC, e reabrir o
+      // documento depois acusaria "o documento foi salvo depois" contra uma
+      // escrita nossa.
+      dropSlot(st, docId, saved);
+      cb.onRecovery({ kind: "none" });
+    },
+    restoreDraft(docId) {
+      const { projectId, userId } = st.keyParts;
+      const slot = readSlot(scopeFor({ projectId, userId }, docId));
+      if (!slot.envelope) {
+        cb.onRecovery({ kind: "none" });
+        return null;
+      }
+      // O envelope permanece no slot: retomar não é enviar. Assumimos a posse
+      // dele para que o compare-and-swap das próximas escritas case.
+      st.states.set(docId, {
+        base: slot.envelope.base,
+        draft: slot.envelope.draft,
+        writeToken: slot.envelope.writeToken,
+        persistedToken: slot.envelope.writeToken,
+        blocked: false,
+      });
+      cb.onRecovery({ kind: "none" });
+      return slot.envelope.draft;
+    },
+    flushAll() {
+      for (const [docId, timer] of st.timers) {
+        window.clearTimeout(timer);
+        const token = st.states.get(docId)?.writeToken;
+        if (token) persist(st, cb, docId, token);
+      }
+      st.timers.clear();
+    },
+  };
+}

--- a/frontend/src/lib/coding-draft.ts
+++ b/frontend/src/lib/coding-draft.ts
@@ -13,7 +13,7 @@ import type { PydanticField } from "@/lib/types";
 // o I/O vive em `useCodingDrafts`.
 export const CODING_DRAFT_FORMAT_VERSION = 1;
 
-export const CODING_DRAFT_KEY_PREFIX = "dataframeit:coding-draft:";
+const CODING_DRAFT_KEY_PREFIX = "dataframeit:coding-draft:";
 
 // O escopo é recebido inteiro, nunca como `projectId: string` solto — é o que
 // impede, por construção, que se construa uma chave sem usuário. O motivo está

--- a/frontend/src/lib/coding-draft.ts
+++ b/frontend/src/lib/coding-draft.ts
@@ -1,0 +1,235 @@
+import { z } from "zod";
+import { stableStringify } from "@/lib/schema-utils";
+import type { PydanticField } from "@/lib/types";
+
+// Rascunho local das RESPOSTAS de codificação. Espelha deliberadamente o
+// desenho de `schema-draft.ts` (envelope versionado + leitura de 4 estados),
+// porque as armadilhas são as mesmas e já foram pagas uma vez lá. O que muda é
+// o escopo — aqui a chave desce até o documento — e o baseline, que aqui é um
+// snapshot de conteúdo em vez de uma `revision` monotônica: respostas não têm
+// versionamento no banco, e `updated_at` não diria QUAIS campos mudaram.
+//
+// Esta camada não toca em `window`: só conhece string -> resultado tipado. Todo
+// o I/O vive em `useCodingDrafts`.
+export const CODING_DRAFT_FORMAT_VERSION = 1;
+
+export const CODING_DRAFT_KEY_PREFIX = "dataframeit:coding-draft:";
+
+// O escopo é recebido inteiro, nunca como `projectId: string` solto — é o que
+// impede, por construção, que se construa uma chave sem usuário. O motivo está
+// em `useSchemaDraft` e vale igual aqui: o localStorage é do navegador, não da
+// sessão, e nada o limpa no logout. Sem o usuário na chave, duas pesquisadoras
+// que dividem a mesma máquina veem o rascunho uma da outra.
+//
+// O `userId` correto é o membro DONO da escrita (`ownMemberUserId` de
+// `resolveProjectQueueIdentity`), nunca o `queueUserId` da impersonação: sob
+// `?viewAsUser=` a fila exibida muda, mas o ator das mutations não. Chavear
+// pelo usuário observado faria o master depositar rascunho no slot alheio.
+export interface CodingDraftScope {
+  userId: string;
+  projectId: string;
+  documentId: string;
+}
+
+export function codingDraftStorageKey(scope: CodingDraftScope): string {
+  return `${CODING_DRAFT_KEY_PREFIX}${scope.userId}:${scope.projectId}:${scope.documentId}`;
+}
+
+// Prefixo de varredura do GC: delimita os slots DESTE usuário. O GC nunca sai
+// daqui — apagar rascunho de outro usuário numa máquina compartilhada é apagar
+// trabalho alheio.
+export function codingDraftUserPrefix(userId: string): string {
+  return `${CODING_DRAFT_KEY_PREFIX}${userId}:`;
+}
+
+// As notas viajam no mesmo diff que as respostas, sob a chave que o servidor já
+// usa para elas (`justifications._notes`, ver `saveResponse`). Um único diff
+// nomeado é o que permite à faixa de recuperação listar o que seria
+// sobrescrito sem manter um caminho paralelo só para as notas.
+export const CODING_DRAFT_NOTES_KEY = "_notes";
+
+const codingSnapshotSchema = z.strictObject({
+  // Sem tipagem por campo, de propósito. O schema Pydantic do projeto pode ter
+  // mudado entre a escrita e a leitura deste envelope; um Zod que conhecesse os
+  // tipos rejeitaria o rascunho INTEIRO por causa de um campo que virou grupo
+  // (o caso real medido no #606). A validação contra o schema acontece na hora
+  // de APLICAR, via `sanitizeStoredAnswers`, que já é a fronteira de leitura dos
+  // dois modos de codificação. Aqui só se exige que a forma seja estrutural.
+  answers: z.record(z.string(), z.unknown()),
+  notes: z.string(),
+});
+
+export type CodingSnapshot = z.infer<typeof codingSnapshotSchema>;
+
+const codingDraftEnvelopeSchema = z.strictObject({
+  formatVersion: z.literal(CODING_DRAFT_FORMAT_VERSION),
+  writeToken: z.string().min(1),
+  // Redundantes com a chave, e não por decoração: o separador é `:` e três
+  // UUIDs se parecem. Sem esta cópia, um bug de composição/parse de chave
+  // aplicaria as respostas do documento A no documento B — fabricar dado de
+  // pesquisa em silêncio é o pior desfecho que esta feature consegue produzir.
+  // Com ela, o mesmo bug degrada para "rascunho descartado".
+  userId: z.string().min(1),
+  projectId: z.string().min(1),
+  documentId: z.string().min(1),
+  // Alimenta três consumidores: o TTL do GC, a evicção por idade e o "há N
+  // horas" da faixa de recuperação. `schema-draft` não tem nenhum dos três
+  // porque lá existe um slot por projeto; aqui existe um por documento.
+  updatedAt: z.number().int().nonnegative(),
+  // O que estava na tela quando este rascunho nasceu. É o que permite
+  // distinguir "o servidor não andou desde então" de "andou, e retomar
+  // sobrescreve" — sem construir um merge de três vias.
+  base: codingSnapshotSchema,
+  draft: codingSnapshotSchema,
+});
+
+export type CodingDraftEnvelope = z.infer<typeof codingDraftEnvelopeSchema>;
+
+// Só o marcador de formato, sem `strictObject`: reconhece um envelope que
+// existe mas que este build não sabe ler.
+const formatMarkerSchema = z.object({ formatVersion: z.number().int() });
+
+// Mesma taxonomia de `schema-draft.ts`, pelo mesmo motivo: colapsar "não tem
+// nada" e "tem algo que não sei ler" num único `null` faz o compare-and-swap
+// concluir "slot livre" e sobrescrever, em silêncio, o rascunho de uma aba mais
+// nova durante um deploy que bumpe o formato.
+export type CodingDraftRead =
+  | { kind: "empty" }
+  | { kind: "draft"; draft: CodingDraftEnvelope }
+  | { kind: "stale-format"; formatVersion: number }
+  | { kind: "newer-format"; formatVersion: number };
+
+export function readCodingDraft(raw: string | null): CodingDraftRead {
+  if (!raw) return { kind: "empty" };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { kind: "empty" };
+  }
+
+  const envelope = codingDraftEnvelopeSchema.safeParse(parsed);
+  if (envelope.success) return { kind: "draft", draft: envelope.data };
+
+  const marker = formatMarkerSchema.safeParse(parsed);
+  if (marker.success) {
+    if (marker.data.formatVersion > CODING_DRAFT_FORMAT_VERSION) {
+      return { kind: "newer-format", formatVersion: marker.data.formatVersion };
+    }
+    return { kind: "stale-format", formatVersion: marker.data.formatVersion };
+  }
+
+  return { kind: "empty" };
+}
+
+export function parseCodingDraft(raw: string | null): CodingDraftEnvelope | null {
+  const read = readCodingDraft(raw);
+  return read.kind === "draft" ? read.draft : null;
+}
+
+// Segunda barreira contra o envelope certo no slot errado. A primeira é a
+// chave; esta prova que o conteúdo concorda com ela.
+export function envelopeMatchesScope(
+  envelope: CodingDraftEnvelope,
+  scope: CodingDraftScope,
+): boolean {
+  return (
+    envelope.userId === scope.userId &&
+    envelope.projectId === scope.projectId &&
+    envelope.documentId === scope.documentId
+  );
+}
+
+// Nomes dos campos em que dois snapshots discordam, restrito aos campos que o
+// schema atual conhece — mais `_notes` quando as notas diferem.
+//
+// A restrição a `fields` não é um detalhe de performance: uma resposta a campo
+// que saiu do schema nunca seria reescrita (`sanitizeStoredAnswers` a descarta
+// ao aplicar), então contá-la como diferença faria a faixa oferecer um rascunho
+// cuja retomada não mudaria nada de visível.
+//
+// A comparação é por `stableStringify` para que reordenar as chaves de um valor
+// composto — um grupo de subcampos, tipicamente — não passe por edição.
+export function diffCodingSnapshots(
+  a: CodingSnapshot,
+  b: CodingSnapshot,
+  fields: PydanticField[],
+): string[] {
+  const changed: string[] = [];
+  for (const field of fields) {
+    if (stableStringify(a.answers[field.name]) !== stableStringify(b.answers[field.name])) {
+      changed.push(field.name);
+    }
+  }
+  if (a.notes !== b.notes) changed.push(CODING_DRAFT_NOTES_KEY);
+  return changed;
+}
+
+export function sameCodingSnapshot(
+  a: CodingSnapshot,
+  b: CodingSnapshot,
+  fields: PydanticField[],
+): boolean {
+  return diffCodingSnapshots(a, b, fields).length === 0;
+}
+
+export type CodingDraftRecovery =
+  // Sem envelope legível: nada a oferecer.
+  | { kind: "none" }
+  // O rascunho repete o que o servidor já tem. Retomá-lo não mudaria nada, e
+  // oferecer seria ruído que ensina a pesquisadora a ignorar a faixa — a
+  // primeira coisa que a tornaria inútil no dia em que ela importa.
+  | { kind: "redundant" }
+  // O servidor não andou desde que o rascunho nasceu: retomar só acrescenta.
+  | {
+      kind: "resumable";
+      draft: CodingSnapshot;
+      updatedAt: number;
+      changedFields: string[];
+    }
+  // O servidor andou. Retomar ainda é legítimo — é trabalho da própria
+  // pesquisadora —, mas ela precisa saber o que perde.
+  | {
+      kind: "diverged";
+      draft: CodingSnapshot;
+      updatedAt: number;
+      changedFields: string[];
+      overwrittenFields: string[];
+    };
+
+// Decide o que oferecer ao reabrir um documento. Puro: recebe o envelope lido,
+// o que o servidor entregou no render (`remote`) e o schema atual.
+export function classifyCodingDraft(
+  envelope: CodingDraftEnvelope | null,
+  remote: CodingSnapshot,
+  fields: PydanticField[],
+): CodingDraftRecovery {
+  if (!envelope) return { kind: "none" };
+
+  // O que retomar mudaria em relação ao que está na tela.
+  const changedFields = diffCodingSnapshots(envelope.draft, remote, fields);
+  if (changedFields.length === 0) return { kind: "redundant" };
+
+  // O que o servidor mudou desde que este rascunho nasceu.
+  const remoteMoved = diffCodingSnapshots(envelope.base, remote, fields);
+  if (remoteMoved.length === 0) {
+    return {
+      kind: "resumable",
+      draft: envelope.draft,
+      updatedAt: envelope.updatedAt,
+      changedFields,
+    };
+  }
+
+  // A INTERSEÇÃO, não `remoteMoved` inteiro: um campo que o servidor mudou e
+  // que o rascunho não toca não seria sobrescrito por retomar. Listá-lo como
+  // perda é mentira que empurra a pesquisadora a descartar trabalho bom.
+  const changedSet = new Set(changedFields);
+  return {
+    kind: "diverged",
+    draft: envelope.draft,
+    updatedAt: envelope.updatedAt,
+    changedFields,
+    overwrittenFields: remoteMoved.filter((name) => changedSet.has(name)),
+  };
+}


### PR DESCRIPTION
Primeiro dos três PRs encadeados da #608. **O autosave continua intacto**: este PR só instala a rede local por baixo dele, para que a remoção dos gatilhos (PR-2) nunca fique descoberta. A issue adverte exatamente isso — "a rede local entra antes de os gatilhos saírem, nunca no mesmo passo cego".

## O que entra

Um rascunho local de respostas em `localStorage`, um indicador honesto de "alterações não enviadas" e a faixa que oferece a recuperação ao reabrir um documento. Nada é aplicado sem clique: o formulário monta sempre com os valores do servidor.

Três camadas, deliberadamente separadas:

- **`lib/coding-draft.ts`** — pura, sem DOM: envelope Zod versionado e a classificação que decide o que a faixa mostra (`none` / `redundant` / `resumable` / `diverged`).
- **`lib/coding-draft-storage.ts`** — acesso ao `localStorage` (compare-and-swap por `writeToken`, GC, TTL, teto) e a máquina de sessão por documento, sem React.
- **`hooks/useCodingDrafts.ts`** — só o ciclo de vida React: debounce de 300 ms, flush em `pagehide`/`visibilitychange`/unmount, e o estado que a faixa consome.

O desenho espelha `useSchemaDraft`, que já pagou estas armadilhas: distinguir "slot vazio" de "envelope ilegível"; ceder o slot a um `formatVersion` maior; apagar sempre pelo `persistedToken`, nunca pelo token submetido; falha de escrita não avançar `persistedToken`. O que `useSchemaDraft` não tem — e aqui é obrigatório, porque há um slot por documento em vez de um por projeto — é **GC, TTL e teto**: sem eles, a quota degradaria em silêncio, que é justamente o modo de falha que a issue existe para eliminar.

## Três decisões que valem revisão

**A chave é do `ownMemberUserId`, não do `queueUserId`.** A issue pede escopo por "usuário + projeto + documento" sem qualificar qual usuário. `resolveProjectQueueIdentity` separa os dois porque `?viewAsUser=` muda a fila exibida mas não o ator das mutations — chavear pelo observado faria o master, sob impersonação, depositar rascunho no slot de uma pesquisadora. Sob impersonação o rascunho é **desligado**, não redirecionado.

**O indicador de "não enviado" vem da sujeira em memória, nunca do storage.** Com o `localStorage` bloqueado (janela anônima) ou a quota estourada, um indicador derivado da persistência diria "tudo enviado" enquanto há edição pendente no reducer. Sujeira é fato de memória; gravar é best-effort. Os dois sinais são distintos e ambos visíveis — há teste para isso.

**O rascunho é descartado no envio confirmado, inclusive com `missingRequired > 0`.** `success: true` significa que a escrita aconteceu; manter o envelope deixaria o indicador aceso sobre trabalho que *foi* enviado. Quem comunica a pendência é o `notifySaved` (#519), não a existência de um arquivo no `localStorage`. O descarte também **rebaseia** o baseline para o que foi gravado — sem isso, reabrir o documento depois acusaria "foi salvo depois" contra uma escrita nossa.

## Correção à issue

A issue descreve o item 4 como pendente e cita `lib/coding-save-feedback.ts:14-24`, mas esse arquivo não existia quando ela foi escrita e **existe hoje**: o #519 já entregou `missingRequiredHumanFields` e `notifySaved`. O que sobra do item 4 — nomear *qual* pergunta falta e levar até ela — fica para o PR-3.

## Verificação

Tier mais alto de `docs/VERIFICATION.md`.

- `npm run invariants`: 13/13 verdes.
- Smoke `coding-save.smoke` verde, com a asserção de persistência no banco.
- Suíte completa: 2042 testes, 190 arquivos.
- **Prova do vermelho** em 13 mutações, cada uma derrubando o teste que alega proteger: interseção de `overwrittenFields`; `strictObject` → `object`; `>` → `>=` no `newer-format`; `submitConfirmed` sem rebase; GC sem `keepKey`; GC sem o prefixo do usuário; falha de escrita avançando `persistedToken`; `discard` que não apaga rascunho oferecido; indicador derivado do storage; descarte só quando o documento fica completo; flush de `pagehide` removido; e o teste de seed discriminando "do servidor" × "do rascunho".

Dois achados do próprio processo, corrigidos e comentados no código:

1. O primeiro teste da interseção de `overwrittenFields` era **vácuo** — o caso escolhido dava o mesmo resultado com e sem a interseção. Só um campo em que o servidor andou *e o rascunho já concorda* discrimina os dois cálculos.
2. O teste de integração do `pagehide` passava **sem** o `pagehide`: com timers reais, o debounce de 300 ms já gravara. O nome e o comentário foram corrigidos para dizer o que o teste de fato prova; o flush de saída é provado na unidade, com fake timers.

Refs #608
