### PR TITLE
fix(codificação): teto do GC não evicta rascunho a mais; faixa não anuncia botões (#608)

### DIFF
--- a/frontend/src/components/coding/CodingDraftBanner.tsx
+++ b/frontend/src/components/coding/CodingDraftBanner.tsx
@@ -64,16 +64,39 @@ export function CodingDraftBanner({
     recovery.kind === "diverged" ? recovery.overwrittenFields : [];
 
   return (
-    <div
-      role="status"
-      className="flex flex-col gap-2 border-b bg-amber-50 px-4 py-2.5 text-sm dark:bg-amber-950/30"
-    >
-      <div className="flex items-center gap-2">
-        <FileClock className="size-4 shrink-0 text-amber-600" aria-hidden />
-        <span className="flex-1">
-          Você tem alterações não enviadas neste documento, salvas neste navegador{" "}
-          {humanizeAge(recovery.updatedAt, reference)}.
-        </span>
+    <div className="border-b bg-amber-50 px-4 py-2.5 text-sm dark:bg-amber-950/30">
+      <div className="flex items-start gap-2">
+        <FileClock className="mt-0.5 size-4 shrink-0 text-amber-600" aria-hidden />
+        {/* A região live cobre os dois textos e nenhum dos botões. Envolvendo o
+            container inteiro, como estava, o leitor de tela reanunciava
+            "Retomar rascunho" e "Descartar" junto do aviso a cada mudança —
+            controle dentro de live region é ruído, não informação. */}
+        <div role="status" className="flex flex-1 flex-col gap-2">
+          <span>
+            Você tem alterações não enviadas neste documento, salvas neste navegador{" "}
+            {humanizeAge(recovery.updatedAt, reference)}.
+          </span>
+
+          {overwritten.length > 0 && (
+            // Só o que retomar de fato sobrescreve — ver `overwrittenFields`, que é
+            // a interseção e não tudo que o servidor mudou.
+            <div className="flex items-start gap-2 text-amber-800 dark:text-amber-200">
+              <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+              <span>
+                Este documento foi salvo depois que o rascunho foi criado. Retomar
+                substitui{" "}
+                {overwritten.length === 1
+                  ? "a resposta de "
+                  : `as respostas de ${overwritten.length} perguntas: `}
+                <strong>
+                  {overwritten.map((name) => fieldLabel(name, fields)).join(", ")}
+                </strong>
+                .
+              </span>
+            </div>
+          )}
+        </div>
+
         <Button size="sm" variant="default" onClick={onRestore}>
           Retomar rascunho
         </Button>
@@ -81,25 +104,6 @@ export function CodingDraftBanner({
           Descartar
         </Button>
       </div>
-
-      {overwritten.length > 0 && (
-        // Só o que retomar de fato sobrescreve — ver `overwrittenFields`, que é
-        // a interseção e não tudo que o servidor mudou.
-        <div className="flex items-start gap-2 text-amber-800 dark:text-amber-200">
-          <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
-          <span>
-            Este documento foi salvo depois que o rascunho foi criado. Retomar
-            substitui{" "}
-            {overwritten.length === 1
-              ? "a resposta de "
-              : `as respostas de ${overwritten.length} perguntas: `}
-            <strong>
-              {overwritten.map((name) => fieldLabel(name, fields)).join(", ")}
-            </strong>
-            .
-          </span>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/coding/CodingDraftBanner.tsx
+++ b/frontend/src/components/coding/CodingDraftBanner.tsx
@@ -70,7 +70,15 @@ export function CodingDraftBanner({
         {/* A região live cobre os dois textos e nenhum dos botões. Envolvendo o
             container inteiro, como estava, o leitor de tela reanunciava
             "Retomar rascunho" e "Descartar" junto do aviso a cada mudança —
-            controle dentro de live region é ruído, não informação. */}
+            controle dentro de live region é ruído, não informação.
+            O layout paga por isso: o aviso de sobrescrita, que antes ocupava uma
+            linha própria em largura total, agora divide esta coluna estreitada
+            pelos botões. É o preço de uma região contígua que contenha os dois
+            textos e nenhum controle — devolvê-lo para a linha de baixo parece
+            ajuste visual inócuo e desfaz a correção de acessibilidade.
+            O que esta região AINDA não resolve: ela nasce populada (a faixa
+            devolve `null` quando não há oferta), e região inserida já cheia
+            costuma não ser anunciada. Ver #635. */}
         <div role="status" className="flex flex-1 flex-col gap-2">
           <span>
             Você tem alterações não enviadas neste documento, salvas neste navegador{" "}

--- a/frontend/src/components/coding/__tests__/CodingDraftBanner.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingDraftBanner.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup, within } from "@testing-library/react";
+import { CodingDraftBanner } from "@/components/coding/CodingDraftBanner";
+import type { CodingDraftRecovery } from "@/lib/coding-draft";
+import type { PydanticField } from "@/lib/types";
+
+afterEach(cleanup);
+
+const FIELDS: PydanticField[] = [
+  { name: "q1", type: "text", options: null, description: "Diagnóstico" },
+];
+
+const DRAFT = { answers: { q1: "do rascunho" }, notes: "" };
+
+// `changedFields` é o que retomar mudaria; `overwrittenFields` é a interseção
+// com o que o servidor andou. A faixa só renderiza o segundo, mas ambos fazem
+// parte do veredito — montar o literal completo é o que mantém o teste falando
+// do mesmo objeto que a classificação produz.
+const diverged: CodingDraftRecovery = {
+  kind: "diverged",
+  updatedAt: Date.now(),
+  draft: DRAFT,
+  changedFields: ["q1"],
+  overwrittenFields: ["q1"],
+};
+
+const resumable: CodingDraftRecovery = {
+  kind: "resumable",
+  updatedAt: Date.now(),
+  draft: DRAFT,
+  changedFields: ["q1"],
+};
+
+function show(recovery: CodingDraftRecovery) {
+  render(
+    <CodingDraftBanner
+      recovery={recovery}
+      fields={FIELDS}
+      onRestore={() => {}}
+      onDiscard={() => {}}
+      now={Date.now()}
+    />,
+  );
+  return screen.getByRole("status");
+}
+
+// A faixa é uma live region: o leitor de tela reanuncia o que estiver dentro
+// dela sempre que muda. O que precisa estar lá é o FATO (há rascunho, e retomar
+// sobrescreve tais respostas); o que não pode estar são os controles, que o
+// leitor já alcança pela navegação normal e que, dentro da região, viram ruído
+// repetido a cada anúncio.
+describe("CodingDraftBanner — o que a região live anuncia", () => {
+  // Mutação vermelha: devolver o `role="status"` ao container externo. Os dois
+  // botões voltam para dentro da região e este teste cai.
+  it("não contém os controles", () => {
+    expect(within(show(diverged)).queryAllByRole("button")).toEqual([]);
+  });
+
+  it("anuncia que há rascunho não enviado", () => {
+    expect(within(show(resumable)).getByText(/alterações não enviadas/)).toBeTruthy();
+  });
+
+  // Mutação vermelha: deixar o bloco de sobrescrita FORA do wrapper (era onde
+  // ele estava). O aviso mais consequente da faixa — quais respostas retomar
+  // substitui — deixaria de ser anunciado.
+  it("anuncia também o que retomar vai sobrescrever", () => {
+    const live = within(show(diverged));
+    expect(live.getByText(/foi salvo depois que o rascunho foi criado/)).toBeTruthy();
+    expect(live.getByText("Diagnóstico")).toBeTruthy();
+  });
+
+  // Os botões continuam na tela e alcançáveis — o que mudou é onde a fronteira
+  // da região live passa, não o que a faixa oferece.
+  it("os botões seguem presentes fora da região", () => {
+    show(diverged);
+    expect(screen.getByRole("button", { name: "Retomar rascunho" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Descartar" })).toBeTruthy();
+  });
+});

--- a/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
+++ b/frontend/src/hooks/__tests__/useCodingDrafts.test.ts
@@ -8,6 +8,7 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCodingDrafts, type UseCodingDraftsParams } from "../useCodingDrafts";
+import { MAX_DRAFTS_PER_USER } from "@/lib/coding-draft-storage";
 import {
   CODING_DRAFT_FORMAT_VERSION,
   codingDraftStorageKey,
@@ -453,6 +454,54 @@ describe("GC — a peça que impede a quota de degradar em silêncio", () => {
     plant({ key, documentId: "outro-completamente" });
     render();
     expect(window.localStorage.getItem(key)).toBeNull();
+  });
+
+  // Planta `count` rascunhos válidos de OUTROS documentos, do mais antigo para o
+  // mais novo. Devolve as chaves na mesma ordem, então `keys[0]` é sempre o
+  // primeiro candidato à eviction — é o que os testes de teto observam.
+  const plantOthers = (count: number) =>
+    Array.from({ length: count }, (_, i) => {
+      const documentId = `doc-teto-${i}`;
+      plant({ documentId, updatedAt: Date.now() - (count - i) * 1000 });
+      return otherDocKey(documentId);
+    });
+
+  // Mutação vermelha: voltar `openSlotTaken` para `keepKey ? 1 : 0`. O teto
+  // passa a contar um slot que não existe e evicta o mais antigo dos válidos —
+  // e é o caminho corriqueiro, porque o GC roda na PRIMEIRA abertura, antes de
+  // qualquer tecla, quando o documento na tela ainda não tem envelope.
+  it("no teto, documento aberto SEM rascunho gravado não evicta ninguém", () => {
+    const keys = plantOthers(MAX_DRAFTS_PER_USER);
+    render();
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+    expect(keys.filter((k) => window.localStorage.getItem(k) === null)).toEqual([]);
+  });
+
+  // O outro lado da mesma régua: quando o slot do documento aberto EXISTE, ele
+  // ocupa lugar e o mais antigo dos outros precisa sair. Sem este caso, zerar o
+  // termo (`+ 0` sempre) passaria despercebido.
+  it("no teto, documento aberto COM rascunho gravado evicta o mais antigo dos outros", () => {
+    const keys = plantOthers(MAX_DRAFTS_PER_USER);
+    plant({ documentId: DOC });
+    render();
+    expect(window.localStorage.getItem(KEY)).not.toBeNull();
+    expect(keys.filter((k) => window.localStorage.getItem(k) === null)).toEqual([keys[0]]);
+  });
+
+  // Mutação vermelha: fazer `keep-foreign` entrar em `survivors`. Um envelope de
+  // aba mais nova passaria a empurrar rascunho NOSSO para fora do teto — o GC
+  // apagaria trabalho recuperável para proteger espaço de trabalho que ele nem
+  // sabe ler.
+  it("envelope de formato maior não empurra o teto", () => {
+    const keys = plantOthers(MAX_DRAFTS_PER_USER - 1);
+    plant({ documentId: DOC });
+    plant({
+      documentId: "doc-de-aba-mais-nova",
+      formatVersion: CODING_DRAFT_FORMAT_VERSION + 1,
+    });
+    render();
+    expect(keys.filter((k) => window.localStorage.getItem(k) === null)).toEqual([]);
+    expect(window.localStorage.getItem(otherDocKey("doc-de-aba-mais-nova"))).not.toBeNull();
   });
 });
 

--- a/frontend/src/lib/coding-draft-storage.ts
+++ b/frontend/src/lib/coding-draft-storage.ts
@@ -30,15 +30,20 @@ const DRAFT_DEBOUNCE_MS = 300;
 // quota estourada degrada em silêncio, que é exatamente o modo de falha que
 // esta issue existe para eliminar.
 //
-// Duas limitações conhecidas e aceitas, registradas aqui para não se perderem
+// Três limitações conhecidas e aceitas, registradas aqui para não se perderem
 // (ver #608). Primeiro, retenção: o envelope guarda RESPOSTAS de codificação em
 // claro no `localStorage` por até 30 dias, e nada o limpa no logout. A chave
 // isola usuários entre si, mas não protege contra quem tenha acesso ao mesmo
 // perfil de navegador — em máquina compartilhada, o isolamento real é o perfil,
 // não esta chave. Segundo, o teto é por USUÁRIO e não por projeto: uma sessão
 // longa num projeto pode evictar o rascunho mais antigo de outro projeto do
-// mesmo usuário. Ambas são aceitáveis enquanto o rascunho for uma rede de
-// segurança de curta duração; deixam de ser se ele virar armazenamento primário.
+// mesmo usuário. Terceiro, envelope de formato maior não tem limite superior
+// nenhum: este build não pode apagá-lo (é de uma aba que sabe mais) e ele
+// tampouco conta para o teto, sob pena de empurrar rascunho nosso para fora —
+// ver `GcVerdict`. Só morde se um formato novo proliferar entre abas, e quem
+// pode limpá-lo é justamente a aba que sabe lê-lo. As três são aceitáveis
+// enquanto o rascunho for uma rede de segurança de curta duração; deixam de ser
+// se ele virar armazenamento primário.
 const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 // Exportado para a suíte: um teste que repetisse o `100` passaria a mentir no
 // dia em que a política mudar, e é justamente o comportamento no teto que ele
@@ -269,6 +274,12 @@ function sweepOwnKeys(
   // "sobreviventes + 1 se há documento aberto", o `+1` contava um slot que
   // muitas vezes não existia — a primeira abertura, antes de qualquer tecla, é
   // exatamente quando o GC roda — e o teto evictava um rascunho válido a mais.
+  //
+  // Ocupação aqui é de QUOTA, não de envelope legível: o slot do documento
+  // aberto conta mesmo guardando lixo ou formato maior, porque ocupa espaço e
+  // nunca será evictado. É a exceção deliberada à isenção que `keep-foreign`
+  // recebe nos demais documentos — lá o envelope pode sair pela mão da aba que
+  // o escreveu, aqui não sai por mão nenhuma.
   openSlotTaken: boolean;
 } {
   const prefix = codingDraftUserPrefix(userId);

--- a/frontend/src/lib/coding-draft-storage.ts
+++ b/frontend/src/lib/coding-draft-storage.ts
@@ -5,7 +5,6 @@ import {
   codingDraftUserPrefix,
   envelopeMatchesScope,
   readCodingDraft,
-  parseCodingDraft,
   sameCodingSnapshot,
   type CodingDraftEnvelope,
   type CodingDraftRecovery,
@@ -41,7 +40,10 @@ const DRAFT_DEBOUNCE_MS = 300;
 // mesmo usuário. Ambas são aceitáveis enquanto o rascunho for uma rede de
 // segurança de curta duração; deixam de ser se ele virar armazenamento primário.
 const DRAFT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
-const MAX_DRAFTS_PER_USER = 100;
+// Exportado para a suíte: um teste que repetisse o `100` passaria a mentir no
+// dia em que a política mudar, e é justamente o comportamento no teto que ele
+// existe para fixar.
+export const MAX_DRAFTS_PER_USER = 100;
 
 interface DocDraftState {
   // O que estava na tela quando este rascunho nasceu.
@@ -208,22 +210,33 @@ interface GcResult {
   removed: number;
 }
 
-// Varredura escopada ao prefixo do PRÓPRIO usuário, uma vez por mount. Nunca
-// toca em chave de outro usuário (numa máquina compartilhada isso seria apagar
-// trabalho alheio) nem em envelope de formato maior (é de uma aba que sabe
-// mais) nem no documento aberto.
 // Destino de uma chave na varredura do GC. Separado do loop porque é a regra
-// que precisa ser lida com atenção: cada `keep` aqui protege trabalho de alguém.
-type GcVerdict = "keep" | "drop";
+// que precisa ser lida com atenção: cada veredito que preserva protege trabalho
+// de alguém.
+//
+// `keep` carrega o `updatedAt` que a classificação já leu. Sem ele, o loop
+// refazia `getItem` + `JSON.parse` + validação para todo slot sobrevivente: dois
+// parses por chave, até `MAX_DRAFTS_PER_USER` deles na primeira abertura.
+//
+// `keep-foreign` é o envelope de formato maior, e está separado de `keep` porque
+// a diferença entre os dois é política, não detalhe: ele é preservado e NÃO
+// conta para o teto. Contá-lo deixaria uma aba mais nova empurrar rascunhos
+// nossos para fora por eviction. Isso já valia antes — o envelope caía fora dos
+// sobreviventes porque `parseCodingDraft` não sabe lê-lo —, mas valia por
+// acidente do parse; aqui a regra está dita.
+type GcVerdict =
+  | { kind: "drop" }
+  | { kind: "keep"; updatedAt: number }
+  | { kind: "keep-foreign" };
 
 function classifyForGc(key: string, now: number): GcVerdict {
   const read = readCodingDraft(window.localStorage.getItem(key));
   // Envelope de formato maior é de uma aba que sabe mais: apagá-lo destruiria
   // trabalho que não temos como recuperar.
-  if (read.kind === "newer-format") return "keep";
+  if (read.kind === "newer-format") return { kind: "keep-foreign" };
   // Ilegível ou de formato antigo: não há como aplicar o conteúdo, e mantê-lo
   // ocuparia quota para sempre — sai do slot como qualquer outro lixo.
-  if (read.kind !== "draft") return "drop";
+  if (read.kind !== "draft") return { kind: "drop" };
 
   const embedded = codingDraftStorageKey({
     userId: read.draft.userId,
@@ -232,38 +245,58 @@ function classifyForGc(key: string, now: number): GcVerdict {
   });
   // Identidade embutida discorda da chave: não dá para saber a que documento o
   // conteúdo pertence, e aplicar no errado seria pior do que descartar.
-  if (key !== embedded) return "drop";
-  return now - read.draft.updatedAt > DRAFT_TTL_MS ? "drop" : "keep";
+  if (key !== embedded) return { kind: "drop" };
+  if (now - read.draft.updatedAt > DRAFT_TTL_MS) return { kind: "drop" };
+  return { kind: "keep", updatedAt: read.draft.updatedAt };
 }
 
-// Varredura: separa os slots do usuário em sobreviventes e condenados. Fica
-// fora de `collectCodingDraftGarbage` para que a coleta (decidir) e o descarte
-// (agir) sejam legíveis um de cada vez.
+// Varredura escopada ao prefixo do PRÓPRIO usuário, uma vez por mount. Separa
+// os slots em sobreviventes e condenados, e fica fora de
+// `collectCodingDraftGarbage` para que a coleta (decidir) e o descarte (agir)
+// sejam legíveis um de cada vez. Nunca condena chave de outro usuário (numa
+// máquina compartilhada isso seria apagar trabalho de um colega), nem envelope
+// de formato maior (é de uma aba que sabe mais), nem o documento aberto.
 function sweepOwnKeys(
   userId: string,
   now: number,
   keepKey: string | null,
-): { survivors: Array<{ key: string; updatedAt: number }>; doomed: string[] } {
+): {
+  survivors: Array<{ key: string; updatedAt: number }>;
+  doomed: string[];
+  // O slot do documento aberto EXISTE no storage? Sai daqui, e não de uma
+  // suposição de quem faz a conta do teto, porque este loop é o único ponto que
+  // de fato olha as chaves. Enquanto o total era recomposto lá fora como
+  // "sobreviventes + 1 se há documento aberto", o `+1` contava um slot que
+  // muitas vezes não existia — a primeira abertura, antes de qualquer tecla, é
+  // exatamente quando o GC roda — e o teto evictava um rascunho válido a mais.
+  openSlotTaken: boolean;
+} {
   const prefix = codingDraftUserPrefix(userId);
   const survivors: Array<{ key: string; updatedAt: number }> = [];
   const doomed: string[] = [];
+  let openSlotTaken = false;
 
   for (let i = 0; i < window.localStorage.length; i += 1) {
     const key = window.localStorage.key(i);
     // Fora do prefixo do próprio usuário, o GC não toca: numa máquina
-    // compartilhada isso seria apagar trabalho de um colega. E o documento
-    // aberto na tela nunca é evictado.
-    if (!key || !key.startsWith(prefix) || key === keepKey) continue;
-
-    const verdict = classifyForGc(key, now);
-    if (verdict === "keep") {
-      const envelope = parseCodingDraft(window.localStorage.getItem(key));
-      if (envelope) survivors.push({ key, updatedAt: envelope.updatedAt });
+    // compartilhada isso seria apagar trabalho de um colega.
+    if (!key || !key.startsWith(prefix)) continue;
+    // O documento aberto na tela nunca é evictado, mas ocupa um slot.
+    if (key === keepKey) {
+      openSlotTaken = true;
       continue;
     }
+
+    const verdict = classifyForGc(key, now);
+    if (verdict.kind === "keep") {
+      survivors.push({ key, updatedAt: verdict.updatedAt });
+      continue;
+    }
+    // Formato maior fica onde está e fora da contagem do teto — ver `GcVerdict`.
+    if (verdict.kind === "keep-foreign") continue;
     doomed.push(key);
   }
-  return { survivors, doomed };
+  return { survivors, doomed, openSlotTaken };
 }
 
 function collectCodingDraftGarbage(
@@ -274,10 +307,11 @@ function collectCodingDraftGarbage(
   if (typeof window === "undefined") return { removed: 0 };
   const result: GcResult = { removed: 0 };
   try {
-    const { survivors, doomed } = sweepOwnKeys(userId, now, keepKey);
+    const { survivors, doomed, openSlotTaken } = sweepOwnKeys(userId, now, keepKey);
 
-    // Teto: acima dele, sai o mais antigo primeiro.
-    const overflow = survivors.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
+    // Teto: acima dele, sai o mais antigo primeiro. O documento aberto entra na
+    // conta quando de fato ocupa um slot, nunca por ser o documento aberto.
+    const overflow = survivors.length + (openSlotTaken ? 1 : 0) - MAX_DRAFTS_PER_USER;
     if (overflow > 0) {
       survivors
         .toSorted((a, b) => a.updatedAt - b.updatedAt)


### PR DESCRIPTION
Fecha o resíduo da revisão do #621. Remedindo os dez achados daquela revisão contra a `main` de hoje, sete já tinham entrado pelo #630 e pelo #632 — três deles por caminhos diferentes do que a revisão propunha (o escopo divergente, por exemplo, foi resolvido na escrita, não apagando o envelope na leitura). Restaram três, todos aqui.

## 1. O teto do GC evictava um rascunho válido a mais

A conta do teto somava o slot do documento aberto sempre que havia documento aberto:

```ts
const overflow = survivors.length + (keepKey ? 1 : 0) - MAX_DRAFTS_PER_USER;
```

Só que `sweepOwnKeys` pula `keepKey` sem verificar se a chave existe. Na **primeira abertura** — que é exatamente quando `runFirstOpenGc` roda, antes de qualquer tecla — o slot ainda não foi escrito, então o `+1` contava um envelope inexistente e a eviction levava junto o mais antigo dos válidos. Sempre na direção de destruir trabalho.

Duas fontes sabiam sobre o `keepKey` e só uma olhava o storage. O fato passa a vir de quem já percorre as chaves, em vez de ser recomposto por suposição na aritmética.

## 2. Dois parses por slot sobrevivente

`classifyForGc` lia e validava o envelope para decidir o veredito e descartava o resultado; o loop refazia `getItem` + `JSON.parse` + Zod para todo `keep`. Até `MAX_DRAFTS_PER_USER` parses redundantes na primeira abertura de cada sessão. O `updatedAt` passa a viajar com o veredito — o import de `parseCodingDraft` ficou órfão, que é a prova de que o segundo parse sumiu.

Junto, os três desfechos ganham nome. `keep-foreign` declara que envelope de formato maior é preservado e **não** conta para o teto — regra que já valia, mas por acidente de `parseCodingDraft` não saber lê-lo. Contá-lo deixaria uma aba mais nova empurrar rascunho nosso para fora.

## 3. A região live da faixa anunciava os botões

`role=\"status\"` estava no container que envolve o texto **e** os dois botões, então o leitor de tela reanunciava \"Retomar rascunho\" e \"Descartar\" a cada mudança. A região passa a cobrir os dois textos — inclusive o de quais respostas retomar sobrescreve, que é o aviso mais consequente — e nenhum controle. `UnsentChangesBadge` e `CodingDraftUnavailableBanner` já acertavam; o desvio era isolado a esta faixa.

## Verificação

**Prova do vermelho** — 4 mutações, cada uma derrubando só o seu teste:

| Mutação | Teste que cai |
|---|---|
| `openSlotTaken` → `keepKey ? 1 : 0` | \"documento aberto SEM rascunho gravado não evicta ninguém\" |
| `keep-foreign` entra em `survivors` | \"envelope de formato maior não empurra o teto\" |
| `role=\"status\"` volta ao container | \"não contém os controles\" |
| região live encolhe para a 1ª frase | \"anuncia também o que retomar vai sobrescrever\" |

O caso de controle do teto (slot ocupado ⇒ o mais antigo dos outros sai) segue **verde** sob a primeira mutação, e é ele que impede o par de ser satisfeito por um `+ 0` incondicional. `MAX_DRAFTS_PER_USER` é exportado para a suíte em vez de repetido nela: um teste que duplicasse o `100` passaria a mentir no dia em que a política mudar.

Verdes: 2129 testes, typecheck, lint:types, react-doctor (100/100 nas linhas alteradas), `fallow audit --base origin/main` sem achado novo, semgrep, e smoke `coding-save` rodado duas vezes em porta dedicada — incluindo o caso que exercita o rascunho local e a faixa.

Refs #608

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyXTbv3kmTFm3wUX9sAPGo