### PR TITLE
fix(comparação): cabeçalho de altura invariante e controles sob demanda (#610)

### DIFF
--- a/frontend/e2e/compare-field-switch.smoke.spec.ts
+++ b/frontend/e2e/compare-field-switch.smoke.spec.ts
@@ -195,6 +195,14 @@ test("comparação: navegar entre campos mostra só os cards do campo atual", as
       // toda a contagem sai deslocada em um campo (medido ao investigar a #613).
       await expect(page.getByTestId("agreement-group")).toHaveCount(1);
 
+      // Posição do topo do primeiro card em cada campo. O critério 1 da #610 é
+      // que ela NÃO se mova ao navegar: o cabeçalho fica acima da área rolável,
+      // então toda variação de altura dele desloca a lista inteira e o revisor
+      // perde a âncora visual a cada `n`. Os campos do fixture variam de
+      // propósito em enunciado e help_text — sem essa variação a asserção
+      // passaria por acidente.
+      const firstCardTops: number[] = [];
+
       for (let i = 0; i < TOTAL_FIELDS; i++) {
         await expect(
           page.getByText(new RegExp(`Campo ${i + 1}/${TOTAL_FIELDS}`)),
@@ -221,8 +229,21 @@ test("comparação: navegar entre campos mostra só os cards do campo atual", as
           ).toBe(true);
         }
 
+        firstCardTops.push(
+          await cards.first().evaluate((el) => el.getBoundingClientRect().top),
+        );
+
         if (i < TOTAL_FIELDS - 1) await page.keyboard.press("n");
       }
+
+      // Tolerância de 1px absorve arredondamento subpixel do layout; qualquer
+      // coisa acima disso é o cabeçalho mudando de altura. Antes do fix o
+      // intervalo media dezenas de pixels.
+      const spread = Math.max(...firstCardTops) - Math.min(...firstCardTops);
+      expect(
+        spread,
+        `posição do primeiro card variou entre campos: ${JSON.stringify(firstCardTops)}`,
+      ).toBeLessThanOrEqual(1);
     },
   });
 });

--- a/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
+++ b/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
@@ -76,7 +76,12 @@ const HELP_TEXTS = [
   // Acima dos 96px que o bloco antigo reservava: é o caso que mais empurrava
   // os cards para baixo.
   "Instrução longa de preenchimento. ".repeat(20),
-  undefined,
+  // Casado de propósito com o enunciado longo (LONG_DESCRIPTION_INDEX): é a
+  // combinação em que o gatilho de ajuda ficaria recortado pelo `line-clamp`
+  // se voltasse para dentro do elemento clampado. Separar as duas
+  // propriedades em campos distintos — como estava — deixa o pior caso fora
+  // da tela medida.
+  "Instrução do campo de enunciado longo, para exercitar as duas coisas juntas.",
   "Verifique a data de assinatura antes de responder.",
   "Instrução média para conferência do respondente. ".repeat(4),
 ];

--- a/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
+++ b/frontend/scripts/e2e-fixtures/create-compare-field-switch-fixture.mts
@@ -62,12 +62,37 @@ export const PROJECT_NAME = "Comparação campo-trocado — teste E2E";
 const SCHEMA_HASH = "e2e-campotrocado-schema-hash";
 const LETTERS = ["ALFA", "BETA", "GAMA", "DELTA", "EPSILON", "ZETA"];
 
+// TERCEIRA PROPRIEDADE LOAD-BEARING — os campos variam DELIBERADAMENTE em
+// comprimento de `description` e `help_text`: nenhum, curto e muito longo, mais
+// um enunciado que não cabe em duas linhas. É essa variação que dá mordida à
+// asserção de que a posição do primeiro card não muda ao navegar (#610): com
+// seis campos de texto uniforme e nenhum help_text — como era antes —, o
+// cabeçalho tinha altura constante por acidente do fixture, e o spec ficaria
+// verde mesmo com o defeito presente. Uniformizar estes textos "para limpar"
+// esvazia a asserção sem quebrá-la.
+const HELP_TEXTS = [
+  undefined,
+  "Considere apenas o dispositivo final.",
+  // Acima dos 96px que o bloco antigo reservava: é o caso que mais empurrava
+  // os cards para baixo.
+  "Instrução longa de preenchimento. ".repeat(20),
+  undefined,
+  "Verifique a data de assinatura antes de responder.",
+  "Instrução média para conferência do respondente. ".repeat(4),
+];
+
+const LONG_DESCRIPTION_INDEX = 3;
+
 const FIELDS = LETTERS.map((letter, i) => ({
   hash: `e2e-ct-f${i + 1}`,
   name: `q${i + 1}_${letter.toLowerCase()}`,
   type: "single" as const,
   options: [`${letter}-opcao-1`, `${letter}-opcao-2`, `${letter}-opcao-3`],
-  description: `Pergunta ${i + 1} (${letter}) — opções exclusivas deste campo`,
+  description:
+    i === LONG_DESCRIPTION_INDEX
+      ? `Pergunta ${i + 1} (${letter}) — enunciado deliberadamente longo, que não cabe em duas linhas no painel de comparação e por isso exercita o clamp do cabeçalho, incluindo texto suficiente para transbordar em telas estreitas e largas`
+      : `Pergunta ${i + 1} (${letter}) — opções exclusivas deste campo`,
+  help_text: HELP_TEXTS[i],
 }));
 
 const DOC_TITLES = ["Doc campo-trocado 1", "Doc campo-trocado 2"];
@@ -90,7 +115,7 @@ async function main() {
 
   const { data: existing } = await supabase
     .from("projects")
-    .select("id")
+    .select("id, schema_revision")
     .eq("name", PROJECT_NAME)
     .maybeSingle();
 
@@ -102,7 +127,18 @@ async function main() {
   };
   if (existing) {
     projectId = existing.id as string;
-    const { error } = await supabase.from("projects").update(schema).eq("id", projectId);
+    // O banco recusa alteração de `pydantic_fields` sem avanço de
+    // `schema_revision` (exatamente +1). Reexecutar o script com os campos
+    // inalterados também passa por aqui: incrementar sem mudança é inofensivo,
+    // enquanto derivar "mudou?" no cliente duplicaria a regra que a própria
+    // trigger já aplica.
+    const { error } = await supabase
+      .from("projects")
+      .update({
+        ...schema,
+        schema_revision: ((existing.schema_revision as number) ?? 0) + 1,
+      })
+      .eq("id", projectId);
     if (error) throw new Error(`update projects: ${error.message}`);
   } else {
     const { data, error } = await supabase

--- a/frontend/src/components/coding/ProgressDots.tsx
+++ b/frontend/src/components/coding/ProgressDots.tsx
@@ -29,6 +29,12 @@ export function ProgressDots({ total, currentIndex, answered, concordant, incomp
           // fileiras passa a ser função apenas de `total` e da largura
           // disponível. Efeito colateral desejado: o alvo de clique fica
           // constante e maior que os 8px de antes.
+          //
+          // O círculo mantém a aparência de antes, mas o ESPAÇAMENTO entre
+          // pontos aumenta — a caixa dos não-correntes vai de 8px para 12px.
+          // Vale também para o AutoReviewFieldPanel, que consome este
+          // componente com a mesma forma (cabeçalho `shrink-0` acima do
+          // scroller) e herda a invariância de altura sem ter sido medido.
           <button
             type="button"
             key={i}

--- a/frontend/src/components/coding/ProgressDots.tsx
+++ b/frontend/src/components/coding/ProgressDots.tsx
@@ -19,23 +19,22 @@ export function ProgressDots({ total, currentIndex, answered, concordant, incomp
         const isConcordant = concordant?.[i] ?? false;
         const isIncomplete = incomplete?.[i] ?? false;
         return (
+          // A CAIXA é sempre `size-3`; só o círculo de dentro muda de tamanho
+          // com o índice corrente. O dot ativo ser 4px mais largo que os
+          // demais tornava a largura do flex-item função de `currentIndex`:
+          // num container `flex-wrap`, isso desloca o ponto de quebra ao
+          // navegar e, no limiar, troca 2 fileiras por 3 — variação de altura
+          // do cabeçalho ENTRE CAMPOS DO MESMO DOCUMENTO, que faz os cards
+          // saltarem a cada `n`/`p` (#610). Com a caixa fixa, o número de
+          // fileiras passa a ser função apenas de `total` e da largura
+          // disponível. Efeito colateral desejado: o alvo de clique fica
+          // constante e maior que os 8px de antes.
           <button
             type="button"
             key={i}
             aria-label={`Ir para pergunta ${i + 1}`}
             onClick={() => onNavigate(i)}
-            className={cn(
-              "rounded-full transition-all",
-              i === currentIndex ? "size-3" : "size-2",
-              isConcordant
-                ? "bg-muted-foreground/30"
-                : answered[i]
-                  ? "bg-brand"
-                  : isIncomplete
-                    ? "border border-amber-500 bg-amber-500/30"
-                    : "border border-muted-foreground/40 bg-transparent",
-              i === currentIndex && "ring-2 ring-brand/30"
-            )}
+            className="flex size-3 shrink-0 items-center justify-center"
             title={`Pergunta ${i + 1}${
               isConcordant
                 ? " (concordante)"
@@ -43,7 +42,22 @@ export function ProgressDots({ total, currentIndex, answered, concordant, incomp
                   ? " (falta justificativa)"
                   : ""
             }`}
-          />
+          >
+            <span
+              className={cn(
+                "rounded-full transition-all",
+                i === currentIndex ? "size-3" : "size-2",
+                isConcordant
+                  ? "bg-muted-foreground/30"
+                  : answered[i]
+                    ? "bg-brand"
+                    : isIncomplete
+                      ? "border border-amber-500 bg-amber-500/30"
+                      : "border border-muted-foreground/40 bg-transparent",
+                i === currentIndex && "ring-2 ring-brand/30"
+              )}
+            />
+          </button>
         );
       })}
     </div>

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -261,7 +261,7 @@ export function AgreementGroup({
                   <button
                     type="button"
                     aria-label="Como funciona a equivalência entre respostas"
-                    className="shrink-0 cursor-help text-muted-foreground hover:text-foreground"
+                    className="shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
                   >
                     <HelpCircle className="size-3.5" />
                   </button>

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -5,12 +5,17 @@ import { AnswerCard, type EquivalentVariant } from "./AnswerCard";
 import type { PendingVerdict } from "./compare-types";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { normalizeForComparison } from "@/lib/utils";
 import { formatPartialDate } from "@/lib/date-parts";
 import {
   buildResponseGroupKeys,
 } from "@/lib/equivalence";
-import { Link2 } from "lucide-react";
+import { HelpCircle, Link2 } from "lucide-react";
 
 interface AgreementResponse {
   id: string;
@@ -240,12 +245,33 @@ export function AgreementGroup({
       */}
       <div className="space-y-1.5" data-testid="agreement-group">
         {allowEquivalence && groups.length > 1 && (
-          <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1.5 text-[11px] leading-tight text-muted-foreground">
-            <p className="min-w-0 flex-1">
-              <Link2 className="mr-1 inline size-3" />
-              Marque os cards equivalentes (ex.: NI ≡ N/A ≡ &ldquo;não
-              informado&rdquo;) e indique qual fica como{" "}
-              <strong>gabarito</strong> (a resposta que será registrada).
+          // Uma linha, não três: a explicação completa (o exemplo de
+          // equivalência e o que "gabarito" significa) vive no popover ao lado.
+          // O texto curto permanece visível porque é ele que revela a
+          // affordance para quem entra na tela pela primeira vez — o que sai do
+          // fluxo é a prosa, não a descoberta (#610).
+          <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1 text-[11px] leading-tight text-muted-foreground">
+            <p className="flex min-w-0 flex-1 items-center gap-1">
+              <Link2 className="size-3 shrink-0" />
+              <span className="truncate">
+                Marque os equivalentes e escolha o gabarito.
+              </span>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Como funciona a equivalência entre respostas"
+                    className="shrink-0 cursor-help text-muted-foreground hover:text-foreground"
+                  >
+                    <HelpCircle className="size-3.5" />
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent align="start" className="w-80 p-3 text-xs">
+                  Marque os cards equivalentes (ex.: NI ≡ N/A ≡ &ldquo;não
+                  informado&rdquo;) e indique qual fica como{" "}
+                  <strong>gabarito</strong> — a resposta que será registrada.
+                </PopoverContent>
+              </Popover>
             </p>
             <Button
               size="sm"

--- a/frontend/src/components/compare/ComparePage.tsx
+++ b/frontend/src/components/compare/ComparePage.tsx
@@ -27,6 +27,8 @@ import {
   type VerdictOrigin,
 } from "./compare-types";
 
+const LIST_COLLAPSED_KEY = "compare:listCollapsed";
+
 interface ComparePageProps {
   projectId: string;
   documents: CompareDocument[];
@@ -339,8 +341,28 @@ export function ComparePage({
     [],
   );
   const exitFullscreen = useCallback(() => setIsFullscreen(false), []);
-  const [listCollapsed, setListCollapsed] = useState(false);
-  const toggleList = useCallback(() => setListCollapsed((v) => !v), []);
+  // Lista lateral recolhida atravessa sessões: quem revisa muito recolhe uma
+  // vez e não quer refazer o gesto todo dia (#610). Mesmo idioma do
+  // `AutoReviewFooter` — lazy initializer no mount, sem flicker — e não o
+  // `usePinnedDoc`: aquele existe para reagir a escrita externa e limpar
+  // órfãos, e um toggle de sidebar não tem escritor concorrente nem domínio de
+  // validade.
+  const [listCollapsed, setListCollapsed] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem(LIST_COLLAPSED_KEY) === "1";
+  });
+  // `setItem` no handler e NÃO dentro do updater: o React pode reexecutar o
+  // updater e o efeito colateral se repetiria. Ler `listCollapsed` do closure
+  // é seguro porque só o clique altera o valor — e a dependência mantém o
+  // closure fresco, ao custo de trocar a identidade da callback uma vez por
+  // alternância.
+  const toggleList = useCallback(() => {
+    const next = !listCollapsed;
+    setListCollapsed(next);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(LIST_COLLAPSED_KEY, next ? "1" : "0");
+    }
+  }, [listCollapsed]);
   // Ponto único de gate da navegação MANUAL (sidebar, nav de doc, nav de
   // campo, teclado). Com rascunho não confirmado, navegar descartaria a
   // seleção em silêncio via guard de contexto — a perda de sessão da issue

--- a/frontend/src/components/compare/CompareWorkspace.tsx
+++ b/frontend/src/components/compare/CompareWorkspace.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDefaultLayout } from "react-resizable-panels";
 import { DocumentReader } from "../coding/DocumentReader";
 import {
   ResizablePanelGroup,
@@ -8,6 +9,26 @@ import {
 } from "@/components/ui/resizable";
 import { ComparisonPanel } from "./ComparisonPanel";
 import { CompareDocList, type DocListEntry } from "./CompareDocList";
+
+// Identificam cada painel DENTRO do layout persistido, que é um mapa
+// `{ [panelId]: tamanho }`. Sem `id` explícito a lib cai em `useId()`, cuja
+// saída muda entre execuções: a gravação funciona, a restauração não acha a
+// chave, e a falha é silenciosa — o pior modo possível para uma preferência.
+const READER_PANEL_ID = "compare-reader";
+const REVIEW_PANEL_ID = "compare-review";
+
+// `useDefaultLayout` lê o storage via `useSyncExternalStore` COM
+// `getServerSnapshot`, e seu default é `localStorage` — que não existe no
+// render de servidor deste componente. O guard mora aqui, numa constante de
+// módulo, porque o objeto entra nas dependências do hook: recriá-lo a cada
+// render o faria reassinar sem parar.
+const layoutStorage = {
+  getItem: (key: string) =>
+    typeof window === "undefined" ? null : window.localStorage.getItem(key),
+  setItem: (key: string, value: string) => {
+    if (typeof window !== "undefined") window.localStorage.setItem(key, value);
+  },
+};
 
 interface CompareWorkspaceProps {
   docs: DocListEntry[];
@@ -33,6 +54,14 @@ export function CompareWorkspace({
   documentText,
   comparisonPanel,
 }: CompareWorkspaceProps) {
+  // Quem revisa muito ajusta a divisão uma vez e a mantém; sem isto, toda
+  // sessão recomeçava em 50/50 (#610).
+  const { defaultLayout, onLayoutChanged } = useDefaultLayout({
+    id: "compare:split",
+    storage: layoutStorage,
+    panelIds: [READER_PANEL_ID, REVIEW_PANEL_ID],
+  });
+
   return (
     <div className="flex flex-1 overflow-hidden">
       <CompareDocList
@@ -43,12 +72,16 @@ export function CompareWorkspace({
         onToggle={onToggleList}
       />
 
-      <ResizablePanelGroup className="flex-1">
-        <ResizablePanel defaultSize={50} minSize={25}>
+      <ResizablePanelGroup
+        className="flex-1"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+      >
+        <ResizablePanel id={READER_PANEL_ID} defaultSize={50} minSize={25}>
           <DocumentReader text={documentText} />
         </ResizablePanel>
         <ResizableHandle withHandle />
-        <ResizablePanel defaultSize={50} minSize={25}>
+        <ResizablePanel id={REVIEW_PANEL_ID} defaultSize={50} minSize={25}>
           <ComparisonPanel {...comparisonPanel} />
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -178,7 +178,18 @@ export function ComparisonPanel({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="shrink-0 border-b px-4 py-1.5">
+      {/*
+        `data-testid` é contrato de medição, não estilo: a comparação de área
+        antes/depois da #610 mede a altura deste bloco em navegador, e casar por
+        classe Tailwind quebraria no primeiro ajuste de layout — em silêncio e
+        sempre para o lado do verde. Mesma razão do `agreement-group`.
+
+        Este cabeçalho é `shrink-0` ACIMA do único scroller do painel: tudo que
+        cresce aqui empurra os cards sem amortecimento. Daí a densidade `fixed`
+        do FieldHeaderLabel e a caixa de tamanho constante do ProgressDots —
+        juntos, tornam a altura deste bloco invariante entre campos.
+      */}
+      <div className="shrink-0 border-b px-4 py-1.5" data-testid="compare-header">
         <ProgressDots
           total={totalFields}
           currentIndex={fieldIndex}
@@ -189,7 +200,11 @@ export function ComparisonPanel({
           <FieldHeaderLabel
             prefix={`Campo ${fieldIndex + 1}/${totalFields}:`}
             helpText={fieldHelpText}
-            helpTextClassName="max-h-24 overflow-y-auto pr-1"
+            density={{
+              kind: "fixed",
+              clampLines: 2,
+              fullText: fieldDescription || fieldName,
+            }}
           >
             {fieldDescription || fieldName}
           </FieldHeaderLabel>
@@ -209,6 +224,14 @@ export function ComparisonPanel({
                   </>
                 )}
               </Badge>
+            )}
+            {isDivergent && (
+              <KeyboardHints
+                readOnly={readOnly}
+                groupCount={groupCount}
+                isMulti={isMulti}
+                optionCount={isMulti ? displayOptions.length : undefined}
+              />
             )}
           </div>
         </div>
@@ -318,14 +341,6 @@ export function ComparisonPanel({
         </div>
       )}
 
-      {isDivergent && (
-        <KeyboardHints
-          readOnly={readOnly}
-          groupCount={groupCount}
-          isMulti={isMulti}
-          optionCount={isMulti ? displayOptions.length : undefined}
-        />
-      )}
     </div>
   );
 }

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -200,11 +200,7 @@ export function ComparisonPanel({
           <FieldHeaderLabel
             prefix={`Campo ${fieldIndex + 1}/${totalFields}:`}
             helpText={fieldHelpText}
-            density={{
-              kind: "fixed",
-              clampLines: 2,
-              fullText: fieldDescription || fieldName,
-            }}
+            density={{ kind: "fixed", clampLines: 2 }}
           >
             {fieldDescription || fieldName}
           </FieldHeaderLabel>

--- a/frontend/src/components/compare/KeyboardHints.tsx
+++ b/frontend/src/components/compare/KeyboardHints.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import type { ReactNode } from "react";
 import { Keyboard } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 
 interface KeyboardHintsProps {
   readOnly: boolean;
@@ -11,94 +16,110 @@ interface KeyboardHintsProps {
   optionCount?: number;
 }
 
+function Key({ children }: { children: ReactNode }) {
+  return (
+    <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+      {children}
+    </kbd>
+  );
+}
+
+function Hint({ keys, children }: { keys: ReactNode; children: ReactNode }) {
+  return (
+    <span className="flex items-center gap-1.5">
+      {keys} {children}
+    </span>
+  );
+}
+
+/**
+ * Legenda dos atalhos, sob demanda.
+ *
+ * Era um bloco fixo no rodapé do painel: uma faixa permanente de ~44px cujo
+ * único conteúdo era um botão que só revelava algo se clicado — a pior razão
+ * entre pixels ocupados e informação exibida da tela (#610). Agora é um ícone
+ * no cabeçalho, ao lado dos badges do campo, com o mesmo conteúdo dentro de um
+ * popover.
+ *
+ * O rótulo antigo anunciava um atalho `?` que nunca existiu: `useCompareKeyboard`
+ * trata `Ctrl+Shift+F`, `Escape`, `n`, `p`, `a`, `s`, `Enter` e dígitos, e nada
+ * mais. Anunciar tecla que não responde é pior que não anunciar nenhuma, então
+ * o `?` saiu em vez de virar TODO. Ligá-lo de verdade exigiria expor o estado
+ * deste popover até o `ComparePage` para alcançar o handler global.
+ */
 export function KeyboardHints({
   readOnly,
   groupCount,
   isMulti,
   optionCount,
 }: KeyboardHintsProps) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <div className="border-t px-4 py-2">
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-6 gap-1.5 px-2 text-xs text-muted-foreground"
-        onClick={() => setOpen(!open)}
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Atalhos de teclado"
+          className="size-5 shrink-0 p-0 text-muted-foreground"
+        >
+          <Keyboard className="size-3.5" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="flex w-72 flex-col gap-1.5 p-3 text-xs text-muted-foreground"
       >
-        <Keyboard className="size-3" />
-        Atalhos
-        <kbd className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">?</kbd>
-      </Button>
-      {open && (
-        <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-          {!readOnly && (
-            <>
-              {isMulti ? (
-                <>
-                  <span>
-                    <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                      1
-                    </kbd>
-                    {(optionCount ?? 0) > 1 && (
-                      <>
-                        –
-                        <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                          {optionCount}
-                        </kbd>
-                      </>
-                    )}{" "}
-                    Marcar/desmarcar
-                  </span>
-                  <span>
-                    <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                      Enter
-                    </kbd>{" "}
-                    Confirmar
-                  </span>
-                </>
-              ) : (
-                <span>
-                  <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                    1
-                  </kbd>
-                  {groupCount > 1 && (
+        {!readOnly && (
+          <>
+            {isMulti ? (
+              <>
+                <Hint
+                  keys={
                     <>
-                      –
-                      <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                        {groupCount}
-                      </kbd>
+                      <Key>1</Key>
+                      {(optionCount ?? 0) > 1 && (
+                        <>
+                          –<Key>{optionCount}</Key>
+                        </>
+                      )}
                     </>
-                  )}{" "}
+                  }
+                >
+                  Marcar/desmarcar
+                </Hint>
+                <Hint keys={<Key>Enter</Key>}>Confirmar</Hint>
+              </>
+            ) : (
+              <>
+                <Hint
+                  keys={
+                    <>
+                      <Key>1</Key>
+                      {groupCount > 1 && (
+                        <>
+                          –<Key>{groupCount}</Key>
+                        </>
+                      )}
+                    </>
+                  }
+                >
                   Escolher resposta
-                </span>
-              )}
-              <span>
-                <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                  A
-                </kbd>{" "}
-                Ambíguo
-              </span>
-              <span>
-                <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                  S
-                </kbd>{" "}
-                Pular
-              </span>
-            </>
-          )}
-          <span>
-            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">P</kbd> Anterior
-          </span>
-          <span>
-            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">N</kbd> Próximo
-          </span>
-          <span>
-            <kbd className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">Ctrl+Shift+F</kbd> Tela cheia
-          </span>
-        </div>
-      )}
-    </div>
+                </Hint>
+                {/* Confirmar também vale em campo simples — o painel só
+                    anunciava no ramo multi, e a omissão fazia parecer que o
+                    fluxo de teclado terminava na escolha (#614). */}
+                <Hint keys={<Key>Enter</Key>}>Confirmar</Hint>
+              </>
+            )}
+            <Hint keys={<Key>A</Key>}>Ambíguo</Hint>
+            <Hint keys={<Key>S</Key>}>Pular</Hint>
+          </>
+        )}
+        <Hint keys={<Key>P</Key>}>Anterior</Hint>
+        <Hint keys={<Key>N</Key>}>Próximo</Hint>
+        <Hint keys={<Key>Ctrl+Shift+F</Key>}>Tela cheia</Hint>
+        <Hint keys={<Key>Esc</Key>}>Sair da tela cheia</Hint>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
+++ b/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
@@ -1,9 +1,26 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
+import { render, screen, cleanup, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { AgreementGroup } from "@/components/compare/AgreementGroup";
+
+// Radix (Popover) usa APIs de Pointer/observer que o jsdom não tem.
+beforeAll(() => {
+  const proto = Element.prototype as unknown as Record<string, unknown>;
+  proto.scrollIntoView = () => {};
+  proto.hasPointerCapture = () => false;
+  proto.setPointerCapture = () => {};
+  proto.releasePointerCapture = () => {};
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
 
 afterEach(cleanup);
 
@@ -182,5 +199,42 @@ describe("AgreementGroup — 'Todas são similares' (issue #247, ponto 5)", () =
     expect(onVote).not.toHaveBeenCalled();
     expect(onConfirmEquivalent).not.toHaveBeenCalled();
     expect(onUnmarkPair).not.toHaveBeenCalled();
+  });
+});
+
+// A prosa que explicava a equivalência saiu do banner permanente (três linhas
+// em todo campo divergente) e foi para um popover, mantendo visíveis a frase
+// curta e o botão — que são a affordance de descoberta (#610).
+//
+// Esta cobertura é nova: o texto explicativo NÃO tinha teste nenhum antes de
+// sair do fluxo. Sem ela, mover a prosa a apagaria do radar.
+describe("AgreementGroup — explicação da equivalência sob demanda (#610)", () => {
+  it("mantém a frase curta e o botão visíveis, com o detalhe no popover", async () => {
+    const user = userEvent.setup();
+    renderGroup();
+
+    expect(
+      screen.getByText(/marque os equivalentes e escolha o gabarito/i),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: /todas são similares/i }),
+    ).toBeTruthy();
+    // O detalhe (o exemplo NI ≡ N/A e o que "gabarito" significa) não ocupa
+    // espaço até ser pedido.
+    expect(screen.queryByText(/NI ≡ N\/A/)).toBeNull();
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /como funciona a equivalência entre respostas/i,
+      }),
+    );
+
+    // Escopado ao popover: "gabarito" também aparece na frase curta que ficou
+    // visível, então um getByText solto casaria dois nós e não distinguiria de
+    // onde veio o texto.
+    const detail = (await screen.findByText(/NI ≡ N\/A/)).closest(
+      '[data-slot="popover-content"]',
+    ) as HTMLElement;
+    expect(within(detail).getByText(/gabarito/i)).toBeTruthy();
   });
 });

--- a/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
+++ b/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
@@ -4,23 +4,9 @@ import { render, screen, cleanup, waitFor, within } from "@testing-library/react
 import userEvent from "@testing-library/user-event";
 
 import { AgreementGroup } from "@/components/compare/AgreementGroup";
+import { stubRadixJsdomApis } from "@/test-utils/radix-jsdom";
 
-// Radix (Popover) usa APIs de Pointer/observer que o jsdom não tem.
-beforeAll(() => {
-  const proto = Element.prototype as unknown as Record<string, unknown>;
-  proto.scrollIntoView = () => {};
-  proto.hasPointerCapture = () => false;
-  proto.setPointerCapture = () => {};
-  proto.releasePointerCapture = () => {};
-  vi.stubGlobal(
-    "ResizeObserver",
-    class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    },
-  );
-});
+beforeAll(stubRadixJsdomApis);
 
 afterEach(cleanup);
 

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -73,12 +73,20 @@ vi.mock("@/components/compare/CompareWorkspace", () => ({
   CompareWorkspace: ({
     documentText,
     comparisonPanel,
+    listCollapsed,
+    onToggleList,
   }: {
     documentText: string;
     comparisonPanel: MockComparisonPanel;
+    listCollapsed: boolean;
+    onToggleList: () => void;
   }) => (
     <div>
       <span data-testid="doc-text">{documentText}</span>
+      <span data-testid="list-collapsed">{String(listCollapsed)}</span>
+      <button data-testid="toggle-list" onClick={onToggleList}>
+        toggle list
+      </button>
       <span data-testid="field-name">{comparisonPanel.fieldName}</span>
       <span data-testid="pending-verdict">
         {comparisonPanel.pendingVerdict
@@ -1103,5 +1111,41 @@ describe("ComparePage — toggle de fila (só coordenador)", () => {
     expect(
       screen.getByText("Nenhum documento na fila com os filtros atuais."),
     ).not.toBeNull();
+  });
+});
+
+// A preferência de layout atravessa sessões (#610). O par de casos é o que
+// tira a vacuidade: um prova que o valor gravado é LIDO no mount, o outro que
+// o toggle o ESCREVE. Testar só um dos lados passaria com metade da ligação.
+describe("ComparePage — lista lateral recolhida persiste entre sessões (#610)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("monta recolhida quando a sessão anterior deixou assim", () => {
+    window.localStorage.setItem("compare:listCollapsed", "1");
+    render(<ComparePage {...makeProps()} />);
+    expect(text("list-collapsed")).toBe("true");
+  });
+
+  it("monta expandida sem preferência gravada", () => {
+    render(<ComparePage {...makeProps()} />);
+    expect(text("list-collapsed")).toBe("false");
+  });
+
+  it("alternar grava a preferência", async () => {
+    const user = userEvent.setup();
+    render(<ComparePage {...makeProps()} />);
+
+    await user.click(screen.getByTestId("toggle-list"));
+    expect(text("list-collapsed")).toBe("true");
+    expect(window.localStorage.getItem("compare:listCollapsed")).toBe("1");
+
+    await user.click(screen.getByTestId("toggle-list"));
+    expect(text("list-collapsed")).toBe("false");
+    expect(window.localStorage.getItem("compare:listCollapsed")).toBe("0");
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
@@ -1,6 +1,24 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Radix (Popover) usa APIs de Pointer/observer que o jsdom não tem.
+beforeAll(() => {
+  const proto = Element.prototype as unknown as Record<string, unknown>;
+  proto.scrollIntoView = () => {};
+  proto.hasPointerCapture = () => false;
+  proto.setPointerCapture = () => {};
+  proto.releasePointerCapture = () => {};
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
 
 vi.mock("@/components/shared/AddNoteButton", () => ({
   AddNoteButton: () => <button type="button">Anotar</button>,
@@ -97,20 +115,53 @@ describe("ComparisonPanel — não preencheu este campo (issue #247, ponto 3)", 
   });
 });
 
-describe("ComparisonPanel — help_text no header (#373)", () => {
+// O help_text continua acessível, mas saiu do fluxo permanente do cabeçalho:
+// era um bloco de até 96px de instrução de PREENCHIMENTO no topo de uma tela de
+// ARBITRAGEM, e a altura variável entre campos fazia os cards saltarem ao
+// navegar (#610).
+//
+// Os três casos formam um par que não pode ficar vácuo: (1) e (2) provam que o
+// texto está fora do DOM ATÉ o clique e dentro DEPOIS dele — se alguém apagar o
+// help_text de vez, (2) fica vermelho; se alguém devolvê-lo ao fluxo, (1) fica
+// vermelho. Sozinho, o caso (3) passaria trivialmente nos dois mundos.
+describe("ComparisonPanel — help_text sob demanda no header (#373/#610)", () => {
   const RESPONSES = [
     resp({ id: "llm", respondent_type: "llm", respondent_name: "Robô", answer: "2021-05-10" }),
   ];
+  const HELP = "Considere apenas a data de assinatura.";
+  const helpButton = () =>
+    screen.queryByRole("button", {
+      name: /instruções de preenchimento do campo/i,
+    });
 
-  it("mostra o help_text do campo quando presente", () => {
-    renderPanel(RESPONSES, "Considere apenas a data de assinatura.");
-    expect(
-      screen.getByText("Considere apenas a data de assinatura."),
-    ).toBeTruthy();
+  it("com help_text, oferece o gatilho e mantém o texto FORA do fluxo", () => {
+    renderPanel(RESPONSES, HELP);
+    expect(helpButton()).not.toBeNull();
+    expect(screen.queryByText(HELP)).toBeNull();
   });
 
-  it("não renderiza bloco de help_text quando ausente", () => {
+  it("o texto integral continua alcançável ao abrir o popover", async () => {
+    const user = userEvent.setup();
+    renderPanel(RESPONSES, HELP);
+    await user.click(helpButton()!);
+    expect(await screen.findByText(HELP)).toBeTruthy();
+  });
+
+  it("sem help_text, não há gatilho nem texto", () => {
     renderPanel(RESPONSES);
+    expect(helpButton()).toBeNull();
     expect(screen.queryByText(/Considere apenas/)).toBeNull();
+  });
+});
+
+// O enunciado é clampado em duas linhas de altura reservada; o texto integral
+// vive no `title`. Sem esta asserção, "otimizar" o clamp removendo a via para o
+// texto completo passaria despercebido.
+describe("ComparisonPanel — enunciado clampado (#610)", () => {
+  it("expõe o enunciado integral mesmo quando ele não cabe em duas linhas", () => {
+    renderPanel([
+      resp({ id: "llm", respondent_type: "llm", respondent_name: "Robô", answer: "2021-05-10" }),
+    ]);
+    expect(screen.getByTitle("Data do parecer")).toBeTruthy();
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.unanswered.test.tsx
@@ -3,22 +3,9 @@ import { describe, it, expect, vi, afterEach, beforeAll } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-// Radix (Popover) usa APIs de Pointer/observer que o jsdom não tem.
-beforeAll(() => {
-  const proto = Element.prototype as unknown as Record<string, unknown>;
-  proto.scrollIntoView = () => {};
-  proto.hasPointerCapture = () => false;
-  proto.setPointerCapture = () => {};
-  proto.releasePointerCapture = () => {};
-  vi.stubGlobal(
-    "ResizeObserver",
-    class {
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    },
-  );
-});
+import { stubRadixJsdomApis } from "@/test-utils/radix-jsdom";
+
+beforeAll(stubRadixJsdomApis);
 
 vi.mock("@/components/shared/AddNoteButton", () => ({
   AddNoteButton: () => <button type="button">Anotar</button>,

--- a/frontend/src/components/shared/FieldHeaderLabel.tsx
+++ b/frontend/src/components/shared/FieldHeaderLabel.tsx
@@ -16,27 +16,29 @@ import { cn } from "@/lib/utils";
  *   quando o cabeçalho é chrome `shrink-0` ACIMA da área rolável: ali cada
  *   linha a mais empurra o conteúdo, e como a altura variava por campo os
  *   cards saltavam de posição ao navegar com `n`/`p` (#610).
- *
- * `fullText` é obrigatório em `fixed` — não é conveniência. Clampar sem uma via
- * para o texto integral é perda de informação, então o tipo torna esse estado
- * irrepresentável em vez de deixá-lo à disciplina do call site.
  */
-// Não exportado: os call sites passam o literal direto, e um export sem
+// Não exportados: os call sites passam o literal direto, e um export sem
 // consumidor é código morto que o gate de grafo acusa.
-type FieldHeaderDensity =
-  | { kind: "flow" }
-  | { kind: "fixed"; clampLines: 2; fullText: string };
-
-interface FieldHeaderLabelProps {
+interface FieldHeaderLabelBaseProps {
   prefix: ReactNode;
-  children: ReactNode;
   helpText?: string | null;
-  density?: FieldHeaderDensity;
   className?: string;
   labelClassName?: string;
   /** Só tem efeito em `flow`; em `fixed` o help_text não vive no fluxo. */
   helpTextClassName?: string;
 }
+
+// Clampar sem uma via para o texto integral seria perda de informação, e a via
+// é o `title` — atributo, que só aceita texto. Daí a união: em `fixed` o
+// enunciado É uma string, e o próprio `children` vira o texto completo. Uma
+// prop `fullText` separada resolveria o mesmo, mas declararia duas vezes o
+// mesmo fato no call site, livre para divergir; aqui o tipo torna a divergência
+// inexprimível em vez de confiá-la à disciplina de quem chama.
+type FieldHeaderLabelProps = FieldHeaderLabelBaseProps &
+  (
+    | { density?: { kind: "flow" }; children: ReactNode }
+    | { density: { kind: "fixed"; clampLines: 2 }; children: string }
+  );
 
 // Prefixo + descrição de um campo (ex.: "Campo 1/5: Data do parecer"), com o
 // help_text opcional. Compartilhado entre Codificação (SortableQuestion),
@@ -60,34 +62,55 @@ export function FieldHeaderLabel({
   const isFixed = density.kind === "fixed";
   const trimmedHelp = helpText?.trim();
 
+  const label = (
+    <p
+      className={cn(
+        "text-sm font-medium",
+        isFixed
+          ? // `line-clamp-2` corta o excesso; o `min-h-10` (2 × leading-5 do
+            // text-sm) é o que RESERVA as duas linhas mesmo em enunciado
+            // curto. Sem ele o clamp não zera a variação de altura — apenas
+            // limita o teto. `min-w-0 flex-1` porque em `fixed` este parágrafo
+            // é flex-item ao lado do gatilho de ajuda.
+            "line-clamp-2 min-h-10 min-w-0 flex-1"
+          : "flex items-center gap-1.5",
+        labelClassName,
+      )}
+      // Texto integral do enunciado clampado. `title` nativo em vez de
+      // Tooltip do Radix de propósito: o alvo desta tela é mouse/desktop, e
+      // um TooltipTrigger focável acrescentaria uma parada de Tab por campo
+      // numa fila percorrida inteiramente por teclado (`n`/`p`/`Enter`).
+      //
+      // Vai sempre, mesmo em enunciado curto que não trunca — a alternativa
+      // seria medir `scrollHeight` no cliente por campo, reintroduzindo
+      // trabalho de layout justamente no bloco cuja invariância é o objetivo.
+      // O custo é um tooltip nativo redundante ao pousar o mouse.
+      title={isFixed && typeof children === "string" ? children : undefined}
+    >
+      <span className={cn("text-muted-foreground", isFixed && "mr-1.5")}>
+        {prefix}
+      </span>
+      {children}
+    </p>
+  );
+
   return (
     <div className={cn("min-w-0", className)}>
-      <p
-        className={cn(
-          "text-sm font-medium",
-          isFixed
-            ? // `line-clamp-2` corta o excesso; o `min-h-10` (2 × leading-5 do
-              // text-sm) é o que RESERVA as duas linhas mesmo em enunciado
-              // curto. Sem ele o clamp não zera a variação de altura — apenas
-              // limita o teto. Nota: `line-clamp-*` implica
-              // `display:-webkit-box`, que anula qualquer `flex` aqui; por isso
-              // prefixo e ícone são inline dentro da caixa, não flex-items.
-              "line-clamp-2 min-h-10"
-            : "flex items-center gap-1.5",
-          labelClassName,
-        )}
-        // Texto integral do enunciado clampado. `title` nativo em vez de
-        // Tooltip do Radix de propósito: o alvo desta tela é mouse/desktop, e
-        // um TooltipTrigger focável acrescentaria uma parada de Tab por campo
-        // numa fila percorrida inteiramente por teclado (`n`/`p`/`Enter`).
-        title={density.kind === "fixed" ? density.fullText : undefined}
-      >
-        <span className={cn("text-muted-foreground", isFixed && "mr-1.5")}>
-          {prefix}
-        </span>
-        {children}
-        {isFixed && trimmedHelp && <FieldHelpPopover helpText={trimmedHelp} />}
-      </p>
+      {isFixed ? (
+        // O gatilho é IRMÃO do parágrafo clampado, nunca filho: `line-clamp-*`
+        // implica `display:-webkit-box` com `overflow:hidden`, então um botão
+        // inline depois do texto sumiria — recortado e inalcançável por mouse,
+        // ainda que focável por Tab — exatamente nos campos de enunciado longo,
+        // que são os que mais precisam da instrução. `items-start` alinha o
+        // ícone à primeira linha; a altura da faixa continua vindo do `min-h-10`
+        // do parágrafo, logo a presença ou ausência do gatilho não move nada.
+        <div className="flex items-start gap-1">
+          {label}
+          {trimmedHelp && <FieldHelpPopover helpText={trimmedHelp} />}
+        </div>
+      ) : (
+        label
+      )}
 
       {!isFixed && helpText && (
         <p
@@ -107,9 +130,6 @@ export function FieldHeaderLabel({
  * Instrução de preenchimento sob demanda. Popover, e não tooltip, porque o
  * texto chega a ~900 caracteres nos projetos reais: precisa rolar, ser
  * selecionável e fechar por teclado.
- *
- * O gatilho é inline dentro da caixa clampada — logo sua presença ou ausência
- * não move nada, que é a propriedade de que o cabeçalho depende.
  */
 function FieldHelpPopover({ helpText }: { helpText: string }) {
   return (
@@ -118,7 +138,7 @@ function FieldHelpPopover({ helpText }: { helpText: string }) {
         <button
           type="button"
           aria-label="Instruções de preenchimento do campo"
-          className="ml-1 inline-flex translate-y-px cursor-help align-text-bottom text-muted-foreground hover:text-foreground"
+          className="mt-0.5 shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
         >
           <HelpCircle className="size-3.5" />
         </button>

--- a/frontend/src/components/shared/FieldHeaderLabel.tsx
+++ b/frontend/src/components/shared/FieldHeaderLabel.tsx
@@ -1,35 +1,95 @@
+"use client";
+
 import type { ReactNode } from "react";
+import { HelpCircle } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+
+/**
+ * Como o cabeçalho ocupa espaço.
+ *
+ * - `flow`: o enunciado cresce quantas linhas precisar e o `help_text` vem num
+ *   bloco abaixo. É o default e o certo quando o cabeçalho está DENTRO de uma
+ *   área rolável — a altura extra é amortizada pelo scroll, e o enunciado é o
+ *   objeto da tarefa (codificação).
+ * - `fixed`: altura reservada e constante, `help_text` sob demanda. É o certo
+ *   quando o cabeçalho é chrome `shrink-0` ACIMA da área rolável: ali cada
+ *   linha a mais empurra o conteúdo, e como a altura variava por campo os
+ *   cards saltavam de posição ao navegar com `n`/`p` (#610).
+ *
+ * `fullText` é obrigatório em `fixed` — não é conveniência. Clampar sem uma via
+ * para o texto integral é perda de informação, então o tipo torna esse estado
+ * irrepresentável em vez de deixá-lo à disciplina do call site.
+ */
+// Não exportado: os call sites passam o literal direto, e um export sem
+// consumidor é código morto que o gate de grafo acusa.
+type FieldHeaderDensity =
+  | { kind: "flow" }
+  | { kind: "fixed"; clampLines: 2; fullText: string };
 
 interface FieldHeaderLabelProps {
   prefix: ReactNode;
   children: ReactNode;
   helpText?: string | null;
+  density?: FieldHeaderDensity;
   className?: string;
   labelClassName?: string;
+  /** Só tem efeito em `flow`; em `fixed` o help_text não vive no fluxo. */
   helpTextClassName?: string;
 }
 
 // Prefixo + descrição de um campo (ex.: "Campo 1/5: Data do parecer"), com o
-// help_text opcional logo abaixo. Compartilhado entre Codificação
-// (QuestionsPanel), Comparação (ComparisonPanel) e Revisão Automática
-// (AutoReviewFieldPanel) — as três telas mostravam essa dupla de formas
-// levemente divergentes e apenas uma exibia help_text (#373/#365).
+// help_text opcional. Compartilhado entre Codificação (SortableQuestion),
+// Comparação (ComparisonPanel) e Revisão Automática (AutoReviewFieldPanel) —
+// as três telas mostravam essa dupla de formas levemente divergentes e apenas
+// uma exibia help_text (#373/#365).
+//
+// O default é `flow`, e isso é deliberado: a Codificação usa este componente
+// como item de lista rolável, onde o enunciado é justamente a pergunta que se
+// está respondendo — clampá-lo lá seria regressão. Só quem é chrome de altura
+// fixa pede `fixed`, tela a tela. Não uniformizar sem medir a tela alvo.
 export function FieldHeaderLabel({
   prefix,
   children,
   helpText,
+  density = { kind: "flow" },
   className,
   labelClassName,
   helpTextClassName,
 }: FieldHeaderLabelProps) {
+  const isFixed = density.kind === "fixed";
+  const trimmedHelp = helpText?.trim();
+
   return (
     <div className={cn("min-w-0", className)}>
-      <p className={cn("flex items-center gap-1.5 text-sm font-medium", labelClassName)}>
-        <span className="text-muted-foreground">{prefix}</span>
+      <p
+        className={cn(
+          "text-sm font-medium",
+          isFixed
+            ? // `line-clamp-2` corta o excesso; o `min-h-10` (2 × leading-5 do
+              // text-sm) é o que RESERVA as duas linhas mesmo em enunciado
+              // curto. Sem ele o clamp não zera a variação de altura — apenas
+              // limita o teto. Nota: `line-clamp-*` implica
+              // `display:-webkit-box`, que anula qualquer `flex` aqui; por isso
+              // prefixo e ícone são inline dentro da caixa, não flex-items.
+              "line-clamp-2 min-h-10"
+            : "flex items-center gap-1.5",
+          labelClassName,
+        )}
+        // Texto integral do enunciado clampado. `title` nativo em vez de
+        // Tooltip do Radix de propósito: o alvo desta tela é mouse/desktop, e
+        // um TooltipTrigger focável acrescentaria uma parada de Tab por campo
+        // numa fila percorrida inteiramente por teclado (`n`/`p`/`Enter`).
+        title={density.kind === "fixed" ? density.fullText : undefined}
+      >
+        <span className={cn("text-muted-foreground", isFixed && "mr-1.5")}>
+          {prefix}
+        </span>
         {children}
+        {isFixed && trimmedHelp && <FieldHelpPopover helpText={trimmedHelp} />}
       </p>
-      {helpText && (
+
+      {!isFixed && helpText && (
         <p
           className={cn(
             "mt-1 whitespace-pre-line text-xs text-muted-foreground",
@@ -40,5 +100,35 @@ export function FieldHeaderLabel({
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * Instrução de preenchimento sob demanda. Popover, e não tooltip, porque o
+ * texto chega a ~900 caracteres nos projetos reais: precisa rolar, ser
+ * selecionável e fechar por teclado.
+ *
+ * O gatilho é inline dentro da caixa clampada — logo sua presença ou ausência
+ * não move nada, que é a propriedade de que o cabeçalho depende.
+ */
+function FieldHelpPopover({ helpText }: { helpText: string }) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label="Instruções de preenchimento do campo"
+          className="ml-1 inline-flex translate-y-px cursor-help align-text-bottom text-muted-foreground hover:text-foreground"
+        >
+          <HelpCircle className="size-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="max-h-64 w-80 overflow-y-auto p-3 text-xs whitespace-pre-line"
+      >
+        {helpText}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/components/shared/__tests__/FieldHeaderLabel.test.tsx
+++ b/frontend/src/components/shared/__tests__/FieldHeaderLabel.test.tsx
@@ -85,11 +85,7 @@ describe("FieldHeaderLabel — densidade", () => {
     const { container } = render(
       <FieldHeaderLabel
         prefix="Campo 1/3:"
-        density={{
-          kind: "fixed",
-          clampLines: 2,
-          fullText: "Data do parecer administrativo",
-        }}
+        density={{ kind: "fixed", clampLines: 2 }}
       >
         Data do parecer administrativo
       </FieldHeaderLabel>,
@@ -99,7 +95,31 @@ describe("FieldHeaderLabel — densidade", () => {
     // O clamp limita o teto; é o min-h que RESERVA as duas linhas e zera a
     // variação de altura entre campos. Sem ele o critério 1 da #610 cai.
     expect(label.className).toContain("min-h-10");
+    // O texto integral sai do PRÓPRIO children, não de uma segunda prop que o
+    // call site teria de manter em sincronia.
     expect(label.getAttribute("title")).toBe("Data do parecer administrativo");
+  });
+
+  // jsdom não faz layout: nenhum teste unitário vê o recorte do `line-clamp`.
+  // A asserção honesta é estrutural — o gatilho tem de estar FORA do elemento
+  // clampado. Dentro dele, `overflow:hidden` do `display:-webkit-box` o apaga
+  // da tela em todo campo cujo enunciado passe de duas linhas, que são
+  // justamente os campos em que a instrução mais faz falta.
+  it("fixed mantém o gatilho de ajuda fora do elemento clampado", () => {
+    const { container } = render(
+      <FieldHeaderLabel
+        prefix="Campo 1/3:"
+        helpText={HELP}
+        density={{ kind: "fixed", clampLines: 2 }}
+      >
+        {"Enunciado deliberadamente longo, ".repeat(12)}
+      </FieldHeaderLabel>,
+    );
+    const clamped = container.querySelector(".line-clamp-2")!;
+    const trigger = screen.getByRole("button", {
+      name: /instruções de preenchimento do campo/i,
+    });
+    expect(clamped.contains(trigger)).toBe(false);
   });
 
   it("fixed tira o help_text do fluxo e o troca por um gatilho", () => {
@@ -107,7 +127,7 @@ describe("FieldHeaderLabel — densidade", () => {
       <FieldHeaderLabel
         prefix="Campo 1/3:"
         helpText={HELP}
-        density={{ kind: "fixed", clampLines: 2, fullText: "Data do parecer" }}
+        density={{ kind: "fixed", clampLines: 2 }}
       >
         Data do parecer
       </FieldHeaderLabel>,
@@ -125,7 +145,7 @@ describe("FieldHeaderLabel — densidade", () => {
     render(
       <FieldHeaderLabel
         prefix="Campo 1/3:"
-        density={{ kind: "fixed", clampLines: 2, fullText: "Data do parecer" }}
+        density={{ kind: "fixed", clampLines: 2 }}
       >
         Data do parecer
       </FieldHeaderLabel>,

--- a/frontend/src/components/shared/__tests__/FieldHeaderLabel.test.tsx
+++ b/frontend/src/components/shared/__tests__/FieldHeaderLabel.test.tsx
@@ -42,7 +42,9 @@ describe("FieldHeaderLabel", () => {
     expect(container.querySelectorAll("p")).toHaveLength(1);
   });
 
-  it("bounds the help text block height with the provided className", () => {
+  // Só vale para `density: flow`; na Comparação o help_text não vive no fluxo,
+  // e a cobertura de lá está em ComparisonPanel.unanswered.test.tsx.
+  it("bounds the help text block height with the provided className (flow)", () => {
     render(
       <FieldHeaderLabel
         prefix="Campo 1/3:"
@@ -57,5 +59,81 @@ describe("FieldHeaderLabel", () => {
     );
     expect(helpText.className).toContain("max-h-28");
     expect(helpText.className).toContain("overflow-y-auto");
+  });
+});
+
+describe("FieldHeaderLabel — densidade", () => {
+  const HELP = "Considere apenas o dispositivo final.";
+
+  // A guarda mais importante do arquivo: a Codificação usa este componente
+  // como item de lista rolável, onde o enunciado É a pergunta que se está
+  // respondendo. Trocar o default para `fixed` — a "uniformização" tentadora —
+  // clamparia a pergunta no momento de respondê-la. Este caso fica vermelho se
+  // isso acontecer.
+  it("sem density, o default é flow: sem clamp e com help_text no fluxo", () => {
+    const { container } = render(
+      <FieldHeaderLabel prefix="Campo 1/3:" helpText={HELP}>
+        Data do parecer
+      </FieldHeaderLabel>,
+    );
+    expect(container.querySelectorAll("p")).toHaveLength(2);
+    expect(screen.getByText(HELP)).toBeTruthy();
+    expect(container.querySelector("p")!.className).not.toContain("line-clamp");
+  });
+
+  it("fixed clampa em duas linhas com altura reservada e expõe o texto integral", () => {
+    const { container } = render(
+      <FieldHeaderLabel
+        prefix="Campo 1/3:"
+        density={{
+          kind: "fixed",
+          clampLines: 2,
+          fullText: "Data do parecer administrativo",
+        }}
+      >
+        Data do parecer administrativo
+      </FieldHeaderLabel>,
+    );
+    const label = container.querySelector("p")!;
+    expect(label.className).toContain("line-clamp-2");
+    // O clamp limita o teto; é o min-h que RESERVA as duas linhas e zera a
+    // variação de altura entre campos. Sem ele o critério 1 da #610 cai.
+    expect(label.className).toContain("min-h-10");
+    expect(label.getAttribute("title")).toBe("Data do parecer administrativo");
+  });
+
+  it("fixed tira o help_text do fluxo e o troca por um gatilho", () => {
+    const { container } = render(
+      <FieldHeaderLabel
+        prefix="Campo 1/3:"
+        helpText={HELP}
+        density={{ kind: "fixed", clampLines: 2, fullText: "Data do parecer" }}
+      >
+        Data do parecer
+      </FieldHeaderLabel>,
+    );
+    expect(container.querySelectorAll("p")).toHaveLength(1);
+    expect(screen.queryByText(HELP)).toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: /instruções de preenchimento do campo/i,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("fixed sem help_text não renderiza o gatilho", () => {
+    render(
+      <FieldHeaderLabel
+        prefix="Campo 1/3:"
+        density={{ kind: "fixed", clampLines: 2, fullText: "Data do parecer" }}
+      >
+        Data do parecer
+      </FieldHeaderLabel>,
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: /instruções de preenchimento do campo/i,
+      }),
+    ).toBeNull();
   });
 });

--- a/frontend/src/test-utils/radix-jsdom.ts
+++ b/frontend/src/test-utils/radix-jsdom.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+
+// Radix (Popover, Select, Tooltip…) usa APIs de Pointer Events e ResizeObserver
+// que o jsdom não implementa: sem estes stubs, abrir um Popover num teste
+// estoura em `hasPointerCapture is not a function`.
+//
+// Chamar de dentro de `beforeAll` do arquivo de teste — a mutação é no
+// protótipo global, e fazê-la no topo do módulo a espalharia para arquivos que
+// não a pediram.
+//
+// Deliberadamente NÃO está em `setupFiles`: um teste que renderiza Radix sem
+// declarar isto denuncia a dependência no próprio arquivo, enquanto um stub
+// global a tornaria invisível. Os arquivos anteriores a este helper mantêm a
+// cópia local; consolidar todos é limpeza que não pertence a esta mudança.
+export function stubRadixJsdomApis() {
+  const proto = Element.prototype as unknown as Record<string, unknown>;
+  proto.scrollIntoView = () => {};
+  proto.hasPointerCapture = () => false;
+  proto.setPointerCapture = () => {};
+  proto.releasePointerCapture = () => {};
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+}


### PR DESCRIPTION
Primeiro de dois PRs empilhados para a #610. Este cobre os itens 1, 3 e 4 do "o que fazer"; o item 2 (custo do fluxo de dois passos do #417) vem no PR seguinte, sobre esta branch — separados porque editam o mesmo arquivo em regiões distintas e têm perfis de risco muito diferentes.

## Por quê

A #610 nasceu do feedback de que *"a parte de revisão deveria ficar mais focadinha"*. A queixa literal era outro defeito — a #613, já corrigida pelo #620 —, e o que resta é o diagnóstico de densidade, medido na issue.

O cabeçalho do painel é `shrink-0` acima do único scroller, então tudo que cresce ali empurra os cards sem amortecimento. Desde o #373 o enunciado crescia sem limite e o `help_text` ocupava até 96px permanentes: a altura mudava a cada campo e os cards saltavam de posição ao navegar com `n`/`p`. Numa fila percorrida por teclado, perder a âncora visual a cada campo é o oposto de "focado".

## Medição em navegador, antes e depois

Viewport 1440×900, fixture E2E, `origin/main` @ 22f4b99c contra esta branch. O medidor espera `networkidle` + `document.fonts.ready` antes da primeira leitura: sem isso o campo 1 era medido durante o FOUC do dev server e saía com 169px de cabeçalho contra os 79px reais.

| | antes | depois |
|---|---|---|
| Δ posição do 1º card entre campos | 97,6px | **0px** |
| área rolável — mediana | 542,0px | **600,0px** (+10,7%) |
| área rolável — pior campo (help_text longo) | 480,4px | **600,0px** (+24,9%) |
| altura do cabeçalho | variável | 79,0px constante |

Duas ressalvas honestas. Primeiro, a área **ocupada** pelos cards não muda (7,68% → 7,51% do viewport): com duas respostas curtas o conteúdo não preenche o espaço, então essa métrica mede o conteúdo, não a folga — a métrica que responde ao critério 2 é o espaço disponível, acima. A leve queda é o banner de equivalência encolhendo dentro do mesmo bloco medido. Segundo, a medição é no fixture, não em produção: a conta E2E não é membro do Zolgensma, e dar-lhe acesso seria escrever em `project_members` de produção só para medir. O fixture foi calibrado com a variação de `help_text` que a issue mediu nos dados reais.

## O que mudou

**Cabeçalho invariante.** `FieldHeaderLabel` ganha variante de densidade opt-in. Em `fixed`, o enunciado é clampado em duas linhas de altura reservada — o clamp limita o teto, é o `min-h` que zera a variação — com o texto integral no `title`, e o `help_text` sai do fluxo para um popover. O default segue `flow`: na Codificação o enunciado é a pergunta que se está respondendo, e clampá-lo ali seria regressão.

**`ProgressDots` — achado que a issue não previa.** O dot corrente era `size-3` contra `size-2` dos demais, dentro de um `flex-wrap`. A largura do flex-item dependia do índice corrente, então o ponto de quebra podia deslocar e, no limiar, trocar duas fileiras por três: variação de altura entre campos do **mesmo documento**, por um caminho independente do cabeçalho. Agora a caixa é constante e só o círculo interno muda de tamanho — aparência preservada, alvo de clique maior.

**Controles permanentes enxutos.** Banner de equivalência de três linhas para uma, com o exemplo `NI ≡ N/A` e a definição de gabarito num popover; a frase curta e o botão "Todas são similares" continuam visíveis, porque são a affordance de descoberta. `KeyboardHints` sai do rodapé (~44px permanentes cujo único conteúdo era um botão que só revelava algo se clicado) e vira ícone no cabeçalho.

Descartada a alternativa de banner dispensável com `localStorage`: recupera mais pixels, mas cria o modo "sumiu e não sei como voltar" justamente para quem usa a tela raramente.

`UnansweredNotice` foi avaliado e **mantido**: não é permanente, vive dentro do scroller e carrega informação que não existe em nenhum outro lugar da tela.

**Layout persistido.** Proporção do split e lista lateral recolhida atravessam sessões. `react-resizable-panels` está na v4, onde `autoSaveId` não existe — a persistência é via `useDefaultLayout`, com `id` explícito por painel (sem ele o fallback é `useId()`, a chave deixa de ser estável e a restauração falha em silêncio) e `storage` guardado contra SSR.

## Verificação

**Critério 1 fixado permanentemente, com prova do vermelho.** O smoke E2E passa a assertar que a posição do primeiro card não varia entre campos. A asserção seria **vácua** com o fixture antigo — seis campos de texto uniforme e nenhum `help_text` —, então o fixture ganhou variação deliberada de enunciado e `help_text`, documentada como terceira propriedade load-bearing ao lado das duas que já existiam. Contra `origin/main` o spec falha com spread de 81,9px; nesta branch passa.

**Testes que ficariam vácuos foram reescritos, não removidos.** Os casos de `help_text` viraram um par que só é verde se o texto estiver **fora** do DOM antes do clique e **dentro** depois — sozinho, o caso negativo passaria trivialmente nos dois mundos. A prosa do banner de equivalência não tinha teste nenhum e passou a ter, em vez de sair do radar ao mudar de lugar. E `FieldHeaderLabel.test.tsx` ganhou a guarda que importa: trocar o default para `fixed` fica vermelho — é o que protege a Codificação da "uniformização" tentadora.

Gates locais: typecheck, 2030 testes, lint:types, fallow (new-only), semgrep, react-doctor e o smoke E2E — todos verdes. O único achado novo do fallow era um tipo exportado sem consumidor; corrigido removendo o `export`, não suprimindo.

## Também resolve

O rótulo do painel de atalhos anunciava um `<kbd>?</kbd>` que `useCompareKeyboard` nunca tratou — anunciar tecla que não responde é pior que não anunciar nenhuma, então saiu. Na mesma passagem o painel passou a listar `Enter` em campo simples (só o ramo multi mencionava) e `Esc`.

Closes #614
Refs #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYSnt4t1mVZTwsi4b78irk


---

## Correções da revisão (commit `c3ce125`)

**Defeito funcional encontrado na revisão.** O `line-clamp-2` implica `display:-webkit-box` com `overflow:hidden`, e o gatilho do `help_text` era renderizado dentro dele. Em todo campo cujo enunciado passasse de duas linhas o botão caía na região recortada — no DOM e focável por Tab, mas invisível e inalcançável por mouse. A instrução de preenchimento sumia justamente nos campos em que ela mais faz falta. O gatilho passou a ser irmão do parágrafo clampado; a altura da faixa continua vindo do `min-h-10`, então sua presença ou ausência não move nada, e a invariante do critério 1 fica intacta.

O fixture não pegava o caso porque as duas propriedades eram disjuntas por construção: o campo de enunciado longo era o único sem `help_text`. Agora coexistem no mesmo campo. A guarda permanente é estrutural, não visual — jsdom não faz layout, então nenhum unitário enxerga o recorte: o caso novo afirma que o gatilho não é descendente do elemento com `line-clamp-2`, e fica vermelho contra o código anterior. Verificado também em navegador: no campo 4, o gatilho fica em x=1222 contra a caixa clampada de 784 a 1218, e o clique abre o popover.

**`fullText` sai da API.** O call site declarava o mesmo enunciado duas vezes — como `children` e como prop —, livre para divergir. A união discriminada passa a exigir `children: string` em `fixed` e deriva o `title` dele. Provado por sonda de tipo: `fixed` com `children` JSX não compila.

**Menores.** `cursor-pointer` nos gatilhos que abrem popover por clique; stub de Radix/jsdom consolidado em `src/test-utils/radix-jsdom.ts` para os dois arquivos tocados aqui (as ~5 cópias legadas ficam onde estão); comentário do `ProgressDots` corrigido — o círculo mantém a aparência, mas o espaçamento entre pontos muda, e o `AutoReviewFieldPanel` herda a mudança sem ter sido medido.

Gates verdes de novo, com 2031 testes.
