### PR TITLE
fix(codificação): rascunho retomado vazava para outro documento e podia gravar resposta trocada (#608)

### DIFF
--- a/frontend/src/components/coding/__tests__/useCodingDraftWiring.test.ts
+++ b/frontend/src/components/coding/__tests__/useCodingDraftWiring.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+//
+// A fiação entre o rascunho local e os dois modos (#608). O que se fixa aqui é a
+// regra mais perigosa da feature: um rascunho retomado só pode ser aplicado ao
+// documento de onde veio. Aplicar o conteúdo de A sobre o formulário de B não é
+// um bug de UI — é fabricar dado de pesquisa, porque o próximo "Enviar" gravaria
+// as respostas de A no documento B, sem que nada na tela denunciasse a troca.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useCodingDraftWiring } from "../useCodingDraftWiring";
+import { useDirtyDocs } from "@/hooks/useDirtyDocs";
+import type { CodingDraftsApi } from "@/hooks/useCodingDrafts";
+import type { CodingDocument } from "@/hooks/useDocumentForCoding";
+import type { CodingSnapshot } from "@/lib/coding-draft";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+const DRAFT_DE_A: CodingSnapshot = { answers: { q1: "resposta-do-doc-A" }, notes: "nota-A" };
+
+function browseDoc(id: string, answers: Record<string, unknown> = {}): CodingDocument {
+  return {
+    document: {
+      id,
+      external_id: `ext-${id}`,
+      title: `Doc ${id}`,
+      text: `texto-${id}`,
+      exclusionPending: null,
+    },
+    initialAnswers: answers,
+    initialNotes: `nota-do-servidor-${id}`,
+  };
+}
+
+function draftsApi(over: Partial<CodingDraftsApi> = {}): CodingDraftsApi {
+  return {
+    openDocument: vi.fn(),
+    recordDraft: vi.fn(),
+    restoreDraft: vi.fn(() => DRAFT_DE_A),
+    discardDraft: vi.fn(),
+    submitConfirmed: vi.fn(),
+    recovery: { kind: "none" },
+    storageAvailable: true,
+    staleDiscardedCount: 0,
+    ...over,
+  } as CodingDraftsApi;
+}
+
+// Roda a fiação em modo Explorar, com o doc de browse podendo trocar entre
+// renders — que é exatamente o que a seleção no picker faz.
+function renderWiring(initialDoc: CodingDocument) {
+  const drafts = draftsApi();
+  const view = renderHook(
+    ({ doc }: { doc: CodingDocument }) => {
+      const dirtyDocs = useDirtyDocs();
+      return useCodingDraftWiring({
+        mode: "browse",
+        activeDocId: doc.document.id,
+        drafts,
+        dirtyDocs,
+        markDirty: dirtyDocs.markDirty,
+        restoreAssignedDraft: vi.fn(),
+        browseDocId: doc.document.id,
+        browseDoc: doc,
+        existingAnswers: {},
+        existingJustifications: {},
+      });
+    },
+    { initialProps: { doc: initialDoc } },
+  );
+  return { ...view, drafts };
+}
+
+describe("useCodingDraftWiring — o rascunho retomado pertence a um documento só", () => {
+  it("aplica o rascunho retomado ao documento de onde ele veio", () => {
+    const { result } = renderWiring(browseDoc("A"));
+
+    act(() => result.current.handleRestoreDraft());
+
+    expect(result.current.browseDocForCoder?.initialAnswers).toEqual(
+      DRAFT_DE_A.answers,
+    );
+  });
+
+  // ESTE é o caso que fabrica dado. Cenário: retomar em A, escolher B no picker.
+  // O `BrowseDocCoder` é keyed por `docId:nonce`, então remonta semeado pelo que
+  // a fiação entregar — e entregava o rascunho de A, sem marcar sujeira e sem
+  // nenhum sinal na tela. Um clique em "Enviar" gravaria as respostas de A no
+  // documento B.
+  it("NÃO vaza o rascunho de um documento para o próximo selecionado", () => {
+    const docB = browseDoc("B", { q1: "resposta-do-servidor-de-B" });
+    const { result, rerender } = renderWiring(browseDoc("A"));
+
+    act(() => result.current.handleRestoreDraft());
+    rerender({ doc: docB });
+
+    expect(result.current.browseDocForCoder?.initialAnswers).toEqual({
+      q1: "resposta-do-servidor-de-B",
+    });
+    expect(result.current.browseDocForCoder?.initialNotes).toBe(
+      "nota-do-servidor-B",
+    );
+    // E o conteúdo de A não aparece em lugar nenhum do que B vai semear.
+    expect(
+      JSON.stringify(result.current.browseDocForCoder?.initialAnswers),
+    ).not.toContain("resposta-do-doc-A");
+  });
+
+  it("voltar ao documento de origem ainda mostra o rascunho retomado", () => {
+    const docA = browseDoc("A");
+    const { result, rerender } = renderWiring(docA);
+
+    act(() => result.current.handleRestoreDraft());
+    rerender({ doc: browseDoc("B") });
+    rerender({ doc: docA });
+
+    // A retomada não é desfeita pela ida e volta: o snapshot continua sendo de A,
+    // e é A quem o recebe.
+    expect(result.current.browseDocForCoder?.initialAnswers).toEqual(
+      DRAFT_DE_A.answers,
+    );
+  });
+});

--- a/frontend/src/components/coding/useCodingDraftWiring.ts
+++ b/frontend/src/components/coding/useCodingDraftWiring.ts
@@ -70,7 +70,16 @@ export function useCodingDraftWiring({
   // setState: `BrowseDocCoder` é construído sem estado derivado e sem setState em
   // effect, e empurrar valor para dentro dele quebraria essa propriedade.
   const [browseRestoreNonce, setBrowseRestoreNonce] = useState(0);
-  const [browseRestored, setBrowseRestored] = useState<CodingSnapshot | null>(null);
+  // O snapshot retomado carrega o documento de onde veio. Não é metadado
+  // decorativo: sem ele o conteúdo fica solto e é aplicado a qualquer doc que a
+  // seleção seguinte trouxer — `BrowseDocCoder` é keyed por `docId:nonce`, então
+  // remonta semeado pelo que esta fiação entregar. O resultado era a tela do
+  // documento B exibindo as respostas de A, sem sujeira e sem sinal, e o próximo
+  // "Enviar" gravando as respostas de A no documento B.
+  const [browseRestored, setBrowseRestored] = useState<{
+    docId: string;
+    snapshot: CodingSnapshot;
+  } | null>(null);
 
   const restoreDraft = drafts.restoreDraft;
   const handleRestoreDraft = useCallback(() => {
@@ -81,7 +90,7 @@ export function useCodingDraftWiring({
     if (!browseDocId) return;
     const restored = restoreDraft(browseDocId);
     if (!restored) return;
-    setBrowseRestored(restored);
+    setBrowseRestored({ docId: browseDocId, snapshot: restored });
     setBrowseRestoreNonce((n) => n + 1);
     markDirty(browseDocId);
   }, [mode, restoreAssignedDraft, browseDocId, restoreDraft, markDirty]);
@@ -96,11 +105,17 @@ export function useCodingDraftWiring({
   // e sem setState em effect, e o remount por `key` já é o mecanismo de aplicação.
   // Resolver aqui mantém aquele componente sem nenhuma decisão nova.
   const browseDocForCoder = useMemo(() => {
-    if (!browseDoc || !browseRestored) return browseDoc;
+    // A checagem de identidade é o que impede a aplicação cruzada: o rascunho só
+    // semeia o documento de onde foi retomado. Trocar de doc volta a semear do
+    // servidor sem precisar limpar nada — e voltar ao doc de origem reexibe o
+    // rascunho, porque a posse continua registrada.
+    if (!browseDoc || browseRestored?.docId !== browseDoc.document.id) {
+      return browseDoc;
+    }
     return {
       ...browseDoc,
-      initialAnswers: browseRestored.answers,
-      initialNotes: browseRestored.notes,
+      initialAnswers: browseRestored.snapshot.answers,
+      initialNotes: browseRestored.snapshot.notes,
     };
   }, [browseDoc, browseRestored]);
 

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -489,3 +489,69 @@ describe("indisponibilidade do storage", () => {
     expect(result.current.storageAvailable).toBe(true);
   });
 });
+
+// A faixa OFERECE o rascunho; ela não bloqueia o formulário. Continuar digitando
+// sem decidir nada sobre a oferta é fluxo corriqueiro — e era o fluxo em que a
+// cópia local deixava de ser mantida: a abertura não assumia a posse do slot que
+// acabara de ler, então a primeira tecla falhava o compare-and-swap contra o
+// próprio envelope ofertado. Sem o salvamento automático, é trabalho perdido.
+describe("oferta pendente — ignorar a faixa não pode desligar a rede local", () => {
+  it("editar sem responder à oferta continua gravando a cópia local", () => {
+    plant({ writeToken: "tok-de-ontem", draft: snap({ q1: "de ontem" }) });
+    const { result } = render();
+    // Pré-condição: a oferta está de pé, ninguém retomou nem descartou.
+    expect(result.current.recovery.kind).not.toBe("none");
+
+    act(() => result.current.recordDraft(DOC, snap({ q1: "digitado agora" })));
+    flushDebounce();
+
+    expect(stored()?.draft.answers).toEqual({ q1: "digitado agora" });
+    expect(result.current.storageAvailable).toBe(true);
+  });
+
+  it("a posse assumida é a do envelope observado, não licença para sobrescrever", () => {
+    plant({ writeToken: "tok-de-ontem", draft: snap({ q1: "de ontem" }) });
+    const { result } = render();
+    // Outra aba toma o slot DEPOIS da nossa leitura: o token observado não vale
+    // mais, e o CAS tem de barrar a escrita como antes.
+    plant({ writeToken: "de-outra-aba", draft: snap({ q1: "da outra aba" }) });
+
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" })));
+    flushDebounce();
+
+    expect(stored()?.draft.answers).toEqual({ q1: "da outra aba" });
+    expect(result.current.storageAvailable).toBe(false);
+  });
+});
+
+// Envelope que este build não sabe usar não é trabalho de outra aba: é lixo
+// nosso. Tratá-lo como slot tomado o fazia barrar toda escrita seguinte daquele
+// documento — o envelope inútil ficava, e o trabalho novo não entrava.
+describe("slot inutilizável — lixo nosso não pode barrar trabalho novo", () => {
+  it("envelope com identidade discordante é sobrescrito pela edição nova", () => {
+    // Gravado NA chave deste documento, mas dizendo pertencer a outro. O `key`
+    // explícito importa: sem ele `plant` derivaria a chave do `documentId`
+    // divergente e plantaria longe do slot sob teste.
+    plant({ key: KEY, documentId: "outro-doc", writeToken: "tok-discordante" });
+    const { result } = render();
+
+    act(() => result.current.recordDraft(DOC, snap({ q1: "novo" })));
+    flushDebounce();
+
+    expect(stored()?.draft.answers).toEqual({ q1: "novo" });
+    expect(stored()?.documentId).toBe(DOC);
+  });
+
+  it("envelope de formato MAIOR continua intocado: é de uma aba que sabe mais", () => {
+    plant({ formatVersion: CODING_DRAFT_FORMAT_VERSION + 1 });
+    const { result } = render();
+
+    act(() => result.current.recordDraft(DOC, snap({ q1: "meu" })));
+    flushDebounce();
+
+    const raw = JSON.parse(window.localStorage.getItem(KEY) ?? "{}");
+    expect(raw.formatVersion).toBe(CODING_DRAFT_FORMAT_VERSION + 1);
+    // E a pesquisadora é avisada de que esta aba não está guardando cópia.
+    expect(result.current.storageAvailable).toBe(false);
+  });
+});

--- a/frontend/src/lib/coding-draft-storage.ts
+++ b/frontend/src/lib/coding-draft-storage.ts
@@ -157,6 +157,17 @@ function writeSlotIfTokenMatches(
     // Envelope que este build não sabe ler pertence a uma aba mais nova;
     // sobrescrevê-lo apagaria trabalho irrecuperável.
     if (stored.kind === "newer-format") return "blocked";
+    // Formato antigo, ou identidade embutida que discorda da chave: é lixo NOSSO,
+    // não trabalho de outra aba. Tratá-lo como slot tomado o deixava barrar, por
+    // CAS, toda escrita seguinte daquele documento — o envelope inútil ficava e o
+    // trabalho novo é que não entrava. Sobrescrever é o que o GC já faria, só sem
+    // esperar a próxima sessão.
+    const usable =
+      stored.kind !== "draft" || envelopeMatchesScope(stored.draft, scope);
+    if (!usable) {
+      window.localStorage.setItem(key, JSON.stringify(envelope));
+      return "written";
+    }
     const storedToken = stored.kind === "draft" ? stored.draft.writeToken : null;
     if (storedToken !== expectedToken) return "blocked";
     window.localStorage.setItem(key, JSON.stringify(envelope));
@@ -451,7 +462,12 @@ function emptyDocState(base: CodingSnapshot): DocDraftState {
   return { base, draft: null, writeToken: null, persistedToken: null, blocked: false };
 }
 
-function seedBaseline(st: SessionState, docId: string, baseline: CodingSnapshot): void {
+function seedBaseline(
+  st: SessionState,
+  docId: string,
+  baseline: CodingSnapshot,
+  observedToken: string | null,
+): void {
   // Um único default (`?? emptyDocState`) em vez de um por propriedade: o
   // espalhamento preserva a posse do slot e o rascunho vivo sem repetir a
   // decisão cinco vezes. Só o baseline é condicional — trocá-lo debaixo de um
@@ -460,6 +476,19 @@ function seedBaseline(st: SessionState, docId: string, baseline: CodingSnapshot)
   st.states.set(docId, {
     ...previous,
     base: previous.draft ? previous.base : baseline,
+    // Assume a posse do envelope que ACABAMOS de observar. Sem isto, a abertura
+    // ofertava um rascunho e seguia com `persistedToken: null`, então a primeira
+    // tecla falhava o compare-and-swap contra o próprio envelope ofertado. Como a
+    // faixa OFERECE sem bloquear o formulário, continuar digitando sem decidir
+    // nada sobre a oferta — fluxo corriqueiro — deixava a pessoa sem cópia local
+    // pelo resto da sessão. Sem o salvamento automático (#624), é trabalho
+    // perdido.
+    //
+    // Isto NÃO afrouxa a proteção entre abas: o token adotado é o valor lido, não
+    // um curinga. Se outra aba escrever depois desta leitura, o token deixa de
+    // bater e a escrita volta a ser barrada — o contrato do CAS continua de pé.
+    // Com rascunho vivo na sessão, a posse já é nossa e é ela que vale.
+    persistedToken: previous.draft ? previous.persistedToken : observedToken,
   });
 }
 
@@ -489,7 +518,7 @@ function openDocumentIn(
   cb.onStorageAvailable(slot.available);
 
   const baseline = remote ?? EMPTY_SNAPSHOT;
-  seedBaseline(st, docId, baseline);
+  seedBaseline(st, docId, baseline, slot.envelope?.writeToken ?? null);
 
   offerOrClean(cb, scope, slot.envelope, baseline, st.fields);
 }


### PR DESCRIPTION
Dois achados da revisão do #621 que **já estão na `main`** — o PR foi mergeado enquanto a revisão corria. Nenhum dos dois é regressão do #624; ambos nasceram com a rede local do rascunho.

## 1. O rascunho retomado vazava para o próximo documento (grave)

`browseRestored` guardava o snapshot retomado **sem a identidade do documento**, e `browseDocForCoder` o aplicava a qualquer `browseDoc` presente. O estado nunca era resetado.

Reproduzido em teste, antes da correção:

1. Explorar, documento A tem rascunho → a faixa oferece → "Retomar";
2. escolher o documento B no picker;
3. o formulário de B nasce com **as respostas de A** — `BrowseDocCoder` é keyed por `docId:nonce` e remonta com o que a fiação entregar;
4. nada marca sujeira, nada avisa, e a tela parece exibir as respostas gravadas de B;
5. um clique em "Enviar" chama `saveResponse(projectId, B, respostas-de-A)`.

É o desfecho que o comentário de `coding-draft.ts` nomeia como o pior que a feature pode produzir — fabricar dado de pesquisa em silêncio. A barreira construída lá protege o `localStorage`; o vazamento acontece em memória, depois da leitura.

**Correção**: acoplar a identidade ao conteúdo, em vez de acrescentar um reset a cada caminho de troca de documento. O snapshot só semeia o documento de onde veio, e o estado ruim deixa de ser construível. Voltar ao documento de origem continua reexibindo o rascunho.

## 2. Ignorar a faixa de recuperação desligava a rede local

A faixa **oferece** o rascunho sem bloquear o formulário, então continuar digitando sem decidir nada sobre a oferta é fluxo corriqueiro. A abertura lia o slot, ofertava o envelope e seguia com `persistedToken: null`; a primeira tecla falhava o compare-and-swap contra o próprio envelope ofertado, e cada edição seguinte repetia o bloqueio. Sem o salvamento automático (#624), fechar a aba nesse estado perde o trabalho.

A parte **visível** disso já havia sido resolvida antes do merge — `blocked` passou a acender a faixa junto com `unavailable`. O que faltava era a causa.

**Correções**: (a) a abertura assume a posse do envelope que acabou de **observar** — token lido, não curinga, então a proteção entre abas continua de pé (há teste fixando a distinção); (b) o CAS distingue "envelope de outra aba" de "lixo nosso" — formato antigo ou identidade que discorda da chave é sobrescrito em vez de barrar toda escrita seguinte daquele documento. Envelope de formato **maior** continua intocado: é de uma aba que sabe mais, e apagá-lo é irreversível.

## Verificação

- **Prova do vermelho, 3 mutações**: sem a identidade no snapshot → cai o teste do vazamento; sem a adoção da posse → cai o teste da oferta pendente; sem o ramo de "lixo nosso" → cai o teste do envelope discordante.
- `vitest`: 2106 testes verdes (5 novos).
- `typecheck`, `lint:types`, `react-doctor`, `semgrep`, `fallow audit --base origin/main` (`No issues in 4 changed files`) e **e2e smoke** verdes no pre-push.

Refs #608