### PR TITLE
refactor(codificação): classifica a fila fora do predicado do filtro e registra a ordem em docs/UI.md (#608)

### DIFF
--- a/docs/UI.md
+++ b/docs/UI.md
@@ -28,6 +28,14 @@ Escolher uma resposta na tela de comparação não grava o veredito: a escolha f
 
 A mudança veio de perda silenciosa observada em produção ([#417](https://github.com/bdcdo/dataframeitGUI/issues/417), [#430](https://github.com/bdcdo/dataframeitGUI/issues/430), corrigida no PR [#434](https://github.com/bdcdo/dataframeitGUI/pull/434)): com gravação implícita, uma navegação que acontecesse antes de a escrita concluir descartava o veredito sem que nada na tela indicasse a falha. O passo de confirmação existe para que o gesto de decidir e o de gravar sejam o mesmo evento, observável pelo usuário.
 
+## A fila de codificação abre no trabalho pendente, e "Ordem de atribuição" ordena por estado
+
+O modo "Ordem de atribuição" não é cronológico — `assignments` não tem `created_at`, então não há ordem de atribuição a recuperar. Ele ordena pelo estado do assignment, com o que exige trabalho primeiro: pendente, em andamento, concluído. Sem `?doc=` na URL, a tela abre na primeira codificação incompleta, com fallback para o primeiro item da ordenação escolhida.
+
+A ordem é declarada em `sortByAssignmentStatus` e não delegada ao banco por um motivo específico: até a [#608](https://github.com/bdcdo/dataframeitGUI/issues/608) a query usava `ORDER BY status`, que ordena pelo **alfabeto do enum** — `concluido` < `em_andamento` < `pendente` —, e por isso a fila abria justamente no que a pesquisadora já tinha terminado. Um enum ordenado por acaso é acoplamento invisível: renomear um dos valores mudaria a fila sem nenhum gate reclamar.
+
+A peça originalmente planejada — abrir no primeiro documento *nunca respondido* — foi descartada depois de medida, em 27/07/2026: nas filas dos dois projetos ativos, nenhum dos 13 pesquisadores tinha documento nunca respondido, e os concluídos da rodada atual já saem no filtro server-side. O que se encontrava na frente da fila eram respostas completas devolvidas por mudança de rodada, que exigem ação. Priorizar o "nunca tocado" não morderia em nenhuma fila real e contradiria o propósito do modo "Codificados recentemente", que existe para retomar de onde parou.
+
 ## Onde procurar o que este arquivo não descreve
 
 - **Mapeamento entre tipo de campo e controle de formulário** (incluindo campos de data, grupos de subcampos e a opção "Outro"): `frontend/src/components/coding/FieldRenderer.tsx` — é a fonte única, e reproduzi-lo em prosa apenas criaria uma cópia para divergir.

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -224,31 +224,39 @@ export default async function CodePage({
   // novo no cliente abriria espaço para o rótulo discordar do filtro que pôs o
   // documento ali (#608).
   //
+  // A classificação acontece UMA vez, aqui, e os dois consumidores leem dela: o
+  // filtro abaixo e o rótulo na tela. É de propósito que ela não more dentro do
+  // predicado do filtro — um `.filter()` que também escreve num mapa externo
+  // esconde a escrita no lugar onde ninguém a procura, e classificaria um
+  // subconjunto no dia em que outro filtro passasse a rodar antes dele.
+  const classified = allDocuments.map((doc) => {
+    const response = responseByDoc.get(doc.id) ?? null;
+    return { doc, response, status: classifyDocStatus(ctx, response, roundsById) };
+  });
+
   // Guarda o status INTEIRO, não só o `kind`: o membro `previous` carrega o
   // `label` da rodada — o rótulo do coordenador na estratégia manual, o semver na
   // `schema_version` — e é ele que torna o texto na tela verdadeiro nas duas.
-  const statusByDoc: Record<string, DocRoundStatus> = {};
+  const statusByDoc: Record<string, DocRoundStatus> = Object.fromEntries(
+    classified.map(({ doc, status }) => [doc.id, status]),
+  );
 
   // Filtro server-side conforme effectiveRound
-  const filteredDocuments = allDocuments.filter((d) => {
-    const resp = responseByDoc.get(d.id);
-    const status = classifyDocStatus(ctx, resp ?? null, roundsById);
-    statusByDoc[d.id] = status;
-
-    if (effectiveRound === "all") return true;
-    if (effectiveRound === CURRENT_FILTER_VALUE) {
-      // Padrao: mostra docs que ainda precisam ser respondidos na rodada atual
-      // (sem resposta OU resposta de rodada anterior). Concluidos da atual saem.
-      return status.kind !== "current_done";
-    }
-    // Rodada especifica: id (manual) ou label (schema_version)
-    if (strategy === "manual") {
-      return resp?.round_id === effectiveRound;
-    }
-    return (
-      status.kind === "previous" && status.label === effectiveRound
-    );
-  });
+  const filteredDocuments = classified
+    .filter(({ response, status }) => {
+      if (effectiveRound === "all") return true;
+      if (effectiveRound === CURRENT_FILTER_VALUE) {
+        // Padrao: mostra docs que ainda precisam ser respondidos na rodada atual
+        // (sem resposta OU resposta de rodada anterior). Concluidos da atual saem.
+        return status.kind !== "current_done";
+      }
+      // Rodada especifica: id (manual) ou label (schema_version)
+      if (strategy === "manual") {
+        return response?.round_id === effectiveRound;
+      }
+      return status.kind === "previous" && status.label === effectiveRound;
+    })
+    .map(({ doc }) => doc);
 
   const allFields = (project?.pydantic_fields || []) as PydanticField[];
   const fields = allFields.filter(


### PR DESCRIPTION
Fecha os dois itens menores que sobraram da revisão do #627, depois que ele já foi mergeado. Nenhum efeito observável na tela.

## A classificação sai do predicado do filtro

`classifyDocStatus` rodava dentro do `.filter()` que monta a fila: o predicado devolvia o booleano **e** escrevia `statusByDoc` como efeito colateral. Funcionava — o `.filter()` visita todos os elementos —, mas escondia a escrita no lugar onde ninguém a procura, e passaria a classificar um subconjunto no dia em que outro filtro passasse a rodar antes dele.

Agora a classificação acontece uma vez, sobre todos os documentos, e os dois consumidores — o filtro e o rótulo na tela — leem do mesmo array. Mudança sem efeito observável: mesma ordem, mesmo conjunto filtrado, mesmo mapa de status. `resp ?? null` virou um `response` já normalizado no `map`, então o braço `manual` do filtro continua comparando `undefined` quando não há resposta.

## `docs/UI.md` registra a ordem da fila

O #608 mudou a ordenação da fila mas a intenção não ficou registrada em lugar nenhum, e é exatamente o tipo de decisão que o `docs/UI.md` existe para guardar (ver #611): que "Ordem de atribuição" ordena **por estado** e não cronologicamente — `assignments` não tem `created_at` —, que a ordem é declarada em `sortByAssignmentStatus` em vez de herdada do alfabeto do enum (`concluido` < `em_andamento` < `pendente`, que era o que fazia a fila abrir no trabalho já terminado), e que priorizar o documento *nunca respondido* foi descartado depois de medido em 27/07/2026.

O terceiro item da revisão — o `id: string` não usado no genérico de `sortByAssignmentStatus` — ficou de fora de propósito: a restrição espelha a de `sortByRecent`, no mesmo módulo, e trocá-la seria churn sem ganho.

## Verificação

- **vitest**: 2171/2171 verdes, 198 arquivos
- **typecheck**, **lint** (0 errors; os 5 warnings são pré-existentes e em arquivos que este PR não toca), **lint:types**, **fallow**, **semgrep**, **e2e smoke**: todos os hooks de pre-push passaram

Ressalva honesta sobre o caminho até aqui: duas tentativas de push falharam no gate de vitest, com 3 e depois 11 testes vermelhos em `MemberList` e outros arquivos de UI que este PR não toca. Era carga da máquina — o mesmo arquivo passou 3/3 isolado e a suíte inteira ficou verde numa execução limpa (o run que falhou levou 129 s contra 36 s do normal). Nenhuma falha ocorreu em arquivo tocado por este PR.

Refs #608