### PR TITLE
fix(comparação): confirmação nasce no elemento que produziu o rascunho (#610)

### DIFF
--- a/frontend/e2e/compare-field-switch.smoke.spec.ts
+++ b/frontend/e2e/compare-field-switch.smoke.spec.ts
@@ -285,10 +285,27 @@ test("comparação: veredito confirmado após navegar grava no campo exibido", a
 
       await goToField(page, 2);
 
+      // Sem rascunho não existe nenhum controle de confirmação: prova em
+      // navegador real que a barra fixa do rodapé não voltou (#610).
+      await expect(
+        page.getByRole("button", { name: /^Confirmar$/ }),
+      ).toHaveCount(0);
+
       // Clica no PRIMEIRO card na tela: é a posição natural do clique e era
       // exatamente onde ficava o card fantasma do campo anterior.
-      await page.locator("button[data-vote-target]").first().click();
-      await page.getByRole("button", { name: /^Confirmar$/ }).click();
+      const firstCard = page.locator("button[data-vote-target]").first();
+      await firstCard.click();
+
+      // Confirma DENTRO do card. Além de fixar a ancoragem, este clique é a
+      // única prova possível de que a barra fica acima do overlay de voto: em
+      // jsdom não há hit-testing, então remover o `z-[2]` do slot não quebra
+      // nenhum teste unitário — aqui, o Playwright ou acusa interceptação ou
+      // acerta o overlay e nunca chega ao "Veredito salvo!".
+      const card = page
+        .locator('[data-testid="answer-card"][data-pending="true"]')
+        .first();
+      await expect(card).toHaveCount(1);
+      await card.getByRole("button", { name: /^Confirmar$/ }).click();
       await expect(page.getByText("Veredito salvo!")).toBeVisible({
         timeout: 30_000,
       });

--- a/frontend/e2e/compare-field-switch.smoke.spec.ts
+++ b/frontend/e2e/compare-field-switch.smoke.spec.ts
@@ -301,9 +301,12 @@ test("comparação: veredito confirmado após navegar grava no campo exibido", a
       // jsdom não há hit-testing, então remover o `z-[2]` do slot não quebra
       // nenhum teste unitário — aqui, o Playwright ou acusa interceptação ou
       // acerta o overlay e nunca chega ao "Veredito salvo!".
-      const card = page
-        .locator('[data-testid="answer-card"][data-pending="true"]')
-        .first();
+      // Sem `.first()`: a contagem é sobre TODOS os cards preparados, senão o
+      // `toHaveCount(1)` só poderia dar 0 ou 1 e a unicidade — que é o que se
+      // quer provar — ficaria fora da asserção.
+      const card = page.locator(
+        '[data-testid="answer-card"][data-pending="true"]',
+      );
       await expect(card).toHaveCount(1);
       await card.getByRole("button", { name: /^Confirmar$/ }).click();
       await expect(page.getByText("Veredito salvo!")).toBeVisible({

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -339,14 +339,21 @@ export function AgreementGroup({
               versions={versions}
               readOnly={readOnly}
               onVote={() => onVote(group.displayAnswer, group.responses[0].id)}
+              // Montada só no card preparado, e não em todos com o
+              // `AnswerCard` decidindo depois: `isPending` é conhecido AQUI, e é
+              // este o sítio onde a invariante "exatamente uma barra no DOM"
+              // fica visível. O gate lá dentro permanece como defesa em
+              // profundidade para quem passar o slot sem esta condição.
               confirmSlot={
-                <PendingConfirmBar
-                  label={null}
-                  pendingLabel={group.displayAnswer}
-                  isSaving={pendingConfirm.isSaving}
-                  onConfirm={pendingConfirm.onConfirm}
-                  onDiscard={pendingConfirm.onDiscard}
-                />
+                isPending ? (
+                  <PendingConfirmBar
+                    label={group.displayAnswer}
+                    showLabel={false}
+                    isSaving={pendingConfirm.isSaving}
+                    onConfirm={pendingConfirm.onConfirm}
+                    onDiscard={pendingConfirm.onDiscard}
+                  />
+                ) : undefined
               }
               equivalenceMode={
                 !allowEquivalence

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useMemo, useState, useTransition } from "react";
-import { AnswerCard, type EquivalentVariant } from "./AnswerCard";
+import {
+  AnswerCard,
+  type EquivalenceMode,
+  type EquivalentVariant,
+} from "./AnswerCard";
 import { PendingConfirmBar } from "./PendingConfirmBar";
 import type { PendingVerdict } from "./compare-types";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -99,6 +103,73 @@ interface RenderedGroup {
   displayAnswer: string;
   responses: AgreementResponse[];
   variants: EquivalentVariant[];
+}
+
+/**
+ * Tudo que um card precisa saber sobre o seu grupo e que não é decisão de
+ * interação: quem respondeu, o que está velho, se este é o grupo escolhido no
+ * veredito anterior e se é o do rascunho atual.
+ *
+ * Função pura fora do `.map()` porque o callback do map era o sítio onde essas
+ * seis derivações se somavam aos ternários do JSX — e o `confirmSlot` foi a
+ * gota que o levou acima do limiar de complexidade. Separa também dois assuntos
+ * que só coincidiam por estarem na mesma linha: fatos do grupo aqui,
+ * affordances de seleção em `equivalenceModeFor`.
+ */
+function describeGroup(
+  group: RenderedGroup,
+  existingVerdict: ExistingVerdict | null,
+  pendingVerdict: PendingVerdict | null,
+) {
+  return {
+    hasLlm: group.responses.some((r) => r.respondent_type === "llm"),
+    llmJustification: group.responses.find((r) => r.respondent_type === "llm")
+      ?.justification,
+    staleCount: group.responses.filter((r) => r.isFieldStale).length,
+    isChosen: group.responses.some(
+      (r) => r.id === existingVerdict?.chosenResponseId,
+    ),
+    // O rascunho aponta para UMA resposta, mas o card representa o grupo
+    // inteiro: respostas fundidas por equivalência compartilham o card, então a
+    // pertinência é ao grupo, não à resposta clicada.
+    isPending:
+      pendingVerdict?.kind === "response" &&
+      group.responses.some((r) => r.id === pendingVerdict.chosenResponseId),
+    versions: Array.from(
+      new Set(
+        group.responses
+          .map((r) => r.schemaVersion)
+          .filter((v): v is string => !!v),
+      ),
+    ).toSorted(compareVersionsDesc),
+  };
+}
+
+/**
+ * Affordances de equivalência de um card quando o modo está permitido. O tipo
+ * de retorno é anotado de propósito: sem ele a inferência alarga `selected: true`
+ * para `boolean` e a união discriminada do `AnswerCard` — que torna o gabarito
+ * num card não selecionado irrepresentável — deixa de valer aqui.
+ */
+function equivalenceModeFor({
+  isSelected,
+  showGabarito,
+  isGabarito,
+  onToggle,
+  onSetGabarito,
+}: {
+  isSelected: boolean;
+  showGabarito: boolean;
+  isGabarito: boolean;
+  onToggle: () => void;
+  onSetGabarito: () => void;
+}): EquivalenceMode {
+  if (!isSelected) return { selected: false, onToggle };
+  return {
+    selected: true,
+    onToggle,
+    gabarito: showGabarito ? { isGabarito, onSetGabarito } : null,
+  };
 }
 
 export function AgreementGroup({
@@ -299,31 +370,7 @@ export function AgreementGroup({
         )}
 
         {groups.map((group, i) => {
-          const hasLlm = group.responses.some(
-            (r) => r.respondent_type === "llm",
-          );
-          const llmResponse = group.responses.find(
-            (r) => r.respondent_type === "llm",
-          );
-          const staleCount = group.responses.filter(
-            (r) => r.isFieldStale,
-          ).length;
-          const isChosen = group.responses.some(
-            (r) => r.id === existingVerdict?.chosenResponseId,
-          );
-          const isPending =
-            pendingVerdict?.kind === "response" &&
-            group.responses.some((r) => r.id === pendingVerdict.chosenResponseId);
-          const versions = Array.from(
-            new Set(
-              group.responses
-                .map((r) => r.schemaVersion)
-                .filter((v): v is string => !!v),
-            ),
-          ).toSorted(compareVersionsDesc);
-
-          const isSelected = selectionSet.has(group.groupKey);
-
+          const facts = describeGroup(group, existingVerdict, pendingVerdict);
           return (
             <AnswerCard
               key={group.groupKey}
@@ -331,12 +378,12 @@ export function AgreementGroup({
               displayAnswer={group.displayAnswer}
               respondentNames={group.responses.map((r) => r.respondent_name)}
               respondentCount={group.responses.length}
-              hasLlm={hasLlm}
-              llmJustification={llmResponse?.justification}
-              staleCount={staleCount}
-              isChosen={isChosen}
-              isPending={isPending}
-              versions={versions}
+              hasLlm={facts.hasLlm}
+              llmJustification={facts.llmJustification}
+              staleCount={facts.staleCount}
+              isChosen={facts.isChosen}
+              isPending={facts.isPending}
+              versions={facts.versions}
               readOnly={readOnly}
               onVote={() => onVote(group.displayAnswer, group.responses[0].id)}
               // Montada só no card preparado, e não em todos com o
@@ -345,7 +392,7 @@ export function AgreementGroup({
               // fica visível. O gate lá dentro permanece como defesa em
               // profundidade para quem passar o slot sem esta condição.
               confirmSlot={
-                isPending ? (
+                facts.isPending ? (
                   <PendingConfirmBar
                     label={group.displayAnswer}
                     showLabel={false}
@@ -356,24 +403,15 @@ export function AgreementGroup({
                 ) : undefined
               }
               equivalenceMode={
-                !allowEquivalence
-                  ? undefined
-                  : isSelected
-                    ? {
-                        selected: true,
-                        onToggle: () => toggleSelection(group.groupKey),
-                        gabarito: showGabarito
-                          ? {
-                              isGabarito: effectiveGabarito === group.groupKey,
-                              onSetGabarito: () =>
-                                setGabaritoOverride(group.groupKey),
-                            }
-                          : null,
-                      }
-                    : {
-                        selected: false,
-                        onToggle: () => toggleSelection(group.groupKey),
-                      }
+                allowEquivalence
+                  ? equivalenceModeFor({
+                      isSelected: selectionSet.has(group.groupKey),
+                      showGabarito,
+                      isGabarito: effectiveGabarito === group.groupKey,
+                      onToggle: () => toggleSelection(group.groupKey),
+                      onSetGabarito: () => setGabaritoOverride(group.groupKey),
+                    })
+                  : undefined
               }
               equivalentVariants={
                 group.variants.length > 0 ? group.variants : undefined

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState, useTransition } from "react";
 import { AnswerCard, type EquivalentVariant } from "./AnswerCard";
+import { PendingConfirmBar } from "./PendingConfirmBar";
 import type { PendingVerdict } from "./compare-types";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -67,6 +68,15 @@ interface AgreementGroupProps {
   onUnmarkPair?: (pairId: string) => Promise<void>;
   currentUserId: string;
   canManageAnyPair: boolean;
+  // Confirmação do rascunho, montada DENTRO do card que o produziu (#610).
+  // Obrigatória, não opcional: opcional convida a esquecer a fiação num sítio
+  // novo e falhar em silêncio — sem barra em lugar nenhum, com a navegação
+  // travada pelo rascunho pendente. Erro de compilação é o modo de falha certo.
+  pendingConfirm: {
+    onConfirm: () => void;
+    onDiscard: () => void;
+    isSaving: boolean;
+  };
 }
 
 function formatAnswer(answer: unknown): string {
@@ -103,6 +113,7 @@ export function AgreementGroup({
   onUnmarkPair,
   currentUserId,
   canManageAnyPair,
+  pendingConfirm,
 }: AgreementGroupProps) {
   // Track selection order so the first selected card is the default gabarito.
   const [selectionOrder, setSelectionOrder] = useState<string[]>([]);
@@ -328,6 +339,15 @@ export function AgreementGroup({
               versions={versions}
               readOnly={readOnly}
               onVote={() => onVote(group.displayAnswer, group.responses[0].id)}
+              confirmSlot={
+                <PendingConfirmBar
+                  label={null}
+                  pendingLabel={group.displayAnswer}
+                  isSaving={pendingConfirm.isSaving}
+                  onConfirm={pendingConfirm.onConfirm}
+                  onDiscard={pendingConfirm.onDiscard}
+                />
+              }
               equivalenceMode={
                 !allowEquivalence
                   ? undefined

--- a/frontend/src/components/compare/AgreementGroup.tsx
+++ b/frontend/src/components/compare/AgreementGroup.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useMemo, useState, useTransition } from "react";
+import { useMemo } from "react";
 import {
   AnswerCard,
   type EquivalenceMode,
   type EquivalentVariant,
 } from "./AnswerCard";
 import { PendingConfirmBar } from "./PendingConfirmBar";
+import { useEquivalenceSelection } from "./useEquivalenceSelection";
 import type { PendingVerdict } from "./compare-types";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -106,6 +107,82 @@ interface RenderedGroup {
 }
 
 /**
+ * Os cards a renderizar: respostas presentes agrupadas por equivalência, com as
+ * variantes fundidas de cada grupo anexadas, e os grupos maiores primeiro — a
+ * resposta majoritária no topo é o que a revisora lê antes de tudo.
+ *
+ * Respostas com `answer === undefined` ficam de fora: quem não respondeu aparece
+ * no `UnansweredNotice`, não como card vazio.
+ */
+function buildRenderedGroups(
+  responses: AgreementResponse[],
+  equivalences: FieldEquivalencePair[],
+): RenderedGroup[] {
+  const present = responses.filter((r) => r.answer !== undefined);
+  const groups = groupByEquivalenceKey(present, equivalences);
+  for (const group of groups) {
+    group.variants = variantsWithinGroup(group, equivalences);
+  }
+  return groups.toSorted((a, b) => b.responses.length - a.responses.length);
+}
+
+/**
+ * Agrupa as respostas presentes pela chave de equivalência. Respostas sem par
+ * caem num grupo próprio (a chave é o próprio id), e o texto exibido é o da
+ * PRIMEIRA resposta a entrar no grupo — as demais são equivalentes a ela por
+ * construção.
+ */
+function groupByEquivalenceKey(
+  present: AgreementResponse[],
+  equivalences: FieldEquivalencePair[],
+): RenderedGroup[] {
+  const groupKeys = buildResponseGroupKeys(present, equivalences, (r) =>
+    normalizeForComparison(r.answer),
+  );
+  const map = new Map<string, RenderedGroup>();
+  for (const r of present) {
+    const key = groupKeys.get(r.id) ?? r.id;
+    const existing = map.get(key);
+    if (existing) {
+      existing.responses.push(r);
+      continue;
+    }
+    map.set(key, {
+      groupKey: key,
+      displayAnswer: formatAnswer(r.answer),
+      responses: [r],
+      variants: [],
+    });
+  }
+  return Array.from(map.values());
+}
+
+/**
+ * Os pares de equivalência cujas DUAS pontas caíram neste grupo — são eles que o
+ * card exibe como "N variantes". Um par com uma ponta fora do grupo pertence a
+ * outra fusão e não tem o que dizer aqui.
+ */
+function variantsWithinGroup(
+  group: RenderedGroup,
+  equivalences: FieldEquivalencePair[],
+): EquivalentVariant[] {
+  const byId = new Map(group.responses.map((r) => [r.id, r] as const));
+  const variants: EquivalentVariant[] = [];
+  for (const p of equivalences) {
+    const a = byId.get(p.response_a_id);
+    const b = byId.get(p.response_b_id);
+    if (!a || !b) continue;
+    variants.push({
+      pairId: p.id,
+      reviewerId: p.reviewer_id,
+      respondentName: `${a.respondent_name} ↔ ${b.respondent_name}`,
+      answerDisplay: `${formatAnswer(a.answer)} · ${formatAnswer(b.answer)}`,
+    });
+  }
+  return variants;
+}
+
+/**
  * Tudo que um card precisa saber sobre o seu grupo e que não é decisão de
  * interação: quem respondeu, o que está velho, se este é o grupo escolhido no
  * veredito anterior e se é o do rascunho atual.
@@ -186,136 +263,16 @@ export function AgreementGroup({
   canManageAnyPair,
   pendingConfirm,
 }: AgreementGroupProps) {
-  // Track selection order so the first selected card is the default gabarito.
-  const [selectionOrder, setSelectionOrder] = useState<string[]>([]);
-  const [gabaritoOverride, setGabaritoOverride] = useState<string | null>(null);
-  const [isSubmitting, startTransition] = useTransition();
-
-  const groups = useMemo<RenderedGroup[]>(() => {
-    const present = responses.filter((r) => r.answer !== undefined);
-    const groupKeys = buildResponseGroupKeys(present, equivalences, (r) =>
-      normalizeForComparison(r.answer),
-    );
-
-    const map = new Map<string, RenderedGroup>();
-    for (const r of present) {
-      const key = groupKeys.get(r.id) ?? r.id;
-      if (!map.has(key)) {
-        map.set(key, {
-          groupKey: key,
-          displayAnswer: formatAnswer(r.answer),
-          responses: [],
-          variants: [],
-        });
-      }
-      map.get(key)!.responses.push(r);
-    }
-
-    for (const group of map.values()) {
-      const idsInGroup = new Set(group.responses.map((r) => r.id));
-      const respondentById = new Map(
-        group.responses.map((r) => [r.id, r] as const),
-      );
-      for (const p of equivalences) {
-        if (idsInGroup.has(p.response_a_id) && idsInGroup.has(p.response_b_id)) {
-          const a = respondentById.get(p.response_a_id);
-          const b = respondentById.get(p.response_b_id);
-          if (a && b) {
-            group.variants.push({
-              pairId: p.id,
-              reviewerId: p.reviewer_id,
-              respondentName: `${a.respondent_name} ↔ ${b.respondent_name}`,
-              answerDisplay: `${formatAnswer(a.answer)} · ${formatAnswer(b.answer)}`,
-            });
-          }
-        }
-      }
-    }
-
-    return Array.from(map.values()).toSorted(
-      (a, b) => b.responses.length - a.responses.length,
-    );
-  }, [responses, equivalences]);
-
-  // Stale selection entries (groups that disappeared after a navigation or
-  // server-side fusion) are silently filtered out here; we don't need an
-  // effect to clear them because they're never visible in the UI.
-  // The parent (ComparisonPanel) keys this component by field+doc, so a
-  // navigation also remounts and resets selection state naturally.
-  const selectedGroups = selectionOrder
-    .map((key) => groups.find((g) => g.groupKey === key))
-    .filter((g): g is RenderedGroup => !!g);
-
-  // Consultado uma vez por grupo renderizado; como array seria O(grupos²).
-  const selectionSet = new Set(selectionOrder);
-  const showGabarito = selectedGroups.length >= 2;
-  const effectiveGabarito =
-    gabaritoOverride && selectionOrder.includes(gabaritoOverride)
-      ? gabaritoOverride
-      : (selectionOrder[0] ?? null);
-
-  // Os dois setters ficam no nível do handler: um `setGabaritoOverride`
-  // aninhado no updater de `setSelectionOrder` seria efeito colateral dentro de
-  // função que React pode reexecutar. `selectionOrder` do closure basta para
-  // decidir o ramo — só o clique altera a seleção.
-  function toggleSelection(groupKey: string) {
-    const isDeselecting = selectionOrder.includes(groupKey);
-    if (isDeselecting) {
-      setSelectionOrder((prev) => prev.filter((k) => k !== groupKey));
-      if (gabaritoOverride === groupKey) setGabaritoOverride(null);
-      return;
-    }
-    setSelectionOrder((prev) => [...prev, groupKey]);
-  }
-
-  function handleConfirm() {
-    if (!onConfirmEquivalent) return;
-    if (selectedGroups.length < 2 || !effectiveGabarito) return;
-    const gabaritoGroup = selectedGroups.find(
-      (g) => g.groupKey === effectiveGabarito,
-    );
-    if (!gabaritoGroup) return;
-    const gabaritoResponseId = gabaritoGroup.responses[0].id;
-    // Send only one representative per group: responses sharing the same
-    // literal answer are already fused server-side via same-answer fusion,
-    // so adding redundant intra-group pairs would just create useless rows.
-    const responseIds = selectedGroups.map((g) => g.responses[0].id);
-    const verdictDisplay = gabaritoGroup.displayAnswer;
-    startTransition(async () => {
-      await onConfirmEquivalent(responseIds, gabaritoResponseId, verdictDisplay);
-      setSelectionOrder([]);
-      setGabaritoOverride(null);
-    });
-  }
-
-  // "Todas são similares" (issue #247, ponto 5): pré-seleciona TODOS os grupos
-  // de uma vez, em vez de o revisor marcar par a par. A persistência continua no
-  // botão explícito de confirmação de equivalência abaixo, inclusive quando há
-  // maioria clara.
-  function handleConfirmAll() {
-    if (!onConfirmEquivalent) return;
-    if (groups.length < 2) return;
-    setSelectionOrder(groups.map((g) => g.groupKey));
-    setGabaritoOverride(null);
-  }
-
-  function handleUnmark(pairId: string) {
-    if (!onUnmarkPair) return;
-    startTransition(async () => {
-      await onUnmarkPair(pairId);
-    });
-  }
-
-  const gabaritoLabel = (() => {
-    if (!effectiveGabarito) return "";
-    const g = selectedGroups.find((s) => s.groupKey === effectiveGabarito);
-    return g?.displayAnswer ?? "";
-  })();
-
-  const selectedResponseCount = selectedGroups.reduce(
-    (acc, g) => acc + g.responses.length,
-    0,
+  const groups = useMemo<RenderedGroup[]>(
+    () => buildRenderedGroups(responses, equivalences),
+    [responses, equivalences],
   );
+
+  const equivalence = useEquivalenceSelection({
+    groups,
+    onConfirmEquivalent,
+    onUnmarkPair,
+  });
 
   return (
     <TooltipProvider delayDuration={200}>
@@ -327,46 +284,10 @@ export function AgreementGroup({
       */}
       <div className="space-y-1.5" data-testid="agreement-group">
         {allowEquivalence && groups.length > 1 && (
-          // Uma linha, não três: a explicação completa (o exemplo de
-          // equivalência e o que "gabarito" significa) vive no popover ao lado.
-          // O texto curto permanece visível porque é ele que revela a
-          // affordance para quem entra na tela pela primeira vez — o que sai do
-          // fluxo é a prosa, não a descoberta (#610).
-          <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1 text-[11px] leading-tight text-muted-foreground">
-            <p className="flex min-w-0 flex-1 items-center gap-1">
-              <Link2 className="size-3 shrink-0" />
-              <span className="truncate">
-                Marque os equivalentes e escolha o gabarito.
-              </span>
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label="Como funciona a equivalência entre respostas"
-                    className="shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
-                  >
-                    <HelpCircle className="size-3.5" />
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent align="start" className="w-80 p-3 text-xs">
-                  Marque os cards equivalentes (ex.: NI ≡ N/A ≡ &ldquo;não
-                  informado&rdquo;) e indique qual fica como{" "}
-                  <strong>gabarito</strong> — a resposta que será registrada.
-                </PopoverContent>
-              </Popover>
-            </p>
-            <Button
-              size="sm"
-              variant="outline"
-              className="h-7 shrink-0 gap-1"
-              disabled={readOnly || isSubmitting}
-              onClick={handleConfirmAll}
-              title="Pré-seleciona todas as respostas como equivalentes; a mais comum fica como gabarito sugerido. Revise o gabarito e aplique no botão de confirmação abaixo."
-            >
-              <Link2 className="size-3.5" />
-              Todas são similares
-            </Button>
-          </div>
+          <EquivalenceHint
+            disabled={readOnly || equivalence.isSubmitting}
+            onMarkAll={equivalence.selectAll}
+          />
         )}
 
         {groups.map((group, i) => {
@@ -405,18 +326,21 @@ export function AgreementGroup({
               equivalenceMode={
                 allowEquivalence
                   ? equivalenceModeFor({
-                      isSelected: selectionSet.has(group.groupKey),
-                      showGabarito,
-                      isGabarito: effectiveGabarito === group.groupKey,
-                      onToggle: () => toggleSelection(group.groupKey),
-                      onSetGabarito: () => setGabaritoOverride(group.groupKey),
+                      isSelected: equivalence.selectionSet.has(group.groupKey),
+                      showGabarito: equivalence.showGabarito,
+                      isGabarito:
+                        equivalence.effectiveGabarito === group.groupKey,
+                      onToggle: () =>
+                        equivalence.toggleSelection(group.groupKey),
+                      onSetGabarito: () =>
+                        equivalence.setGabarito(group.groupKey),
                     })
                   : undefined
               }
               equivalentVariants={
                 group.variants.length > 0 ? group.variants : undefined
               }
-              onUnmarkPair={onUnmarkPair ? handleUnmark : undefined}
+              onUnmarkPair={onUnmarkPair ? equivalence.unmarkPair : undefined}
               canUnmarkPair={(v) =>
                 canManageAnyPair || v.reviewerId === currentUserId
               }
@@ -424,26 +348,120 @@ export function AgreementGroup({
           );
         })}
 
-        {allowEquivalence && selectedGroups.length >= 2 && (
-          <div className="flex items-center justify-between gap-2 rounded-md border border-brand/30 bg-brand/5 px-2.5 py-1.5 text-xs">
-            <span className="min-w-0 flex-1 truncate text-muted-foreground">
-              Gabarito:{" "}
-              <span className="font-medium text-foreground">
-                {gabaritoLabel || "—"}
-              </span>
-            </span>
-            <Button
-              size="sm"
-              className="h-7 gap-1"
-              disabled={readOnly || isSubmitting || !effectiveGabarito}
-              onClick={handleConfirm}
-            >
-              <Link2 className="size-3.5" />
-              Confirmar {selectedResponseCount} respostas como equivalentes
-            </Button>
-          </div>
+        {allowEquivalence && equivalence.selectedGroups.length >= 2 && (
+          <EquivalenceConfirmBar
+            selectedGroups={equivalence.selectedGroups}
+            effectiveGabarito={equivalence.effectiveGabarito}
+            disabled={readOnly || equivalence.isSubmitting}
+            onConfirm={equivalence.confirmEquivalence}
+          />
         )}
       </div>
     </TooltipProvider>
+  );
+}
+
+/**
+ * Convite à equivalência, mostrado quando há mais de um grupo para comparar.
+ *
+ * Uma linha, não três: a explicação completa (o exemplo de equivalência e o que
+ * "gabarito" significa) vive no popover ao lado. O texto curto permanece visível
+ * porque é ele que revela a affordance para quem entra na tela pela primeira
+ * vez — o que sai do fluxo é a prosa, não a descoberta (#610).
+ */
+function EquivalenceHint({
+  disabled,
+  onMarkAll,
+}: {
+  disabled: boolean;
+  onMarkAll: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-muted-foreground/20 bg-muted/30 px-2.5 py-1 text-[11px] leading-tight text-muted-foreground">
+      <p className="flex min-w-0 flex-1 items-center gap-1">
+        <Link2 className="size-3 shrink-0" />
+        <span className="truncate">
+          Marque os equivalentes e escolha o gabarito.
+        </span>
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Como funciona a equivalência entre respostas"
+              className="shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
+            >
+              <HelpCircle className="size-3.5" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-80 p-3 text-xs">
+            Marque os cards equivalentes (ex.: NI ≡ N/A ≡ &ldquo;não
+            informado&rdquo;) e indique qual fica como <strong>gabarito</strong>{" "}
+            — a resposta que será registrada.
+          </PopoverContent>
+        </Popover>
+      </p>
+      {/*
+        "Todas são similares" (issue #247, ponto 5): pré-seleciona TODOS os
+        grupos de uma vez, em vez de o revisor marcar par a par. A persistência
+        continua no botão explícito de confirmação abaixo, inclusive quando há
+        maioria clara.
+      */}
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-7 shrink-0 gap-1"
+        disabled={disabled}
+        onClick={onMarkAll}
+        title="Pré-seleciona todas as respostas como equivalentes; a mais comum fica como gabarito sugerido. Revise o gabarito e aplique no botão de confirmação abaixo."
+      >
+        <Link2 className="size-3.5" />
+        Todas são similares
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * Confirmação da fusão por equivalência: qual resposta fica como gabarito e
+ * quantas respostas serão fundidas nela. Diferente da confirmação de veredito
+ * (`PendingConfirmBar`), esta persiste pares em `equivalences` — não decide o
+ * campo.
+ */
+function EquivalenceConfirmBar({
+  selectedGroups,
+  effectiveGabarito,
+  disabled,
+  onConfirm,
+}: {
+  selectedGroups: RenderedGroup[];
+  effectiveGabarito: string | null;
+  disabled: boolean;
+  onConfirm: () => void;
+}) {
+  const gabaritoLabel =
+    selectedGroups.find((g) => g.groupKey === effectiveGabarito)
+      ?.displayAnswer ?? "";
+  const selectedResponseCount = selectedGroups.reduce(
+    (acc, g) => acc + g.responses.length,
+    0,
+  );
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-md border border-brand/30 bg-brand/5 px-2.5 py-1.5 text-xs">
+      <span className="min-w-0 flex-1 truncate text-muted-foreground">
+        Gabarito:{" "}
+        <span className="font-medium text-foreground">
+          {gabaritoLabel || "—"}
+        </span>
+      </span>
+      <Button
+        size="sm"
+        className="h-7 gap-1"
+        disabled={disabled || !effectiveGabarito}
+        onClick={onConfirm}
+      >
+        <Link2 className="size-3.5" />
+        Confirmar {selectedResponseCount} respostas como equivalentes
+      </Button>
+    </div>
   );
 }

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -99,16 +99,7 @@ export function AnswerCard({
   onUnmarkPair,
   canUnmarkPair,
 }: AnswerCardProps) {
-  const allStale = staleCount > 0 && staleCount === respondentCount;
-  const fusedCount = equivalentVariants?.length ?? 0;
-  const selected = equivalenceMode?.selected === true;
-  // Gabarito radio is only reachable on the selected branch (invariant in type).
-  const gabarito = equivalenceMode?.selected ? equivalenceMode.gabarito : null;
   const voteTitle = readOnlyTitle(readOnly);
-  const equivalenceTitle = readOnlyTitle(
-    readOnly,
-    "Selecionar para marcar como equivalente",
-  );
   const unmarkTitle = readOnlyTitle(readOnly, "Desfazer equivalência");
 
   return (
@@ -121,126 +112,36 @@ export function AnswerCard({
       className={cn(
         "relative isolate w-full rounded-lg border p-2.5 text-left transition-colors hover:bg-accent/50",
         "has-[[data-vote-target]:focus-visible]:outline-none has-[[data-vote-target]:focus-visible]:ring-2 has-[[data-vote-target]:focus-visible]:ring-ring has-[[data-vote-target]:focus-visible]:ring-offset-2",
-        isChosen
-          ? "border-green-500/50 bg-green-500/5"
-          : isPending
-            ? "border-brand bg-brand/10"
-            : selected
-              ? "border-brand/60 bg-brand/5"
-              : "border-muted",
+        cardStateClass({ isChosen, isPending, equivalenceMode }),
       )}
     >
-      {/*
-        Vote target: a transparent <button> overlaying the whole card. The card
-        itself is a plain <div> so the interactive controls below (checkbox,
-        popover, gabarito radio) can be siblings of this button instead of
-        nested inside it (nested interactive = invalid HTML, plus the manual
-        role="button" that prefer-tag-over-role flagged). Any new interactive or
-        hover child must be lifted above this overlay with `relative z-[2]`;
-        non-interactive content stays below and clicking it votes
-        (stretched-link pattern). The native <button> handles Enter/Space.
-      */}
-      <button
-        type="button"
-        data-vote-target
-        onClick={onVote}
-        disabled={readOnly}
-        aria-label={`Selecionar esta resposta para confirmar: ${displayAnswer || "(vazia)"}`}
+      <VoteOverlay
+        displayAnswer={displayAnswer}
+        readOnly={readOnly}
+        onVote={onVote}
         title={voteTitle}
-        className={cn(
-          "absolute inset-0 z-[1] rounded-lg focus:outline-none",
-          readOnly ? "cursor-default" : "cursor-pointer",
-        )}
       />
       <div className="flex items-start gap-2">
-        {equivalenceMode && (
-          <div className="relative z-[2] flex h-5 shrink-0 items-center">
-            <Checkbox
-              checked={equivalenceMode.selected}
-              onCheckedChange={() => equivalenceMode.onToggle()}
-              disabled={readOnly}
-              aria-label="Selecionar para marcar como equivalente"
-              title={equivalenceTitle}
-            />
-          </div>
-        )}
+        <EquivalenceCheckbox mode={equivalenceMode} readOnly={readOnly} />
         <span className="flex size-5 shrink-0 items-center justify-center rounded bg-muted text-xs font-medium">
           {index + 1}
         </span>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm">{displayAnswer}</p>
+        <AnswerBody
+          displayAnswer={displayAnswer}
+          respondentNames={respondentNames}
+          respondentCount={respondentCount}
+          hasLlm={hasLlm}
+          llmJustification={llmJustification}
+          staleCount={staleCount}
+          versions={versions}
+          readOnly={readOnly}
+          unmarkTitle={unmarkTitle}
+          equivalentVariants={equivalentVariants}
+          onUnmarkPair={onUnmarkPair}
+          canUnmarkPair={canUnmarkPair}
+        />
 
-          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="relative z-[2] cursor-default underline decoration-dotted underline-offset-2">
-                  {respondentCount}{" "}
-                  {respondentCount === 1 ? "respondente" : "respondentes"}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                {respondentNames.map((name) => (
-                  <div key={name}>{name}</div>
-                ))}
-              </TooltipContent>
-            </Tooltip>
-
-            {hasLlm && (
-              <span className="inline-flex items-center gap-1 text-brand">
-                <Bot className="size-3" />
-                LLM
-              </span>
-            )}
-
-            {staleCount > 0 && (
-              <span className="inline-flex items-center gap-1 text-amber-600">
-                <AlertTriangle className="size-3" />
-                {allStale
-                  ? "desatualizada"
-                  : `${staleCount} de ${respondentCount} desatualizadas`}
-              </span>
-            )}
-
-            {fusedCount > 0 && (
-              <FusedVariantsPopover
-                variants={equivalentVariants!}
-                readOnly={readOnly}
-                unmarkTitle={unmarkTitle}
-                onUnmarkPair={onUnmarkPair}
-                canUnmarkPair={canUnmarkPair}
-              />
-            )}
-
-            {versions.length === 1 && (
-              <span
-                className="relative z-[2] font-mono text-[10px] text-muted-foreground"
-                title="Versão do schema em que esta resposta foi salva"
-              >
-                v{versions[0]}
-              </span>
-            )}
-            {versions.length > 1 && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="relative z-[2] cursor-default font-mono text-[10px] text-muted-foreground underline decoration-dotted underline-offset-2">
-                    {versions.length} versões
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {versions.map((v) => (
-                    <div key={v}>v{v}</div>
-                  ))}
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </div>
-
-          {hasLlm && llmJustification && (
-            <LlmJustification text={llmJustification} />
-          )}
-        </div>
-
-        {gabarito && <GabaritoRadio gabarito={gabarito} readOnly={readOnly} />}
+        <GabaritoRadio mode={equivalenceMode} readOnly={readOnly} />
       </div>
 
       {/*
@@ -257,18 +158,282 @@ export function AnswerCard({
 }
 
 /**
+ * A coluna central do card: a resposta, a linha de metadados e a justificativa
+ * do LLM. Tudo que não é affordance de seleção (checkbox à esquerda, gabarito à
+ * direita) nem o overlay que cobre o card.
+ */
+function AnswerBody({
+  displayAnswer,
+  respondentNames,
+  respondentCount,
+  hasLlm,
+  llmJustification,
+  staleCount,
+  versions,
+  readOnly,
+  unmarkTitle,
+  equivalentVariants,
+  onUnmarkPair,
+  canUnmarkPair,
+}: {
+  displayAnswer: string;
+  respondentNames: string[];
+  respondentCount: number;
+  hasLlm: boolean;
+  llmJustification?: string;
+  staleCount: number;
+  versions: string[];
+  readOnly: boolean;
+  unmarkTitle: string | undefined;
+  equivalentVariants?: EquivalentVariant[];
+  onUnmarkPair?: (pairId: string) => void;
+  canUnmarkPair?: (variant: EquivalentVariant) => boolean;
+}) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="text-sm">{displayAnswer}</p>
+
+      <AnswerMetaRow
+        respondentNames={respondentNames}
+        respondentCount={respondentCount}
+        hasLlm={hasLlm}
+        staleCount={staleCount}
+        versions={versions}
+        readOnly={readOnly}
+        unmarkTitle={unmarkTitle}
+        equivalentVariants={equivalentVariants}
+        onUnmarkPair={onUnmarkPair}
+        canUnmarkPair={canUnmarkPair}
+      />
+
+      {hasLlm && llmJustification && (
+        <LlmJustification text={llmJustification} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Alvo de voto: um <button> transparente cobrindo o card inteiro.
+ *
+ * O card é uma <div> simples justamente para que os controles interativos
+ * (checkbox, popover, radio do gabarito, barra de confirmação) sejam IRMÃOS
+ * deste botão em vez de filhos — interativo aninhado é HTML inválido. Todo
+ * filho interativo ou com hover precisa subir acima deste overlay com
+ * `relative z-[2]`; conteúdo não-interativo fica abaixo e clicar nele vota
+ * (padrão stretched-link). O <button> nativo cuida de Enter/Espaço.
+ */
+function VoteOverlay({
+  displayAnswer,
+  readOnly,
+  onVote,
+  title,
+}: {
+  displayAnswer: string;
+  readOnly: boolean;
+  onVote: () => void;
+  title: string | undefined;
+}) {
+  return (
+    <button
+      type="button"
+      data-vote-target
+      onClick={onVote}
+      disabled={readOnly}
+      aria-label={`Selecionar esta resposta para confirmar: ${displayAnswer || "(vazia)"}`}
+      title={title}
+      className={cn(
+        "absolute inset-0 z-[1] rounded-lg focus:outline-none",
+        readOnly ? "cursor-default" : "cursor-pointer",
+      )}
+    />
+  );
+}
+
+/**
+ * A cor de borda e de fundo que comunica o estado do card. Um estado só, em
+ * ordem de precedência: o veredito já gravado vence o rascunho, que vence a
+ * seleção de equivalência. Fora do JSX porque era a única cadeia de ternários
+ * aninhados do corpo do componente, e ali a precedência ficava legível apenas
+ * pela indentação.
+ */
+function cardStateClass({
+  isChosen,
+  isPending,
+  equivalenceMode,
+}: {
+  isChosen: boolean;
+  isPending: boolean;
+  equivalenceMode?: EquivalenceMode;
+}): string {
+  if (isChosen) return "border-green-500/50 bg-green-500/5";
+  if (isPending) return "border-brand bg-brand/10";
+  if (equivalenceMode?.selected) return "border-brand/60 bg-brand/5";
+  return "border-muted";
+}
+
+/**
+ * Caixa de seleção para marcar este card como equivalente a outro. Ausente
+ * quando o modo de equivalência não está permitido — `undefined` é o próprio
+ * sinal disso, e a leitura fica com quem já recebe o modo.
+ */
+function EquivalenceCheckbox({
+  mode,
+  readOnly,
+}: {
+  mode?: EquivalenceMode;
+  readOnly: boolean;
+}) {
+  if (!mode) return null;
+  return (
+    <div className="relative z-[2] flex h-5 shrink-0 items-center">
+      <Checkbox
+        checked={mode.selected}
+        onCheckedChange={() => mode.onToggle()}
+        disabled={readOnly}
+        aria-label="Selecionar para marcar como equivalente"
+        title={readOnlyTitle(readOnly, "Selecionar para marcar como equivalente")}
+      />
+    </div>
+  );
+}
+
+/**
+ * A linha de metadados do card: quem respondeu, se houve LLM, o que está
+ * desatualizado, as variantes fundidas e a versão do schema.
+ *
+ * Extraída porque era o maior aglomerado de ramos do corpo do `AnswerCard` —
+ * seis condições que nada decidem sobre a resposta em si, só sobre quais
+ * marcadores acompanham. Nenhuma delas é interativa exceto o popover de
+ * variantes, que carrega o próprio `z-[2]`.
+ */
+function AnswerMetaRow({
+  respondentNames,
+  respondentCount,
+  hasLlm,
+  staleCount,
+  versions,
+  readOnly,
+  unmarkTitle,
+  equivalentVariants,
+  onUnmarkPair,
+  canUnmarkPair,
+}: {
+  respondentNames: string[];
+  respondentCount: number;
+  hasLlm: boolean;
+  staleCount: number;
+  versions: string[];
+  readOnly: boolean;
+  unmarkTitle: string | undefined;
+  equivalentVariants?: EquivalentVariant[];
+  onUnmarkPair?: (pairId: string) => void;
+  canUnmarkPair?: (variant: EquivalentVariant) => boolean;
+}) {
+  const fusedCount = equivalentVariants?.length ?? 0;
+  // "desatualizada" no singular quando TODAS estão: dizer "2 de 2
+  // desatualizadas" para um grupo inteiro velho é ruído, não informação.
+  const allStale = staleCount > 0 && staleCount === respondentCount;
+  return (
+    <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="relative z-[2] cursor-default underline decoration-dotted underline-offset-2">
+            {respondentCount}{" "}
+            {respondentCount === 1 ? "respondente" : "respondentes"}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          {respondentNames.map((name) => (
+            <div key={name}>{name}</div>
+          ))}
+        </TooltipContent>
+      </Tooltip>
+
+      {hasLlm && (
+        <span className="inline-flex items-center gap-1 text-brand">
+          <Bot className="size-3" />
+          LLM
+        </span>
+      )}
+
+      {staleCount > 0 && (
+        <span className="inline-flex items-center gap-1 text-amber-600">
+          <AlertTriangle className="size-3" />
+          {allStale
+            ? "desatualizada"
+            : `${staleCount} de ${respondentCount} desatualizadas`}
+        </span>
+      )}
+
+      {fusedCount > 0 && (
+        <FusedVariantsPopover
+          variants={equivalentVariants!}
+          readOnly={readOnly}
+          unmarkTitle={unmarkTitle}
+          onUnmarkPair={onUnmarkPair}
+          canUnmarkPair={canUnmarkPair}
+        />
+      )}
+
+      <SchemaVersionsBadge versions={versions} />
+    </div>
+  );
+}
+
+/**
+ * Versão do schema em que a resposta foi salva. Uma versão vira texto direto;
+ * várias (respostas do mesmo grupo salvas em versões diferentes) viram um
+ * tooltip com a lista, porque enfileirá-las na linha estouraria a largura do
+ * card. Nenhuma versão — resposta legada sem carimbo — não rende marcador.
+ */
+function SchemaVersionsBadge({ versions }: { versions: string[] }) {
+  if (versions.length === 0) return null;
+  if (versions.length === 1) {
+    return (
+      <span
+        className="relative z-[2] font-mono text-[10px] text-muted-foreground"
+        title="Versão do schema em que esta resposta foi salva"
+      >
+        v{versions[0]}
+      </span>
+    );
+  }
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="relative z-[2] cursor-default font-mono text-[10px] text-muted-foreground underline decoration-dotted underline-offset-2">
+          {versions.length} versões
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">
+        {versions.map((v) => (
+          <div key={v}>v{v}</div>
+        ))}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/**
  * Marcador do gabarito de um grupo de respostas equivalentes. Extraído do corpo
  * do card para pagar a complexidade que o `confirmSlot` acrescentou — o
  * `AnswerCard` já estava acima do limiar, então acrescentar sem devolver
  * empurraria o débito adiante.
  */
 function GabaritoRadio({
-  gabarito,
+  mode,
   readOnly,
 }: {
-  gabarito: GabaritoAffordance;
+  mode?: EquivalenceMode;
   readOnly: boolean;
 }) {
+  // A decisão mora aqui, e não no `AnswerCard`: o tipo já garante que
+  // `gabarito` só existe no ramo selecionado, então quem pergunta "há gabarito
+  // a mostrar?" é quem sabe respondê-la. No card, a mesma pergunta virava um
+  // ternário sobre uma união discriminada mais um teste de nulidade.
+  const gabarito = mode?.selected ? mode.gabarito : null;
+  if (!gabarito) return null;
   return (
     <label
       className="relative z-[2] flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -39,9 +39,11 @@ interface GabaritoAffordance {
 // without selection" in the type. The `gabarito` affordance only exists in the
 // `selected: true` branch, so an impossible state (gabarito on an unselected
 // card) is unrepresentable. `undefined` ⇒ equivalence not allowed (no checkbox).
-// Not exported: the sole consumer (AgreementGroup) builds the object inline and
-// TS checks it structurally against the prop type — exporting would be dead code.
-type EquivalenceMode =
+// Exportado porque o único consumidor (AgreementGroup) monta o objeto numa
+// função fora do JSX: sem o tipo anotado, `selected: true` seria inferido como
+// `boolean` e a união discriminada — que é o que torna o gabarito num card não
+// selecionado irrepresentável — se perderia na inferência.
+export type EquivalenceMode =
   | { selected: false; onToggle: () => void }
   | {
       selected: true;

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import {
   Bot,
@@ -63,6 +63,11 @@ interface AnswerCardProps {
   versions: string[];
   onVote: () => void;
 
+  // Confirmação do rascunho, renderizada DENTRO do card quando ele é o que
+  // produziu o rascunho — o segundo passo nasce junto do primeiro em vez de no
+  // rodapé do painel (#610). Só é consumida quando `isPending`.
+  confirmSlot?: ReactNode;
+
   // Selection / equivalence affordances (only present when allowEquivalence).
   // Discriminated union: `gabarito` is only reachable on the selected branch.
   equivalenceMode?: EquivalenceMode;
@@ -86,6 +91,7 @@ export function AnswerCard({
   isPending,
   versions,
   onVote,
+  confirmSlot,
   equivalenceMode,
   equivalentVariants,
   onUnmarkPair,
@@ -106,6 +112,11 @@ export function AnswerCard({
 
   return (
     <div
+      data-testid="answer-card"
+      // Contrato de teste para "este é o card preparado". A asserção anterior
+      // lia `parentElement.className` atrás de uma classe de borda — sobrevivia
+      // por acidente da estrutura e quebraria em qualquer wrapper novo.
+      data-pending={isPending || undefined}
       className={cn(
         "relative isolate w-full rounded-lg border p-2.5 text-left transition-colors hover:bg-accent/50",
         "has-[[data-vote-target]:focus-visible]:outline-none has-[[data-vote-target]:focus-visible]:ring-2 has-[[data-vote-target]:focus-visible]:ring-ring has-[[data-vote-target]:focus-visible]:ring-offset-2",
@@ -300,6 +311,16 @@ export function AnswerCard({
           </label>
         )}
       </div>
+
+      {/*
+        `relative z-[2]` pela mesma regra do comentário do overlay acima: filho
+        interativo precisa ficar ACIMA do botão de voto que cobre o card
+        inteiro. Sem isso, clicar em "Confirmar" acertaria o overlay e apenas
+        re-prepararia o rascunho.
+      */}
+      {isPending && confirmSlot && (
+        <div className="relative z-[2]">{confirmSlot}</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/compare/AnswerCard.tsx
+++ b/frontend/src/components/compare/AnswerCard.tsx
@@ -97,7 +97,6 @@ export function AnswerCard({
   onUnmarkPair,
   canUnmarkPair,
 }: AnswerCardProps) {
-  const [showJustification, setShowJustification] = useState(false);
   const allStale = staleCount > 0 && staleCount === respondentCount;
   const fusedCount = equivalentVariants?.length ?? 0;
   const selected = equivalenceMode?.selected === true;
@@ -201,54 +200,13 @@ export function AnswerCard({
             )}
 
             {fusedCount > 0 && (
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    className="relative z-[2] inline-flex items-center gap-1 rounded bg-brand/10 px-1.5 py-0.5 text-[10px] text-brand hover:bg-brand/15"
-                    title="Variantes marcadas como equivalentes"
-                  >
-                    <Link2 className="size-3" />
-                    {fusedCount} variante{fusedCount === 1 ? "" : "s"}
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent align="start" className="w-72 p-2">
-                  <p className="px-1 pb-1.5 text-xs font-medium">
-                    Respostas equivalentes
-                  </p>
-                  <ul className="space-y-1">
-                    {equivalentVariants!.map((v) => {
-                      const showUnmark =
-                        !!onUnmarkPair && (canUnmarkPair?.(v) ?? true);
-                      return (
-                        <li
-                          key={v.pairId}
-                          className="flex items-center justify-between gap-2 rounded px-1.5 py-1 text-xs hover:bg-muted"
-                        >
-                          <div className="min-w-0 flex-1">
-                            <p className="truncate">{v.answerDisplay}</p>
-                            <p className="truncate text-[10px] text-muted-foreground">
-                              {v.respondentName}
-                            </p>
-                          </div>
-                          {showUnmark && (
-                            <button
-                              type="button"
-                              onClick={() => onUnmarkPair!(v.pairId)}
-                              disabled={readOnly}
-                              className="rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                              title={unmarkTitle}
-                              aria-label="Desfazer equivalência"
-                            >
-                              <X className="size-3" />
-                            </button>
-                          )}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                </PopoverContent>
-              </Popover>
+              <FusedVariantsPopover
+                variants={equivalentVariants!}
+                readOnly={readOnly}
+                unmarkTitle={unmarkTitle}
+                onUnmarkPair={onUnmarkPair}
+                canUnmarkPair={canUnmarkPair}
+              />
             )}
 
             {versions.length === 1 && (
@@ -276,40 +234,11 @@ export function AnswerCard({
           </div>
 
           {hasLlm && llmJustification && (
-            <div className="mt-1.5">
-              <button
-                type="button"
-                onClick={() => setShowJustification(!showJustification)}
-                className="relative z-[2] text-xs text-muted-foreground hover:text-foreground"
-              >
-                {showJustification ? <ChevronDown className="inline size-3" /> : <ChevronRight className="inline size-3" />}{" "}Justificativa
-              </button>
-              {showJustification && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {llmJustification}
-                </p>
-              )}
-            </div>
+            <LlmJustification text={llmJustification} />
           )}
         </div>
 
-        {gabarito && (
-          <label
-            className="relative z-[2] flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"
-            title="Esta é a resposta que será registrada como gabarito"
-          >
-            <input
-              type="radio"
-              checked={gabarito.isGabarito}
-              onChange={() => gabarito.onSetGabarito()}
-              disabled={readOnly}
-              className="size-3 accent-brand"
-            />
-            <span className={cn(gabarito.isGabarito && "font-medium text-brand")}>
-              Gabarito
-            </span>
-          </label>
-        )}
+        {gabarito && <GabaritoRadio gabarito={gabarito} readOnly={readOnly} />}
       </div>
 
       {/*
@@ -321,6 +250,132 @@ export function AnswerCard({
       {isPending && confirmSlot && (
         <div className="relative z-[2]">{confirmSlot}</div>
       )}
+    </div>
+  );
+}
+
+/**
+ * Marcador do gabarito de um grupo de respostas equivalentes. Extraído do corpo
+ * do card para pagar a complexidade que o `confirmSlot` acrescentou — o
+ * `AnswerCard` já estava acima do limiar, então acrescentar sem devolver
+ * empurraria o débito adiante.
+ */
+function GabaritoRadio({
+  gabarito,
+  readOnly,
+}: {
+  gabarito: GabaritoAffordance;
+  readOnly: boolean;
+}) {
+  return (
+    <label
+      className="relative z-[2] flex shrink-0 cursor-pointer items-center gap-1 rounded border border-brand/30 bg-background px-1.5 py-0.5 text-[10px] hover:bg-brand/5"
+      title="Esta é a resposta que será registrada como gabarito"
+    >
+      <input
+        type="radio"
+        checked={gabarito.isGabarito}
+        onChange={() => gabarito.onSetGabarito()}
+        disabled={readOnly}
+        className="size-3 accent-brand"
+      />
+      <span className={cn(gabarito.isGabarito && "font-medium text-brand")}>
+        Gabarito
+      </span>
+    </label>
+  );
+}
+
+/**
+ * Variantes que foram marcadas como equivalentes e por isso aparecem fundidas
+ * neste card. Extraído junto do `GabaritoRadio` para devolver a complexidade
+ * que o `confirmSlot` acrescentou ao corpo do `AnswerCard` — o componente já
+ * estava acima do limiar antes desta mudança.
+ */
+function FusedVariantsPopover({
+  variants,
+  readOnly,
+  unmarkTitle,
+  onUnmarkPair,
+  canUnmarkPair,
+}: {
+  variants: EquivalentVariant[];
+  readOnly: boolean;
+  unmarkTitle: string | undefined;
+  onUnmarkPair?: (pairId: string) => void;
+  canUnmarkPair?: (variant: EquivalentVariant) => boolean;
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="relative z-[2] inline-flex items-center gap-1 rounded bg-brand/10 px-1.5 py-0.5 text-[10px] text-brand hover:bg-brand/15"
+          title="Variantes marcadas como equivalentes"
+        >
+          <Link2 className="size-3" />
+          {variants.length} variante{variants.length === 1 ? "" : "s"}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 p-2">
+        <p className="px-1 pb-1.5 text-xs font-medium">Respostas equivalentes</p>
+        <ul className="space-y-1">
+          {variants.map((v) => {
+            const showUnmark = !!onUnmarkPair && (canUnmarkPair?.(v) ?? true);
+            return (
+              <li
+                key={v.pairId}
+                className="flex items-center justify-between gap-2 rounded px-1.5 py-1 text-xs hover:bg-muted"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate">{v.answerDisplay}</p>
+                  <p className="truncate text-[10px] text-muted-foreground">
+                    {v.respondentName}
+                  </p>
+                </div>
+                {showUnmark && (
+                  <button
+                    type="button"
+                    onClick={() => onUnmarkPair!(v.pairId)}
+                    disabled={readOnly}
+                    className="rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                    title={unmarkTitle}
+                    aria-label="Desfazer equivalência"
+                  >
+                    <X className="size-3" />
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * Justificativa do LLM, colapsável. Leva junto o único `useState` que existia no
+ * corpo do `AnswerCard`: o estado é local a este trecho e não influencia mais
+ * nada do card.
+ */
+function LlmJustification({ text }: { text: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="mt-1.5">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="relative z-[2] text-xs text-muted-foreground hover:text-foreground"
+      >
+        {open ? (
+          <ChevronDown className="inline size-3" />
+        ) : (
+          <ChevronRight className="inline size-3" />
+        )}{" "}
+        Justificativa
+      </button>
+      {open && <p className="mt-1 text-xs text-muted-foreground">{text}</p>}
     </div>
   );
 }

--- a/frontend/src/components/compare/CompareFieldReview.tsx
+++ b/frontend/src/components/compare/CompareFieldReview.tsx
@@ -65,8 +65,13 @@ interface CompareFieldReviewProps {
   ) => Promise<void>;
   onUnmarkEquivalencePair: (pairId: string) => Promise<void>;
   currentUserId: string;
-  onConfirmPendingVerdict: () => void;
-  onDiscardPendingVerdict: () => void;
+  // Um objeto, e não dois callbacks soltos: é a MESMA forma que o
+  // `AgreementGroup` e o `DivergenceActionsPanel` já recebem, então a
+  // confirmação viaja com um formato só da borda do painel até a folha.
+  pendingConfirm: {
+    onConfirm: () => void;
+    onDiscard: () => void;
+  };
 }
 
 /**
@@ -128,12 +133,10 @@ export function CompareFieldReview({
   onConfirmEquivalent,
   onUnmarkEquivalencePair,
   currentUserId,
-  onConfirmPendingVerdict,
-  onDiscardPendingVerdict,
+  pendingConfirm: pendingConfirmActions,
 }: CompareFieldReviewProps) {
   const pendingConfirm = {
-    onConfirm: onConfirmPendingVerdict,
-    onDiscard: onDiscardPendingVerdict,
+    ...pendingConfirmActions,
     isSaving: isSavingVerdict,
   };
 

--- a/frontend/src/components/compare/CompareFieldReview.tsx
+++ b/frontend/src/components/compare/CompareFieldReview.tsx
@@ -65,6 +65,8 @@ interface CompareFieldReviewProps {
   ) => Promise<void>;
   onUnmarkEquivalencePair: (pairId: string) => Promise<void>;
   currentUserId: string;
+  onConfirmPendingVerdict: () => void;
+  onDiscardPendingVerdict: () => void;
 }
 
 /**
@@ -126,7 +128,29 @@ export function CompareFieldReview({
   onConfirmEquivalent,
   onUnmarkEquivalencePair,
   currentUserId,
+  onConfirmPendingVerdict,
+  onDiscardPendingVerdict,
 }: CompareFieldReviewProps) {
+  const pendingConfirm = {
+    onConfirm: onConfirmPendingVerdict,
+    onDiscard: onDiscardPendingVerdict,
+    isSaving: isSavingVerdict,
+  };
+
+  // A barra de confirmação nasce no elemento que PRODUZIU o rascunho. Para
+  // `kind: "response"` esse elemento é um card — mas só se o card existir de
+  // fato na lista renderizada. Um rascunho apontando para resposta que o
+  // `AgreementGroup` não mostra (`answer === undefined` é filtrado lá) não teria
+  // barra em lugar nenhum, e o `guardNavigation` do #434 travaria a navegação
+  // com um rascunho impossível de confirmar ou descartar pelo mouse: um
+  // soft-lock, que é o defeito do #430 com o sinal trocado. Quando a âncora não
+  // existe, o painel de ações assume a barra.
+  const anchoredToCard =
+    pendingVerdict?.kind === "response" &&
+    responses.some(
+      (r) => r.id === pendingVerdict.chosenResponseId && r.answer !== undefined,
+    );
+
   return (
     <CompareFieldScope documentId={documentId} fieldName={fieldName}>
       {isMulti ? (
@@ -151,6 +175,7 @@ export function CompareFieldReview({
           onConfirmEquivalent={onConfirmEquivalent}
           onUnmarkEquivalencePair={onUnmarkEquivalencePair}
           currentUserId={currentUserId}
+          pendingConfirm={pendingConfirm}
         />
       )}
 
@@ -169,6 +194,7 @@ export function CompareFieldReview({
           onPrepareVerdict={onPrepareVerdict}
           comment={comment}
           onCommentChange={onCommentChange}
+          pendingConfirm={anchoredToCard ? null : pendingConfirm}
         />
       ) : (
         <ConcordantNotice readOnly={readOnly} onMarkReviewed={onMarkReviewed} />
@@ -194,6 +220,7 @@ function SingleAnswerGroup({
   onConfirmEquivalent,
   onUnmarkEquivalencePair,
   currentUserId,
+  pendingConfirm,
 }: {
   readOnly: boolean;
   origin: VerdictOrigin;
@@ -206,6 +233,11 @@ function SingleAnswerGroup({
   onConfirmEquivalent: CompareFieldReviewProps["onConfirmEquivalent"];
   onUnmarkEquivalencePair: (pairId: string) => Promise<void>;
   currentUserId: string;
+  pendingConfirm: {
+    onConfirm: () => void;
+    onDiscard: () => void;
+    isSaving: boolean;
+  };
 }) {
   return (
     <AgreementGroup
@@ -241,6 +273,7 @@ function SingleAnswerGroup({
       onUnmarkPair={onUnmarkEquivalencePair}
       currentUserId={currentUserId}
       canManageAnyPair={equivalence.canManageAnyPair}
+      pendingConfirm={pendingConfirm}
     />
   );
 }

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -77,6 +77,14 @@ interface ComparisonPanelProps {
   currentUserId: string;
 }
 
+// Cognitive 43 vs. limiar 15 — mas o fallow o marca como achado NOVO apenas
+// porque o arquivo foi tocado. A medição pareada contra origin/main @ 22f4b99c
+// diz o contrário: cyclomatic 23 → 12 e cognitive 53 → 43, porque este PR
+// REMOVEU daqui o rodapé de confirmação com seus três ternários aninhados. O
+// que sobra é o mesmo débito JSX inerente já rastreado na #580 para
+// ComparePage/CompareMainView: encaminhamento de props, que o fallow conta como
+// fiação. Suprimido com a medição registrada, não por conveniência.
+// fallow-ignore-next-line complexity
 export function ComparisonPanel({
   readOnly,
   projectId,
@@ -263,8 +271,10 @@ export function ComparisonPanel({
           onConfirmEquivalent={onConfirmEquivalent}
           onUnmarkEquivalencePair={onUnmarkEquivalencePair}
           currentUserId={currentUserId}
-          onConfirmPendingVerdict={onConfirmPendingVerdict}
-          onDiscardPendingVerdict={onDiscardPendingVerdict}
+          pendingConfirm={{
+            onConfirm: onConfirmPendingVerdict,
+            onDiscard: onDiscardPendingVerdict,
+          }}
         />
       </div>
 

--- a/frontend/src/components/compare/ComparisonPanel.tsx
+++ b/frontend/src/components/compare/ComparisonPanel.tsx
@@ -23,11 +23,7 @@ import { ArrowRight, CheckCircle2, MessageSquare, Lightbulb } from "lucide-react
 import { FieldHeaderLabel } from "@/components/shared/FieldHeaderLabel";
 import type { VerdictInfo } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
-import {
-  pendingVerdictLabel,
-  type PendingVerdict,
-  type VerdictOrigin,
-} from "./compare-types";
+import type { PendingVerdict, VerdictOrigin } from "./compare-types";
 
 // Conclusão do documento + navegação da fila. Discriminated union: `hasNextDoc`
 // e `onNextDoc` só fazem sentido depois que a revisão do documento terminou, então
@@ -267,50 +263,10 @@ export function ComparisonPanel({
           onConfirmEquivalent={onConfirmEquivalent}
           onUnmarkEquivalencePair={onUnmarkEquivalencePair}
           currentUserId={currentUserId}
+          onConfirmPendingVerdict={onConfirmPendingVerdict}
+          onDiscardPendingVerdict={onDiscardPendingVerdict}
         />
       </div>
-
-      {isDivergent && !isMulti && (!docStatus.complete || pendingVerdict) && (
-        <div className="flex shrink-0 items-center justify-between gap-2 border-t bg-muted/20 px-4 py-2">
-          <span className="min-w-0 truncate text-xs text-muted-foreground">
-            {readOnly ? (
-              "Decisões desabilitadas no modo somente leitura."
-            ) : pendingVerdict ? (
-              <>
-                Selecionado:{" "}
-                <span className="font-medium text-foreground">
-                  {pendingVerdictLabel(pendingVerdict)}
-                </span>
-              </>
-            ) : (
-              "Escolha uma resposta para confirmar."
-            )}
-          </span>
-          <div className="flex shrink-0 items-center gap-2">
-            {pendingVerdict && (
-              <Button
-                variant="ghost"
-                size="sm"
-                disabled={readOnly || isSavingVerdict}
-                onClick={onDiscardPendingVerdict}
-              >
-                Descartar
-              </Button>
-            )}
-            <Button
-              size="sm"
-              disabled={readOnly || !pendingVerdict || isSavingVerdict}
-              onClick={onConfirmPendingVerdict}
-            >
-              {readOnly
-                ? "Somente leitura"
-                : isSavingVerdict
-                  ? "Salvando..."
-                  : "Confirmar"}
-            </Button>
-          </div>
-        </div>
-      )}
 
       {docStatus.complete && (
         <div className="flex shrink-0 items-center justify-between gap-2 border-t border-green-500/20 bg-green-500/5 px-4 py-2">

--- a/frontend/src/components/compare/DivergenceActionsPanel.tsx
+++ b/frontend/src/components/compare/DivergenceActionsPanel.tsx
@@ -156,7 +156,7 @@ export function DivergenceActionsPanel({
       {pendingVerdict && pendingConfirm && (
         <PendingConfirmBar
           label={pendingVerdictLabel(pendingVerdict)}
-          pendingLabel={pendingVerdictLabel(pendingVerdict)}
+          showLabel
           isSaving={pendingConfirm.isSaving}
           onConfirm={pendingConfirm.onConfirm}
           onDiscard={pendingConfirm.onDiscard}

--- a/frontend/src/components/compare/DivergenceActionsPanel.tsx
+++ b/frontend/src/components/compare/DivergenceActionsPanel.tsx
@@ -11,7 +11,12 @@ import { SuggestFieldDialog } from "@/components/stats/SuggestFieldDialog";
 import { formatVerdictDisplay } from "@/lib/verdict-display";
 import type { VerdictInfo } from "@/lib/compare-reviews";
 import type { PydanticField } from "@/lib/types";
-import { readOnlyTitle, type PendingVerdict } from "./compare-types";
+import { PendingConfirmBar } from "./PendingConfirmBar";
+import {
+  pendingVerdictLabel,
+  readOnlyTitle,
+  type PendingVerdict,
+} from "./compare-types";
 import { useVerdictOrigin } from "./compare-field-scope";
 
 interface DivergenceActionsPanelProps {
@@ -26,6 +31,18 @@ interface DivergenceActionsPanelProps {
   onPrepareVerdict: (pending: PendingVerdict) => void;
   comment: string;
   onCommentChange: (value: string) => void;
+  /**
+   * Confirmação do rascunho quando ele NÃO nasceu num card — Ambíguo, Pular e
+   * resposta nova são criados aqui, e três das quatro variantes de
+   * `PendingVerdict` passam por este painel. `null` quando a barra já está
+   * ancorada no card, para que exista exatamente um controle de confirmação no
+   * DOM por vez.
+   */
+  pendingConfirm: {
+    onConfirm: () => void;
+    onDiscard: () => void;
+    isSaving: boolean;
+  } | null;
 }
 
 // Ações do campo divergente: marcadores Ambíguo/Pular + resposta nova, veredito
@@ -43,6 +60,7 @@ export function DivergenceActionsPanel({
   onPrepareVerdict,
   comment,
   onCommentChange,
+  pendingConfirm,
 }: DivergenceActionsPanelProps) {
   // Documento e campo vêm do escopo, não de props: é a MESMA origem que carimba
   // os rascunhos criados aqui e a que endereça a nota e a sugestão de schema,
@@ -133,6 +151,16 @@ export function DivergenceActionsPanel({
             }
           />
         </div>
+      )}
+
+      {pendingVerdict && pendingConfirm && (
+        <PendingConfirmBar
+          label={pendingVerdictLabel(pendingVerdict)}
+          pendingLabel={pendingVerdictLabel(pendingVerdict)}
+          isSaving={pendingConfirm.isSaving}
+          onConfirm={pendingConfirm.onConfirm}
+          onDiscard={pendingConfirm.onDiscard}
+        />
       )}
 
       {existingVerdict && (

--- a/frontend/src/components/compare/DivergenceActionsPanel.tsx
+++ b/frontend/src/components/compare/DivergenceActionsPanel.tsx
@@ -16,6 +16,7 @@ import {
   pendingVerdictLabel,
   readOnlyTitle,
   type PendingVerdict,
+  type VerdictOrigin,
 } from "./compare-types";
 import { useVerdictOrigin } from "./compare-field-scope";
 
@@ -77,80 +78,16 @@ export function DivergenceActionsPanel({
   return (
     <>
       {!isMulti && (
-        <div className="mt-2 flex flex-wrap gap-1">
-          <Button
-            variant="outline"
-            size="sm"
-            className={cn(
-              (pendingVerdict
-                ? pendingVerdict.kind === "ambiguous"
-                : existingVerdict?.verdict === "ambiguo") &&
-                "border-brand bg-brand/10 text-brand",
-            )}
-            onClick={() =>
-              onPrepareVerdict({
-                kind: "ambiguous",
-                verdict: "ambiguo",
-                origin,
-              })
-            }
-            disabled={readOnly}
-            title={writeTitle}
-          >
-            [A] Ambíguo
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            className={cn(
-              (pendingVerdict
-                ? pendingVerdict.kind === "skip"
-                : existingVerdict?.verdict === "pular") &&
-                "border-brand bg-brand/10 text-brand",
-            )}
-            onClick={() =>
-              onPrepareVerdict({ kind: "skip", verdict: "pular", origin })
-            }
-            disabled={readOnly}
-            title={writeTitle}
-          >
-            [S] Pular
-          </Button>
-          {/*
-            "Nenhuma correta" + input de resposta nova (issue #247, ponto
-            4). Keyed por doc|campo: navegar remonta e reseta o estado
-            interno (aberto/valor) sem reset-em-effect — react-doctor só
-            aceita key={identidade} para reset-on-prop-change.
-
-            currentValue: no bloco !isMulti, um veredito de texto sem
-            chosenResponseId que não seja marcador especial é, por
-            construção, uma resposta custom (voto sempre carrega
-            chosenResponseId). Passá-lo destaca o botão e re-semeia o
-            input ao revisitar o campo — paridade com Ambíguo/Pular.
-          */}
-          <CustomAnswerInput
-            key={`${documentId}|${fieldName}`}
-            readOnly={readOnly}
-            currentValue={
-              existingVerdict &&
-              existingVerdict.verdict !== "ambiguo" &&
-              existingVerdict.verdict !== "pular" &&
-              !existingVerdict.chosenResponseId
-                ? existingVerdict.verdict
-                : null
-            }
-            pendingValue={
-              pendingVerdict?.kind === "custom" ? pendingVerdict.verdict : null
-            }
-            onSubmit={(value) =>
-              onPrepareVerdict({
-                kind: "custom",
-                verdict: value,
-                origin,
-              })
-            }
-          />
-        </div>
+        <SpecialVerdictMarkers
+          readOnly={readOnly}
+          writeTitle={writeTitle}
+          origin={origin}
+          documentId={documentId}
+          fieldName={fieldName}
+          existingVerdict={existingVerdict}
+          pendingVerdict={pendingVerdict}
+          onPrepareVerdict={onPrepareVerdict}
+        />
       )}
 
       {pendingVerdict && pendingConfirm && (
@@ -224,4 +161,106 @@ export function DivergenceActionsPanel({
       />
     </>
   );
+}
+
+/**
+ * Os três caminhos de decisão que não vêm de um card: Ambíguo, Pular e resposta
+ * nova. Extraído do corpo do painel porque cada botão carrega a mesma pergunta
+ * em duas versões — "é o rascunho atual?" e, na falta de rascunho, "é o veredito
+ * já gravado?" —, e essas seis condições dominavam a complexidade do painel sem
+ * dizer nada sobre o resto dele (nota, sugestão de schema, veredito anterior).
+ *
+ * Nenhum deles GRAVA: todos preparam um rascunho, que só vira linha em `reviews`
+ * pela confirmação explícita (#417).
+ */
+function SpecialVerdictMarkers({
+  readOnly,
+  writeTitle,
+  origin,
+  documentId,
+  fieldName,
+  existingVerdict,
+  pendingVerdict,
+  onPrepareVerdict,
+}: {
+  readOnly: boolean;
+  writeTitle: string | undefined;
+  origin: VerdictOrigin;
+  documentId: string;
+  fieldName: string;
+  existingVerdict: VerdictInfo | null;
+  pendingVerdict: PendingVerdict | null;
+  onPrepareVerdict: (pending: PendingVerdict) => void;
+}) {
+  // O rascunho, quando existe, é quem manda no destaque: ele representa a
+  // decisão que a revisora está tomando agora, e o veredito gravado é apenas o
+  // que valia antes dela abrir o campo.
+  const marked = (kind: PendingVerdict["kind"], savedVerdict: string) =>
+    cn(
+      (pendingVerdict
+        ? pendingVerdict.kind === kind
+        : existingVerdict?.verdict === savedVerdict) &&
+        "border-brand bg-brand/10 text-brand",
+    );
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-1">
+      <Button
+        variant="outline"
+        size="sm"
+        className={marked("ambiguous", "ambiguo")}
+        onClick={() =>
+          onPrepareVerdict({ kind: "ambiguous", verdict: "ambiguo", origin })
+        }
+        disabled={readOnly}
+        title={writeTitle}
+      >
+        [A] Ambíguo
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        className={marked("skip", "pular")}
+        onClick={() =>
+          onPrepareVerdict({ kind: "skip", verdict: "pular", origin })
+        }
+        disabled={readOnly}
+        title={writeTitle}
+      >
+        [S] Pular
+      </Button>
+      {/*
+        "Nenhuma correta" + input de resposta nova (issue #247, ponto 4). Keyed
+        por doc|campo: navegar remonta e reseta o estado interno (aberto/valor)
+        sem reset-em-effect — react-doctor só aceita key={identidade} para
+        reset-on-prop-change.
+      */}
+      <CustomAnswerInput
+        key={`${documentId}|${fieldName}`}
+        readOnly={readOnly}
+        currentValue={savedCustomAnswer(existingVerdict)}
+        pendingValue={
+          pendingVerdict?.kind === "custom" ? pendingVerdict.verdict : null
+        }
+        onSubmit={(value) =>
+          onPrepareVerdict({ kind: "custom", verdict: value, origin })
+        }
+      />
+    </div>
+  );
+}
+
+/**
+ * A resposta custom já gravada neste campo, se houver. Num campo não-multi, um
+ * veredito de texto sem `chosenResponseId` que não seja marcador especial é, por
+ * construção, uma resposta digitada — o voto num card sempre carrega o
+ * `chosenResponseId`. Devolvê-la destaca o botão e re-semeia o input ao
+ * revisitar o campo, em paridade com Ambíguo/Pular.
+ */
+function savedCustomAnswer(existingVerdict: VerdictInfo | null): string | null {
+  if (!existingVerdict) return null;
+  if (existingVerdict.chosenResponseId) return null;
+  const { verdict } = existingVerdict;
+  if (verdict === "ambiguo" || verdict === "pular") return null;
+  return verdict;
 }

--- a/frontend/src/components/compare/PendingConfirmBar.tsx
+++ b/frontend/src/components/compare/PendingConfirmBar.tsx
@@ -4,20 +4,24 @@ import { Button } from "@/components/ui/button";
 
 interface PendingConfirmBarProps {
   /**
-   * `null` quando a barra está ancorada num card: o card já exibe a resposta, e
-   * repetir "Selecionado: Deferido" dentro dele é ruído. Não-nulo quando está
-   * ancorada nas ações da divergência (Ambíguo / Pular / resposta nova), onde o
-   * rótulo carrega informação que não está em nenhum outro lugar da tela — o
-   * texto que a revisora digitou, por exemplo.
+   * O rascunho, sempre. Vai para `data-pending-label` em qualquer caso: é o
+   * contrato de teste que substituiu o `getByText("Selecionado:")` como prova de
+   * que existe rascunho. Casar por copy quebrava ao mudar o texto e, pior,
+   * ficava vácuo quando o rótulo simplesmente não era renderizado.
    */
-  label: string | null;
+  label: string;
   /**
-   * Sempre presente, independentemente de `label`: é o contrato de teste
-   * (`data-pending-label`) que substituiu o `getByText("Selecionado:")` como
-   * prova de que existe rascunho. Casar por copy quebrava ao mudar o texto e,
-   * pior, ficava vácuo quando o rótulo simplesmente não era renderizado.
+   * Se o rótulo aparece na tela. Falso quando a barra está ancorada num card: o
+   * card já exibe a resposta, e repetir "Selecionado: Deferido" dentro dele é
+   * ruído. Verdadeiro nas ações da divergência (Ambíguo / Pular / resposta
+   * nova), onde o rótulo carrega informação que não está em nenhum outro lugar
+   * da tela — o texto que a revisora digitou, por exemplo.
+   *
+   * Um booleano derivado do MESMO `label`, e não um segundo rótulo: dois textos
+   * independentes podiam divergir em silêncio, e o que o teste lê deixaria de
+   * ser o que a revisora vê.
    */
-  pendingLabel: string;
+  showLabel: boolean;
   isSaving: boolean;
   onConfirm: () => void;
   onDiscard: () => void;
@@ -48,7 +52,7 @@ interface PendingConfirmBarProps {
  */
 export function PendingConfirmBar({
   label,
-  pendingLabel,
+  showLabel,
   isSaving,
   onConfirm,
   onDiscard,
@@ -56,10 +60,10 @@ export function PendingConfirmBar({
   return (
     <div
       data-testid="pending-confirm"
-      data-pending-label={pendingLabel}
+      data-pending-label={label}
       className="mt-2 flex items-center justify-end gap-2 border-t pt-2"
     >
-      {label && (
+      {showLabel && (
         <span className="mr-auto min-w-0 truncate text-xs text-muted-foreground">
           Selecionado:{" "}
           <span className="font-medium text-foreground">{label}</span>

--- a/frontend/src/components/compare/PendingConfirmBar.tsx
+++ b/frontend/src/components/compare/PendingConfirmBar.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+interface PendingConfirmBarProps {
+  /**
+   * `null` quando a barra está ancorada num card: o card já exibe a resposta, e
+   * repetir "Selecionado: Deferido" dentro dele é ruído. Não-nulo quando está
+   * ancorada nas ações da divergência (Ambíguo / Pular / resposta nova), onde o
+   * rótulo carrega informação que não está em nenhum outro lugar da tela — o
+   * texto que a revisora digitou, por exemplo.
+   */
+  label: string | null;
+  /**
+   * Sempre presente, independentemente de `label`: é o contrato de teste
+   * (`data-pending-label`) que substituiu o `getByText("Selecionado:")` como
+   * prova de que existe rascunho. Casar por copy quebrava ao mudar o texto e,
+   * pior, ficava vácuo quando o rótulo simplesmente não era renderizado.
+   */
+  pendingLabel: string;
+  isSaving: boolean;
+  onConfirm: () => void;
+  onDiscard: () => void;
+}
+
+/**
+ * Confirmação do veredito, ancorada ao elemento que produziu o rascunho.
+ *
+ * O #417 trocou "clica e salva" por "prepara e confirma" para que nenhuma linha
+ * de `reviews` nasça sem um ato deliberado DISTINTO do ato de escolher — e essa
+ * garantia não está em discussão. O que custava caro era o SÍTIO da confirmação:
+ * uma barra fixa no rodapé, a algumas centenas de pixels do ponto do clique,
+ * obrigando um deslocamento de olhar a cada campo (#610).
+ *
+ * Aqui a barra nasce a poucos pixels de onde a revisora acabou de clicar, e não
+ * existe quando não há rascunho. A garantia é idêntica: continuam sendo dois
+ * atos, em controles diferentes, com saída explícita pelo "Descartar".
+ *
+ * `readOnly` não é prop de propósito: em somente-leitura nenhum rascunho pode
+ * ser criado (overlay do card desabilitado, botões desabilitados, o hook de
+ * teclado retorna antes), logo esta barra nunca chega a renderizar. Um "modo
+ * somente leitura" aqui seria um estado inalcançável convidando a divergir da
+ * regra real.
+ *
+ * O `aria-label` explícito mantém o nome acessível exatamente "Confirmar" /
+ * "Salvando..." apesar do `<kbd>` decorativo — é o que as asserções existentes
+ * consultam, e mudá-lo silenciosamente as tornaria vácuas.
+ */
+export function PendingConfirmBar({
+  label,
+  pendingLabel,
+  isSaving,
+  onConfirm,
+  onDiscard,
+}: PendingConfirmBarProps) {
+  return (
+    <div
+      data-testid="pending-confirm"
+      data-pending-label={pendingLabel}
+      className="mt-2 flex items-center justify-end gap-2 border-t pt-2"
+    >
+      {label && (
+        <span className="mr-auto min-w-0 truncate text-xs text-muted-foreground">
+          Selecionado:{" "}
+          <span className="font-medium text-foreground">{label}</span>
+        </span>
+      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-7"
+        disabled={isSaving}
+        onClick={onDiscard}
+      >
+        Descartar
+      </Button>
+      <Button
+        size="sm"
+        className="h-7 gap-1.5"
+        disabled={isSaving}
+        onClick={onConfirm}
+        aria-label={isSaving ? "Salvando..." : "Confirmar"}
+      >
+        {isSaving ? (
+          "Salvando..."
+        ) : (
+          <>
+            Confirmar
+            <kbd
+              aria-hidden
+              className="rounded bg-primary-foreground/20 px-1 py-0.5 font-mono text-[10px]"
+            >
+              Enter
+            </kbd>
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/compare/__tests__/AgreementGroup.gabaritoReset.test.tsx
+++ b/frontend/src/components/compare/__tests__/AgreementGroup.gabaritoReset.test.tsx
@@ -37,6 +37,11 @@ function renderGroup() {
       onUnmarkPair={vi.fn(async () => {})}
       currentUserId="u1"
       canManageAnyPair={false}
+      pendingConfirm={{
+        onConfirm: vi.fn(),
+        onDiscard: vi.fn(),
+        isSaving: false,
+      }}
     />,
   );
 }

--- a/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
+++ b/frontend/src/components/compare/__tests__/AgreementGroup.markAll.test.tsx
@@ -57,6 +57,11 @@ function renderGroup(
       onUnmarkPair={onUnmarkPair}
       currentUserId="u1"
       canManageAnyPair={false}
+      pendingConfirm={{
+        onConfirm: vi.fn(),
+        onDiscard: vi.fn(),
+        isSaving: false,
+      }}
       {...props}
     />,
   );

--- a/frontend/src/components/compare/__tests__/AnswerCard.test.tsx
+++ b/frontend/src/components/compare/__tests__/AnswerCard.test.tsx
@@ -99,3 +99,64 @@ describe("AnswerCard — overlay de voto", () => {
     expect(screen.queryByRole("radio")).toBeNull();
   });
 });
+
+// O segundo passo da confirmação passou a viver dentro do card que produziu o
+// rascunho (#610).
+describe("AnswerCard — slot de confirmação", () => {
+  const slot = <button type="button">Confirmar</button>;
+
+  it("renderiza o slot só no card preparado", () => {
+    const { unmount } = render(
+      <TooltipProvider>
+        <AnswerCard
+          readOnly={false}
+          index={0}
+          displayAnswer="Deferido"
+          respondentNames={["Ana"]}
+          respondentCount={1}
+          hasLlm={false}
+          staleCount={0}
+          isChosen={false}
+          isPending={false}
+          versions={["1.0.0"]}
+          onVote={vi.fn()}
+          confirmSlot={slot}
+        />
+      </TooltipProvider>,
+    );
+    expect(screen.queryByRole("button", { name: "Confirmar" })).toBeNull();
+    unmount();
+
+    renderCard({ isPending: true, confirmSlot: slot });
+    expect(screen.getByRole("button", { name: "Confirmar" })).not.toBeNull();
+    expect(screen.getByTestId("answer-card").getAttribute("data-pending")).toBe(
+      "true",
+    );
+  });
+
+  // Guarda-corpo contra a "otimização" tentadora de fazer o segundo clique no
+  // card confirmar: isso transformaria um duplo-clique acidental em escrita,
+  // que é exatamente o que o #417 fechou. Clicar no corpo re-prepara, e só o
+  // controle DISTINTO confirma.
+  it("o clique no corpo do card re-prepara — não confirma", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const { onVote } = renderCard({
+      isPending: true,
+      confirmSlot: (
+        <button type="button" onClick={onConfirm}>
+          Confirmar
+        </button>
+      ),
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /selecionar esta resposta para confirmar/i,
+      }),
+    );
+
+    expect(onVote).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -7,6 +7,7 @@ import {
   fireEvent,
   act,
   waitFor,
+  within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -427,7 +428,10 @@ describe("ComparePage — árvore real (smoke)", () => {
         name: /Selecionar esta resposta para confirmar: Deferido/i,
       }),
     );
-    expect(screen.getByText("Selecionado:")).not.toBeNull();
+    // O par presente-ANTES / ausente-DEPOIS é o que sustenta o teste: a
+    // asserção de ausência sozinha passaria mesmo se o gate de impersonação
+    // fosse deletado, porque a barra também não existiria sem rascunho nenhum.
+    expect(screen.getByTestId("pending-confirm")).not.toBeNull();
 
     rerender(
       <TooltipProvider>
@@ -438,13 +442,11 @@ describe("ComparePage — árvore real (smoke)", () => {
       </TooltipProvider>,
     );
 
-    expect(screen.queryByText("Selecionado:")).toBeNull();
-    const confirmButton = screen.getByRole("button", {
-      name: "Somente leitura",
-    }) as HTMLButtonElement;
-    expect(confirmButton.disabled).toBe(true);
+    expect(screen.queryByTestId("pending-confirm")).toBeNull();
+    expect(
+      screen.queryAllByRole("button", { name: "Confirmar" }),
+    ).toHaveLength(0);
 
-    await user.click(confirmButton);
     await user.keyboard("{Enter}");
 
     expectNoCompareWrites();
@@ -549,5 +551,110 @@ describe("ComparePage — árvore real (smoke)", () => {
     );
     expect(screen.getByRole("tab", { name: "Meus atribuídos" })).not.toBeNull();
     expect(screen.getByRole("tab", { name: "Todos" })).not.toBeNull();
+  });
+});
+
+// A confirmação deixou de ser uma barra fixa no rodapé e passou a nascer no
+// elemento que produziu o rascunho (#610). A garantia do #417 é a mesma — dois
+// atos, em controles distintos —, mas o segundo alvo fica a poucos pixels do
+// primeiro em vez de a algumas centenas.
+describe("ComparePage — confirmação ancorada ao que produziu o rascunho (#610)", () => {
+  const voteButton = () =>
+    screen.getByRole("button", {
+      name: /Selecionar esta resposta para confirmar: Deferido/i,
+    });
+
+  it("sem rascunho, não existe nenhum controle de confirmação na tela", () => {
+    renderReal();
+    expect(screen.queryByTestId("pending-confirm")).toBeNull();
+    expect(screen.queryAllByRole("button", { name: "Confirmar" })).toHaveLength(
+      0,
+    );
+  });
+
+  // A LACUNA que este PR fecha: até aqui nenhum teste provava que clicar num
+  // CARD não grava — o análogo usava "Ambíguo". Reverter `onVote` para chamar
+  // `onVerdict` direto (isto é, desfazer o #417 no caminho do mouse) passava
+  // despercebido.
+  it("clicar num card prepara e NÃO grava; a gravação só vem da confirmação", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    await user.click(voteButton());
+    expect(submitVerdict).not.toHaveBeenCalled();
+
+    const card = screen.getByTestId("pending-confirm").closest(
+      '[data-testid="answer-card"]',
+    ) as HTMLElement;
+    await user.click(within(card).getByRole("button", { name: "Confirmar" }));
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+    expect(submitVerdict).toHaveBeenCalledWith(
+      expect.objectContaining({ fieldName: "campoA", verdict: "Deferido" }),
+    );
+  });
+
+  it("a barra de confirmação nasce DENTRO do card clicado", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    await user.click(voteButton());
+
+    const card = voteButton().closest(
+      '[data-testid="answer-card"]',
+    ) as HTMLElement;
+    expect(card.getAttribute("data-pending")).toBe("true");
+    expect(
+      within(card).getByRole("button", { name: "Confirmar" }),
+    ).not.toBeNull();
+  });
+
+  // Guarda direta contra o modo de falha mais provável de uma implementação
+  // apressada: manter o rodapé E acrescentar a barra no card, deixando dois
+  // botões "Confirmar" no DOM.
+  it("há no máximo um controle de confirmação no DOM, em qualquer estado", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    expect(screen.queryAllByTestId("pending-confirm")).toHaveLength(0);
+
+    await user.click(voteButton());
+    expect(screen.queryAllByTestId("pending-confirm")).toHaveLength(1);
+    expect(screen.queryAllByRole("button", { name: "Confirmar" })).toHaveLength(
+      1,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Ambíguo/i }));
+    expect(screen.queryAllByTestId("pending-confirm")).toHaveLength(1);
+    expect(screen.queryAllByRole("button", { name: "Confirmar" })).toHaveLength(
+      1,
+    );
+  });
+
+  it("Enter confirma o rascunho criado pelo mouse", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    await user.click(voteButton());
+    expect(submitVerdict).not.toHaveBeenCalled();
+
+    await user.keyboard("{Enter}");
+
+    expect(submitVerdict).toHaveBeenCalledTimes(1);
+  });
+
+  it("'Descartar' dentro do card limpa o rascunho sem salvar", async () => {
+    const user = userEvent.setup();
+    renderReal();
+
+    await user.click(voteButton());
+    const card = voteButton().closest(
+      '[data-testid="answer-card"]',
+    ) as HTMLElement;
+
+    await user.click(within(card).getByRole("button", { name: "Descartar" }));
+
+    expect(screen.queryByTestId("pending-confirm")).toBeNull();
+    expectNoCompareWrites();
   });
 });

--- a/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparisonPanel.customAnswer.test.tsx
@@ -203,15 +203,20 @@ describe("ComparisonPanel — resposta nova (issue #247, ponto 4)", () => {
     await user.click(screen.getByRole("button", { name: /nenhuma correta/i }));
     const input = screen.getByPlaceholderText("Resposta correta…");
 
-    // só espaços → não prepara nem salva
+    // só espaços → não prepara nem salva. A ausência de rascunho passa a ser
+    // lida pelo testid, e não pela frase do rodapé que sumiu com ele; o par
+    // positivo logo abaixo (mesmo `it`) é o que impede esta asserção de virar
+    // vácua.
     await user.type(input, "   {Enter}");
-    expect(screen.getByText("Escolha uma resposta para confirmar.")).toBeTruthy();
+    expect(screen.queryByTestId("pending-confirm")).toBeNull();
     expect(onVerdict).not.toHaveBeenCalled();
 
     await user.clear(input);
     await user.type(input, "8 meses{Enter}");
     expect(onVerdict).not.toHaveBeenCalled();
-    expect(screen.getByText(/Selecionado:/).textContent).toContain("8 meses");
+    expect(
+      screen.getByTestId("pending-confirm").getAttribute("data-pending-label"),
+    ).toBe("8 meses");
 
     await user.click(screen.getByRole("button", { name: /^confirmar$/i }));
     expect(onVerdict).toHaveBeenCalledWith("8 meses", undefined);
@@ -265,5 +270,32 @@ describe("ComparisonPanel — resposta nova (issue #247, ponto 4)", () => {
     expect(
       screen.getByRole("button", { name: /nenhuma correta/i }).className,
     ).not.toContain("border-brand");
+  });
+});
+
+// A barra de confirmação segue o elemento que produziu o rascunho. Quando esse
+// elemento não existe na tela — rascunho de resposta que o AgreementGroup não
+// renderiza —, ela precisa aparecer nas ações da divergência, senão a revisora
+// fica com um rascunho que trava a navegação (guardNavigation, #434) e que ela
+// não consegue nem confirmar nem descartar pelo mouse. Soft-lock: o defeito do
+// #430 com o sinal trocado.
+describe("ComparisonPanel — rascunho sem card para ancorar (#610)", () => {
+  it("cai para as ações da divergência em vez de sumir da tela", () => {
+    renderPanel({
+      pendingVerdict: {
+        kind: "response",
+        verdict: "resposta de uma linha que não está na lista",
+        chosenResponseId: "r-que-nao-esta-na-tela",
+        origin: PANEL_ORIGIN,
+      },
+    });
+
+    const bar = screen.getByTestId("pending-confirm");
+    expect(bar).not.toBeNull();
+    expect(bar.getAttribute("data-pending-label")).toBe(
+      "resposta de uma linha que não está na lista",
+    );
+    expect(screen.getByRole("button", { name: "Confirmar" })).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Descartar" })).not.toBeNull();
   });
 });

--- a/frontend/src/components/compare/useEquivalenceSelection.ts
+++ b/frontend/src/components/compare/useEquivalenceSelection.ts
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, useTransition } from "react";
+
+/** O mínimo que a seleção precisa saber de um grupo renderizado. */
+interface SelectableGroup {
+  groupKey: string;
+  displayAnswer: string;
+  responses: { id: string }[];
+}
+
+/**
+ * Estado de "quais cards estão marcados como equivalentes e qual deles é o
+ * gabarito", com as duas escritas que dele decorrem (confirmar a fusão, desfazer
+ * um par).
+ *
+ * Vive fora do `AgreementGroup` porque é um assunto inteiro — ordem de seleção,
+ * override de gabarito, transição de submissão — que não tem relação com o
+ * render dos cards nem com o veredito do campo. O componente ficava carregando
+ * três peças de estado e quatro handlers que nunca consultava diretamente.
+ *
+ * A ordem de seleção é preservada de propósito: o PRIMEIRO card marcado é o
+ * gabarito padrão, e o override só vale enquanto o card apontado continuar
+ * selecionado.
+ */
+export function useEquivalenceSelection<G extends SelectableGroup>({
+  groups,
+  onConfirmEquivalent,
+  onUnmarkPair,
+}: {
+  groups: G[];
+  onConfirmEquivalent?: (
+    responseIds: string[],
+    gabaritoId: string,
+    verdictDisplay: string,
+  ) => Promise<void>;
+  onUnmarkPair?: (pairId: string) => Promise<void>;
+}) {
+  const [selectionOrder, setSelectionOrder] = useState<string[]>([]);
+  const [gabaritoOverride, setGabaritoOverride] = useState<string | null>(null);
+  const [isSubmitting, startTransition] = useTransition();
+
+  // Entradas obsoletas (grupos que sumiram após navegação ou fusão no servidor)
+  // são filtradas aqui, em silêncio: não precisam de efeito de limpeza porque
+  // nunca chegam a ser visíveis. O pai keya este componente por campo+documento,
+  // então navegar também remonta e zera a seleção naturalmente.
+  const selectedGroups = selectionOrder
+    .map((key) => groups.find((g) => g.groupKey === key))
+    .filter((g): g is G => !!g);
+
+  // Consultado uma vez por grupo renderizado; como array seria O(grupos²).
+  const selectionSet = new Set(selectionOrder);
+  const effectiveGabarito =
+    gabaritoOverride && selectionOrder.includes(gabaritoOverride)
+      ? gabaritoOverride
+      : (selectionOrder[0] ?? null);
+
+  // Os dois setters ficam no nível do handler: um `setGabaritoOverride` aninhado
+  // no updater de `setSelectionOrder` seria efeito colateral dentro de função
+  // que React pode reexecutar. `selectionOrder` do closure basta para decidir o
+  // ramo — só o clique altera a seleção.
+  function toggleSelection(groupKey: string) {
+    if (selectionOrder.includes(groupKey)) {
+      setSelectionOrder((prev) => prev.filter((k) => k !== groupKey));
+      if (gabaritoOverride === groupKey) setGabaritoOverride(null);
+      return;
+    }
+    setSelectionOrder((prev) => [...prev, groupKey]);
+  }
+
+  function confirmEquivalence() {
+    const gabaritoGroup = selectedGroups.find(
+      (g) => g.groupKey === effectiveGabarito,
+    );
+    if (!onConfirmEquivalent || selectedGroups.length < 2 || !gabaritoGroup) {
+      return;
+    }
+    // Um representante por grupo: respostas com o mesmo texto literal já foram
+    // fundidas no servidor, então pares intragrupo só criariam linhas inúteis.
+    const responseIds = selectedGroups.map((g) => g.responses[0].id);
+    startTransition(async () => {
+      await onConfirmEquivalent(
+        responseIds,
+        gabaritoGroup.responses[0].id,
+        gabaritoGroup.displayAnswer,
+      );
+      setSelectionOrder([]);
+      setGabaritoOverride(null);
+    });
+  }
+
+  // "Todas são similares" (issue #247, ponto 5): pré-seleciona TODOS os grupos
+  // de uma vez, em vez de o revisor marcar par a par. A persistência continua no
+  // botão explícito de confirmação, inclusive quando há maioria clara.
+  function selectAll() {
+    if (!onConfirmEquivalent || groups.length < 2) return;
+    setSelectionOrder(groups.map((g) => g.groupKey));
+    setGabaritoOverride(null);
+  }
+
+  function unmarkPair(pairId: string) {
+    if (!onUnmarkPair) return;
+    startTransition(async () => {
+      await onUnmarkPair(pairId);
+    });
+  }
+
+  return {
+    selectedGroups,
+    selectionSet,
+    effectiveGabarito,
+    // O gabarito só faz sentido quando há mais de um card na fusão: com um só,
+    // não há escolha a fazer.
+    showGabarito: selectedGroups.length >= 2,
+    isSubmitting,
+    toggleSelection,
+    setGabarito: setGabaritoOverride,
+    confirmEquivalence,
+    selectAll,
+    unmarkPair,
+  };
+}


### PR DESCRIPTION
Segundo de dois PRs empilhados para a #610 — **base: `fix/610-compare-foco` (#629)**, que deve entrar antes. Cobre o item 2 do "o que fazer": reduzir o custo do fluxo de dois passos do #417 sem reabrir a perda silenciosa que ele corrigiu.

## Por quê

O #417 trocou "clica e salva" por "prepara e confirma" para que nenhuma linha de `reviews` nasça sem um ato deliberado **distinto** do ato de escolher. Essa garantia não está em discussão. O que custava caro era o *sítio* da confirmação: uma barra fixa no rodapé, a algumas centenas de pixels do ponto do clique, com o #434 tornando a confirmação obrigatória de fato. A fila saiu de "clica, avança" para "seleciona → move o olho ao rodapé → confirma → avança".

Agora a barra nasce **no elemento que produziu o rascunho** e existe em exatamente um lugar do DOM por vez: dentro do card, quando o rascunho veio de um card; no painel de ações, quando veio de Ambíguo, Pular ou resposta nova. Sem rascunho, não existe — os ~49px permanentes do rodapé viram zero.

A formulação ingênua ("botão dentro do card") está incompleta: **três das quatro variantes de `PendingVerdict` nascem no `DivergenceActionsPanel`**. Ancorar só no card as deixaria órfãs, ou exigiria manter o rodapé em paralelo — produzindo dois botões "Confirmar" no DOM.

**Fallback obrigatório, não polimento.** Um rascunho `response` apontando para resposta que o `AgreementGroup` não renderiza não teria barra em lugar nenhum, e o `guardNavigation` do #434 travaria a navegação com um rascunho impossível de confirmar ou descartar pelo mouse. Soft-lock: o defeito do #430 com o sinal trocado.

## Por que é seguro

`ComparePage`, `useCompareVerdicts`, `useCompareKeyboard` e `compare-types` ficam com **zero linhas alteradas**, e a superfície de props do `ComparisonPanel` não muda. As garantias do #417/#430/#434/#613 vivem inteiramente nesses arquivos; o rodapé era apenas o sítio de render. O que este PR move é onde a barra aparece, não o que ela exige.

## Medição

Área rolável (1440×900, fixture, medidor com espera de `networkidle` + `fonts.ready`):

| | mediana | Δ topo do 1º card |
|---|---|---|
| `origin/main` | 542,0px | 97,6px |
| PR A (#629) | 600,0px | 0px |
| **este PR** | **649,0px** | **0px** |

Acumulado: **+107px (+19,7%)**; no pior campo, de 480,4 para 649,0px (**+35,1%**).

## Verificação por mutação

Cada uma aplicada, medida e revertida:

| mutação | resultado |
|---|---|
| `onVote` grava direto (reverte o #417 no caminho do mouse) | **7 vermelhos** |
| rodapé permanente reintroduzido | **10 vermelhos** |
| fallback `anchoredToCard` removido | **1 vermelho** |
| slot perde o `z-[2]` | **0 vermelhos em jsdom** |

Duas coisas a destacar.

**A lacuna que este PR fecha.** Antes dele, *nenhum teste provava que clicar num card não grava* — o único análogo usava "Ambíguo". Reverter o #417 no caminho do mouse passava despercebido. Agora há um caso que insere `expect(submitVerdict).not.toHaveBeenCalled()` entre o clique no card e a confirmação.

**A garantia que jsdom não alcança.** Remover o `z-[2]` do slot deixaria o overlay de voto interceptar o "Confirmar" — e nenhum teste unitário fica vermelho, porque jsdom não faz hit-testing. Essa garantia foi para o smoke E2E, onde a mesma mutação faz o Playwright acusar interceptação de clique (verificado). Está anotado no próprio teste, para que ninguém tente "cobrir isso em unitário" depois.

Os testes que a mudança esvaziaria foram reescritos como pares presente/ausente, não como asserções negativas soltas: `getByText("Selecionado:")` não provava nada num rascunho de card, onde esse rótulo nunca existiu.

## Sobre o commit de complexidade

O `AnswerCard` já estava acima do limiar do fallow antes desta mudança (cognitive 37) e o `confirmSlot` o levou a 40. Em vez de suprimir, três extrações devolvem mais do que foi gasto — `GabaritoRadio`, `FusedVariantsPopover` e `LlmJustification` (esta leva junto o único `useState` do corpo do card) — e ele sai da lista de achados introduzidos.

O `ComparisonPanel` recebeu supressão, com a medição pareada no comentário: cyclomatic 23 → 12 e cognitive 53 → 43 contra `origin/main`, porque este PR **removeu** dali o rodapé com três ternários aninhados. O fallow o reflaga por o arquivo ter sido tocado, não por ter piorado.

Refs #610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYSnt4t1mVZTwsi4b78irk