### PR TITLE
refactor(codificação): remove isAutoSave do caminho de gravação (#608, PR 3/4)

### DIFF
--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -222,81 +222,28 @@ async function loadSaveResponse() {
   return (await import("@/actions/responses")).saveResponse;
 }
 
-describe("saveResponse — auto-save vs submit explicito", () => {
-  it("auto-save com todos os campos preenchidos NAO promove assignment para concluido", async () => {
+describe("saveResponse — gravação pelo envio explícito", () => {
+  it("com todos os campos preenchidos promove assignment para concluido", async () => {
     const saveResponse = await loadSaveResponse();
-    const r = await saveResponse(
-      "proj-1",
-      "doc-1",
-      { q1: "a" },
-      { isAutoSave: true },
-    );
-    expect(r.success).toBe(true);
-    // Auto-save em assignment pendente promove apenas para em_andamento — nunca concluido.
-    expect(state.assignmentUpdatePayload?.status).toBe("em_andamento");
-    expect(state.assignmentUpdatePayload?.completed_at).toBeNull();
-  });
-
-  it("submit explicito com todos os campos preenchidos promove assignment para concluido", async () => {
-    const saveResponse = await loadSaveResponse();
-    const r = await saveResponse(
-      "proj-1",
-      "doc-1",
-      { q1: "a" },
-      // isAutoSave default = false
-    );
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
     expect(r.success).toBe(true);
     expect(state.assignmentUpdatePayload?.status).toBe("concluido");
     expect(typeof state.assignmentUpdatePayload?.completed_at).toBe("string");
   });
 
-  it("auto-save em response nova grava is_partial=true (INSERT)", async () => {
-    const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
-    expect(state.responseInsertPayload?.is_partial).toBe(true);
-  });
-
-  it("submit explicito grava response com is_partial=false", async () => {
+  it("grava response com is_partial=false", async () => {
     const saveResponse = await loadSaveResponse();
     await saveResponse("proj-1", "doc-1", { q1: "a" });
     expect(state.responseInsertPayload?.is_partial).toBe(false);
   });
 
-  it("auto-save em response existente parcial mantem is_partial=true (UPDATE)", async () => {
-    // Pesquisador ja salvou parcial antes; novo auto-save deve continuar parcial.
-    state.existingResponse = { id: "resp-1", is_partial: true };
-    const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
-    expect(state.responseUpdatePayload?.is_partial).toBe(true);
-  });
-
-  it("auto-save em response ja submetida NAO rebaixa is_partial (UPDATE)", async () => {
-    // Cenario critico: response existe com is_partial=false (foi submetida) e
-    // assignment esta concluido. Pesquisador reabre e edita; auto-save NAO
-    // deve flipar is_partial para true, senao classifyDocStatus passa a tratar
-    // o doc como pendente mesmo com o assignment.status preservado pelo guard
-    // como concluido — estado inconsistente.
-    state.existingResponse = { id: "resp-1", is_partial: false };
-    state.currentAssignmentStatus = "concluido";
-    const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
-    expect(state.responseUpdatePayload?.is_partial).toBe(false);
-    // Assignment.status nao deve regredir (guard pre-existente).
-    expect(state.assignmentUpdatePayload).toBeNull();
-  });
-
-  it("auto-save em response já submetida invalida imediatamente a auto-revisão", async () => {
+  it("editar uma response já submetida invalida imediatamente a auto-revisão", async () => {
     state.existingResponse = { id: "resp-1", is_partial: false };
     state.currentAssignmentStatus = "concluido";
     state.automationMode = "compare_humans";
     const saveResponse = await loadSaveResponse();
 
-    const result = await saveResponse(
-      "proj-1",
-      "doc-1",
-      { q1: "b" },
-      { isAutoSave: true },
-    );
+    const result = await saveResponse("proj-1", "doc-1", { q1: "b" });
 
     expect(result.success).toBe(true);
     expect(drainAutoReviewReconciliationRequests).toHaveBeenCalledWith({
@@ -304,9 +251,10 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     });
   });
 
-  it("submit apos auto-save sobrescreve is_partial: true -> false (UPDATE)", async () => {
-    // Cenario: o pesquisador deu auto-save antes (response existe com is_partial=true)
-    // e agora clica Enviar — o submit deve fazer UPDATE com is_partial=false.
+  it("envio sobre response parcial sobrescreve is_partial: true -> false (UPDATE)", async () => {
+    // A linha parcial pode vir de um envio incompleto anterior ou, nas anteriores
+    // ao #608, do auto-save que marcava "nunca submetida". Completar o conjunto
+    // e enviar deve fazer UPDATE com is_partial=false nos dois casos.
     state.existingResponse = { id: "resp-1", is_partial: true };
     const saveResponse = await loadSaveResponse();
     await saveResponse("proj-1", "doc-1", { q1: "a" });
@@ -329,7 +277,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(r.success && r.missingRequired).toBe(1);
   });
 
-  it("auto-save que ENCOLHE uma response submetida devolve is_partial=true", async () => {
+  it("envio que ENCOLHE uma response submetida devolve is_partial=true", async () => {
     // A heranca do sinal ("ja foi submetida uma vez") sobrevivia a uma escrita
     // posterior com menos respostas, carimbando de submetido um conjunto
     // incompleto. Distinto do caso vizinho, onde o conjunto continua completo.
@@ -344,12 +292,12 @@ describe("saveResponse — auto-save vs submit explicito", () => {
       answer_field_hashes: { q1: "h-q1", q2: "h-q2" },
     };
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "a" });
     expect(state.responseUpdatePayload?.answers).toEqual({ q1: "a" });
     expect(state.responseUpdatePayload?.is_partial).toBe(true);
   });
 
-  it("campo obrigatorio criado depois NAO rebaixa codificacao antiga em auto-save", async () => {
+  it("campo obrigatorio criado depois NAO rebaixa codificacao antiga", async () => {
     // Espelho do caso real: a codificacao estava completa contra o schema da
     // epoca; o campo novo so entra na regua se o carimbo provar que ele existia.
     state.pydanticFields = [
@@ -363,7 +311,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
       answer_field_hashes: { q1: "h-q1" },
     };
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "a" });
     expect(state.responseUpdatePayload?.is_partial).toBe(false);
     expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({ q1: "h-q1" });
   });
@@ -401,7 +349,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(state.assignmentUpdatePayload?.status).toBe("em_andamento");
   });
 
-  it("auto-save em doc codificado antes do bump NAO passa a dever o campo novo (#520)", async () => {
+  it("doc codificado antes do bump NAO passa a dever o campo novo (#520)", async () => {
     // Critério de aceite da #520: a codificação foi completa à época; o schema
     // ganhou um obrigatório depois. Basta o pesquisador reabrir o doc e tocar
     // qualquer coisa para o save reestampar o mapa — e a leitura retroativa
@@ -418,12 +366,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     };
 
     const saveResponse = await loadSaveResponse();
-    const result = await saveResponse(
-      "proj-1",
-      "doc-1",
-      { q1: "b" },
-      { isAutoSave: true },
-    );
+    const result = await saveResponse("proj-1", "doc-1", { q1: "b" });
 
     expect(result.success).toBe(true);
     const gravado = state.responseUpdatePayload?.answer_field_hashes as AnswerFieldHashes;
@@ -460,7 +403,11 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     expect(state.assignmentUpdatePayload?.status).toBe("concluido");
   });
 
-  it("response legacy conserva o sentinela em vez de ganhar chaves (#520)", async () => {
+  it("response legacy INCOMPLETA conserva o sentinela em vez de ganhar chaves (#520)", async () => {
+    // `q_novo` fica em branco, então a recodificação não fica completa contra o
+    // schema atual e o sentinela é conservado. Desde o #608 a incompletude é a
+    // condição inteira — antes o auto-save também suprimia a promoção, e era ele
+    // que este caso exercitava.
     state.pydanticFields = [
       { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
       { name: "q_novo", type: "single", required: true, options: ["x"], hash: "h-novo" },
@@ -473,7 +420,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     };
 
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "b" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "b" });
 
     expect(state.responseUpdatePayload?.answer_field_hashes).toEqual({});
   });
@@ -485,7 +432,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     ];
 
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "a" });
 
     expect(state.responseInsertPayload?.answer_field_hashes).toEqual({
       q1: "h1",
@@ -499,8 +446,13 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     // coluna no mesmo save tornaria esse fallback permissivo — a codificacao
     // antiga passaria a ser lida como feita contra o schema de hoje, e nenhum
     // campo apareceria stale. Omitir as colunas preserva o que esta na linha.
+    //
+    // `q2` em branco mantém a recodificação incompleta, que é o que conserva o
+    // sentinela. O caso simétrico — recodificação COMPLETA, que promove tudo —
+    // é o teste da #548 mais abaixo, e é ele que fixa a fronteira entre os dois.
     state.pydanticFields = [
       { name: "q1", type: "single", required: true, options: ["a", "b"], hash: "h1" },
+      { name: "q2", type: "text", required: true, hash: "h2" },
     ];
     state.existingResponse = {
       id: "resp-1",
@@ -510,7 +462,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     };
 
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "b" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "b" });
 
     const payload = state.responseUpdatePayload ?? {};
     expect(payload).not.toHaveProperty("pydantic_hash");
@@ -541,7 +493,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     };
 
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "b" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "b" });
 
     expect(state.responseUpdatePayload?.pydantic_hash).toBe("hash-1");
     expect(state.responseUpdatePayload?.schema_version_major).toBe(1);
@@ -550,8 +502,9 @@ describe("saveResponse — auto-save vs submit explicito", () => {
 
   it("toque sem revisao preserva as colunas de versao da epoca (#529)", async () => {
     // Prova do vermelho do #529: o pesquisador reabre um doc codificado sob a
-    // versao anterior e re-submete o MESMO valor (auto-save por navegacao, sem
-    // editar nada). Nenhum campo e revisado, entao o mapa per-campo (#528) ja
+    // versao anterior e re-envia o MESMO valor, sem editar nada (o gatilho
+    // original era o auto-save por navegacao; hoje e um clique em Enviar sobre
+    // um formulario intocado). Nenhum campo e revisado, entao o mapa per-campo (#528) ja
     // conserva a epoca — as colunas de versao devem acompanhar e NAO promover
     // para o schema de hoje. Antes deste fix, `buildResponsePayload` promovia em
     // todo save, deixando a linha assimetrica (hashes de epoca x versao de hoje)
@@ -567,7 +520,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     };
 
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "a" });
 
     const payload = state.responseUpdatePayload ?? {};
     expect(payload).not.toHaveProperty("pydantic_hash");
@@ -585,7 +538,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     state.pydanticFields = [];
 
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", {}, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", {});
 
     expect(state.responseInsertPayload?.answer_field_hashes).toEqual({});
     expect(state.responseInsertPayload?.pydantic_hash).toBe("hash-1");
@@ -611,7 +564,7 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     };
 
     const saveResponse = await loadSaveResponse();
-    // Submit explícito (isAutoSave default = false) completando o schema atual.
+    // Envio que completa o schema atual.
     await saveResponse("proj-1", "doc-1", { q1: "b" });
 
     // (a) proveniência corrente estampada — deixa de ser o sentinela.
@@ -640,28 +593,37 @@ describe("saveResponse — auto-save vs submit explicito", () => {
     ).toBe(true);
   });
 
-  it("auto-save com campo obrigatorio vazio mantem pendente em em_andamento", async () => {
+  it("envio com campo obrigatorio vazio mantem pendente em em_andamento", async () => {
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "" }, { isAutoSave: true });
+    await saveResponse("proj-1", "doc-1", { q1: "" });
     expect(state.assignmentUpdatePayload?.status).toBe("em_andamento");
   });
 
-  it("auto-save NAO regride um assignment ja concluido para em_andamento", async () => {
+  it("envio incompleto rebaixa is_partial mas NAO regride o assignment concluido", async () => {
+    // Os dois sinais divergem de propósito, e é este o caso que os separa: o
+    // conjunto gravado deixou de estar completo (`is_partial` volta a true),
+    // mas a conclusão foi um ato do pesquisador e só ele a desfaz. Quem sustenta
+    // a segunda metade é o guard de `keepCodingAssignmentInProgress` — sem ele,
+    // reabrir e apagar uma resposta tiraria o documento de "concluído".
+    //
+    // Até o #608 o mesmo cenário era alcançado pelo auto-save de navegação; hoje
+    // exige um clique em Enviar, mas a invariante é a mesma.
     state.currentAssignmentStatus = "concluido";
+    state.existingResponse = {
+      id: "resp-1",
+      is_partial: false,
+      answers: { q1: "a" },
+      answer_field_hashes: { q1: "h1" },
+    };
     const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "" }, { isAutoSave: true });
-    // Nao deve ter chamado update em assignments (status nao muda).
+    await saveResponse("proj-1", "doc-1", { q1: "" });
+
+    expect(state.responseUpdatePayload?.is_partial).toBe(true);
+    // Nenhum update em assignments — o status nao muda.
     expect(state.assignmentUpdatePayload).toBeNull();
   });
 
-  it("auto-save NAO dispara revalidatePath nem revalidateTag", async () => {
-    const saveResponse = await loadSaveResponse();
-    await saveResponse("proj-1", "doc-1", { q1: "a" }, { isAutoSave: true });
-    expect(revalidatePath).not.toHaveBeenCalled();
-    expect(revalidateTag).not.toHaveBeenCalled();
-  });
-
-  it("submit explicito dispara revalidatePath e revalidateTag das rotas relevantes", async () => {
+  it("o envio dispara revalidatePath e revalidateTag das rotas relevantes", async () => {
     const saveResponse = await loadSaveResponse();
     await saveResponse("proj-1", "doc-1", { q1: "a" });
     expect(revalidatePath).toHaveBeenCalledWith("/projects/proj-1/analyze/code");

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -11,7 +11,6 @@ import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 export interface SaveResponseOpts {
   notes?: string;
-  isAutoSave?: boolean;
 }
 
 export type SaveResponseResult =
@@ -107,7 +106,6 @@ interface BuildResponsePayloadParams {
   stampsCurrentSchema: boolean;
   project: SaveResponseProjectFields | null | undefined;
   existing: { is_partial: boolean | null } | null | undefined;
-  isAutoSave: boolean;
   notes?: string;
 }
 
@@ -174,7 +172,6 @@ function buildResponsePayload({
   stampsCurrentSchema,
   project,
   existing,
-  isAutoSave,
   notes,
 }: BuildResponsePayloadParams) {
   const justifications = notes ? { _notes: notes } : null;
@@ -182,14 +179,15 @@ function buildResponsePayload({
   const roundIdToPersist =
     project?.round_strategy === "manual" ? (project?.current_round_id ?? null) : null;
 
-  // Para humanos is_partial descreve O QUE FOI GRAVADO, não por qual canal a
-  // escrita chegou: uma resposta só deixa de ser parcial quando o conjunto
-  // gravado satisfaz a régua de completude E o pesquisador já enviou (submit
-  // explícito). Enquanto o sinal era função apenas do canal
+  // Para humanos is_partial descreve O QUE FOI GRAVADO: uma resposta só deixa
+  // de ser parcial quando o conjunto gravado satisfaz a régua de completude.
+  // Enquanto o sinal era função do canal de escrita
   // (`isAutoSave && existing?.is_partial !== false`), um auto-save herdava o
   // `false` de um submit anterior e podia carimbar "submetida" um conjunto que
   // já não estava completo — o estado que fazia o documento voltar à fila com
-  // aparência de concluído (#519).
+  // aparência de concluído (#519). Removido o auto-save (#608), o canal deixou
+  // de existir como variável: toda escrita é submit explícito, e o conjunto
+  // gravado é a condição inteira.
   //
   // `codingIsComplete` chega pronto de `saveResponse`, do MESMO cálculo que
   // produz o `missingRequired` devolvido ao cliente: o sinal gravado no banco e o
@@ -199,14 +197,11 @@ function buildResponsePayload({
   // campo obrigatório criado depois não rebaixe codificação completa à época)
   // vive em coding-completeness, onde está documentada.
   //
-  // O auto-save continua sem promover nada por conta própria — quem nunca enviou
-  // segue parcial mesmo com tudo preenchido; combinado com o guard que preserva
-  // assignment.status = "concluido" em coding-sync, um auto-save posterior a um
-  // submit também não rebaixa um doc já concluído (salvo se o conjunto encolheu e
-  // deixou de estar completo). A imutabilidade descrita na migration
-  // 20260425000000 vale so para o fluxo LLM.
-  const submittedBefore = existing?.is_partial === false;
-  const isPartialToWrite = !codingIsComplete || (isAutoSave && !submittedBefore);
+  // Um submit que encolhe o conjunto rebaixa `is_partial` de volta a `true`,
+  // mas NÃO rebaixa `assignment.status = "concluido"` — quem sustenta isso é o
+  // guard de `keepCodingAssignmentInProgress` (coding-sync). A imutabilidade
+  // descrita na migration 20260425000000 vale só para o fluxo LLM.
+  const isPartialToWrite = !codingIsComplete;
 
   const payload = {
     answers: answersToPersist,
@@ -300,12 +295,11 @@ async function persistResponseRow({
   return { status: "error", error: insErr.message };
 }
 
-// Auto-save nao revalida o RSC tree — evita re-fetch do servidor a cada
-// troca de aba / navegacao entre docs e qualquer flicker residual no
-// formulario. Submit explicito (handleSubmit / handleBrowseSubmit) revalida
-// normalmente, propagando o efeito para Compare, Reviews e o progresso.
-function revalidateAfterSave(projectId: string, isAutoSave: boolean): void {
-  if (isAutoSave) return;
+// Propaga o efeito do envio para as telas que leem a mesma resposta —
+// Comparação, Revisões e o progresso do projeto. Até o #608 o auto-save pulava
+// esta função inteira (para não re-buscar o servidor a cada troca de aba, com o
+// flicker que isso trazia ao formulário); sem ele, todo save revalida.
+function revalidateAfterSave(projectId: string): void {
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/analyze/compare`);
   revalidatePath(`/projects/${projectId}/analyze/auto-revisao`);
@@ -319,7 +313,6 @@ interface BuildSaveWriteParams {
   existing: ExistingResponseRow | null | undefined;
   project: SaveResponseProjectFields | null | undefined;
   answers: Record<string, unknown>;
-  isAutoSave: boolean;
   notes?: string;
 }
 
@@ -332,7 +325,6 @@ function buildSaveWrite({
   existing,
   project,
   answers,
-  isAutoSave,
   notes,
 }: BuildSaveWriteParams) {
   // O formulário devolve um snapshot sanitizado, não um patch. A reconciliação
@@ -344,9 +336,6 @@ function buildSaveWrite({
       ? { answers: existing.answers, hashes: existing.answer_field_hashes }
       : null,
     rawSubmittedAnswers: answers,
-    // Só um submit explícito atesta a codificação inteira; auto-save não pode
-    // promover uma response legacy à versão corrente (#548).
-    promoteLegacyIfComplete: !isAutoSave,
   });
 
   // Régua de completude aplicada UMA vez, ao conjunto que vai ser gravado
@@ -368,7 +357,6 @@ function buildSaveWrite({
     stampsCurrentSchema: snapshot.stampsCurrentSchema,
     project,
     existing,
-    isAutoSave,
     notes,
   });
 
@@ -413,7 +401,6 @@ interface SaveAttemptParams {
   userEmail: string;
   answers: Record<string, unknown>;
   notes?: string;
-  isAutoSave: boolean;
 }
 
 // Uma tentativa completa de gravação: lê o contexto, monta o snapshot a partir
@@ -435,7 +422,6 @@ async function runSaveAttempt({
   userEmail,
   answers,
   notes,
-  isAutoSave,
 }: SaveAttemptParams): Promise<SaveResponseResult | { conflict: true }> {
   const { profile, existing, existingErr, project, projErr, doc } =
     await fetchSaveContext(supabase, projectId, documentId, effectiveId);
@@ -451,7 +437,6 @@ async function runSaveAttempt({
     existing,
     project,
     answers,
-    isAutoSave,
     notes,
   });
 
@@ -476,11 +461,10 @@ async function runSaveAttempt({
     project,
     existing,
     snapshot,
-    isAutoSave,
   });
   if (syncErr) return { success: false, error: syncErr };
 
-  revalidateAfterSave(projectId, isAutoSave);
+  revalidateAfterSave(projectId);
   return { success: true, missingRequired };
 }
 
@@ -495,7 +479,6 @@ async function syncAssignmentAfterSave({
   project,
   existing,
   snapshot,
-  isAutoSave,
 }: {
   supabase: SupabaseServerClient;
   projectId: string;
@@ -505,7 +488,6 @@ async function syncAssignmentAfterSave({
   project: { automation_mode?: string | null } | null | undefined;
   existing: { is_partial: boolean | null } | null | undefined;
   snapshot: { submittedAnswers: Record<string, unknown> };
-  isAutoSave: boolean;
 }): Promise<string | undefined> {
   if (fields.length === 0) return undefined;
   const { error } = await syncCodingAssignmentStatus(supabase, {
@@ -514,7 +496,6 @@ async function syncAssignmentAfterSave({
     userId: effectiveId,
     fields,
     sanitizedAnswers: snapshot.submittedAnswers,
-    isAutoSave,
     automationMode: project?.automation_mode,
     // Lido ANTES da escrita: distingue "já estava concluída" de "concluiu
     // agora", que é o que impede o rebaixamento descrito em
@@ -550,7 +531,7 @@ export async function saveResponse(
   answers: Record<string, unknown>,
   opts: SaveResponseOpts = {},
 ): Promise<SaveResponseResult> {
-  const { notes, isAutoSave = false } = opts;
+  const { notes } = opts;
 
   try {
     const actor = await resolveProjectMemberActor(projectId);
@@ -568,7 +549,6 @@ export async function saveResponse(
         userEmail: user.email,
         answers,
         notes,
-        isAutoSave,
       });
       if (!("conflict" in result)) return result;
 

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -192,7 +192,7 @@ describe("flush — os gatilhos de que depende 'fechar a aba não perde trabalho
   // `pagehide` dispara em TODO descarregamento da página, inclusive nos que um
   // `beforeunload` pegaria — por isso este hook não registra o segundo: ele não
   // acrescentaria cobertura e tiraria a página do back/forward cache no Firefox
-  // e no Safari. O `beforeunload` de `useAutosaveOnExit` é outro caso: lá ele
+  // e no Safari. O `beforeunload` de `useUnsavedWorkGuard` é outro caso: lá ele
   // serve ao aviso nativo do navegador, que só existe por meio dele.
   it("pagehide persiste antes do debounce", () => {
     const { result } = render();

--- a/frontend/src/hooks/useCodingDrafts.ts
+++ b/frontend/src/hooks/useCodingDrafts.ts
@@ -80,7 +80,7 @@ export function useCodingDrafts(params: UseCodingDraftsParams): CodingDraftsApi 
   // aqui (`pagehide` dispara em todo descarregamento, inclusive nos que o
   // `beforeunload` pega) e registrá-lo tira a página do back/forward cache no
   // Firefox e no Safari — voltar para a fila deixaria de ser instantâneo em
-  // troca de nada. O `beforeunload` que existe em `useAutosaveOnExit` é outro
+  // troca de nada. O `beforeunload` que existe em `useUnsavedWorkGuard` é outro
   // caso: lá ele serve ao aviso nativo do navegador, que só existe por meio dele.
   useEffect(() => {
     const flush = () => session.flushAll();

--- a/frontend/src/lib/__tests__/coding-initial-status.test.ts
+++ b/frontend/src/lib/__tests__/coding-initial-status.test.ts
@@ -70,8 +70,9 @@ describe("resolveInitialCodingStatus", () => {
   });
 
   it("codificação COMPLETA mas nunca enviada (is_partial) → em_andamento, não concluido", () => {
-    // `is_partial` marca "não clicou em Enviar", não "faltam campos": o
-    // auto-save grava true com o formulário inteiro preenchido. Nascer
+    // Nas linhas ANTERIORES ao #608 `is_partial` marca "não clicou em Enviar",
+    // não "faltam campos": o auto-save gravava true com o formulário inteiro
+    // preenchido, e essas linhas continuam no banco. Nascer
     // `concluido` aqui seria a #521 ao contrário, e definitivo —
     // `keepCodingAssignmentInProgress` nunca regride de `concluido`. O par com
     // o caso acima prova que o veredito vem do is_partial, e não do conteúdo:

--- a/frontend/src/lib/__tests__/response-snapshot.test.ts
+++ b/frontend/src/lib/__tests__/response-snapshot.test.ts
@@ -132,7 +132,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: storedAnswers, hashes: storedHashes },
       rawSubmittedAnswers,
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -172,7 +171,6 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", detalhe: "d-old" },
       },
       rawSubmittedAnswers: { gatilho: "nao" },
-      promoteLegacyIfComplete: false,
     });
 
     // Só o gatilho foi revisado, então só ele ganha a proveniência de hoje. O
@@ -201,7 +199,6 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", detalhe: "d-old" },
       },
       rawSubmittedAnswers: { gatilho: "nao" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.submittedAnswers).toEqual({ gatilho: "nao" });
@@ -233,7 +230,6 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", filho: "f-old", neto: "n-old" },
       },
       rawSubmittedAnswers: { gatilho: "nao" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({ gatilho: "nao" });
@@ -272,7 +268,6 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", intermediario: "i-old", descendente: "d-old" },
       },
       rawSubmittedAnswers: { gatilho: "B", intermediario: "ocultar" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -301,7 +296,6 @@ describe("buildPersistedResponseSnapshot", () => {
         hashes: { gatilho: "g-old", detalhe: "d-old" },
       },
       rawSubmittedAnswers: { outro: "novo" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({
@@ -323,17 +317,25 @@ describe("buildPersistedResponseSnapshot", () => {
       // `fieldExistedWhenCoded` os lê como "todos existiam". Estampar chaves aqui
       // inverteria o sentinela em "só os campos que estampei existiam", tornando
       // qualquer codificação antiga trivialmente completa — inclusive as que de
-      // fato ficaram com obrigatórios em branco. Ver #520.
+      // fato ficaram com obrigatórios em branco. Ver #520. As duas formas do
+      // sentinela precisam se comportar igual, daí o `it.each`.
+      //
+      // `em_branco` é o que sustenta a asserção: a via de saída da #548 promove
+      // quando a recodificação fica COMPLETA contra o schema atual, então só um
+      // conjunto incompleto conserva o sentinela. Até o #608 este caso passava
+      // `promoteLegacyIfComplete: false` e ficava completo — provava a supressão
+      // do auto-save, não a regra que o título enuncia; sob envio explícito o
+      // mesmo cenário já promovia desde a #548.
       const fields = [
         field({ name: "stale", type: "single", options: ["X"], hash: "stale-new" }),
         field({ name: "outro", hash: "outro-new" }),
+        field({ name: "em_branco", hash: "branco-new" }),
       ];
 
       const result = buildPersistedResponseSnapshot({
         fields,
         existing: { answers: { stale: "A" }, hashes: storedHashes },
         rawSubmittedAnswers: { outro: "novo" },
-        promoteLegacyIfComplete: false,
       });
 
       expect(result.persistedAnswers).toEqual({ stale: "A", outro: "novo" });
@@ -354,7 +356,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: { q1: "a", q2: "velho" }, hashes: null },
       rawSubmittedAnswers: { q1: "b", q2: "novo" },
-      promoteLegacyIfComplete: true,
     });
 
     expect(result.answerFieldHashes).toEqual({ q1: "h1", q2: "h2" });
@@ -375,7 +376,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: { q1: "a", q2: "velho" }, hashes: null },
       rawSubmittedAnswers: { q1: "b", q2: "novo" },
-      promoteLegacyIfComplete: true,
     });
 
     const currentFieldHashes = buildFieldHashMap(fields);
@@ -406,24 +406,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: { q1: "a" }, hashes: null },
       rawSubmittedAnswers: { q1: "b" },
-      promoteLegacyIfComplete: true,
-    });
-
-    expect(result.answerFieldHashes).toEqual({});
-  });
-
-  it("auto-save de response legacy nunca promove, ainda que completa (#548)", () => {
-    // Auto-save não atesta a codificação inteira: mesmo com todos os obrigatórios
-    // respondidos, `promoteLegacyIfComplete: false` conserva o sentinela.
-    const fields = [
-      field({ name: "q1", type: "single", options: ["a", "b"], hash: "h1" }),
-    ];
-
-    const result = buildPersistedResponseSnapshot({
-      fields,
-      existing: { answers: { q1: "a" }, hashes: null },
-      rawSubmittedAnswers: { q1: "b" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.answerFieldHashes).toEqual({});
@@ -442,7 +424,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: null,
       rawSubmittedAnswers: { respondido: "x" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.answerFieldHashes).toEqual({
@@ -465,7 +446,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: { antigo: "a" }, hashes: { antigo: "antigo-hash" } },
       rawSubmittedAnswers: { antigo: "b" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({ antigo: "b" });
@@ -482,7 +462,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields,
       existing: { answers: { antigo: "a" }, hashes: { antigo: "antigo-hash" } },
       rawSubmittedAnswers: { antigo: "a", novo_obrigatorio: "resposta" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.answerFieldHashes).toEqual({
@@ -496,7 +475,6 @@ describe("buildPersistedResponseSnapshot", () => {
       fields: [],
       existing: { answers: { legado: "valor" }, hashes: { legado: "hash-antigo" } },
       rawSubmittedAnswers: {},
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.persistedAnswers).toEqual({ legado: "valor" });
@@ -537,7 +515,6 @@ describe("buildPersistedResponseSnapshot", () => {
           hashes: { q7: "q7-antigo" },
         },
         rawSubmittedAnswers: { q7: "18 anos e 6 meses" },
-        promoteLegacyIfComplete: false,
       });
 
       expect(result.persistedAnswers.q7).toBe("18 anos e 6 meses");
@@ -553,7 +530,6 @@ describe("buildPersistedResponseSnapshot", () => {
           hashes: { q7: "q7-antigo" },
         },
         rawSubmittedAnswers: { q7: { anos: "18 anos e 6 meses" } },
-        promoteLegacyIfComplete: false,
       });
 
       expect(result.persistedAnswers.q7).toEqual({ anos: "18 anos e 6 meses" });
@@ -575,7 +551,6 @@ describe("buildPersistedResponseSnapshot — stampsCurrentSchema (#529/#548)", (
       fields: [single("q1", "h1")],
       existing: { answers: { q1: "a" }, hashes: { q1: "h1" } },
       rawSubmittedAnswers: { q1: "a" },
-      promoteLegacyIfComplete: false,
     });
 
     expect(result.stampsCurrentSchema).toBe(false);
@@ -586,7 +561,6 @@ describe("buildPersistedResponseSnapshot — stampsCurrentSchema (#529/#548)", (
       fields: [single("q1", "h1")],
       existing: { answers: { q1: "a" }, hashes: { q1: "h1" } },
       rawSubmittedAnswers: { q1: "b" },
-      promoteLegacyIfComplete: true,
     });
 
     expect(result.stampsCurrentSchema).toBe(true);
@@ -598,7 +572,6 @@ describe("buildPersistedResponseSnapshot — stampsCurrentSchema (#529/#548)", (
       fields: [single("antigo", "antigo-hash"), single("novo", "novo-hash")],
       existing: { answers: { antigo: "a" }, hashes: { antigo: "antigo-hash" } },
       rawSubmittedAnswers: { antigo: "a", novo: "b" },
-      promoteLegacyIfComplete: true,
     });
 
     expect(result.stampsCurrentSchema).toBe(true);
@@ -611,7 +584,6 @@ describe("buildPersistedResponseSnapshot — stampsCurrentSchema (#529/#548)", (
       fields: [single("q1", "h1")],
       existing: { answers: { q1: "a" }, hashes: { q1: "h1" } },
       rawSubmittedAnswers: {},
-      promoteLegacyIfComplete: true,
     });
 
     expect(result.persistedAnswers).toEqual({});
@@ -623,13 +595,12 @@ describe("buildPersistedResponseSnapshot — stampsCurrentSchema (#529/#548)", (
       fields: [single("q1", "h1")],
       existing: null,
       rawSubmittedAnswers: { q1: "a" },
-      promoteLegacyIfComplete: true,
     });
 
     expect(result.stampsCurrentSchema).toBe(true);
   });
 
-  it("true na via de saída legacy: submit completo recodifica e estampa (#548)", () => {
+  it("via de saída legacy: recodificação completa desliga o sentinela e estampa (#548)", () => {
     // A interação que exige o sinal UNIFICADO: aqui `changedFieldNames` pode até
     // estar vazio (valores iguais aos apresentados), mas a recodificação completa
     // desliga o sentinela e estampa o mapa inteiro — então `stampsCurrentSchema`
@@ -640,24 +611,9 @@ describe("buildPersistedResponseSnapshot — stampsCurrentSchema (#529/#548)", (
       fields: [single("q1", "h1")],
       existing: { answers: { q1: "a" }, hashes: null },
       rawSubmittedAnswers: { q1: "a" },
-      promoteLegacyIfComplete: true,
     });
 
     expect(result.answerFieldHashes).toEqual({ q1: "h1" });
     expect(result.stampsCurrentSchema).toBe(true);
-  });
-
-  it("false na legacy sob auto-save: conserva a época (#548)", () => {
-    // Mesmo cenário, mas auto-save não atesta a codificação inteira: o sentinela
-    // é conservado (`{}`) e o sinal fica false, simétrico ao mapa.
-    const result = buildPersistedResponseSnapshot({
-      fields: [single("q1", "h1")],
-      existing: { answers: { q1: "a" }, hashes: null },
-      rawSubmittedAnswers: { q1: "a" },
-      promoteLegacyIfComplete: false,
-    });
-
-    expect(result.answerFieldHashes).toEqual({});
-    expect(result.stampsCurrentSchema).toBe(false);
   });
 });

--- a/frontend/src/lib/coding-completeness.ts
+++ b/frontend/src/lib/coding-completeness.ts
@@ -129,9 +129,10 @@ export function missingRequiredHumanFields(
 //   • o gate de `is_partial` em saveResponse, que avalia contra o snapshot da
 //     própria escrita (buildPersistedResponseSnapshot). Para uma codificação NOVA
 //     esse snapshot estampa o schema inteiro como chaves, então aware ≡ blind e
-//     nenhum obrigatório em branco é perdoado; a distinção só morde no auto-save de
+//     nenhum obrigatório em branco é perdoado; a distinção só morde ao reenviar
 //     uma resposta JÁ submetida sob schema que cresceu — exatamente o caso que não
-//     deve rebaixar um doc concluído (#519/#520).
+//     deve rebaixar um doc concluído (#519/#520). Até o #608 o gatilho era o
+//     auto-save de navegação; hoje é reabrir o doc e clicar em Enviar.
 // Quem permanece staleness-BLIND de propósito é a promoção a `concluido` em
 // syncCodingAssignmentStatus (coding-sync): lá é o guard de não-rebaixar um
 // assignment já concluído que sustenta a invariante, não o carimbo per-campo.

--- a/frontend/src/lib/coding-initial-status.ts
+++ b/frontend/src/lib/coding-initial-status.ts
@@ -46,10 +46,10 @@ export interface InitialCodingStatus {
  * quando o UPDATE do assignment não afeta linha nenhuma — que é exatamente o
  * caso em que o assignment ainda não existia.
  *
- * O terceiro juiz é o guard de auto-save, replicado aqui a partir de
- * `syncCodingAssignmentStatus` porque `classifyDocStatus` não o expõe: ele
- * colapsa `is_partial` em `current_pending`, que é o mesmo ramo de uma response
- * enviada e incompleta. Ver o comentário no corpo da função.
+ * O terceiro juiz é o guard de `is_partial`, que precisa viver aqui porque
+ * `classifyDocStatus` não o expõe: ele colapsa `is_partial` em
+ * `current_pending`, o mesmo ramo de uma response enviada e incompleta. Ver o
+ * comentário no corpo da função.
  */
 export function resolveInitialCodingStatus(
   ctx: RoundContext,
@@ -64,13 +64,19 @@ export function resolveInitialCodingStatus(
     return { status: "pendente", completed_at: null };
   }
 
-  // `is_partial` significa "nunca submetida", não "incompleta": o auto-save
-  // grava true enquanto o pesquisador não clicar em Enviar, mesmo com todos os
-  // campos preenchidos (actions/responses.ts, isPartialToWrite). Promover isso
-  // a `concluido` seria a #521 ao contrário — e um estado do qual não se sai:
-  // `keepCodingAssignmentInProgress` nunca regride de `concluido`, então nem o
-  // auto-save seguinte nem o submit posterior corrigiriam a linha. Mesmo motivo
-  // do gate `!isAutoSave` em `syncCodingAssignmentStatus`.
+  // `is_partial === true` não é promovível a `concluido`, por duas razões que
+  // hoje coincidem mas têm origens distintas:
+  //
+  //   • nas linhas gravadas a partir do #608, significa "o conjunto gravado
+  //     está incompleto" (actions/responses.ts, `isPartialToWrite`);
+  //   • nas linhas ANTERIORES ao #608, significa "nunca submetida" — o
+  //     auto-save gravava `true` enquanto o pesquisador não clicasse em Enviar,
+  //     mesmo com todos os campos preenchidos. Essas linhas continuam no banco
+  //     e esta função as lê.
+  //
+  // Promover qualquer uma delas seria a #521 ao contrário — e um estado do qual
+  // não se sai: `keepCodingAssignmentInProgress` nunca regride de `concluido`,
+  // então nem um submit posterior corrigiria a linha.
   if (response.is_partial === true) {
     return { status: "em_andamento", completed_at: null };
   }

--- a/frontend/src/lib/coding-sync.ts
+++ b/frontend/src/lib/coding-sync.ts
@@ -59,7 +59,6 @@ export interface SyncCodingAssignmentParams {
   userId: string;
   fields: PydanticField[];
   sanitizedAnswers: Record<string, unknown>;
-  isAutoSave: boolean;
   automationMode: string | null | undefined;
   hadCompletedResponse: boolean;
 }
@@ -134,13 +133,11 @@ async function keepCodingAssignmentInProgress(
   return error ? { error: error.message } : {};
 }
 
-// Recomputes the reviewer's "codificacao" assignment status right after a
-// save: completes it (and fires the project's automation) when every field
-// is answered and this isn't an autosave; otherwise regresses it back to
-// em_andamento — but never out of concluido, so autosave never undoes
-// progress. Mirrors the "recompute + update assignment" shape already
-// established by syncCompareAssignment (compare-sync.ts) for the
-// "comparacao" assignment type.
+// Recalcula o status do assignment de "codificacao" logo depois de um save:
+// conclui (e dispara a automação do projeto) quando todo campo está
+// respondido; caso contrário regride para em_andamento — mas nunca para fora
+// de concluido. Mesma forma "recalcula + atualiza assignment" já estabelecida
+// por syncCompareAssignment (compare-sync.ts) para o tipo "comparacao".
 export async function syncCodingAssignmentStatus(
   supabase: SupabaseServerClient,
   params: SyncCodingAssignmentParams,
@@ -150,21 +147,26 @@ export async function syncCodingAssignmentStatus(
   const allAnswered = isCodingComplete(params.fields, params.sanitizedAnswers);
 
   // A response humana continua sendo a mesma row depois do primeiro submit.
-  // Portanto, qualquer save posterior (inclusive autosave) precisa reconciliar
-  // imediatamente os ciclos que dependiam do valor anterior.
+  // Portanto, qualquer save posterior precisa reconciliar imediatamente os
+  // ciclos que dependiam do valor anterior.
   if (params.hadCompletedResponse) {
     const reconciliation = await reconcileEditedResponse(params);
     if (reconciliation.error) return reconciliation;
   }
 
-  // Auto-save nunca promove para "concluido" — mesmo que todos os campos
-  // estejam preenchidos, o pesquisador ainda nao clicou em Enviar. Sem essa
-  // guarda, sair da pagina dispara visibilitychange -> saveResponse -> doc
-  // some da lista no filtro padrao por virar current_done.
-  if (allAnswered && !params.isAutoSave) {
+  // Até o #608 a promoção era gateada também pelo canal de escrita
+  // (`allAnswered && !isAutoSave`): sair da página disparava
+  // visibilitychange -> saveResponse, e sem o gate o documento sumia do filtro
+  // padrão por virar current_done sem ninguém ter clicado em Enviar. Removido
+  // o auto-save, todo save que chega aqui é submit explícito — a completude
+  // voltou a ser a condição inteira.
+  if (allAnswered) {
     return completeCodingAssignment(supabase, params);
   }
 
-  // So regredir se NAO esta concluido (evita desfazer progresso por auto-save)
+  // Um submit incompleto sobre um assignment já concluído NÃO o rebaixa: a
+  // conclusão foi um ato do pesquisador, e o guard de
+  // `keepCodingAssignmentInProgress` é quem sustenta essa invariante agora que
+  // o gate por canal saiu.
   return keepCodingAssignmentInProgress(supabase, params);
 }

--- a/frontend/src/lib/response-snapshot.ts
+++ b/frontend/src/lib/response-snapshot.ts
@@ -92,10 +92,6 @@ interface BuildPersistedResponseSnapshotParams {
   fields: PydanticField[];
   existing: ExistingResponseSnapshot | null;
   rawSubmittedAnswers: Record<string, unknown>;
-  // Submit explícito (não auto-save): habilita a promoção de uma response
-  // legacy à proveniência corrente quando este save a recodifica por completo
-  // contra o schema atual (#548). Auto-save nunca promove — não atesta nada.
-  promoteLegacyIfComplete: boolean;
 }
 
 function samePresentedValue(
@@ -231,7 +227,6 @@ function buildReconciledFieldHashes(
   existing: ExistingResponseSnapshot | null,
   persistedAnswers: Record<string, unknown>,
   changedFieldNames: Set<string>,
-  promoteLegacyIfComplete: boolean,
 ): ReconciledFieldHashes {
   const currentHashes = buildFieldHashMap(fields);
 
@@ -251,16 +246,20 @@ function buildReconciledFieldHashes(
   // ficaram em branco de verdade. Permanece grosseiro até que uma codificação
   // nova estabeleça proveniência.
   //
-  // Via de saída (#548): uma recodificação COMPLETA — submit explícito
-  // (`promoteLegacyIfComplete`) cuja codificação fica completa contra o schema
-  // ATUAL — é o único momento em que dá para afirmar que todos os campos de
-  // hoje existiam. Aí estampamos o schema inteiro como uma codificação nova,
-  // desligando o sentinela e marcando `stampsCurrentSchema` — o que libera
+  // Via de saída (#548): uma recodificação COMPLETA contra o schema ATUAL é o
+  // único momento em que dá para afirmar que todos os campos de hoje existiam.
+  // Aí estampamos o schema inteiro como uma codificação nova, desligando o
+  // sentinela e marcando `stampsCurrentSchema` — o que libera
   // `buildResponsePayload` a promover `pydantic_hash` + `schema_version_*`, e a
-  // response volta à fila `latest_major`. Fora daí (parcial ou auto-save) o
-  // sentinela é conservado, mantendo o fallback de staleness conservador.
+  // response volta à fila `latest_major`. Uma gravação parcial conserva o
+  // sentinela, mantendo o fallback de staleness conservador.
+  //
+  // Até o #608 a promoção era gateada também pelo canal de escrita
+  // (`promoteLegacyIfComplete`, falso no auto-save, que não atestava nada).
+  // Removido o auto-save, toda escrita que chega aqui é submit explícito: a
+  // completude do conjunto gravado voltou a ser a condição inteira.
   if (!storedHashes || Object.keys(storedHashes).length === 0) {
-    if (promoteLegacyIfComplete && isCodingComplete(fields, persistedAnswers)) {
+    if (isCodingComplete(fields, persistedAnswers)) {
       return {
         hashes: withAnswerProvenanceFallback(currentHashes, persistedAnswers),
         stampsCurrentSchema: true,
@@ -290,7 +289,6 @@ export function buildPersistedResponseSnapshot({
   fields,
   existing,
   rawSubmittedAnswers,
-  promoteLegacyIfComplete,
 }: BuildPersistedResponseSnapshotParams): PersistedResponseSnapshot {
   const storedAnswers = existing?.answers;
   // A leitura sem schema expõe o JSON bruto por compatibilidade, mas não há
@@ -314,7 +312,6 @@ export function buildPersistedResponseSnapshot({
     existing,
     persistedAnswers,
     reconciled.changedFieldNames,
-    promoteLegacyIfComplete,
   );
 
   return { submittedAnswers, persistedAnswers, answerFieldHashes, stampsCurrentSchema };

--- a/frontend/src/lib/rounds.ts
+++ b/frontend/src/lib/rounds.ts
@@ -59,8 +59,10 @@ export function classifyDocStatus(
 ): DocRoundStatus {
   if (!response) return { kind: "no_response" };
 
-  // Resposta parcial (autosave em andamento) ainda precisa ser concluida —
-  // tratar como pendente da rodada atual independente de schema/round_id.
+  // Resposta parcial ainda precisa ser concluida — tratar como pendente da
+  // rodada atual independente de schema/round_id. Vale tanto para o conjunto
+  // gravado incompleto (semântica a partir do #608) quanto para as linhas
+  // legadas que o auto-save deixou marcadas como nunca submetidas.
   if (response.is_partial === true) return { kind: "current_pending" };
 
   if (ctx.strategy === "manual") {


### PR DESCRIPTION
**Rebaseado sobre `main`** depois que o #624 entrou (via #632) — a base deste PR é `main`. O #627 (PR 4/4) ainda está empilhado sobre esta branch: reapontar a base dele antes de deletar esta.

## Por que agora, e não junto com o #624

O #624 removeu os quatro gatilhos de gravação automática — e com eles **todos** os produtores de `isAutoSave`. O que sobrou foi um parâmetro sem nenhum produtor governando quatro ramos do write path: exatamente o tipo de estado que fica correto por acidente até alguém reintroduzir um caller.

Ficou separado do #624 porque são leituras diferentes: lá o diff é de UI, aqui é do caminho que grava. Sob `revisão: integral`, juntar os dois daria um PR grande demais para leitura humana honesta.

## Os quatro ramos

| | O que `isAutoSave = true` fazia | Depois |
|---|---|---|
| **A** revalidação RSC | `return` imediato — nenhum `revalidatePath`/`revalidateTag` | todo save propaga para Comparação, Revisões e progresso |
| **B** `is_partial` | herdava "já foi submetida uma vez" do canal (`isAutoSave && !submittedBefore`) | descreve só o conjunto gravado |
| **C** promoção a `concluido` | nunca promovia, mesmo com tudo preenchido | a completude é a condição inteira |
| **D** promoção de response legacy (#548) | conservava o sentinela | idem |

Nos ramos A, C e D remover a flag é literalmente "parar de pular o efeito". Só o **B** escrevia um valor próprio, e é dele que vem a única mudança de semântica deste PR.

## A mudança de semântica, e por que ela não quebra o passado

`is_partial = true` deixa de significar **"nunca enviada"** e passa a significar **"conjunto gravado incompleto"**.

As linhas gravadas **antes** deste PR conservam o sentido antigo — o auto-save marcava `true` mesmo com tudo preenchido, e essas linhas continuam no banco. `resolveInitialCodingStatus` lê justamente essas linhas, e por isso continua recusando promovê-las a `concluido`: agora por duas razões que coincidem, com origens distintas. O comentário lá registra as duas, para quem reler daqui a um ano não concluir que uma delas é redundante.

## Sai junto

- **`promoteLegacyIfComplete`** (`response-snapshot.ts`): sem a flag, seria um parâmetro de um valor só.

(O rename `coding-autosave.ts` → `coding-save.ts`, anunciado aqui numa versão anterior deste corpo, acabou entrando junto com o #632 — não está neste diff.)

## Um teste que enunciava mais do que provava

`"mantém o sentinela legacy de uma response já existente"` (`response-snapshot.test.ts`) passava `promoteLegacyIfComplete: false` sobre um conjunto **completo**. Ou seja: afirmava uma invariante geral, mas só exercitava a supressão do auto-save — sob envio explícito o mesmo cenário **já promovia**, desde a #548. O gate que este PR remove era a única coisa que fazia a asserção passar.

Reescrito com conjunto incompleto, que é a condição sob a qual a regra do título de fato vale. É o inverso da vacuidade usual: não um teste que sobrevive sem provar nada, mas um cujo enunciado era mais amplo que o ramo que ele tocava.

## Contabilidade dos testes: −7, todos nomeados

Medido comparando a lista de nomes de teste antes e depois (o `describe` foi renomeado, o que infla o diff bruto):

- **5 saem** de `responses.test.ts` — os que só existiam para o ramo autosave;
- **2 saem** de `response-snapshot.test.ts` — idem;
- os demais foram **renomeados**, mantendo as asserções.

A asserção de não-regressão do assignment concluído, que morava num teste removido, foi **realocada** para um caso de envio incompleto — o cenário que ainda a alcança. Sem isso o guard de `keepCodingAssignmentInProgress` ficaria descoberto justamente quando passa a ser o único sustentáculo da invariante.

## Prova do vermelho — 5 mutações

| Mutação | Teste que cai |
|---|---|
| revalidação sempre pulada | `o envio dispara revalidatePath e revalidateTag` |
| `is_partial` volta a herdar do canal | `grava response com is_partial=false` (+1) |
| promoção a `concluido` gateada | `com todos os campos preenchidos promove` (+2) |
| promoção legacy suprimida | `recodifica a legacy por completo (#548)` (+3 em snapshot) |
| guard de não-regressão removido | `envio incompleto NÃO regride o assignment concluido` |

## Resíduo de comentário, corrigido na revisão

Quatro comentários descreviam o auto-save no presente, dois deles nomeando `useAutosaveOnExit` — um hook que não existe desde o #624. Como é este o PR que limpa o resíduo do `isAutoSave`, entraram aqui (commit à parte, só comentários): `useCodingDrafts` e seu teste passam a contrastar com `useUnsavedWorkGuard`, que já apontava para `useCodingDrafts` na direção contrária; `coding-completeness` troca o gatilho citado (reabrir e enviar, não auto-save de navegação); e `coding-initial-status.test` data a semântica antiga, como o comentário do arquivo de produção já fazia.

## Verificação

- **vitest**: 2026 testes / 191 arquivos, verdes (baseline do #624: 2033/191 — o delta é o −7 acima)
- **E2E**: 8 passaram, 0 falharam, numa execução; os 2 de `coding-save.smoke` incluem o discriminador que afirma no banco que sair sem enviar não grava
- **typecheck / lint / lint:types / react-doctor / fallow / semgrep**: verdes; lint com 0 errors e os mesmos 7 warnings pré-existentes
- Todos os hooks de pre-push passaram no push que publicou a branch

`npm run invariants` segue **12/13**, com a **mesma violação única** do #625 (mesmo id de review, `8ad2b0da`) — nenhuma nova ocorrência desde ontem, e este PR não toca write path de reviews.

Refs #608
