### PR TITLE
Rodadas explícitas no sorteio de atribuições

### DIFF
--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -219,6 +219,11 @@ def _persist_run_snapshot(sb, job_id: str, project: dict, doc_count: int) -> Non
             "llm_model": project.get("llm_model"),
             "document_count": doc_count,
             "pydantic_code": project.get("pydantic_code"),
+            # A rodada é capturada junto do restante do snapshot da execução.
+            # Mesmo que o coordenador inicie outra rodada enquanto o provider
+            # processa os documentos, todas as respostas desta run continuam
+            # apontando para a rodada que estava ativa no início.
+            "round_id": project.get("current_round_id"),
         }
     ).eq("job_id", job_id).execute()
 
@@ -410,6 +415,7 @@ class _RunMetadata:
     """
 
     project_id: str
+    round_id: str
     llm_provider: str
     llm_model: str
     pydantic_hash: str
@@ -474,6 +480,7 @@ def _build_llm_response_row(
     """
     return {
         "project_id": run.project_id,
+        "round_id": run.round_id,
         "document_id": doc_id,
         "respondent_type": "llm",
         "respondent_name": f"{run.llm_provider}/{run.llm_model}",
@@ -1206,7 +1213,7 @@ async def run_llm(
         project = (
             sb.table("projects")
             .select(
-                "pydantic_code, prompt_template, llm_provider, llm_model, llm_kwargs, description, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch"
+                "pydantic_code, prompt_template, llm_provider, llm_model, llm_kwargs, description, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, current_round_id"
             )
             .eq("id", project_id)
             .single()
@@ -1282,6 +1289,7 @@ async def run_llm(
 
         run_metadata = _RunMetadata(
             project_id=project_id,
+            round_id=project["current_round_id"],
             llm_provider=llm_provider,
             llm_model=llm_model,
             pydantic_hash=pydantic_hash,

--- a/backend/tests/test_llm_runner_response_row.py
+++ b/backend/tests/test_llm_runner_response_row.py
@@ -11,6 +11,7 @@ from services.llm_runner import _build_llm_response_row, _RunMetadata
 def _run(**overrides) -> _RunMetadata:
     base = dict(
         project_id="proj-1",
+        round_id="round-1",
         llm_provider="google_genai",
         llm_model="gemini-3-flash-preview",
         pydantic_hash="3c5e901f76547135",
@@ -69,6 +70,7 @@ def test_campos_basicos_preservados():
     assert row["pydantic_hash"] == "3c5e901f76547135"
     assert row["llm_job_id"] == "job-1"
     assert row["llm_error"] is None
+    assert row["round_id"] == "round-1"
 
 
 def test_justifications_vazio_vira_none():

--- a/backend/tests/test_llm_runner_run_llm.py
+++ b/backend/tests/test_llm_runner_run_llm.py
@@ -139,8 +139,14 @@ class _FakeTable:
 
 
 class _FakeSupabase:
-    def __init__(self, tables: dict[str, _FakeTable]):
+    def __init__(
+        self,
+        tables: dict[str, _FakeTable],
+        *,
+        rpc_errors: dict[str, Exception] | None = None,
+    ):
         self._tables = tables
+        self._rpc_errors = rpc_errors or {}
         self.rpc_calls: list[tuple[str, dict]] = []
         self.operation_log: list[
             tuple[str, str, dict, list[tuple[str, str, object]]]
@@ -153,6 +159,9 @@ class _FakeSupabase:
         return self._tables[name]
 
     def rpc(self, name, params):
+        if name in self._rpc_errors:
+            return _RaisingQuery(self._rpc_errors[name])
+
         def record(_filters):
             self.rpc_calls.append((name, params))
 
@@ -171,6 +180,7 @@ def _project_row(**overrides) -> dict:
         "schema_version_major": 1,
         "schema_version_minor": 0,
         "schema_version_patch": 0,
+        "current_round_id": "round-1",
     }
     row.update(overrides)
     return row
@@ -221,14 +231,21 @@ def _make_fake_dataframeit(row_specs: dict[str, dict], calls: list[dict] | None 
     return _fake
 
 
-def _build_supabase(project_row, docs, *, documents_error=None) -> _FakeSupabase:
+def _build_supabase(
+    project_row,
+    docs,
+    *,
+    documents_error=None,
+    rpc_errors: dict[str, Exception] | None = None,
+) -> _FakeSupabase:
     return _FakeSupabase(
         {
             "projects": _FakeTable(select_data=project_row),
             "documents": _FakeTable(select_data=docs, select_error=documents_error),
             "responses": _FakeTable(),
             "llm_runs": _FakeTable(),
-        }
+        },
+        rpc_errors=rpc_errors,
     )
 
 
@@ -305,6 +322,7 @@ def test_run_llm_happy_path(monkeypatch):
         row["is_partial"] is False and row["is_latest"] is True for row in inserts
     )
     assert all(row["llm_error"] is None for row in inserts)
+    assert all(row["round_id"] == "round-1" for row in inserts)
     assert all(
         row["answer_field_hashes"] == {"campo_a": "ha", "campo_b": None}
         for row in inserts
@@ -317,6 +335,49 @@ def test_run_llm_happy_path(monkeypatch):
 
     project_updates = sb.table("projects").update_calls
     assert any("pydantic_hash" in payload for payload in project_updates)
+
+    snapshot = next(
+        payload
+        for payload in sb.table("llm_runs").update_calls
+        if "document_count" in payload
+    )
+    assert snapshot["round_id"] == "round-1"
+
+
+def test_run_llm_preserves_captured_round_and_propagates_stale_round_error(
+    monkeypatch,
+):
+    docs = _docs(1)
+    sb = _build_supabase(
+        _project_row(current_round_id="round-captured"),
+        docs,
+        rpc_errors={
+            "publish_latest_llm_response": RuntimeError(
+                "round changed while LLM run was processing"
+            )
+        },
+    )
+
+    _run_llm_sync(
+        monkeypatch,
+        sb,
+        {"doc-0": {"campo_a": "a", "campo_b": "b", "campo_c": "c"}},
+    )
+
+    snapshot = next(
+        payload
+        for payload in sb.table("llm_runs").update_calls
+        if "document_count" in payload
+    )
+    assert snapshot["round_id"] == "round-captured"
+    assert _jobs[JOB_ID]["status"] == "error"
+    assert _jobs[JOB_ID]["error_type"] == "RuntimeError"
+    assert _jobs[JOB_ID]["errors"] == ["round changed while LLM run was processing"]
+    error_update = _last_update_where(sb.table("llm_runs"), status="error")
+    assert error_update is not None
+    assert error_update["error_message"] == (
+        "round changed while LLM run was processing"
+    )
 
 
 def test_run_llm_routes_kwargs_without_leaking_internal_options(monkeypatch):

--- a/frontend/e2e/coding-save.smoke.spec.ts
+++ b/frontend/e2e/coding-save.smoke.spec.ts
@@ -196,6 +196,7 @@ test("codificação: enviar respostas persiste response e conclui assignment", a
       // "current" esconde docs concluídos da rodada atual) e confere que os
       // valores persistidos voltam pré-preenchidos no formulário.
       await page.goto(`/projects/${projectId}/analyze/code?round=all`);
+      await page.getByRole("button", { name: new RegExp(DOC_TITLE) }).click();
       const reloaded = page.getByPlaceholder("Digite sua resposta...");
       await expect(reloaded.nth(0)).toHaveValue(RESUMO_VALUE, {
         timeout: 30_000,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "test:db:column-guard": "npm run test:db:psql -- supabase/tests/project_members_column_guard.test.sql",
     "test:db:responses-human-latest": "npm run test:db:psql -- supabase/tests/responses_one_latest_human.test.sql",
     "test:db:responses-human-concurrency": "npm run test:db:psql -- supabase/tests/responses_latest_human_concurrency.test.sql",
+    "test:db:response-round-serialization": "npm run test:db:psql -- supabase/tests/response_round_serialization.test.sql",
     "test:db:remove-member": "npm run test:db:psql -- supabase/tests/remove_project_member_self_identity.test.sql",
     "test:db:unmark-equivalence": "npm run test:db:psql -- supabase/tests/unmark_equivalence_atomic.test.sql",
     "test:db:arbitration-reopen": "npm run test:db:psql -- supabase/tests/arbitration_reopen.test.sql",

--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -48,6 +48,7 @@ GATE_SUITES=(
   clerk_mapping_completion
   auto_review_assignment_sync
   atomic_replace_rpcs
+  explicit_assignment_rounds
   llm_rate_limit
   member_permission_rpcs
   project_members_column_guard

--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -55,6 +55,7 @@ GATE_SUITES=(
   responses_one_latest_human
   auto_review_assignment_concurrency
   responses_latest_human_concurrency
+  response_round_serialization
   unmark_equivalence_atomic
   auto_review_reconciliation_outbox
   arbitration_reopen

--- a/frontend/src/actions/__tests__/assignments.test.ts
+++ b/frontend/src/actions/__tests__/assignments.test.ts
@@ -24,6 +24,7 @@ vi.mock("next/cache", () => ({
 }));
 vi.mock("@/lib/auth", () => ({
   getAuthUser: async () => ({ id: "user-1", isMaster: false }),
+  requireCoordinator: async () => ({ ok: true, user: { id: "user-1" } }),
 }));
 vi.mock("@/lib/supabase/server", () => ({
   createSupabaseServer: async () => {
@@ -92,7 +93,7 @@ describe("getLotteryDocStats", () => {
         data: [{ id: "b1", label: "Lote 1", created_at: "2026-01-01" }],
       },
       projects: {
-        data: { min_responses_for_comparison: 2, automation_mode: "compare_llm" },
+        data: { min_responses_for_comparison: 2, automation_mode: "compare_llm", current_round_id: "round-1" },
       },
     };
 
@@ -129,7 +130,7 @@ describe("getLotteryDocStats", () => {
     serverTableResults = {
       lottery_doc_stats: { data: [] },
       assignment_batches: { data: [] },
-      projects: { data: { min_responses_for_comparison: 2, automation_mode: null } },
+      projects: { data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" } },
     };
 
     await getLotteryDocStats("p1");
@@ -160,7 +161,7 @@ describe("previewLottery", () => {
         ],
       },
       assignment_batches: { data: [] },
-      projects: { data: { min_responses_for_comparison: 2, automation_mode: null } },
+      projects: { data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" } },
       assignments: { data: [] },
     };
 
@@ -209,7 +210,7 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
         ],
       },
       assignment_batches: { data: [] },
-      projects: { data: { min_responses_for_comparison: 2, automation_mode: null } },
+      projects: { data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" } },
       assignments: { data: assignments },
     };
   }
@@ -351,10 +352,7 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
     expect(rpc?.args).toMatchObject({ p_type: "comparacao" });
     expect((rpc?.args as { p_assignments: unknown[] }).p_assignments).toHaveLength(1);
 
-    const lote = writeCalls.find(
-      (c) => c.table === "assignment_batches" && c.op === "insert",
-    );
-    expect(lote?.payload).toMatchObject({ researchers_per_doc: 1 });
+    expect((rpc?.args as { p_batch: unknown }).p_batch).toMatchObject({ researchers_per_doc: 1 });
   });
 });
 
@@ -372,7 +370,7 @@ describe("status inicial do assignment de codificação (#521)", () => {
     automation_mode: null,
     pydantic_fields: FIELDS,
     round_strategy: "schema_version",
-    current_round_id: null,
+    current_round_id: "round-1",
     schema_version_major: 1,
     schema_version_minor: 0,
     schema_version_patch: 0,

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -4,6 +4,7 @@ import { isCodingComplete } from "@/lib/coding-completeness";
 import { responseQualifiesForVersion } from "@/lib/compare-version";
 import type { VersionedResponse } from "@/lib/compare-version";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
+import type { SaveResponseOpts } from "@/actions/responses";
 
 const drainAutoReviewReconciliationRequests = vi.hoisted(() => vi.fn(async () => ({
   processed: 1,
@@ -219,7 +220,17 @@ vi.mock("@/lib/supabase/server", () => ({
 }));
 
 async function loadSaveResponse() {
-  return (await import("@/actions/responses")).saveResponse;
+  const saveResponse = (await import("@/actions/responses")).saveResponse;
+  return (
+    projectId: string,
+    documentId: string,
+    answers: Record<string, unknown>,
+    opts: Partial<SaveResponseOpts> = {},
+  ) =>
+    saveResponse(projectId, documentId, answers, {
+      expectedRoundId: "round-1",
+      ...opts,
+    });
 }
 
 describe("saveResponse — gravação pelo envio explícito", () => {
@@ -776,6 +787,21 @@ describe("saveResponse — unicidade da resposta corrente (#609)", () => {
       error: "codificador não pode responder documento em comparação",
     });
     expect(state.existingReadCount).toBe(1);
+  });
+
+  it("rodada alterada atomicamente no banco devolve mensagem de recarga", async () => {
+    state.existingResponse = null;
+    state.responseInsertErrorQueue = [
+      { code: "40001", message: "a rodada atual mudou; recarregue o formulario" },
+    ];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r).toEqual({
+      success: false,
+      error: "A rodada mudou enquanto este formulário estava aberto. Recarregue a página.",
+    });
+    expect(state.assignmentUpdatePayload).toBeNull();
   });
 
   it("conflito nas DUAS tentativas devolve erro explícito, sem girar", async () => {

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -128,7 +128,7 @@ vi.mock("@/lib/supabase/server", () => ({
                   schema_version_minor: state.schemaVersion.minor,
                   schema_version_patch: state.schemaVersion.patch,
                   round_strategy: "schema_version",
-                  current_round_id: null,
+                  current_round_id: "round-1",
                   automation_mode: state.automationMode,
                 },
                 error: null,
@@ -680,6 +680,7 @@ describe("saveResponse — unicidade da resposta corrente (#609)", () => {
       "document_id",
       "respondent_id",
       "respondent_type",
+      "round_id",
       "is_latest",
     ]);
     expect(state.responseUpdateFilters).toContainEqual({

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createSupabaseServer } from "@/lib/supabase/server";
-import { getAuthUser } from "@/lib/auth";
+import { getAuthUser, requireCoordinator } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
 import {
   createRng,
@@ -27,7 +27,7 @@ import {
 } from "@/lib/coding-initial-status";
 import type { ResponseRoundFields, RoundContext } from "@/lib/rounds";
 import type { SupabaseServerClient } from "@/lib/supabase/server";
-import type { AnswerFieldHashes, PydanticField, Round, RoundStrategy } from "@/lib/types";
+import type { AnswerFieldHashes, PydanticField, Round } from "@/lib/types";
 
 // --- Status inicial do assignment de codificação (issue #521) ---
 
@@ -97,15 +97,13 @@ function requireData<T>(
   return result.data;
 }
 
-/** Só a estratégia manual consulta o mapa de rodadas em classifyDocStatus. */
-async function loadRoundsIfManual(
+async function loadRounds(
   supabase: SupabaseServerClient,
   projectId: string,
-  strategy: RoundStrategy,
 ): Promise<Round[]> {
-  if (strategy !== "manual") return [];
   const result = await supabase.from("rounds").select("id, label").eq("project_id", projectId);
-  return requireData(result, "Erro ao ler as rodadas do projeto") as Round[];
+  if (result.error) throw new Error(`Erro ao ler as rodadas do projeto: ${result.error.message}`);
+  return (result.data ?? []) as Round[];
 }
 
 async function loadInitialStatusInputs(
@@ -116,9 +114,7 @@ async function loadInitialStatusInputs(
   const [projectResult, ...answerResults] = await Promise.all([
     supabase
       .from("projects")
-      .select(
-        "pydantic_fields, round_strategy, current_round_id, schema_version_major, schema_version_minor, schema_version_patch",
-      )
+      .select("pydantic_fields, current_round_id")
       .eq("id", projectId)
       .single(),
     ...chunk(responseIds, RESPONSE_ID_CHUNK).map((ids) =>
@@ -134,9 +130,8 @@ async function loadInitialStatusInputs(
     requireData(result, "Erro ao ler as codificações existentes"),
   );
 
-  const strategy = (project.round_strategy as RoundStrategy) ?? "schema_version";
   return {
-    ctx: buildRoundContext(project, strategy, await loadRoundsIfManual(supabase, projectId, strategy)),
+    ctx: buildRoundContext(project, await loadRounds(supabase, projectId)),
     fields: (project.pydantic_fields as PydanticField[]) ?? [],
     answersById: indexAnswers(answerRows),
   };
@@ -144,17 +139,12 @@ async function loadInitialStatusInputs(
 
 function buildRoundContext(
   project: Record<string, unknown>,
-  strategy: RoundStrategy,
   rounds: Round[],
 ): RoundContext {
   return {
-    strategy,
+    strategy: "manual",
     currentRoundId: (project.current_round_id as string | null) ?? null,
-    currentVersion: {
-      major: (project.schema_version_major as number | null) ?? 0,
-      minor: (project.schema_version_minor as number | null) ?? 0,
-      patch: (project.schema_version_patch as number | null) ?? 0,
-    },
+    currentVersion: { major: 0, minor: 0, patch: 0 },
     rounds,
   };
 }
@@ -190,6 +180,7 @@ async function resolveInitialCodingStatuses(
     const payload = answersById.get(candidate.id);
     const response = {
       ...candidate,
+      round_id: candidate.round_id ?? ctx.currentRoundId,
       answers: payload?.answers ?? null,
       answer_field_hashes: payload?.answer_field_hashes,
     };
@@ -290,13 +281,23 @@ export async function cycleAssignment(
   documentId: string,
   userId: string,
 ): Promise<{ error?: string }> {
+  const gate = await requireCoordinator(projectId, "Apenas coordenadores podem alterar atribuições.");
+  if (!gate.ok) return { error: gate.error };
   const supabase = await createSupabaseServer();
+  const { data: project } = await supabase
+    .from("projects")
+    .select("current_round_id")
+    .eq("id", projectId)
+    .single();
+  if (!project?.current_round_id) return { error: "O projeto não possui uma rodada atual." };
 
   const { data: existing } = await supabase
     .from("assignments")
     .select("id, status, type")
     .eq("document_id", documentId)
-    .eq("user_id", userId);
+    .eq("user_id", userId)
+    .eq("project_id", projectId)
+    .eq("round_id", project.current_round_id);
 
   const rows = existing || [];
 
@@ -343,14 +344,23 @@ export async function clearPendingAssignments(
   projectId: string,
   type: "codificacao" | "comparacao" = "codificacao"
 ): Promise<{ deleted?: number; error?: string }> {
+  const gate = await requireCoordinator(projectId, "Apenas coordenadores podem limpar atribuições.");
+  if (!gate.ok) return { error: gate.error };
   const supabase = await createSupabaseServer();
+  const { data: project } = await supabase
+    .from("projects")
+    .select("current_round_id")
+    .eq("id", projectId)
+    .single();
+  if (!project?.current_round_id) return { error: "O projeto não possui uma rodada atual." };
 
   const { count, error } = await supabase
     .from("assignments")
     .delete({ count: "exact" })
     .eq("project_id", projectId)
     .eq("status", "pendente")
-    .eq("type", type);
+    .eq("type", type)
+    .eq("round_id", project.current_round_id);
 
   if (error) {
     return { error: error.message || "Erro ao limpar as atribuições pendentes" };
@@ -382,6 +392,14 @@ interface LotteryParamsBase {
    * project_members ao sortear para pré-preencher o próximo sorteio.
    */
   participantSettings?: Record<string, { weight?: number; cap?: number | null }>;
+  target?:
+    | { kind: "current"; expectedRoundId: string }
+    | {
+        kind: "new";
+        expectedRoundId: string;
+        roundLabel: string;
+        confirmOpenWork: boolean;
+      };
 }
 
 /**
@@ -414,6 +432,7 @@ export interface LotteryPreview {
   eligibleDocs: number;
   /** semente usada; o dialog a reenvia em smartRandomize (research D13) */
   seed: number;
+  targetRoundLabel?: string;
 }
 
 interface LotteryDocStatsResult {
@@ -422,6 +441,9 @@ interface LotteryDocStatsResult {
   minResponsesForComparison: number;
   /** modo de automação do projeto — governa o gate de comparação */
   automationMode: string | null;
+  currentRoundId: string | null;
+  currentRoundLabel: string | null;
+  openAssignmentCount: number;
 }
 
 interface LotteryData extends LotteryDocStatsResult {
@@ -430,6 +452,7 @@ interface LotteryData extends LotteryDocStatsResult {
     user_id: string;
     status: string;
     type: string;
+    round_id: string;
   }[];
   humanCoderRows: HumanCoderRow[];
 }
@@ -443,7 +466,7 @@ interface LotteryData extends LotteryDocStatsResult {
 async function fetchLotteryDocStats(projectId: string): Promise<LotteryDocStatsResult> {
   const supabase = await createSupabaseServer();
 
-  const [{ data: docs }, { data: batches }, { data: project }] = await Promise.all([
+  const [{ data: docs }, { data: batches }, { data: project }, { data: rounds }] = await Promise.all([
     supabase
       .from("lottery_doc_stats")
       .select(
@@ -452,15 +475,20 @@ async function fetchLotteryDocStats(projectId: string): Promise<LotteryDocStatsR
       .eq("project_id", projectId),
     supabase
       .from("assignment_batches")
-      .select("id, label, created_at")
+      .select("id, label, created_at, round_id")
       .eq("project_id", projectId)
       .order("created_at", { ascending: false }),
     supabase
       .from("projects")
-      .select("min_responses_for_comparison, automation_mode")
+      .select("min_responses_for_comparison, automation_mode, current_round_id")
       .eq("id", projectId)
       .single(),
+    supabase
+      .from("rounds")
+      .select("id, label")
+      .eq("project_id", projectId)
   ]);
+  const currentRound = (rounds ?? []).find((round) => round.id === project?.current_round_id);
 
   return {
     docs: (docs || []).map((d) => ({
@@ -476,13 +504,19 @@ async function fetchLotteryDocStats(projectId: string): Promise<LotteryDocStatsR
       hasAnyAssignmentEver: d.has_any_assignment_ever,
       batchIds: d.batch_ids || [],
     })),
-    batches: (batches || []).map((b) => ({
+    batches: (batches || []).filter((b) => b.round_id === project?.current_round_id).map((b) => ({
       id: b.id,
       label: b.label,
       createdAt: b.created_at,
     })),
     minResponsesForComparison: project?.min_responses_for_comparison ?? 2,
     automationMode: project?.automation_mode ?? null,
+    currentRoundId: project?.current_round_id ?? null,
+    currentRoundLabel: currentRound?.label ?? null,
+    openAssignmentCount: (docs || []).reduce(
+      (total, d) => total + d.active_codificacao + d.active_comparacao,
+      0,
+    ),
   };
 }
 
@@ -500,7 +534,7 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
     fetchLotteryDocStats(projectId),
     supabase
       .from("assignments")
-      .select("document_id, user_id, status, type")
+      .select("document_id, user_id, status, type, round_id")
       .eq("project_id", projectId),
     // Mesmo predicado do trigger enforce_comparison_assignment_actor
     // (20260716160100): resposta humana is_latest define quem codificou.
@@ -526,6 +560,7 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
       user_id: a.user_id,
       status: a.status,
       type: a.type,
+      round_id: a.round_id ?? stats.currentRoundId ?? "",
     })),
     humanCoderRows: (humanCoders || []).flatMap((r) =>
       r.respondent_id
@@ -535,7 +570,7 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
               document_id: r.document_id,
               respondent_id: r.respondent_id,
               updated_at: r.updated_at,
-              round_id: r.round_id,
+              round_id: r.round_id ?? stats.currentRoundId,
               is_partial: r.is_partial,
               schema_version_major: r.schema_version_major,
               schema_version_minor: r.schema_version_minor,
@@ -558,9 +593,7 @@ export async function getLotteryDocStats(
   if (!user) return { error: "Não autenticado" };
 
   try {
-    const { docs, batches, minResponsesForComparison, automationMode } =
-      await fetchLotteryDocStats(projectId);
-    return { docs, batches, minResponsesForComparison, automationMode };
+    return await fetchLotteryDocStats(projectId);
   } catch (e) {
     return { error: errorMessage(e) || "Erro ao carregar as estatísticas do sorteio" };
   }
@@ -577,6 +610,7 @@ async function computeLottery(params: LotteryParams): Promise<{
   assignmentType: "codificacao" | "comparacao";
   /** fase 1 do status inicial (#521): responses humanas leves do projeto */
   humanCoderRows: HumanCoderRow[];
+  target: NonNullable<LotteryParams["target"]>;
 }> {
   const supabase = await createSupabaseServer();
   // Normaliza em vez de confiar no literal: o payload chega por HTTP e não passa
@@ -603,6 +637,21 @@ async function computeLottery(params: LotteryParams): Promise<{
     fetchLotteryData(params.projectId),
   ]);
 
+  const target = params.target ?? {
+    kind: "current" as const,
+    expectedRoundId: data.currentRoundId ?? "",
+  };
+  if (!data.currentRoundId || target.expectedRoundId !== data.currentRoundId) {
+    throw new Error("A rodada atual mudou. Reabra o sorteio e tente novamente.");
+  }
+  const startsNewRound = target.kind === "new";
+  if (startsNewRound && assignmentType !== "codificacao") {
+    throw new Error("Uma nova rodada só pode ser iniciada pelo sorteio de codificação.");
+  }
+  if (target.kind === "new" && !target.roundLabel.trim()) {
+    throw new Error("Informe o nome da nova rodada.");
+  }
+
   // Pool de participantes: deduplicado e validado contra project_members
   // (qualquer role) — defesa em profundidade além do RLS (research D5)
   const memberIds = new Set((members || []).map((m) => m.user_id));
@@ -618,7 +667,16 @@ async function computeLottery(params: LotteryParams): Promise<{
 
   // Gate de comparação derivado do modo de automação — compõe com os filtros.
   // compare_llm exige 1 humano + LLM; demais modos exigem N humanos.
-  let candidateDocs = data.docs;
+  let candidateDocs = startsNewRound
+    ? data.docs.map((doc) => ({
+        ...doc,
+        humanCodingCount: 0,
+        hasLlmResponse: false,
+        activeAssignments: { codificacao: 0, comparacao: 0 },
+        hasAnyAssignmentEver: false,
+        batchIds: [],
+      }))
+    : data.docs;
   if (assignmentType === "comparacao") {
     candidateDocs = filterComparisonEligible(
       candidateDocs,
@@ -647,8 +705,11 @@ async function computeLottery(params: LotteryParams): Promise<{
       ? ["pendente", "em_andamento", "concluido"]
       : ["em_andamento", "concluido"]
   );
-  const preserved = data.assignmentRows.filter(
-    (a) => a.type === assignmentType && preservedStatuses.has(a.status)
+  const currentRoundRows = startsNewRound
+    ? []
+    : data.assignmentRows.filter((a) => a.round_id === data.currentRoundId);
+  const preserved = currentRoundRows.filter(
+    (a) => a.type === assignmentType && preservedStatuses.has(a.status),
   );
 
   // Anti-duplicidade de par: continua derivando de `preserved` (dependente do
@@ -664,7 +725,9 @@ async function computeLottery(params: LotteryParams): Promise<{
   // mesmo invariante entra como par vetado do sorteio manual — veto de par,
   // não de vaga: o codificador continua elegível para outros documentos.
   if (assignmentType === "comparacao") {
-    for (const row of data.humanCoderRows) {
+    for (const row of data.humanCoderRows.filter(
+      (candidate) => candidate.round_id === data.currentRoundId,
+    )) {
       preservedSet.add(`${row.document_id}:${row.respondent_id}`);
     }
   }
@@ -693,8 +756,12 @@ async function computeLottery(params: LotteryParams): Promise<{
   // Carga acumulada segue em `preserved`: uma comparação concluída é trabalho
   // feito — conta para o equilíbrio `history` e é o "existing" da prévia, ainda
   // que não ocupe mais a vaga do documento.
+  const loadRows =
+    params.balancing === "history"
+      ? data.assignmentRows.filter((a) => a.type === assignmentType)
+      : preserved;
   const preservedByUser: Record<string, number> = {};
-  for (const a of preserved) {
+  for (const a of loadRows) {
     preservedByUser[a.user_id] = (preservedByUser[a.user_id] || 0) + 1;
   }
 
@@ -796,17 +863,21 @@ async function computeLottery(params: LotteryParams): Promise<{
     batchData,
     assignmentType,
     humanCoderRows: data.humanCoderRows,
+    target,
   };
 }
 
 export async function previewLottery(
   params: LotteryParams,
 ): Promise<{ preview?: LotteryPreview; error?: string }> {
-  const user = await getAuthUser();
-  if (!user) return { error: "Não autenticado" };
+  const gate = await requireCoordinator(
+    params.projectId,
+    "Apenas coordenadores podem sortear atribuições.",
+  );
+  if (!gate.ok) return { error: gate.error };
 
   try {
-    const { newAssignments, preservedCount, preservedByUser, eligibleCount, seed } =
+    const { newAssignments, preservedCount, preservedByUser, eligibleCount, seed, target } =
       await computeLottery(params);
 
     const newCounts: Record<string, number> = {};
@@ -825,6 +896,10 @@ export async function previewLottery(
         totalPreserved: preservedCount,
         eligibleDocs: eligibleCount,
         seed,
+        targetRoundLabel:
+          target.kind === "new"
+            ? target.roundLabel.trim()
+            : "Rodada atual",
       },
     };
   } catch (e) {
@@ -835,8 +910,11 @@ export async function previewLottery(
 export async function smartRandomize(
   params: LotteryParams,
 ): Promise<{ count?: number; preserved?: number; error?: string }> {
-  const user = await getAuthUser();
-  if (!user) return { error: "Não autenticado" };
+  const gate = await requireCoordinator(
+    params.projectId,
+    "Apenas coordenadores podem sortear atribuições.",
+  );
+  if (!gate.ok) return { error: gate.error };
 
   const supabase = await createSupabaseServer();
 
@@ -846,7 +924,7 @@ export async function smartRandomize(
   // Operação crítica: computeLottery + registro do lote + RPC transacional. Só
   // um erro aqui (nada gravado, ou gravação abortada) deve virar { error }.
   try {
-    const { newAssignments, preservedCount, batchData, assignmentType, humanCoderRows } =
+    const { newAssignments, preservedCount, batchData, assignmentType, humanCoderRows, target } =
       await computeLottery(params);
 
     // Status inicial por linha (#521): um documento já codificado por completo
@@ -858,28 +936,17 @@ export async function smartRandomize(
       assignmentType === "codificacao"
         ? new Map(humanCoderRows.map((r) => [pairKey(r.document_id, r.respondent_id), r]))
         : new Map<string, HumanCoderRow>();
-    const initialStatuses = await resolveInitialCodingStatuses(
-      supabase,
-      params.projectId,
-      newAssignments.flatMap((a) => {
-        const response = responsesByPair.get(pairKey(a.document_id, a.user_id));
-        return response ? [response] : [];
-      }),
-    );
-
-    // O batch é criado antes de qualquer mudança em assignments: se falhar
-    // (ex.: migration ausente), nada foi deletado ainda
-    const { data: batch, error: batchError } = await supabase
-      .from("assignment_batches")
-      .insert({ ...batchData, created_by: user.id })
-      .select("id")
-      .single();
-
-    if (batchError || !batch) {
-      throw new Error(
-        `Erro ao registrar o lote do sorteio: ${batchError?.message ?? "resposta vazia"}`
-      );
-    }
+    const initialStatuses =
+      target.kind === "new"
+        ? new Map<string, InitialCodingStatus>()
+        : await resolveInitialCodingStatuses(
+            supabase,
+            params.projectId,
+            newAssignments.flatMap((a) => {
+              const response = responsesByPair.get(pairKey(a.document_id, a.user_id));
+              return response ? [response] : [];
+            }),
+          );
 
     // Descarte das pendentes (modo substituir) + gravação das novas numa
     // transação única via RPC (issue #181): uma falha entre o delete e o insert
@@ -895,12 +962,17 @@ export async function smartRandomize(
           : {}),
       };
     });
-    const { data: inserted, error: rpcError } = await supabase.rpc(
+    const { data: result, error: rpcError } = await supabase.rpc(
       "apply_lottery_assignments",
       {
         p_project_id: params.projectId,
         p_type: assignmentType,
-        p_batch_id: batch.id,
+        p_expected_round_id: target.expectedRoundId,
+        p_new_round_label:
+          target.kind === "new" ? target.roundLabel.trim() : null,
+        p_confirm_open_work:
+          target.kind === "new" && target.confirmOpenWork,
+        p_batch: batchData,
         p_assignments: assignmentRows,
         p_replace: params.mode === "replace",
       },
@@ -914,7 +986,8 @@ export async function smartRandomize(
     // comparação do documento entre a leitura do computeLottery (fora da
     // transação) e este INSERT. Reportar o pretendido faria o coordenador ver
     // um número que não está no banco.
-    count = typeof inserted === "number" ? inserted : newAssignments.length;
+    const rpcResult = result as { inserted?: number } | null;
+    count = rpcResult?.inserted ?? newAssignments.length;
     preserved = preservedCount;
   } catch (e) {
     return { error: errorMessage(e) || "Erro ao sortear" };

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -269,6 +269,77 @@ async function promoteToComparison(
   return error ? { error: error.message } : {};
 }
 
+async function getCurrentRoundId(
+  supabase: SupabaseServerClient,
+  projectId: string,
+): Promise<string | null> {
+  const { data: project } = await supabase
+    .from("projects")
+    .select("current_round_id")
+    .eq("id", projectId)
+    .single();
+  return project?.current_round_id ?? null;
+}
+
+async function insertCodingAssignmentOrThrow(
+  supabase: SupabaseServerClient,
+  projectId: string,
+  documentId: string,
+  userId: string,
+): Promise<void> {
+  const { error } = await insertCodingAssignment(
+    supabase,
+    projectId,
+    documentId,
+    userId,
+  );
+  if (error) throw new Error(error);
+}
+
+async function promoteToComparisonOrThrow(
+  supabase: SupabaseServerClient,
+  assignmentId: string,
+): Promise<string | undefined> {
+  const { error, conflict } = await promoteToComparison(supabase, assignmentId);
+  if (conflict) return error;
+  if (error) throw new Error(error);
+  return undefined;
+}
+
+async function deleteAssignmentsOrThrow(
+  supabase: SupabaseServerClient,
+  assignmentIds: string[],
+): Promise<void> {
+  const { error } = await supabase.from("assignments").delete().in("id", assignmentIds);
+  if (error) throw new Error(error.message);
+}
+
+async function applyPendingAssignmentTransition(
+  supabase: SupabaseServerClient,
+  projectId: string,
+  documentId: string,
+  userId: string,
+  pendingCoding: { id: string } | undefined,
+  pendingComparison: { id: string } | undefined,
+): Promise<string | undefined> {
+  const transition = `${Number(Boolean(pendingCoding))}${Number(Boolean(pendingComparison))}`;
+  switch (transition) {
+    case "00":
+      await insertCodingAssignmentOrThrow(supabase, projectId, documentId, userId);
+      return undefined;
+    case "10":
+      return promoteToComparisonOrThrow(supabase, pendingCoding!.id);
+    case "01":
+      await deleteAssignmentsOrThrow(supabase, [pendingComparison!.id]);
+      return undefined;
+    case "11":
+      await deleteAssignmentsOrThrow(supabase, [pendingCoding!.id, pendingComparison!.id]);
+      return undefined;
+    default:
+      throw new Error("Transição de atribuição inválida");
+  }
+}
+
 /**
  * Cicla a atribuição de um par (documento, pesquisador) por três estados:
  *   vazio → codificacao → comparacao → vazio
@@ -284,12 +355,8 @@ export async function cycleAssignment(
   const gate = await requireCoordinator(projectId, "Apenas coordenadores podem alterar atribuições.");
   if (!gate.ok) return { error: gate.error };
   const supabase = await createSupabaseServer();
-  const { data: project } = await supabase
-    .from("projects")
-    .select("current_round_id")
-    .eq("id", projectId)
-    .single();
-  if (!project?.current_round_id) return { error: "O projeto não possui uma rodada atual." };
+  const currentRoundId = await getCurrentRoundId(supabase, projectId);
+  if (!currentRoundId) return { error: "O projeto não possui uma rodada atual." };
 
   const { data: existing } = await supabase
     .from("assignments")
@@ -297,7 +364,7 @@ export async function cycleAssignment(
     .eq("document_id", documentId)
     .eq("user_id", userId)
     .eq("project_id", projectId)
-    .eq("round_id", project.current_round_id);
+    .eq("round_id", currentRoundId);
 
   const rows = existing || [];
 
@@ -309,27 +376,15 @@ export async function cycleAssignment(
   const pendingComp = rows.find((r) => r.type === "comparacao");
 
   try {
-    if (!pendingCod && !pendingComp) {
-      // vazio → codificacao
-      const { error } = await insertCodingAssignment(supabase, projectId, documentId, userId);
-      if (error) throw new Error(error);
-    } else if (pendingCod && !pendingComp) {
-      // codificacao → comparacao
-      const { error, conflict } = await promoteToComparison(supabase, pendingCod.id);
-      if (conflict) return { error };
-      if (error) throw new Error(error);
-    } else if (pendingComp && !pendingCod) {
-      // comparacao → vazio
-      const { error } = await supabase.from("assignments").delete().eq("id", pendingComp.id);
-      if (error) throw new Error(error.message);
-    } else if (pendingCod && pendingComp) {
-      // "ambos" (vindo de sorteio): remover tudo para voltar ao vazio
-      const { error } = await supabase
-        .from("assignments")
-        .delete()
-        .in("id", [pendingCod.id, pendingComp.id]);
-      if (error) throw new Error(error.message);
-    }
+    const conflictError = await applyPendingAssignmentTransition(
+      supabase,
+      projectId,
+      documentId,
+      userId,
+      pendingCod,
+      pendingComp,
+    );
+    if (conflictError) return { error: conflictError };
   } catch (e) {
     return { error: errorMessage(e) || "Erro ao alterar a atribuição" };
   }
@@ -347,12 +402,8 @@ export async function clearPendingAssignments(
   const gate = await requireCoordinator(projectId, "Apenas coordenadores podem limpar atribuições.");
   if (!gate.ok) return { error: gate.error };
   const supabase = await createSupabaseServer();
-  const { data: project } = await supabase
-    .from("projects")
-    .select("current_round_id")
-    .eq("id", projectId)
-    .single();
-  if (!project?.current_round_id) return { error: "O projeto não possui uma rodada atual." };
+  const currentRoundId = await getCurrentRoundId(supabase, projectId);
+  if (!currentRoundId) return { error: "O projeto não possui uma rodada atual." };
 
   const { count, error } = await supabase
     .from("assignments")
@@ -360,7 +411,7 @@ export async function clearPendingAssignments(
     .eq("project_id", projectId)
     .eq("status", "pendente")
     .eq("type", type)
-    .eq("round_id", project.current_round_id);
+    .eq("round_id", currentRoundId);
 
   if (error) {
     return { error: error.message || "Erro ao limpar as atribuições pendentes" };

--- a/frontend/src/actions/projects.ts
+++ b/frontend/src/actions/projects.ts
@@ -29,27 +29,21 @@ export async function createProject(_prev: unknown, formData: FormData) {
     ? (rawMode as AutomationMode)
     : "auto_review_llm";
 
-  const { data: project, error } = await supabase
-    .from("projects")
-    .insert({ name, description, created_by: user.id, automation_mode })
-    .select()
-    .single();
+  const { data: projectId, error } = await supabase.rpc(
+    "create_project_with_initial_round",
+    {
+      p_name: name,
+      p_description: description || null,
+      p_created_by: user.id,
+      p_automation_mode: automation_mode,
+    },
+  );
 
   if (error) return { error: error.message };
-
-  // Add creator as coordinator
-  const { error: memberError } = await supabase
-    .from("project_members")
-    .insert({
-      project_id: project.id,
-      user_id: user.id,
-      role: "coordenador",
-    });
-
-  if (memberError) return { error: memberError.message };
+  if (!projectId) return { error: "Não foi possível criar o projeto." };
 
   revalidatePath("/dashboard");
-  redirect(`/projects/${project.id}/documents`);
+  redirect(`/projects/${projectId}/documents`);
 }
 
 // Retorno { error } em vez de throw: o Next mascara a message de erros

--- a/frontend/src/actions/projects.ts
+++ b/frontend/src/actions/projects.ts
@@ -34,7 +34,6 @@ export async function createProject(_prev: unknown, formData: FormData) {
     {
       p_name: name,
       p_description: description || null,
-      p_created_by: user.id,
       p_automation_mode: automation_mode,
     },
   );

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -11,6 +11,8 @@ import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
 export interface SaveResponseOpts {
   notes?: string;
+  /** Rodada exibida quando o formulário foi aberto; evita salvar aba obsoleta. */
+  expectedRoundId?: string;
 }
 
 export type SaveResponseResult =
@@ -62,7 +64,17 @@ async function fetchSaveContext(
   projectId: string,
   documentId: string,
   effectiveId: string,
+  expectedRoundId?: string,
 ) {
+  let existingQuery = supabase
+    .from("responses")
+    .select("id, is_partial, answers, answer_field_hashes")
+    .eq("project_id", projectId)
+    .eq("document_id", documentId)
+    .eq("respondent_id", effectiveId)
+    .eq("respondent_type", "humano");
+  if (expectedRoundId) existingQuery = existingQuery.eq("round_id", expectedRoundId);
+
   const [
     { data: profile },
     { data: existing, error: existingErr },
@@ -74,19 +86,13 @@ async function fetchSaveContext(
       .select("first_name, last_name")
       .eq("id", effectiveId)
       .single(),
-    supabase
-      .from("responses")
-      .select("id, is_partial, answers, answer_field_hashes")
-      .eq("project_id", projectId)
-      .eq("document_id", documentId)
-      .eq("respondent_id", effectiveId)
-      .eq("respondent_type", "humano")
+    existingQuery
       .eq("is_latest", true)
       .maybeSingle<ExistingResponseRow>(),
     supabase
       .from("projects")
       .select(
-        "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, round_strategy, current_round_id, automation_mode",
+        "pydantic_hash, pydantic_fields, schema_version_major, schema_version_minor, schema_version_patch, current_round_id, automation_mode",
       )
       .eq("id", projectId)
       .single(),
@@ -105,7 +111,6 @@ interface SaveResponseProjectFields {
   schema_version_major: number | null;
   schema_version_minor: number | null;
   schema_version_patch: number | null;
-  round_strategy: string | null;
   current_round_id: string | null;
 }
 
@@ -187,8 +192,7 @@ function buildResponsePayload({
 }: BuildResponsePayloadParams) {
   const justifications = notes ? { _notes: notes } : null;
 
-  const roundIdToPersist =
-    project?.round_strategy === "manual" ? (project?.current_round_id ?? null) : null;
+  const roundIdToPersist = project?.current_round_id ?? null;
 
   // Para humanos is_partial descreve O QUE FOI GRAVADO: uma resposta só deixa
   // de ser parcial quando o conjunto gravado satisfaz a régua de completude.
@@ -236,6 +240,7 @@ interface PersistResponseRowParams {
   effectiveId: string;
   respondentName: string;
   payload: Record<string, unknown>;
+  roundId: string;
 }
 
 // "conflict" = outra sessão criou a resposta corrente entre o UPDATE e o
@@ -271,6 +276,7 @@ async function persistResponseRow({
   effectiveId,
   respondentName,
   payload,
+  roundId,
 }: PersistResponseRowParams): Promise<PersistOutcome> {
   // O payload não toca coluna-chave, então este UPDATE não dispara
   // enforce_comparison_response_actor_trigger, que só observa project_id,
@@ -282,6 +288,7 @@ async function persistResponseRow({
     .eq("document_id", documentId)
     .eq("respondent_id", effectiveId)
     .eq("respondent_type", "humano")
+    .eq("round_id", roundId)
     .eq("is_latest", true)
     .select("id");
   if (updErr) return { status: "error", error: updErr.message };
@@ -413,6 +420,7 @@ interface SaveAttemptParams {
   userEmail: string;
   answers: Record<string, unknown>;
   notes?: string;
+  expectedRoundId?: string;
 }
 
 // Uma tentativa completa de gravação: lê o contexto, monta o snapshot a partir
@@ -434,12 +442,29 @@ async function runSaveAttempt({
   userEmail,
   answers,
   notes,
+  expectedRoundId,
 }: SaveAttemptParams): Promise<SaveResponseResult | { conflict: true }> {
   const { profile, existing, existingErr, project, projErr, doc } =
-    await fetchSaveContext(supabase, projectId, documentId, effectiveId);
+    await fetchSaveContext(
+      supabase,
+      projectId,
+      documentId,
+      effectiveId,
+      expectedRoundId,
+    );
 
   const rejection = rejectedSaveContext({ projErr, existingErr, doc });
   if (rejection) return rejection;
+
+  if (!project?.current_round_id) {
+    return { success: false, error: "O projeto não possui uma rodada atual." };
+  }
+  if (expectedRoundId && project.current_round_id !== expectedRoundId) {
+    return {
+      success: false,
+      error: "A rodada mudou enquanto este formulário estava aberto. Recarregue a página.",
+    };
+  }
 
   const respondentName = resolveRespondentName(profile, userEmail);
 
@@ -459,6 +484,7 @@ async function runSaveAttempt({
     effectiveId,
     respondentName,
     payload,
+    roundId: project.current_round_id,
   });
   if (outcome.status === "error")
     return { success: false, error: outcome.error };
@@ -473,6 +499,7 @@ async function runSaveAttempt({
     project,
     existing,
     snapshot,
+    roundId: project.current_round_id,
   });
   if (syncErr) return { success: false, error: syncErr };
 
@@ -491,6 +518,7 @@ async function syncAssignmentAfterSave({
   project,
   existing,
   snapshot,
+  roundId,
 }: {
   supabase: SupabaseServerClient;
   projectId: string;
@@ -500,6 +528,7 @@ async function syncAssignmentAfterSave({
   project: { automation_mode?: string | null } | null | undefined;
   existing: { is_partial: boolean | null } | null | undefined;
   snapshot: { submittedAnswers: Record<string, unknown> };
+  roundId: string;
 }): Promise<string | undefined> {
   if (fields.length === 0) return undefined;
   const { error } = await syncCodingAssignmentStatus(supabase, {
@@ -513,6 +542,7 @@ async function syncAssignmentAfterSave({
     // agora", que é o que impede o rebaixamento descrito em
     // buildResponsePayload.
     hadCompletedResponse: existing?.is_partial === false,
+    roundId,
   });
   return error;
 }
@@ -543,7 +573,7 @@ export async function saveResponse(
   answers: Record<string, unknown>,
   opts: SaveResponseOpts = {},
 ): Promise<SaveResponseResult> {
-  const { notes } = opts;
+  const { notes, expectedRoundId } = opts;
 
   try {
     const actor = await resolveProjectMemberActor(projectId);
@@ -561,6 +591,7 @@ export async function saveResponse(
         userEmail: user.email,
         answers,
         notes,
+        expectedRoundId,
       });
       if (!("conflict" in result)) return result;
 

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -12,7 +12,7 @@ import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 export interface SaveResponseOpts {
   notes?: string;
   /** Rodada exibida quando o formulário foi aberto; evita salvar aba obsoleta. */
-  expectedRoundId?: string;
+  expectedRoundId: string;
 }
 
 export type SaveResponseResult =
@@ -64,16 +64,16 @@ async function fetchSaveContext(
   projectId: string,
   documentId: string,
   effectiveId: string,
-  expectedRoundId?: string,
+  expectedRoundId: string,
 ) {
-  let existingQuery = supabase
+  const existingQuery = supabase
     .from("responses")
     .select("id, is_partial, answers, answer_field_hashes")
     .eq("project_id", projectId)
     .eq("document_id", documentId)
     .eq("respondent_id", effectiveId)
-    .eq("respondent_type", "humano");
-  if (expectedRoundId) existingQuery = existingQuery.eq("round_id", expectedRoundId);
+    .eq("respondent_type", "humano")
+    .eq("round_id", expectedRoundId);
 
   const [
     { data: profile },
@@ -122,6 +122,7 @@ interface BuildResponsePayloadParams {
   stampsCurrentSchema: boolean;
   project: SaveResponseProjectFields | null | undefined;
   existing: { is_partial: boolean | null } | null | undefined;
+  roundId: string;
   notes?: string;
 }
 
@@ -188,11 +189,10 @@ function buildResponsePayload({
   stampsCurrentSchema,
   project,
   existing,
+  roundId,
   notes,
 }: BuildResponsePayloadParams) {
   const justifications = notes ? { _notes: notes } : null;
-
-  const roundIdToPersist = project?.current_round_id ?? null;
 
   // Para humanos is_partial descreve O QUE FOI GRAVADO: uma resposta só deixa
   // de ser parcial quando o conjunto gravado satisfaz a régua de completude.
@@ -223,7 +223,9 @@ function buildResponsePayload({
     justifications,
     answer_field_hashes: answerFieldHashes,
     ...resolveSchemaProvenance({ project, stampsCurrentSchema, existing }),
-    round_id: roundIdToPersist,
+    // O id vem da tela, não da releitura feita durante o save. O trigger do
+    // banco compara este valor sob lock com projects.current_round_id.
+    round_id: roundId,
     is_partial: isPartialToWrite,
     // Marca a codificacao do pesquisador no tempo — alimenta a ordenacao
     // "codificados recentemente" da navegacao da aba Codificar (issue #108).
@@ -248,7 +250,7 @@ interface PersistResponseRowParams {
 type PersistOutcome =
   | { status: "ok" }
   | { status: "conflict" }
-  | { status: "error"; error: string };
+  | { status: "error"; error: string; code?: string };
 
 // O índice único parcial que sustenta o ramo de conflito abaixo. Conferir o
 // nome é o que separa "perdi a corrida, releia" de qualquer outra violação de
@@ -291,7 +293,7 @@ async function persistResponseRow({
     .eq("round_id", roundId)
     .eq("is_latest", true)
     .select("id");
-  if (updErr) return { status: "error", error: updErr.message };
+  if (updErr) return { status: "error", error: updErr.message, code: updErr.code };
   if (updated && updated.length > 0) return { status: "ok" };
 
   const { error: insErr } = await supabase.from("responses").insert({
@@ -310,7 +312,7 @@ async function persistResponseRow({
   ) {
     return { status: "conflict" };
   }
-  return { status: "error", error: insErr.message };
+  return { status: "error", error: insErr.message, code: insErr.code };
 }
 
 // Propaga o efeito do envio para as telas que leem a mesma resposta —
@@ -331,6 +333,7 @@ interface BuildSaveWriteParams {
   existing: ExistingResponseRow | null | undefined;
   project: SaveResponseProjectFields | null | undefined;
   answers: Record<string, unknown>;
+  roundId: string;
   notes?: string;
 }
 
@@ -343,6 +346,7 @@ function buildSaveWrite({
   existing,
   project,
   answers,
+  roundId,
   notes,
 }: BuildSaveWriteParams) {
   // O formulário devolve um snapshot sanitizado, não um patch. A reconciliação
@@ -376,6 +380,7 @@ function buildSaveWrite({
     stampsCurrentSchema: snapshot.stampsCurrentSchema,
     project,
     existing,
+    roundId,
     notes,
   });
 
@@ -420,7 +425,7 @@ interface SaveAttemptParams {
   userEmail: string;
   answers: Record<string, unknown>;
   notes?: string;
-  expectedRoundId?: string;
+  expectedRoundId: string;
 }
 
 // Uma tentativa completa de gravação: lê o contexto, monta o snapshot a partir
@@ -459,7 +464,7 @@ async function runSaveAttempt({
   if (!project?.current_round_id) {
     return { success: false, error: "O projeto não possui uma rodada atual." };
   }
-  if (expectedRoundId && project.current_round_id !== expectedRoundId) {
+  if (project.current_round_id !== expectedRoundId) {
     return {
       success: false,
       error: "A rodada mudou enquanto este formulário estava aberto. Recarregue a página.",
@@ -474,6 +479,7 @@ async function runSaveAttempt({
     existing,
     project,
     answers,
+    roundId: expectedRoundId,
     notes,
   });
 
@@ -484,10 +490,17 @@ async function runSaveAttempt({
     effectiveId,
     respondentName,
     payload,
-    roundId: project.current_round_id,
+    roundId: expectedRoundId,
   });
-  if (outcome.status === "error")
-    return { success: false, error: outcome.error };
+  if (outcome.status === "error") {
+    return {
+      success: false,
+      error:
+        outcome.code === "40001"
+          ? "A rodada mudou enquanto este formulário estava aberto. Recarregue a página."
+          : outcome.error,
+    };
+  }
   if (outcome.status === "conflict") return { conflict: true };
 
   const syncErr = await syncAssignmentAfterSave({
@@ -499,7 +512,7 @@ async function runSaveAttempt({
     project,
     existing,
     snapshot,
-    roundId: project.current_round_id,
+    roundId: expectedRoundId,
   });
   if (syncErr) return { success: false, error: syncErr };
 
@@ -571,7 +584,7 @@ export async function saveResponse(
   projectId: string,
   documentId: string,
   answers: Record<string, unknown>,
-  opts: SaveResponseOpts = {},
+  opts: SaveResponseOpts,
 ): Promise<SaveResponseResult> {
   const { notes, expectedRoundId } = opts;
 

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/__tests__/page.test.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/__tests__/page.test.tsx
@@ -14,6 +14,7 @@ function makeClient() {
       for (const method of ["select", "eq", "is", "order"]) {
         builder[method] = () => builder;
       }
+      builder.single = async () => ({ data: { current_round_id: null }, error: null });
       builder.then = (resolve: (value: unknown) => unknown) =>
         resolve({ data: [], error: null });
       return builder;

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
@@ -9,6 +9,7 @@ import { LotteryDialog } from "@/components/assignments/LotteryDialog";
 import { ClearPendingButton } from "@/components/assignments/ClearPendingButton";
 import type { ProjectMember } from "@/lib/types";
 import { notFound } from "next/navigation";
+import Link from "next/link";
 import {
   activeAliasMemberIds,
   clerkMappingAccessStatesByUserId,
@@ -87,10 +88,16 @@ async function getMembers(
 
 export default async function AssignmentsPage({
   params,
+  searchParams,
 }: {
   params: Promise<{ id: string }>;
+  searchParams?: Promise<{ round?: string }>;
 }) {
-  const [{ id }, user] = await Promise.all([params, requirePageAuthUser()]);
+  const [{ id }, query, user] = await Promise.all([
+    params,
+    searchParams ?? Promise.resolve<{ round?: string }>({}),
+    requirePageAuthUser(),
+  ]);
   const access = requireResolvedProjectAccess(
     await getProjectAccessContext(id, user),
   );
@@ -98,16 +105,25 @@ export default async function AssignmentsPage({
 
   const supabase = await createSupabaseServer();
 
-  const [documents, memberState, { data: assignments }] = await Promise.all([
+  const [documents, memberState, { data: project }, { data: rounds }] = await Promise.all([
     getCachedDocuments(id),
     getMembers(supabase, id),
+    supabase.from("projects").select("current_round_id").eq("id", id).single(),
+    supabase.from("rounds").select("id, label, created_at").eq("project_id", id).order("created_at", { ascending: false }),
+  ]);
+  const selectedRoundId = (rounds ?? []).some((round) => round.id === query.round)
+    ? query.round!
+    : project?.current_round_id;
+  const isCurrentRound = selectedRoundId === project?.current_round_id;
+  const { data: assignments } = await (
     supabase
       .from("assignments")
       .select(
-        "id, project_id, document_id, user_id, status, type, batch_id, completed_at",
+        "id, project_id, document_id, user_id, status, type, batch_id, completed_at, round_id",
       )
-      .eq("project_id", id),
-  ]);
+      .eq("project_id", id)
+      .eq("round_id", selectedRoundId ?? "00000000-0000-0000-0000-000000000000")
+  );
 
   type TypedMember = ProjectMember & {
     profiles: {
@@ -184,10 +200,21 @@ export default async function AssignmentsPage({
           </span>
         </div>
         <div className="flex items-center gap-2">
-          {hasPending && (
+          {(rounds ?? []).map((round) => (
+            <Link
+              key={round.id}
+              href={`/projects/${id}/analyze/assignments?round=${round.id}`}
+              className={round.id === selectedRoundId ? "text-sm font-medium text-brand" : "text-sm text-muted-foreground"}
+            >
+              {round.label}
+            </Link>
+          ))}
+          {access.isCoordinator && isCurrentRound && hasPending && (
             <ClearPendingButton projectId={id} pendingByType={pendingByType} />
           )}
-          <LotteryDialog projectId={id} members={lotteryMembers} />
+          {access.isCoordinator && isCurrentRound && (
+            <LotteryDialog projectId={id} members={lotteryMembers} />
+          )}
         </div>
       </div>
       <AssignmentTable
@@ -195,6 +222,7 @@ export default async function AssignmentsPage({
         documents={sortedDocuments}
         researchers={allResearchersForTable}
         assignments={assignments || []}
+        readOnly={!access.isCoordinator || !isCurrentRound}
       />
     </div>
   );

--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -14,18 +14,14 @@ import type {
   Assignment,
   PydanticField,
   Round,
-  RoundStrategy,
 } from "@/lib/types";
 import {
   classifyDocStatus,
-  versionLabel,
   getCurrentRoundDescriptor,
-  compareVersionLabels,
   resolveRoundFilter,
   CURRENT_FILTER_VALUE,
   type RoundContext,
   type ResponseRoundFields,
-  type SchemaVersion,
   type DocRoundStatus,
 } from "@/lib/rounds";
 
@@ -58,26 +54,14 @@ export default async function CodePage({
 
   const supabase = await createSupabaseServer();
 
-  const [
-    { data: project },
-    { data: assignments },
-    { data: rounds },
-    { data: pendingExclusions },
-  ] = await Promise.all([
+  const [{ data: project }, { data: rounds }, { data: pendingExclusions }] = await Promise.all([
     supabase
       .from("projects")
       .select(
-        "pydantic_fields, round_strategy, current_round_id, schema_version_major, schema_version_minor, schema_version_patch, out_of_scope_enabled",
+        "pydantic_fields, current_round_id, out_of_scope_enabled",
       )
       .eq("id", id)
       .single(),
-    supabase
-      .from("assignments")
-      .select("id, status, document_id, documents!inner(id, external_id, title, text)")
-      .eq("project_id", id)
-      .eq("user_id", queueUserId)
-      .eq("type", "codificacao")
-      .is("documents.excluded_at", null),
     supabase
       .from("rounds")
       .select("id, project_id, label, created_at")
@@ -93,6 +77,39 @@ export default async function CodePage({
       .eq("kind", "exclusion_request")
       .is("resolved_at", null)
       .is("rejected_at", null),
+  ]);
+
+  const ctx: RoundContext = {
+    strategy: "manual",
+    currentRoundId: project?.current_round_id ?? null,
+    currentVersion: { major: 0, minor: 0, patch: 0 },
+    rounds: (rounds ?? []) as Round[],
+  };
+  const roundsById = new Map(ctx.rounds.map((r) => [r.id, r]));
+  const { key: currentRoundKey, label: currentRoundLabel } =
+    getCurrentRoundDescriptor(ctx, roundsById);
+  const effectiveRound = resolveRoundFilter(roundParam, ctx, currentRoundKey, []);
+  const selectedRoundId =
+    effectiveRound === CURRENT_FILTER_VALUE ? ctx.currentRoundId : effectiveRound;
+
+  const [{ data: assignments }, { data: responses }] = await Promise.all([
+    supabase
+      .from("assignments")
+      .select("id, status, document_id, round_id, documents!inner(id, external_id, title, text)")
+      .eq("project_id", id)
+      .eq("user_id", queueUserId)
+      .eq("type", "codificacao")
+      .eq("round_id", selectedRoundId ?? "00000000-0000-0000-0000-000000000000")
+      .is("documents.excluded_at", null),
+    supabase
+      .from("responses")
+      .select(
+        "document_id, answers, justifications, round_id, schema_version_major, schema_version_minor, schema_version_patch, is_partial, updated_at",
+      )
+      .eq("project_id", id)
+      .eq("respondent_id", queueUserId)
+      .eq("respondent_type", "humano")
+      .eq("round_id", selectedRoundId ?? "00000000-0000-0000-0000-000000000000"),
   ]);
 
   const pendingExclusionByDoc: Record<string, string> = {};
@@ -132,17 +149,6 @@ export default async function CodePage({
   // Responses incluem agora round_id e schema_version para classificacao por rodada.
   // Filtra respondent_type=humano: respostas LLM usam respondent_id NULL, mas o
   // filtro explícito alinha com saveResponse e protege contra colisões futuras.
-  const docIds = allDocuments.map((d) => d.id);
-  const { data: responses } = await supabase
-    .from("responses")
-    .select(
-      "document_id, answers, justifications, round_id, schema_version_major, schema_version_minor, schema_version_patch, is_partial, updated_at",
-    )
-    .eq("project_id", id)
-    .eq("respondent_id", queueUserId)
-    .eq("respondent_type", "humano")
-    .in("document_id", docIds.length > 0 ? docIds : ["__none__"]);
-
   const responseByDoc = new Map<
     string,
     ResponseRoundFields & {
@@ -169,55 +175,6 @@ export default async function CodePage({
     if (r.updated_at) codedAtByDoc[r.document_id] = r.updated_at;
   });
 
-  const currentVersion: SchemaVersion = {
-    major: project?.schema_version_major ?? 0,
-    minor: project?.schema_version_minor ?? 1,
-    patch: project?.schema_version_patch ?? 0,
-  };
-  const strategy: RoundStrategy =
-    (project?.round_strategy as RoundStrategy) ?? "schema_version";
-  const ctx: RoundContext = {
-    strategy,
-    currentRoundId: project?.current_round_id ?? null,
-    currentVersion,
-    rounds: (rounds ?? []) as Round[],
-  };
-  const roundsById = new Map(ctx.rounds.map((r) => [r.id, r]));
-
-  // Versoes anteriores presentes em responses — so faz sentido em schema_version.
-  // Em manual, o select de rodadas anteriores vem da tabela `rounds`.
-  // Sort numerico (compareVersionLabels) para ordenar 0.9.0 < 0.10.0 corretamente.
-  const previousVersions =
-    strategy === "schema_version"
-      ? Array.from(
-          new Set(
-            (responses ?? [])
-              .map((r) => {
-                const m = r.schema_version_major;
-                const n = r.schema_version_minor;
-                const p = r.schema_version_patch;
-                if (m == null || n == null || p == null) return null;
-                const v = versionLabel({ major: m, minor: n, patch: p });
-                if (v === versionLabel(currentVersion)) return null;
-                return v;
-              })
-              .filter((v): v is string => v != null),
-          ),
-        ).sort(compareVersionLabels)
-      : [];
-
-  const { key: currentRoundKey, label: currentRoundLabel } =
-    getCurrentRoundDescriptor(ctx, roundsById);
-
-  // Normaliza ?round= para evitar lista vazia silenciosa (URL manipulada,
-  // troca de estrategia com filtro stale, ou ?round=<currentRoundKey>).
-  const effectiveRound = resolveRoundFilter(
-    roundParam,
-    ctx,
-    currentRoundKey,
-    previousVersions,
-  );
-
   // Estado por documento, capturado do MESMO `classifyDocStatus` que decide o
   // filtro: a tela precisa dizer à pesquisadora por que o documento à sua frente
   // está na fila (parcial dela × resposta de rodada anterior), e classificar de
@@ -235,19 +192,12 @@ export default async function CodePage({
     const status = classifyDocStatus(ctx, resp ?? null, roundsById);
     statusByDoc[d.id] = status;
 
-    if (effectiveRound === "all") return true;
     if (effectiveRound === CURRENT_FILTER_VALUE) {
       // Padrao: mostra docs que ainda precisam ser respondidos na rodada atual
       // (sem resposta OU resposta de rodada anterior). Concluidos da atual saem.
       return status.kind !== "current_done";
     }
-    // Rodada especifica: id (manual) ou label (schema_version)
-    if (strategy === "manual") {
-      return resp?.round_id === effectiveRound;
-    }
-    return (
-      status.kind === "previous" && status.label === effectiveRound
-    );
+    return true;
   });
 
   const allFields = (project?.pydantic_fields || []) as PydanticField[];
@@ -271,7 +221,7 @@ export default async function CodePage({
   // que pesquisador edite achando que ainda esta na rodada antiga.
   // (Salvar promove para a rodada atual de qualquer jeito.)
   const isViewingPreviousRound =
-    effectiveRound !== CURRENT_FILTER_VALUE && effectiveRound !== "all";
+    effectiveRound !== CURRENT_FILTER_VALUE;
 
   return (
     <Suspense fallback={<div className="p-6 text-sm text-muted-foreground">Carregando…</div>}>
@@ -290,11 +240,9 @@ export default async function CodePage({
         pendingExclusionByDoc={pendingExclusionByDoc}
         readOnly={isImpersonating || isViewingPreviousRound}
         roundFilter={{
-          strategy,
           currentRoundKey,
           currentRoundLabel,
           rounds: ctx.rounds,
-          previousVersions,
           selected: effectiveRound,
         }}
       />

--- a/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/config/rounds/page.tsx
@@ -3,8 +3,7 @@ import { getProjectAccessContext } from "@/lib/auth";
 import { requirePageAuthUser } from "@/lib/page-auth";
 import { RoundsConfig } from "@/components/config/RoundsConfig";
 import { requireResolvedProjectAccess } from "@/lib/project-access";
-import type { Round, RoundStrategy } from "@/lib/types";
-import { versionLabel } from "@/lib/rounds";
+import type { Round } from "@/lib/types";
 
 export default async function RoundsConfigPage({
   params,
@@ -20,9 +19,7 @@ export default async function RoundsConfigPage({
   const [{ data: project }, { data: rounds }, accessResult] = await Promise.all([
     supabase
       .from("projects")
-      .select(
-        "round_strategy, current_round_id, schema_version_major, schema_version_minor, schema_version_patch",
-      )
+      .select("current_round_id")
       .eq("id", id)
       .single(),
     supabase
@@ -33,23 +30,13 @@ export default async function RoundsConfigPage({
     getProjectAccessContext(id, user),
   ]);
 
-  const { isCoordinator } = requireResolvedProjectAccess(accessResult);
-
-  const currentVersion = versionLabel({
-    major: project?.schema_version_major ?? 0,
-    minor: project?.schema_version_minor ?? 1,
-    patch: project?.schema_version_patch ?? 0,
-  });
+  requireResolvedProjectAccess(accessResult);
 
   return (
     <div className="mx-auto max-w-3xl p-6">
       <RoundsConfig
-        projectId={id}
-        strategy={(project?.round_strategy as RoundStrategy) ?? "schema_version"}
         currentRoundId={project?.current_round_id ?? null}
-        currentVersion={currentVersion}
         rounds={(rounds ?? []) as Round[]}
-        isCoordinator={isCoordinator}
       />
     </div>
   );

--- a/frontend/src/components/assignments/AssignmentTable.tsx
+++ b/frontend/src/components/assignments/AssignmentTable.tsx
@@ -17,6 +17,7 @@ interface AssignmentTableProps {
   documents: Pick<Document, "id" | "external_id">[];
   researchers: (ProjectMember & { profiles: { first_name: string | null; email: string } })[];
   assignments: Assignment[];
+  readOnly?: boolean;
 }
 
 type CellState = {
@@ -59,6 +60,7 @@ function cycleOptimistic(
     type,
     batch_id: null,
     completed_at: null,
+    round_id: "optimistic",
   });
 
   if (!hasCod && !hasComp) return [...others, stub("codificacao")];
@@ -68,7 +70,7 @@ function cycleOptimistic(
   return others;
 }
 
-export function AssignmentTable({ projectId, documents, researchers, assignments }: AssignmentTableProps) {
+export function AssignmentTable({ projectId, documents, researchers, assignments, readOnly = false }: AssignmentTableProps) {
   const [isPending, startTransition] = useTransition();
 
   const [optimisticAssignments, applyOptimistic] = useOptimistic(
@@ -157,11 +159,11 @@ export function AssignmentTable({ projectId, documents, researchers, assignments
                     <button
                       type="button"
                       onClick={() => handleCycle(doc.id, r.user_id)}
-                      disabled={isNonRemovable || isPending}
+                      disabled={readOnly || isNonRemovable || isPending}
                       className={cn(
                         "relative size-6 rounded border transition-colors",
                         baseColor,
-                        (isNonRemovable || isPending) && "cursor-default",
+                        (readOnly || isNonRemovable || isPending) && "cursor-default",
                       )}
                       aria-label={
                         !hasAny

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Separator } from "@/components/ui/separator";
+import { Checkbox } from "@/components/ui/checkbox";
 import type { LotteryMode } from "@/lib/lottery-utils";
 import type { LotteryMember } from "./lottery-dialog-types";
 import { useLotteryStats } from "./useLotteryStats";
@@ -37,8 +38,11 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
   const { stats, statsError } = useLotteryStats(projectId, open);
 
   const params = useLotteryParams();
-  const { type, setType, mode, setMode, label, setLabel, setPreviewState } =
-    params;
+  const {
+    type, setType, targetKind, setTargetKind, roundLabel, setRoundLabel,
+    confirmOpenWork, setConfirmOpenWork, mode, setMode, label, setLabel,
+    setPreviewState,
+  } = params;
 
   const {
     isComparacao,
@@ -99,7 +103,11 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
             <Label>Tipo</Label>
             <RadioGroup
               value={type}
-              onValueChange={(v) => setType(v as "codificacao" | "comparacao")}
+              onValueChange={(v) => {
+                const nextType = v as "codificacao" | "comparacao";
+                setType(nextType);
+                if (nextType === "comparacao") setTargetKind("current");
+              }}
               className="mt-2 flex gap-4"
             >
               <div className="flex items-center gap-2">
@@ -121,6 +129,58 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
                   ? "Elegíveis: documentos com ao menos 1 codificação humana e 1 resposta do LLM."
                   : `Elegíveis: documentos com ao menos ${stats?.minResponsesForComparison ?? 2} codificações humanas.`}
               </p>
+            )}
+          </div>
+
+          <Separator />
+
+          <div className="space-y-2">
+            <Label>Rodada</Label>
+            <RadioGroup
+              value={targetKind}
+              onValueChange={(value) => {
+                setTargetKind(value as "current" | "new");
+                setConfirmOpenWork(false);
+              }}
+              className="space-y-1"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="current" id="round-current" />
+                <Label htmlFor="round-current" className="font-normal">
+                  Rodada atual{stats?.currentRoundLabel ? ` — ${stats.currentRoundLabel}` : ""}
+                </Label>
+              </div>
+              {!isComparacao && (
+                <div className="flex items-center gap-2">
+                  <RadioGroupItem value="new" id="round-new" />
+                  <Label htmlFor="round-new" className="font-normal">Iniciar nova rodada</Label>
+                </div>
+              )}
+            </RadioGroup>
+            {targetKind === "new" && (
+              <div className="space-y-2 pt-1">
+                <Input
+                  aria-label="Nome da nova rodada"
+                  placeholder="Ex: Segunda rodada"
+                  value={roundLabel}
+                  onChange={(event) => setRoundLabel(event.target.value)}
+                />
+                {(stats?.openAssignmentCount ?? 0) > 0 && (
+                  <div className="flex items-start gap-2 rounded-md border p-3">
+                    <Checkbox
+                      id="confirm-open-work"
+                      checked={confirmOpenWork}
+                      onCheckedChange={(checked) => setConfirmOpenWork(checked === true)}
+                    />
+                    <Label htmlFor="confirm-open-work" className="font-normal leading-snug">
+                      Confirmo iniciar a nova rodada apesar de {stats?.openAssignmentCount} atribuições em andamento ou pendentes na rodada atual.
+                    </Label>
+                  </div>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  As respostas anteriores ficam no histórico; os documentos começam sem respostas nesta rodada.
+                </p>
+              </div>
             )}
           </div>
 

--- a/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
+++ b/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
@@ -42,6 +42,9 @@ const stats: LotteryStats = {
   batches: [],
   minResponsesForComparison: 2,
   automationMode: null,
+  currentRoundId: "round-1",
+  currentRoundLabel: "Rodada inicial",
+  openAssignmentCount: 0,
 };
 
 const previewResult: LotteryPreview = {

--- a/frontend/src/components/assignments/lottery-dialog-types.ts
+++ b/frontend/src/components/assignments/lottery-dialog-types.ts
@@ -21,6 +21,9 @@ export interface LotteryStats {
   batches: { id: string; label: string | null; createdAt: string }[];
   minResponsesForComparison: number;
   automationMode: string | null;
+  currentRoundId?: string | null;
+  currentRoundLabel?: string | null;
+  openAssignmentCount?: number;
 }
 
 export type CodingsFilterMode = "all" | "none" | "atMost";

--- a/frontend/src/components/assignments/useLotteryParams.ts
+++ b/frontend/src/components/assignments/useLotteryParams.ts
@@ -14,6 +14,9 @@ import type { CodingsFilterMode } from "./lottery-dialog-types";
 export function useLotteryParams() {
   // Tipo do sorteio (codificação ou comparação)
   const [type, setType] = useState<"codificacao" | "comparacao">("codificacao");
+  const [targetKind, setTargetKind] = useState<"current" | "new">("current");
+  const [roundLabel, setRoundLabel] = useState("");
+  const [confirmOpenWork, setConfirmOpenWork] = useState(false);
 
   // Distribuição
   const [researchersPerDoc, setResearchersPerDoc] = useState(2);
@@ -64,6 +67,12 @@ export function useLotteryParams() {
   return {
     type,
     setType,
+    targetKind,
+    setTargetKind,
+    roundLabel,
+    setRoundLabel,
+    confirmOpenWork,
+    setConfirmOpenWork,
     researchersPerDoc,
     setResearchersPerDoc,
     docsPerResearcherEnabled,

--- a/frontend/src/components/assignments/useLotteryRun.ts
+++ b/frontend/src/components/assignments/useLotteryRun.ts
@@ -42,6 +42,9 @@ export function useLotteryRun({
 
   const {
     type,
+    targetKind,
+    roundLabel,
+    confirmOpenWork,
     researchersPerDoc,
     docsPerResearcherEnabled,
     docsPerResearcher,
@@ -148,7 +151,16 @@ export function useLotteryRun({
   // Contagem de elegíveis ao vivo, com a mesma função pura do server
   const eligibleCount = useMemo(() => {
     if (!stats) return null;
-    let candidates = stats.docs;
+    let candidates = targetKind === "new"
+      ? stats.docs.map((doc) => ({
+          ...doc,
+          humanCodingCount: 0,
+          hasLlmResponse: false,
+          activeAssignments: { codificacao: 0, comparacao: 0 },
+          hasAnyAssignmentEver: false,
+          batchIds: [],
+        }))
+      : stats.docs;
     if (isComparacao) {
       candidates = filterComparisonEligible(
         candidates,
@@ -157,10 +169,18 @@ export function useLotteryRun({
       );
     }
     return filterEligibleDocs(candidates, type, filters).length;
-  }, [stats, type, isComparacao, filters]);
+  }, [stats, type, isComparacao, filters, targetKind]);
 
   const blockedMessage =
-    participantIds.length === 0
+    !stats?.currentRoundId
+      ? "O projeto não tem uma rodada atual."
+      : targetKind === "new" && type !== "codificacao"
+        ? "Uma nova rodada começa com um sorteio de codificação."
+        : targetKind === "new" && !roundLabel.trim()
+          ? "Informe o nome da nova rodada."
+        : targetKind === "new" && (stats.openAssignmentCount ?? 0) > 0 && !confirmOpenWork
+            ? "Confirme a abertura da nova rodada com trabalho ainda aberto."
+            : participantIds.length === 0
       ? "Nenhum participante selecionado."
       : eligibleCount === 0
         ? "Nenhum documento passa nos filtros atuais."
@@ -182,6 +202,17 @@ export function useLotteryRun({
       filters,
       participantIds,
       participantSettings,
+      target: targetKind === "new"
+        ? {
+            kind: "new" as const,
+            expectedRoundId: stats?.currentRoundId ?? "",
+            roundLabel: roundLabel.trim(),
+            confirmOpenWork,
+          }
+        : {
+            kind: "current" as const,
+            expectedRoundId: stats?.currentRoundId ?? "",
+          },
     };
     // A união discriminada não tem researchersPerDoc no braço de comparação —
     // um revisor por documento é a regra, não uma configuração.

--- a/frontend/src/components/assignments/useLotteryStats.ts
+++ b/frontend/src/components/assignments/useLotteryStats.ts
@@ -27,6 +27,9 @@ export function useLotteryStats(projectId: string, open: boolean) {
               batches: s.batches ?? [],
               minResponsesForComparison: s.minResponsesForComparison ?? 2,
               automationMode: s.automationMode ?? null,
+              currentRoundId: s.currentRoundId ?? null,
+              currentRoundLabel: s.currentRoundLabel ?? null,
+              openAssignmentCount: s.openAssignmentCount ?? 0,
             },
             error: false,
           });

--- a/frontend/src/components/coding/CodingHeader.tsx
+++ b/frontend/src/components/coding/CodingHeader.tsx
@@ -192,20 +192,13 @@ function RoundSelect({ data }: { data: RoundFilterData }) {
           <SelectItem value={CURRENT_FILTER_VALUE}>
             Atual ({data.currentRoundLabel}): pendentes
           </SelectItem>
-          <SelectItem value="all">Todas as rodadas</SelectItem>
-          {data.strategy === "manual"
-            ? data.rounds
-                .filter((r) => r.id !== data.currentRoundKey)
-                .map((r) => (
-                  <SelectItem key={r.id} value={r.id}>
-                    {r.label}
-                  </SelectItem>
-                ))
-            : data.previousVersions.map((v) => (
-                <SelectItem key={v} value={v}>
-                  Versão {v}
-                </SelectItem>
-              ))}
+          {data.rounds
+            .filter((r) => r.id !== data.currentRoundKey)
+            .map((r) => (
+              <SelectItem key={r.id} value={r.id}>
+                {r.label}
+              </SelectItem>
+            ))}
         </SelectContent>
       </Select>
     </div>

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -28,15 +28,12 @@ import type {
   PydanticField,
   AssignedDoc,
   Round,
-  RoundStrategy,
 } from "@/lib/types";
 
 export interface RoundFilterData {
-  strategy: RoundStrategy;
   currentRoundKey: string;
   currentRoundLabel: string;
   rounds: Round[];
-  previousVersions: string[];
   selected: string;
 }
 
@@ -282,6 +279,7 @@ function CodingPageInner({
 
   const assigned = useAssignedCoding({
     projectId,
+    currentRoundId: roundFilter?.currentRoundKey ?? "",
     documents,
     // `orderedFields`, e não `fields`: o toast de pendência nomeia a primeira
     // obrigatória em aberto NESTA ordem, que é a mesma em que o painel procura o
@@ -308,6 +306,7 @@ function CodingPageInner({
 
   const browse = useBrowseCoding({
     projectId,
+    currentRoundId: roundFilter?.currentRoundKey ?? "",
     documents,
     // Mesma razão do modo Atribuídos: a ordem daqui é a que o toast nomeia.
     fields: orderedFields,

--- a/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
@@ -106,6 +106,13 @@ vi.mock("@/components/coding/FullscreenNav", () => ({
 
 import { CodingPage } from "@/components/coding/CodingPage";
 
+const ROUND_FILTER = {
+  currentRoundKey: "round-1",
+  currentRoundLabel: "Rodada inicial",
+  rounds: [],
+  selected: "round-1",
+};
+
 const FIELDS: PydanticField[] = [
   { name: "q1", type: "text", options: null, description: "" },
 ];
@@ -163,6 +170,7 @@ describe("CodingPage — documento inicial (#608)", () => {
   it("abre na primeira codificação incompleta, não no primeiro da lista", async () => {
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={TRES}
@@ -181,6 +189,7 @@ describe("CodingPage — documento inicial (#608)", () => {
     // ela mexeu, e pular dali quebraria "retomar de onde parei".
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={TRES}
@@ -200,6 +209,7 @@ describe("CodingPage — documento inicial (#608)", () => {
     urlParams.current = { doc: "a3" };
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={TRES}
@@ -216,6 +226,7 @@ describe("CodingPage — documento inicial (#608)", () => {
   it("sem statusByDoc (prop ausente) cai no índice 0 sem quebrar", async () => {
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={TRES}
@@ -245,6 +256,7 @@ describe("CodingPage — onSubmit devolve o veredito do servidor (#608)", () => 
     const user = userEvent.setup();
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={UM}
@@ -266,6 +278,7 @@ describe("CodingPage — onSubmit devolve o veredito do servidor (#608)", () => 
     const user = userEvent.setup();
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={UM}
@@ -306,6 +319,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
 
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}
@@ -326,13 +340,14 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
       "p1",
       "a1",
       { q1: "sim" },
-      { notes: "" },
+      { notes: "", expectedRoundId: "round-1" },
     );
   });
 
   it("documento normal: renderiza o doc certo com as respostas existentes", async () => {
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1"), assignedDoc("a2")]}
@@ -351,6 +366,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
   it("fora do escopo habilitado no projeto: config chega ao QuestionsPanel com status normal", async () => {
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}
@@ -376,6 +392,7 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
   it("fora do escopo com pendência do próprio usuário: status pending_mine com o motivo", async () => {
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}

--- a/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
@@ -146,6 +146,13 @@ vi.mock("@/components/coding/FullscreenNav", () => ({
 
 import { CodingPage } from "@/components/coding/CodingPage";
 
+const ROUND_FILTER = {
+  currentRoundKey: "round-1",
+  currentRoundLabel: "Rodada inicial",
+  rounds: [],
+  selected: "round-1",
+};
+
 const FIELDS: PydanticField[] = [
   { name: "q1", type: "text", options: null, description: "" },
 ];
@@ -210,7 +217,7 @@ describe("CodingPage/Explorar — o veredito do servidor atravessa o BrowseDocCo
     });
 
     render(
-      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage roundFilter={ROUND_FILTER} userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -227,7 +234,7 @@ describe("CodingPage/Explorar — o veredito do servidor atravessa o BrowseDocCo
     saveResponse.mockResolvedValue({ success: true, missingRequiredFields: [] });
 
     render(
-      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage roundFilter={ROUND_FILTER} userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -249,7 +256,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     saveResponse.mockResolvedValue({ success: true, missingRequiredFields: [] });
 
     render(
-      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage roundFilter={ROUND_FILTER} userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -276,7 +283,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     saveResponse.mockResolvedValue({ success: true, missingRequiredFields: [] });
 
     render(
-      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage roundFilter={ROUND_FILTER} userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     expect((await screen.findByTestId("count-d1")).textContent).toBe("0");
@@ -300,7 +307,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     );
 
     render(
-      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage roundFilter={ROUND_FILTER} userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -330,6 +337,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
 
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId="user-teste"
         projectId="p1"
         documents={[assignedDoc("a1")]}
@@ -351,7 +359,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     getDocumentForCoding.mockResolvedValue(codingResult("d1", null));
 
     render(
-      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage roundFilter={ROUND_FILTER} userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));
@@ -391,7 +399,7 @@ describe("CodingPage — modo Explorar (integração)", () => {
     );
 
     render(
-      <CodingPage userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
+      <CodingPage roundFilter={ROUND_FILTER} userId="user-teste" projectId="p1" documents={[]} fields={FIELDS} existingAnswers={{}} />,
     );
 
     await userEvent.click(await screen.findByText("pick-d1"));

--- a/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
@@ -91,6 +91,13 @@ import { CodingPage } from "@/components/coding/CodingPage";
 import { codingDraftStorageKey, parseCodingDraft } from "@/lib/coding-draft";
 import { requestNavigation } from "@/lib/unsaved-work-guard";
 
+const ROUND_FILTER = {
+  currentRoundKey: "round-1",
+  currentRoundLabel: "Rodada inicial",
+  rounds: [],
+  selected: "round-1",
+};
+
 const USER = "user-teste";
 const PROJECT = "p1";
 const DOC = "d1";
@@ -126,6 +133,7 @@ function renderPage(
 ) {
   return render(
     <CodingPage
+      roundFilter={ROUND_FILTER}
       userId={USER}
       projectId={PROJECT}
       documents={documents}
@@ -374,6 +382,7 @@ describe("veredito do servidor chega ao painel (#608, critério 5)", () => {
     const user = userEvent.setup();
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId={USER}
         projectId={PROJECT}
         documents={[assignedDoc(DOC)]}
@@ -409,6 +418,7 @@ describe("veredito do servidor chega ao painel (#608, critério 5)", () => {
     const user = userEvent.setup();
     render(
       <CodingPage
+        roundFilter={ROUND_FILTER}
         userId={USER}
         projectId={PROJECT}
         documents={[assignedDoc(DOC)]}

--- a/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useAssignedCoding.test.ts
@@ -38,6 +38,7 @@ function setup(overrides?: {
   const dirty = overrides?.dirty ?? new Set<string>();
   const params = {
     projectId: "p1",
+    currentRoundId: "round-1",
     documents: DOCS,
     fields: overrides?.fields ?? [],
     sortedDocuments: DOCS,
@@ -93,6 +94,7 @@ describe("useAssignedCoding", () => {
     });
     expect(mockSave).toHaveBeenCalledWith("p1", "d1", { q1: "sim" }, {
       notes: "",
+      expectedRoundId: "round-1",
     });
     expect(params.markClean).toHaveBeenCalledWith("d1");
     expect(view.result.current.currentDoc?.id).toBe("d2");

--- a/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
+++ b/frontend/src/components/coding/__tests__/useBrowseCoding.test.ts
@@ -66,6 +66,7 @@ function setDoc(over?: Partial<ReturnType<typeof useDocumentForCoding>>) {
 function setup(docParam: string | null, dirty = new Set<string>()) {
   const params = {
     projectId: "p1",
+    currentRoundId: "round-1",
     documents: [], // nenhum atribuído → docParam vira browseDocId
     fields: [],
     mode: "browse" as const,
@@ -105,7 +106,10 @@ describe("useBrowseCoding", () => {
       await view.result.current.handleBrowseSubmit({ answers: { q: "sim" }, notes: "n" });
     });
 
-    expect(mockSave).toHaveBeenCalledWith("p1", "b1", { q: "sim" }, { notes: "n" });
+    expect(mockSave).toHaveBeenCalledWith("p1", "b1", { q: "sim" }, {
+      notes: "n",
+      expectedRoundId: "round-1",
+    });
     expect(params.markClean).toHaveBeenCalledWith("b1");
     expect(markResponded).toHaveBeenCalledWith("b1");
     expect(invalidate).toHaveBeenCalledWith("b1");

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -83,6 +83,7 @@ function notesFromJustifications(
 
 interface UseAssignedCodingParams {
   projectId: string;
+  currentRoundId?: string;
   documents: AssignedDoc[];
   /** Schema completo — usado para limpar condicionais órfãs ao responder (#252). */
   fields: PydanticField[];
@@ -125,6 +126,7 @@ interface UseAssignedCodingParams {
  */
 export function useAssignedCoding({
   projectId,
+  currentRoundId = "",
   documents,
   fields,
   sortedDocuments,
@@ -226,6 +228,7 @@ export function useAssignedCoding({
     try {
       const result = await saveCodingResponse(projectId, currentDoc.id, docAnswers, {
         notes: docNotes,
+        ...(currentRoundId ? { expectedRoundId: currentRoundId } : {}),
       });
       if (!result.success) {
         toast.error(result.error);
@@ -272,6 +275,7 @@ export function useAssignedCoding({
     docNotes,
     fields,
     projectId,
+    currentRoundId,
     docIndex,
     sortedDocuments,
     updateDocParam,

--- a/frontend/src/components/coding/useAssignedCoding.ts
+++ b/frontend/src/components/coding/useAssignedCoding.ts
@@ -222,13 +222,17 @@ export function useAssignedCoding({
 
   const handleSubmit = useCallback(async () => {
     if (!currentDoc || Object.keys(docAnswers).length === 0) return;
+    if (!currentRoundId) {
+      toast.error("O projeto não possui uma rodada atual.");
+      return;
+    }
     if (savingRef.current) return;
     savingRef.current = true;
     setSubmitting(true);
     try {
       const result = await saveCodingResponse(projectId, currentDoc.id, docAnswers, {
         notes: docNotes,
-        ...(currentRoundId ? { expectedRoundId: currentRoundId } : {}),
+        expectedRoundId: currentRoundId,
       });
       if (!result.success) {
         toast.error(result.error);

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -12,6 +12,7 @@ import type { AssignedDoc, PydanticField } from "@/lib/types";
 
 interface UseBrowseCodingParams {
   projectId: string;
+  currentRoundId?: string;
   /** Docs atribuídos — usados para excluir da seleção do modo Explorar. */
   documents: AssignedDoc[];
   /** Schema carregado no formulário — resolve o enunciado da pergunta pendente. */
@@ -40,6 +41,7 @@ interface UseBrowseCodingParams {
  */
 export function useBrowseCoding({
   projectId,
+  currentRoundId = "",
   documents,
   fields,
   mode,
@@ -131,6 +133,7 @@ export function useBrowseCoding({
       try {
         const result = await saveCodingResponse(projectId, browseDocId, answers, {
           notes,
+          ...(currentRoundId ? { expectedRoundId: currentRoundId } : {}),
         });
         if (result.success) {
           markClean(browseDocId);
@@ -168,6 +171,7 @@ export function useBrowseCoding({
     [
       browseDocId,
       projectId,
+      currentRoundId,
       fields,
       markClean,
       submitConfirmed,

--- a/frontend/src/components/coding/useBrowseCoding.ts
+++ b/frontend/src/components/coding/useBrowseCoding.ts
@@ -127,13 +127,17 @@ export function useBrowseCoding({
   const handleBrowseSubmit = useCallback(
     async ({ answers, notes }: CodingDraft) => {
       if (!browseDocId || Object.keys(answers).length === 0) return;
+      if (!currentRoundId) {
+        toast.error("O projeto não possui uma rodada atual.");
+        return;
+      }
       if (browseSavingRef.current) return;
       browseSavingRef.current = true;
       setSubmitting(true);
       try {
         const result = await saveCodingResponse(projectId, browseDocId, answers, {
           notes,
-          ...(currentRoundId ? { expectedRoundId: currentRoundId } : {}),
+          expectedRoundId: currentRoundId,
         });
         if (result.success) {
           markClean(browseDocId);

--- a/frontend/src/components/config/RoundsConfig.tsx
+++ b/frontend/src/components/config/RoundsConfig.tsx
@@ -1,286 +1,56 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Badge } from "@/components/ui/badge";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import { Trash2, Plus, Check } from "lucide-react";
-import { toast } from "sonner";
-import {
-  createRound,
-  deleteRound,
-  setCurrentRound,
-  setRoundStrategy,
-} from "@/actions/rounds";
-import type { Round, RoundStrategy } from "@/lib/types";
+import type { Round } from "@/lib/types";
 
 interface Props {
-  projectId: string;
-  strategy: RoundStrategy;
   currentRoundId: string | null;
-  currentVersion: string;
   rounds: Round[];
-  isCoordinator: boolean;
 }
 
-export function RoundsConfig({
-  projectId,
-  strategy,
-  currentRoundId,
-  currentVersion,
-  rounds,
-  isCoordinator,
-}: Props) {
-  const { refresh } = useRouter();
-  const [isPending, startTransition] = useTransition();
-  const [newLabel, setNewLabel] = useState("");
-  const [pendingDelete, setPendingDelete] = useState<Round | null>(null);
-
-  const handleStrategyChange = (next: string) => {
-    if (next !== "schema_version" && next !== "manual") return;
-    startTransition(async () => {
-      const r = await setRoundStrategy(projectId, next as RoundStrategy);
-      if (r.error) toast.error(r.error);
-      else {
-        toast.success("Estratégia atualizada");
-        refresh();
-      }
-    });
-  };
-
-  const handleCreate = () => {
-    const label = newLabel.trim();
-    if (!label) return;
-    startTransition(async () => {
-      const r = await createRound(projectId, label, rounds.length === 0);
-      if (r.error) {
-        toast.error(r.error);
-        // Estado parcial: a rodada existe mas não virou a atual — atualiza a
-        // lista para o coordenador poder marcá-la manualmente.
-        if (r.id) {
-          setNewLabel("");
-          refresh();
-        }
-      } else {
-        toast.success("Rodada criada");
-        setNewLabel("");
-        refresh();
-      }
-    });
-  };
-
-  const handleSetCurrent = (roundId: string) => {
-    startTransition(async () => {
-      const r = await setCurrentRound(projectId, roundId);
-      if (r.error) toast.error(r.error);
-      else {
-        toast.success("Rodada atual atualizada");
-        refresh();
-      }
-    });
-  };
-
-  const handleConfirmDelete = () => {
-    const round = pendingDelete;
-    if (!round) return;
-    setPendingDelete(null);
-    startTransition(async () => {
-      const r = await deleteRound(projectId, round.id);
-      if (r.error) toast.error(r.error);
-      else {
-        toast.success("Rodada excluída");
-        refresh();
-      }
-    });
-  };
-
-  const disabled = !isCoordinator || isPending;
-
+export function RoundsConfig({ currentRoundId, rounds }: Props) {
   return (
     <div className="space-y-6">
       <div>
         <h2 className="text-lg font-semibold">Rodadas</h2>
         <p className="mt-1 text-sm text-muted-foreground">
-          Define como as rodadas de codificação são identificadas. O filtro na aba
-          Codificar usa essa configuração para separar o que ainda precisa ser
-          respondido na rodada vigente das respostas de rodadas anteriores.
+          Cada resposta, atribuição e revisão pertence a uma rodada nomeada. A
+          versão do formulário continua registrada apenas para auditoria.
         </p>
       </div>
 
       <div className="rounded-lg border p-4 space-y-4">
         <div>
-          <Label className="text-sm font-medium">Estratégia</Label>
-          <p className="text-xs text-muted-foreground mt-1">
-            Como definir a rodada atual.
+          <p className="text-sm font-medium">Histórico do projeto</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Uma nova rodada é criada junto com o sorteio de codificação. Rodadas
+            anteriores permanecem disponíveis para consulta e não podem ser
+            reativadas ou excluídas.
           </p>
         </div>
-        <RadioGroup
-          value={strategy}
-          onValueChange={handleStrategyChange}
-          disabled={disabled}
-          className="gap-3"
-        >
-          <div className="flex items-start gap-3 rounded-md border p-3">
-            <RadioGroupItem value="schema_version" id="strategy-schema" className="mt-0.5" />
-            <div className="flex-1">
-              <Label htmlFor="strategy-schema" className="text-sm font-medium">
-                Versão do schema (automático)
-              </Label>
-              <p className="text-xs text-muted-foreground mt-1">
-                A rodada atual é a versão atual do formulário (
-                <span className="font-mono">{currentVersion}</span>). Cada bump de
-                versão inicia uma nova rodada implicitamente.
-              </p>
-            </div>
-          </div>
-          <div className="flex items-start gap-3 rounded-md border p-3">
-            <RadioGroupItem value="manual" id="strategy-manual" className="mt-0.5" />
-            <div className="flex-1">
-              <Label htmlFor="strategy-manual" className="text-sm font-medium">
-                Rodadas manuais
-              </Label>
-              <p className="text-xs text-muted-foreground mt-1">
-                Você cria e nomeia rodadas explicitamente. Marque uma como atual
-                para que novas respostas sejam atribuídas a ela.
-              </p>
-            </div>
-          </div>
-        </RadioGroup>
+
+        {rounds.length === 0 ? (
+          <p className="text-xs text-muted-foreground italic">
+            Nenhuma rodada registrada.
+          </p>
+        ) : (
+          <ol className="space-y-1.5">
+            {rounds.map((round) => (
+              <li
+                key={round.id}
+                className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
+              >
+                <span className="truncate text-sm">{round.label}</span>
+                {round.id === currentRoundId && (
+                  <Badge variant="default" className="text-xs">
+                    Atual
+                  </Badge>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
       </div>
-
-      {strategy === "manual" && (
-        <div className="rounded-lg border p-4 space-y-4">
-          <div>
-            <Label className="text-sm font-medium">Rodadas do projeto</Label>
-            <p className="text-xs text-muted-foreground mt-1">
-              Marque qual é a rodada atual. Respostas novas em /analyze/code serão
-              associadas a ela.
-            </p>
-          </div>
-
-          <div className="flex gap-2">
-            <Input
-              value={newLabel}
-              onChange={(e) => setNewLabel(e.target.value)}
-              placeholder="Ex.: Piloto, Rodada 2…"
-              disabled={disabled}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleCreate();
-                }
-              }}
-            />
-            <Button
-              onClick={handleCreate}
-              disabled={disabled || !newLabel.trim()}
-              size="sm"
-              className="shrink-0"
-            >
-              <Plus className="size-4" />
-              Criar
-            </Button>
-          </div>
-
-          {rounds.length === 0 ? (
-            <p className="text-xs text-muted-foreground italic">
-              Nenhuma rodada criada ainda.
-            </p>
-          ) : (
-            <ul className="space-y-1.5">
-              {rounds.map((r) => {
-                const isCurrent = r.id === currentRoundId;
-                return (
-                  <li
-                    key={r.id}
-                    className="flex items-center justify-between gap-2 rounded-md border px-3 py-2"
-                  >
-                    <div className="flex items-center gap-2 min-w-0">
-                      <span className="text-sm truncate">{r.label}</span>
-                      {isCurrent && (
-                        <Badge variant="default" className="text-xs">
-                          Atual
-                        </Badge>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-1 shrink-0">
-                      {!isCurrent && (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleSetCurrent(r.id)}
-                          disabled={disabled}
-                          className="h-7 text-xs"
-                        >
-                          <Check className="size-3.5" />
-                          Tornar atual
-                        </Button>
-                      )}
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={() => setPendingDelete(r)}
-                        disabled={disabled}
-                        className="size-7"
-                        aria-label="Excluir rodada"
-                      >
-                        <Trash2 className="size-3.5" />
-                      </Button>
-                    </div>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </div>
-      )}
-
-      {!isCoordinator && (
-        <p className="text-xs text-muted-foreground">
-          Apenas coordenadores podem alterar essas configurações.
-        </p>
-      )}
-
-      <AlertDialog
-        open={pendingDelete !== null}
-        onOpenChange={(open) => {
-          if (!open) setPendingDelete(null);
-        }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Excluir rodada?</AlertDialogTitle>
-            <AlertDialogDescription>
-              {pendingDelete && (
-                <>
-                  Excluir a rodada <strong>{pendingDelete.label}</strong>? As respostas
-                  associadas continuam preservadas, mas ficam sem rodada (aparecem como
-                  &quot;Sem rodada&quot; no filtro).
-                </>
-              )}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancelar</AlertDialogCancel>
-            <AlertDialogAction onClick={handleConfirmDelete} disabled={isPending}>
-              {isPending ? "Excluindo…" : "Excluir"}
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/lib/__tests__/coding-save.test.ts
+++ b/frontend/src/lib/__tests__/coding-save.test.ts
@@ -17,7 +17,9 @@ describe("saveCodingResponse", () => {
   it("normaliza a rejeição de transporte para o contrato de falha", async () => {
     mockSave.mockRejectedValue(new Error("Failed to find Server Action"));
 
-    const result = await saveCodingResponse("p1", "d1", { q: "sim" });
+    const result = await saveCodingResponse("p1", "d1", { q: "sim" }, {
+      expectedRoundId: "round-1",
+    });
 
     expect(result).toEqual({
       success: false,
@@ -31,7 +33,9 @@ describe("saveCodingResponse", () => {
       error: "Documento removido do escopo do projeto",
     });
 
-    const result = await saveCodingResponse("p1", "d1", { q: "sim" });
+    const result = await saveCodingResponse("p1", "d1", { q: "sim" }, {
+      expectedRoundId: "round-1",
+    });
 
     expect(result).toEqual({
       success: false,

--- a/frontend/src/lib/__tests__/viewas-no-write.test.ts
+++ b/frontend/src/lib/__tests__/viewas-no-write.test.ts
@@ -110,7 +110,7 @@ describe("saveResponse — escrita persiste o ator real, nunca o viewAs", () => 
       "project-1",
       "doc-1",
       {},
-      {},
+      { expectedRoundId: "round-1" },
       "member-viewed",
     );
 
@@ -135,7 +135,9 @@ describe("saveResponse — escrita persiste o ator real, nunca o viewAs", () => 
     );
     const { saveResponse } = await import("@/actions/responses");
 
-    const result = await saveResponse("project-1", "doc-1", {});
+    const result = await saveResponse("project-1", "doc-1", {}, {
+      expectedRoundId: "round-1",
+    });
 
     expect(result).toEqual({
       success: false,

--- a/frontend/src/lib/__tests__/viewas-no-write.test.ts
+++ b/frontend/src/lib/__tests__/viewas-no-write.test.ts
@@ -87,7 +87,7 @@ describe("saveResponse — escrita persiste o ator real, nunca o viewAs", () => 
           schema_version_minor: 0,
           schema_version_patch: 0,
           round_strategy: null,
-          current_round_id: null,
+          current_round_id: "round-1",
           automation_mode: null,
         },
       },

--- a/frontend/src/lib/coding-save.ts
+++ b/frontend/src/lib/coding-save.ts
@@ -19,7 +19,7 @@ export async function saveCodingResponse(
   projectId: string,
   documentId: string,
   answers: Record<string, unknown>,
-  opts: SaveResponseOpts = {},
+  opts: SaveResponseOpts,
 ): Promise<SaveResponseResult> {
   try {
     return await saveResponse(projectId, documentId, answers, opts);

--- a/frontend/src/lib/coding-sync.ts
+++ b/frontend/src/lib/coding-sync.ts
@@ -61,6 +61,7 @@ export interface SyncCodingAssignmentParams {
   sanitizedAnswers: Record<string, unknown>;
   automationMode: string | null | undefined;
   hadCompletedResponse: boolean;
+  roundId: string;
 }
 
 async function reconcileEditedResponse(
@@ -95,7 +96,8 @@ async function completeCodingAssignment(
     .eq("project_id", params.projectId)
     .eq("document_id", params.documentId)
     .eq("user_id", params.userId)
-    .eq("type", "codificacao");
+    .eq("type", "codificacao")
+    .eq("round_id", params.roundId);
   if (error) return { error: error.message };
 
   if (!params.hadCompletedResponse) {
@@ -120,6 +122,7 @@ async function keepCodingAssignmentInProgress(
     .eq("document_id", params.documentId)
     .eq("user_id", params.userId)
     .eq("type", "codificacao")
+    .eq("round_id", params.roundId)
     .maybeSingle();
   if (!currentAssignment || currentAssignment.status === "concluido") return {};
 
@@ -129,7 +132,8 @@ async function keepCodingAssignmentInProgress(
     .eq("project_id", params.projectId)
     .eq("document_id", params.documentId)
     .eq("user_id", params.userId)
-    .eq("type", "codificacao");
+    .eq("type", "codificacao")
+    .eq("round_id", params.roundId);
   return error ? { error: error.message } : {};
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -188,6 +188,7 @@ export interface Assignment {
   type: AssignmentType;
   batch_id: string | null;
   completed_at: string | null;
+  round_id: string;
 }
 
 /**

--- a/frontend/supabase/migrations/20260731120000_explicit_assignment_rounds.sql
+++ b/frontend/supabase/migrations/20260731120000_explicit_assignment_rounds.sql
@@ -92,6 +92,44 @@ ALTER TABLE public.assignments
   ADD CONSTRAINT assignments_document_user_type_round_key
   UNIQUE (document_id, user_id, type, round_id);
 
+-- Funcoes de revisao criadas por migrations anteriores reabrem assignments com
+-- ON CONFLICT. O alvo precisa acompanhar a nova chave; manter a assinatura
+-- antiga faria a funcao falhar em runtime assim que o indice global fosse
+-- substituido pelo indice por rodada.
+DO $$
+DECLARE
+  v_function record;
+  v_definition text;
+BEGIN
+  FOR v_function IN
+    SELECT p.oid
+    FROM pg_proc AS p
+    JOIN pg_namespace AS n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'f'
+      AND pg_get_functiondef(p.oid) LIKE '%ON CONFLICT (document_id, user_id, type)%'
+  LOOP
+    v_definition := replace(
+      pg_get_functiondef(v_function.oid),
+      'ON CONFLICT (document_id, user_id, type)',
+      'ON CONFLICT (document_id, user_id, type, round_id)'
+    );
+    EXECUTE v_definition;
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1
+    FROM pg_proc AS p
+    JOIN pg_namespace AS n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.prokind = 'f'
+      AND pg_get_functiondef(p.oid) LIKE '%ON CONFLICT (document_id, user_id, type)%'
+  ) THEN
+    RAISE EXCEPTION 'explicit rounds: funcao ainda usa conflito global de assignments';
+  END IF;
+END;
+$$;
+
 DROP INDEX public.assignments_one_active_comparacao_per_doc;
 CREATE UNIQUE INDEX assignments_one_active_comparacao_per_doc_round
   ON public.assignments (document_id, round_id)
@@ -146,7 +184,7 @@ CREATE OR REPLACE FUNCTION public.create_project_with_initial_round(
   p_automation_mode text DEFAULT 'auto_review_llm'
 ) RETURNS uuid
 LANGUAGE plpgsql
-SECURITY INVOKER
+SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
@@ -186,7 +224,7 @@ ALTER TABLE public.projects
 CREATE OR REPLACE FUNCTION public.fill_current_round_id()
 RETURNS trigger
 LANGUAGE plpgsql
-SECURITY INVOKER
+SECURITY DEFINER
 SET search_path = ''
 AS $$
 BEGIN

--- a/frontend/supabase/migrations/20260731120000_explicit_assignment_rounds.sql
+++ b/frontend/supabase/migrations/20260731120000_explicit_assignment_rounds.sql
@@ -1,0 +1,409 @@
+-- Rodadas explicitas para sorteios repetidos do mesmo formulario.
+--
+-- A migration e deliberadamente fail-fast: a estrategia manual nunca foi
+-- ativada em producao e `rounds` ainda estava vazia na auditoria que originou
+-- esta mudanca. Se esse estado mudar antes do deploy, o backfill precisa ser
+-- redesenhado com os dados reais em vez de inferir a rodada historica.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.projects WHERE round_strategy <> 'schema_version') THEN
+    RAISE EXCEPTION 'explicit rounds: projeto com round_strategy inesperada; revise o backfill';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.rounds) THEN
+    RAISE EXCEPTION 'explicit rounds: rounds ja contem dados; revise o backfill';
+  END IF;
+END $$;
+
+ALTER TABLE public.rounds
+  ADD CONSTRAINT rounds_project_id_id_key UNIQUE (project_id, id);
+
+INSERT INTO public.rounds (project_id, label)
+SELECT id, 'Rodada inicial'
+FROM public.projects;
+
+UPDATE public.projects AS project
+SET current_round_id = round.id
+FROM public.rounds AS round
+WHERE round.project_id = project.id;
+
+ALTER TABLE public.assignment_batches
+  ADD COLUMN round_id uuid,
+  ADD COLUMN type text;
+
+ALTER TABLE public.assignments
+  ADD COLUMN round_id uuid;
+
+UPDATE public.assignment_batches AS batch
+SET round_id = project.current_round_id,
+    type = COALESCE(
+      (SELECT CASE WHEN count(DISTINCT assignment.type) = 1 THEN min(assignment.type) END
+       FROM public.assignments AS assignment
+       WHERE assignment.batch_id = batch.id),
+      'legado'
+    )
+FROM public.projects AS project
+WHERE project.id = batch.project_id;
+
+UPDATE public.assignments AS assignment
+SET round_id = project.current_round_id
+FROM public.projects AS project
+WHERE project.id = assignment.project_id;
+
+UPDATE public.responses AS response
+SET round_id = project.current_round_id
+FROM public.projects AS project
+WHERE project.id = response.project_id;
+
+ALTER TABLE public.assignment_batches
+  ALTER COLUMN project_id SET NOT NULL,
+  ALTER COLUMN round_id SET NOT NULL,
+  ALTER COLUMN type SET NOT NULL,
+  ALTER COLUMN type SET DEFAULT 'legado',
+  ADD CONSTRAINT assignment_batches_type_check
+    CHECK (type IN ('codificacao', 'comparacao', 'legado')),
+  ADD CONSTRAINT assignment_batches_project_round_fk
+    FOREIGN KEY (project_id, round_id)
+    REFERENCES public.rounds(project_id, id);
+
+ALTER TABLE public.assignments
+  ALTER COLUMN project_id SET NOT NULL,
+  ALTER COLUMN round_id SET NOT NULL,
+  ADD CONSTRAINT assignments_project_round_fk
+    FOREIGN KEY (project_id, round_id)
+    REFERENCES public.rounds(project_id, id);
+
+ALTER TABLE public.responses
+  ALTER COLUMN project_id SET NOT NULL,
+  ALTER COLUMN round_id SET NOT NULL,
+  ADD CONSTRAINT responses_project_round_fk
+    FOREIGN KEY (project_id, round_id)
+    REFERENCES public.rounds(project_id, id);
+
+ALTER TABLE public.projects DROP CONSTRAINT projects_current_round_fk;
+ALTER TABLE public.projects
+  ADD CONSTRAINT projects_current_round_fk
+  FOREIGN KEY (id, current_round_id)
+  REFERENCES public.rounds(project_id, id);
+
+ALTER TABLE public.assignments
+  DROP CONSTRAINT assignments_document_id_user_id_type_key;
+ALTER TABLE public.assignments
+  ADD CONSTRAINT assignments_document_user_type_round_key
+  UNIQUE (document_id, user_id, type, round_id);
+
+DROP INDEX public.assignments_one_active_comparacao_per_doc;
+CREATE UNIQUE INDEX assignments_one_active_comparacao_per_doc_round
+  ON public.assignments (document_id, round_id)
+  WHERE type = 'comparacao' AND status IS DISTINCT FROM 'concluido';
+
+DROP INDEX public.responses_one_latest_human_per_document;
+CREATE UNIQUE INDEX responses_one_latest_human_per_document
+  ON public.responses (project_id, round_id, document_id, respondent_id)
+  WHERE respondent_type = 'humano' AND is_latest;
+
+CREATE INDEX idx_assignments_project_round_queue
+  ON public.assignments (project_id, round_id, type, status);
+CREATE INDEX idx_assignment_batches_project_round
+  ON public.assignment_batches (project_id, round_id, created_at DESC);
+
+-- Projetos novos ja nascem com uma rodada valida. O trigger e SECURITY DEFINER
+-- porque a policy de rounds exige que o projeto ja seja visivel ao criador, o
+-- que nem sempre e verdade durante o AFTER INSERT do proprio projeto.
+CREATE OR REPLACE FUNCTION public.create_initial_project_round()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_round_id uuid;
+BEGIN
+  INSERT INTO public.rounds (project_id, label)
+  VALUES (NEW.id, 'Rodada inicial')
+  RETURNING id INTO v_round_id;
+
+  UPDATE public.projects SET current_round_id = v_round_id WHERE id = NEW.id;
+  NEW.current_round_id := v_round_id;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER projects_create_initial_round
+AFTER INSERT ON public.projects
+FOR EACH ROW
+EXECUTE FUNCTION public.create_initial_project_round();
+
+REVOKE ALL ON FUNCTION public.create_initial_project_round() FROM PUBLIC, anon, authenticated;
+
+-- Caminho canonico de criacao: projeto, membership do criador e rodada inicial
+-- pertencem a mesma transacao. O trigger acima continua cobrindo imports e a
+-- release anterior do frontend durante a janela de compatibilidade.
+CREATE OR REPLACE FUNCTION public.create_project_with_initial_round(
+  p_name text,
+  p_description text,
+  p_created_by uuid,
+  p_automation_mode text DEFAULT 'auto_review_llm'
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_project_id uuid;
+BEGIN
+  INSERT INTO public.projects (name, description, created_by, automation_mode)
+  VALUES (p_name, p_description, p_created_by, p_automation_mode)
+  RETURNING id INTO v_project_id;
+
+  INSERT INTO public.project_members (project_id, user_id, role)
+  VALUES (v_project_id, p_created_by, 'coordenador');
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.projects
+    WHERE id = v_project_id AND current_round_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'projeto criado sem rodada inicial';
+  END IF;
+
+  RETURN v_project_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_project_with_initial_round(text, text, uuid, text)
+  FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.create_project_with_initial_round(text, text, uuid, text) TO authenticated;
+
+ALTER TABLE public.projects
+  DROP CONSTRAINT projects_round_strategy_check;
+UPDATE public.projects SET round_strategy = 'manual';
+ALTER TABLE public.projects
+  ALTER COLUMN round_strategy SET DEFAULT 'manual';
+
+-- Compatibilidade de escrita para a release anterior. Valor explicito nunca e
+-- sobrescrito: clientes round-aware mantem a protecao contra abas obsoletas;
+-- somente payloads legados, que omitem round_id, recebem a rodada atual.
+CREATE OR REPLACE FUNCTION public.fill_current_round_id()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.round_id IS NULL THEN
+    SELECT current_round_id INTO NEW.round_id
+    FROM public.projects WHERE id = NEW.project_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER assignment_batches_fill_current_round
+BEFORE INSERT ON public.assignment_batches
+FOR EACH ROW EXECUTE FUNCTION public.fill_current_round_id();
+
+CREATE TRIGGER assignments_fill_current_round
+BEFORE INSERT ON public.assignments
+FOR EACH ROW EXECUTE FUNCTION public.fill_current_round_id();
+
+CREATE TRIGGER responses_fill_current_round
+BEFORE INSERT ON public.responses
+FOR EACH ROW EXECUTE FUNCTION public.fill_current_round_id();
+
+REVOKE ALL ON FUNCTION public.fill_current_round_id() FROM PUBLIC, anon, authenticated;
+
+-- Nova operacao atomica. `p_new_round_label IS NULL` opera na rodada atual;
+-- quando ha label, cria e ativa uma rodada antes do sorteio. Qualquer excecao,
+-- inclusive zero insercoes, reverte rodada, arquivamento, lote e assignments.
+CREATE OR REPLACE FUNCTION public.apply_lottery_assignments(
+  p_project_id uuid,
+  p_type text,
+  p_expected_round_id uuid,
+  p_new_round_label text,
+  p_confirm_open_work boolean,
+  p_batch jsonb,
+  p_assignments jsonb,
+  p_replace boolean
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_current_round_id uuid;
+  v_target_round_id uuid;
+  v_batch_id uuid;
+  v_inserted integer;
+  v_preserved integer;
+  v_open_work integer;
+  v_label text;
+BEGIN
+  IF p_type NOT IN ('codificacao', 'comparacao') THEN
+    RAISE EXCEPTION 'tipo de sorteio invalido: %', p_type USING ERRCODE = '22023';
+  END IF;
+  IF jsonb_typeof(p_assignments) IS DISTINCT FROM 'array' THEN
+    RAISE EXCEPTION 'assignments deve ser um array JSON' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT current_round_id INTO v_current_round_id
+  FROM public.projects
+  WHERE id = p_project_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'projeto inexistente ou inacessivel' USING ERRCODE = 'P0002';
+  END IF;
+  IF v_current_round_id IS DISTINCT FROM p_expected_round_id THEN
+    RAISE EXCEPTION 'a rodada atual mudou; recarregue o sorteio' USING ERRCODE = '40001';
+  END IF;
+
+  v_target_round_id := v_current_round_id;
+  IF p_new_round_label IS NOT NULL THEN
+    IF p_type <> 'codificacao' THEN
+      RAISE EXCEPTION 'somente sorteio de codificacao pode iniciar rodada' USING ERRCODE = '22023';
+    END IF;
+    v_label := btrim(p_new_round_label);
+    IF v_label = '' THEN
+      RAISE EXCEPTION 'nome da rodada nao pode ser vazio' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT count(*) INTO v_open_work
+    FROM public.assignments
+    WHERE project_id = p_project_id
+      AND round_id = v_current_round_id
+      AND type = 'codificacao'
+      AND status IN ('pendente', 'em_andamento');
+
+    IF v_open_work > 0 AND NOT p_confirm_open_work THEN
+      RAISE EXCEPTION 'a rodada atual possui % atribuicoes abertas', v_open_work
+        USING ERRCODE = 'P0001';
+    END IF;
+
+    INSERT INTO public.rounds (project_id, label)
+    VALUES (p_project_id, v_label)
+    RETURNING id INTO v_target_round_id;
+
+    UPDATE public.responses
+    SET is_latest = false
+    WHERE project_id = p_project_id
+      AND round_id = v_current_round_id
+      AND is_latest;
+
+    UPDATE public.projects
+    SET current_round_id = v_target_round_id,
+        round_strategy = 'manual'
+    WHERE id = p_project_id;
+  END IF;
+
+  INSERT INTO public.assignment_batches (
+    project_id, round_id, type, created_by, researchers_per_doc,
+    docs_per_researcher, doc_subset_size, label, mode, balancing, filters
+  ) VALUES (
+    p_project_id,
+    v_target_round_id,
+    p_type,
+    NULLIF(p_batch->>'created_by', '')::uuid,
+    COALESCE((p_batch->>'researchers_per_doc')::integer, 2),
+    NULLIF(p_batch->>'docs_per_researcher', '')::integer,
+    NULLIF(p_batch->>'doc_subset_size', '')::integer,
+    NULLIF(p_batch->>'label', ''),
+    COALESCE(NULLIF(p_batch->>'mode', ''), CASE WHEN p_replace THEN 'replace' ELSE 'append' END),
+    COALESCE(NULLIF(p_batch->>'balancing', ''), 'history'),
+    p_batch->'filters'
+  ) RETURNING id INTO v_batch_id;
+
+  IF p_replace THEN
+    DELETE FROM public.assignments
+    WHERE project_id = p_project_id
+      AND round_id = v_target_round_id
+      AND status = 'pendente'
+      AND type = p_type;
+  END IF;
+
+  SELECT count(*) INTO v_preserved
+  FROM public.assignments
+  WHERE project_id = p_project_id
+    AND round_id = v_target_round_id
+    AND type = p_type;
+
+  INSERT INTO public.assignments (
+    project_id, round_id, document_id, user_id, batch_id, type, status, completed_at
+  )
+  SELECT p_project_id,
+         v_target_round_id,
+         (entry->>'document_id')::uuid,
+         (entry->>'user_id')::uuid,
+         v_batch_id,
+         p_type,
+         COALESCE(entry->>'status', 'pendente'),
+         (entry->>'completed_at')::timestamptz
+  FROM jsonb_array_elements(p_assignments) AS entry
+  ON CONFLICT DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  IF v_inserted = 0 THEN
+    RAISE EXCEPTION 'o sorteio nao criou nenhuma atribuicao' USING ERRCODE = 'P0001';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'round_id', v_target_round_id,
+    'batch_id', v_batch_id,
+    'inserted', v_inserted,
+    'preserved', v_preserved
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.apply_lottery_assignments(
+  uuid, text, uuid, text, boolean, jsonb, jsonb, boolean
+) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.apply_lottery_assignments(
+  uuid, text, uuid, text, boolean, jsonb, jsonb, boolean
+) TO authenticated;
+
+-- Compatibilidade de uma release com o frontend anterior: lote e assignments
+-- recebem a rodada atual mesmo quando o chamador ainda usa a assinatura antiga.
+CREATE OR REPLACE FUNCTION public.apply_lottery_assignments(
+  p_project_id uuid,
+  p_type text,
+  p_batch_id uuid,
+  p_assignments jsonb,
+  p_replace boolean
+) RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_round_id uuid;
+  v_inserted integer;
+BEGIN
+  SELECT current_round_id INTO v_round_id
+  FROM public.projects WHERE id = p_project_id;
+
+  IF p_batch_id IS NOT NULL THEN
+    UPDATE public.assignment_batches
+    SET round_id = v_round_id,
+        type = CASE WHEN type = 'legado' THEN p_type ELSE type END
+    WHERE id = p_batch_id AND project_id = p_project_id;
+  END IF;
+
+  IF p_replace THEN
+    DELETE FROM public.assignments
+    WHERE project_id = p_project_id AND round_id = v_round_id
+      AND status = 'pendente' AND type = p_type;
+  END IF;
+
+  INSERT INTO public.assignments (
+    project_id, round_id, document_id, user_id, batch_id, type, status, completed_at
+  )
+  SELECT p_project_id, v_round_id, (entry->>'document_id')::uuid,
+         (entry->>'user_id')::uuid, p_batch_id, p_type,
+         COALESCE(entry->>'status', 'pendente'),
+         (entry->>'completed_at')::timestamptz
+  FROM jsonb_array_elements(p_assignments) AS entry
+  ON CONFLICT DO NOTHING;
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  RETURN v_inserted;
+END;
+$$;

--- a/frontend/supabase/migrations/20260731120000_explicit_assignment_rounds.sql
+++ b/frontend/supabase/migrations/20260731120000_explicit_assignment_rounds.sql
@@ -180,7 +180,6 @@ REVOKE ALL ON FUNCTION public.create_initial_project_round() FROM PUBLIC, anon, 
 CREATE OR REPLACE FUNCTION public.create_project_with_initial_round(
   p_name text,
   p_description text,
-  p_created_by uuid,
   p_automation_mode text DEFAULT 'auto_review_llm'
 ) RETURNS uuid
 LANGUAGE plpgsql
@@ -189,13 +188,19 @@ SET search_path = ''
 AS $$
 DECLARE
   v_project_id uuid;
+  v_created_by uuid;
 BEGIN
+  v_created_by := public.clerk_uid();
+  IF v_created_by IS NULL THEN
+    RAISE EXCEPTION 'identidade autenticada indisponivel' USING ERRCODE = '28000';
+  END IF;
+
   INSERT INTO public.projects (name, description, created_by, automation_mode)
-  VALUES (p_name, p_description, p_created_by, p_automation_mode)
+  VALUES (p_name, p_description, v_created_by, p_automation_mode)
   RETURNING id INTO v_project_id;
 
   INSERT INTO public.project_members (project_id, user_id, role)
-  VALUES (v_project_id, p_created_by, 'coordenador');
+  VALUES (v_project_id, v_created_by, 'coordenador');
 
   IF NOT EXISTS (
     SELECT 1 FROM public.projects
@@ -208,9 +213,9 @@ BEGIN
 END;
 $$;
 
-REVOKE ALL ON FUNCTION public.create_project_with_initial_round(text, text, uuid, text)
+REVOKE ALL ON FUNCTION public.create_project_with_initial_round(text, text, text)
   FROM PUBLIC, anon, service_role;
-GRANT EXECUTE ON FUNCTION public.create_project_with_initial_round(text, text, uuid, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_project_with_initial_round(text, text, text) TO authenticated;
 
 ALTER TABLE public.projects
   DROP CONSTRAINT projects_round_strategy_check;
@@ -244,11 +249,162 @@ CREATE TRIGGER assignments_fill_current_round
 BEFORE INSERT ON public.assignments
 FOR EACH ROW EXECUTE FUNCTION public.fill_current_round_id();
 
-CREATE TRIGGER responses_fill_current_round
-BEFORE INSERT ON public.responses
-FOR EACH ROW EXECUTE FUNCTION public.fill_current_round_id();
-
 REVOKE ALL ON FUNCTION public.fill_current_round_id() FROM PUBLIC, anon, authenticated;
+
+-- Toda escrita de response se lineariza com a troca de rodada pelo mesmo row
+-- lock de projects. FOR SHARE permite saves concorrentes, mas conflita com o
+-- FOR UPDATE de apply_lottery_assignments. Assim, ou o save termina antes da
+-- ativacao, ou observa a nova rodada e falha; nunca grava no historico depois.
+CREATE OR REPLACE FUNCTION public.enforce_current_response_round_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_current_round_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE'
+     AND (
+       NEW.project_id IS DISTINCT FROM OLD.project_id
+       OR NEW.round_id IS DISTINCT FROM OLD.round_id
+     ) THEN
+    RAISE EXCEPTION 'project_id e round_id da response sao imutaveis'
+      USING ERRCODE = '23514';
+  END IF;
+
+  SELECT project.current_round_id INTO v_current_round_id
+  FROM public.projects AS project
+  WHERE project.id = NEW.project_id
+  FOR SHARE;
+
+  IF NOT FOUND OR v_current_round_id IS NULL THEN
+    RAISE EXCEPTION 'projeto sem rodada atual' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Compatibilidade com a release imediatamente anterior. Clientes round-aware
+  -- sempre enviam o id exibido e, portanto, passam pela comparacao abaixo.
+  IF NEW.round_id IS NULL THEN
+    NEW.round_id := v_current_round_id;
+  ELSIF NEW.round_id IS DISTINCT FROM v_current_round_id THEN
+    RAISE EXCEPTION 'a rodada atual mudou; recarregue o formulario'
+      USING ERRCODE = '40001';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER responses_enforce_current_round_write
+BEFORE INSERT OR UPDATE ON public.responses
+FOR EACH ROW EXECUTE FUNCTION public.enforce_current_response_round_write();
+
+REVOKE ALL ON FUNCTION public.enforce_current_response_round_write()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+-- Publicacao LLM antiga falha antes de tocar latest ou outbox. A ordem de
+-- locks projects -> documents acompanha apply_lottery_assignments e o trigger
+-- de reconciliacao, evitando o ciclo project->document / document->project.
+CREATE OR REPLACE FUNCTION public.publish_latest_llm_response(
+  p_response jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_project_id uuid;
+  v_document_id uuid;
+  v_round_id uuid;
+  v_current_round_id uuid;
+  v_document_project_id uuid;
+  v_response_id uuid;
+  v_is_partial boolean;
+BEGIN
+  IF p_response IS NULL OR pg_catalog.jsonb_typeof(p_response) <> 'object' THEN
+    RAISE EXCEPTION 'p_response must be a JSON object';
+  END IF;
+  IF pg_catalog.jsonb_typeof(p_response->'answers') <> 'object'
+     OR (
+       p_response->'justifications' IS NOT NULL
+       AND p_response->'justifications' <> 'null'::jsonb
+       AND pg_catalog.jsonb_typeof(p_response->'justifications') <> 'object'
+     )
+     OR (
+       p_response->'answer_field_hashes' IS NOT NULL
+       AND p_response->'answer_field_hashes' <> 'null'::jsonb
+       AND pg_catalog.jsonb_typeof(p_response->'answer_field_hashes') <> 'object'
+     ) THEN
+    RAISE EXCEPTION 'LLM response answers, justifications, and field hashes must be JSON objects';
+  END IF;
+
+  v_project_id := (p_response->>'project_id')::uuid;
+  v_document_id := (p_response->>'document_id')::uuid;
+  v_round_id := NULLIF(p_response->>'round_id', '')::uuid;
+  v_is_partial := COALESCE((p_response->>'is_partial')::boolean, false);
+
+  IF v_round_id IS NULL THEN
+    RAISE EXCEPTION 'LLM response round_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT project.current_round_id INTO v_current_round_id
+  FROM public.projects AS project
+  WHERE project.id = v_project_id
+  FOR SHARE;
+
+  IF NOT FOUND OR v_current_round_id IS DISTINCT FROM v_round_id THEN
+    RAISE EXCEPTION 'LLM response round is no longer current'
+      USING ERRCODE = '40001';
+  END IF;
+
+  SELECT document.project_id INTO v_document_project_id
+  FROM public.documents AS document
+  WHERE document.id = v_document_id
+  FOR UPDATE;
+
+  IF v_document_project_id IS NULL
+     OR v_document_project_id IS DISTINCT FROM v_project_id THEN
+    RAISE EXCEPTION 'LLM response document does not belong to project';
+  END IF;
+
+  DELETE FROM public.auto_review_reconciliation_requests AS request
+  WHERE request.document_id = v_document_id;
+
+  UPDATE public.responses AS response
+  SET is_latest = false
+  WHERE response.project_id = v_project_id
+    AND response.round_id = v_round_id
+    AND response.document_id = v_document_id
+    AND response.respondent_type = 'llm'
+    AND response.is_latest = true;
+
+  INSERT INTO public.responses (
+    project_id, document_id, respondent_id, respondent_type, respondent_name,
+    answers, justifications, is_latest, is_partial, pydantic_hash,
+    answer_field_hashes, llm_job_id, llm_error, schema_version_major,
+    schema_version_minor, schema_version_patch, version_inferred_from, round_id
+  ) VALUES (
+    v_project_id, v_document_id, NULL, 'llm', p_response->>'respondent_name',
+    COALESCE(p_response->'answers', '{}'::jsonb),
+    NULLIF(p_response->'justifications', 'null'::jsonb),
+    NOT v_is_partial, v_is_partial, p_response->>'pydantic_hash',
+    NULLIF(p_response->'answer_field_hashes', 'null'::jsonb),
+    NULLIF(p_response->>'llm_job_id', '')::uuid, p_response->>'llm_error',
+    COALESCE((p_response->>'schema_version_major')::integer, 0),
+    COALESCE((p_response->>'schema_version_minor')::integer, 1),
+    COALESCE((p_response->>'schema_version_patch')::integer, 0),
+    p_response->>'version_inferred_from', v_round_id
+  )
+  RETURNING id INTO v_response_id;
+
+  RETURN v_response_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.publish_latest_llm_response(jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_latest_llm_response(jsonb)
+  TO service_role;
 
 -- Nova operacao atomica. `p_new_round_label IS NULL` opera na rodada atual;
 -- quando ha label, cria e ativa uma rodada antes do sorteio. Qualquer excecao,

--- a/frontend/supabase/tests/auto_review_reconciliation_outbox.test.sql
+++ b/frontend/supabase/tests/auto_review_reconciliation_outbox.test.sql
@@ -577,6 +577,7 @@ DECLARE
 BEGIN
   v_first_id := public.publish_latest_llm_response(pg_catalog.jsonb_build_object(
     'project_id', 'b0000000-0000-0000-0000-000000000001',
+    'round_id', (SELECT current_round_id FROM public.projects WHERE id = 'b0000000-0000-0000-0000-000000000001'),
     'document_id', 'c0000000-0000-0000-0000-000000000001',
     'respondent_name', 'test/model',
     'answers', '{"q1":"llm-v2"}'::JSONB,
@@ -593,6 +594,7 @@ BEGIN
 
   v_second_id := public.publish_latest_llm_response(pg_catalog.jsonb_build_object(
     'project_id', 'b0000000-0000-0000-0000-000000000001',
+    'round_id', (SELECT current_round_id FROM public.projects WHERE id = 'b0000000-0000-0000-0000-000000000001'),
     'document_id', 'c0000000-0000-0000-0000-000000000001',
     'respondent_name', 'test/model',
     'answers', '{"q1":"llm-v3"}'::JSONB,
@@ -649,6 +651,7 @@ BEGIN
   BEGIN
     PERFORM public.publish_latest_llm_response(pg_catalog.jsonb_build_object(
       'project_id', 'b0000000-0000-0000-0000-000000000001',
+      'round_id', (SELECT current_round_id FROM public.projects WHERE id = 'b0000000-0000-0000-0000-000000000001'),
       'document_id', 'c0000000-0000-0000-0000-000000000001',
       'answers', '{"q1":"must-rollback"}'::JSONB,
       'is_partial', false,
@@ -670,6 +673,7 @@ BEGIN
 
   PERFORM public.publish_latest_llm_response(pg_catalog.jsonb_build_object(
     'project_id', 'b0000000-0000-0000-0000-000000000001',
+    'round_id', (SELECT current_round_id FROM public.projects WHERE id = 'b0000000-0000-0000-0000-000000000001'),
     'document_id', 'c0000000-0000-0000-0000-000000000001',
     'respondent_name', 'test/model',
     'answers', '{"q1":null}'::JSONB,

--- a/frontend/supabase/tests/explicit_assignment_rounds.test.sql
+++ b/frontend/supabase/tests/explicit_assignment_rounds.test.sql
@@ -3,13 +3,34 @@
 BEGIN;
 
 INSERT INTO auth.users (id, email) VALUES
-  ('70000000-0000-0000-0000-000000000001', 'round-creator@example.test');
+  ('70000000-0000-0000-0000-000000000001', 'round-creator@example.test'),
+  ('70000000-0000-0000-0000-000000000002', 'round-victim@example.test');
+
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+VALUES
+  ('round-creator-clerk', '70000000-0000-0000-0000-000000000001', 1);
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"round-creator-clerk","supabase_uid":"70000000-0000-0000-0000-000000000001"}',
+  true
+);
+CREATE TEMP TABLE created_project_result (project_id uuid NOT NULL);
+GRANT INSERT ON created_project_result TO authenticated;
+SET LOCAL ROLE authenticated;
+
+INSERT INTO created_project_result
+SELECT public.create_project_with_initial_round(
+  'created atomically', NULL, 'auto_review_llm');
+
+RESET ROLE;
+SELECT set_config('request.jwt.claims', '{}', true);
 
 DO $$
 DECLARE v_project_id uuid;
 BEGIN
-  v_project_id := public.create_project_with_initial_round(
-    'created atomically', NULL, '70000000-0000-0000-0000-000000000001', 'auto_review_llm');
+  SELECT project_id INTO STRICT v_project_id FROM created_project_result;
   IF NOT EXISTS (
        SELECT 1 FROM public.project_members
        WHERE project_members.project_id = v_project_id
@@ -17,11 +38,37 @@ BEGIN
          AND role = 'coordenador'
      ) OR NOT EXISTS (
        SELECT 1 FROM public.projects
-       WHERE id = v_project_id AND current_round_id IS NOT NULL
+       WHERE id = v_project_id
+         AND created_by = '70000000-0000-0000-0000-000000000001'
+         AND current_round_id IS NOT NULL
+     ) OR EXISTS (
+       SELECT 1 FROM public.project_members
+       WHERE project_members.project_id = v_project_id
+         AND user_id = '70000000-0000-0000-0000-000000000002'
      ) THEN
-    RAISE EXCEPTION 'FALHOU: criacao atomica nao criou coordenador/rodada';
+    RAISE EXCEPTION 'FALHOU: criacao atomica aceitou identidade diferente do JWT';
+  END IF;
+  IF pg_catalog.to_regprocedure(
+       'public.create_project_with_initial_round(text,text,uuid,text)'
+     ) IS NOT NULL THEN
+    RAISE EXCEPTION 'FALHOU: assinatura vulneravel com p_created_by continua exposta';
   END IF;
   RAISE NOTICE 'OK: projeto, coordenador e rodada inicial criados atomicamente';
+END $$;
+
+DO $$
+DECLARE v_rejected boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.create_project_with_initial_round(
+      'sem identidade', NULL, 'auto_review_llm');
+  EXCEPTION WHEN invalid_authorization_specification THEN
+    v_rejected := true;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: criacao sem identidade autenticada foi aceita';
+  END IF;
+  RAISE NOTICE 'OK: criacao sem identidade falha fechado';
 END $$;
 
 INSERT INTO public.projects (id, name) VALUES
@@ -133,6 +180,103 @@ BEGIN
   EXCEPTION WHEN unique_violation THEN NULL;
   END;
   RAISE NOTICE 'OK: FKs cross-project e comparacao ativa por rodada';
+END $$;
+
+-- Uma resposta humana ou LLM capturada na rodada anterior não pode tocar o
+-- histórico depois da ativação, mesmo usando service_role/postgres.
+DO $$
+DECLARE
+  v_old_round uuid;
+  v_current_round uuid;
+  v_current_llm uuid;
+  v_rejected boolean := false;
+BEGIN
+  SELECT current_round_id INTO v_current_round
+  FROM public.projects
+  WHERE id = '71000000-0000-0000-0000-000000000001';
+
+  SELECT id INTO v_old_round
+  FROM public.rounds
+  WHERE project_id = '71000000-0000-0000-0000-000000000001'
+    AND id <> v_current_round;
+
+  v_current_llm := public.publish_latest_llm_response(
+    pg_catalog.jsonb_build_object(
+      'project_id', '71000000-0000-0000-0000-000000000001',
+      'document_id', '72000000-0000-0000-0000-000000000001',
+      'round_id', v_current_round,
+      'respondent_name', 'test/current',
+      'answers', '{"q1":"current"}'::jsonb,
+      'is_partial', false
+    )
+  );
+
+  v_rejected := false;
+  BEGIN
+    PERFORM public.publish_latest_llm_response(
+      pg_catalog.jsonb_build_object(
+        'project_id', '71000000-0000-0000-0000-000000000001',
+        'document_id', '72000000-0000-0000-0000-000000000001',
+        'answers', '{}'::jsonb,
+        'is_partial', false
+      )
+    );
+  EXCEPTION WHEN invalid_parameter_value THEN
+    v_rejected := true;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: publicacao LLM sem round_id foi aceita';
+  END IF;
+
+  v_rejected := false;
+  BEGIN
+    PERFORM public.publish_latest_llm_response(
+      pg_catalog.jsonb_build_object(
+        'project_id', '71000000-0000-0000-0000-000000000001',
+        'document_id', '72000000-0000-0000-0000-000000000001',
+        'round_id', v_old_round,
+        'respondent_name', 'test/stale',
+        'answers', '{"q1":"stale"}'::jsonb,
+        'is_partial', false
+      )
+    );
+  EXCEPTION WHEN serialization_failure THEN
+    v_rejected := true;
+  END;
+
+  IF NOT v_rejected
+     OR NOT EXISTS (
+       SELECT 1 FROM public.responses
+       WHERE id = v_current_llm AND is_latest
+     )
+     OR EXISTS (
+       SELECT 1 FROM public.responses
+       WHERE project_id = '71000000-0000-0000-0000-000000000001'
+         AND round_id = v_old_round
+         AND respondent_type = 'llm'
+         AND answers = '{"q1":"stale"}'::jsonb
+     ) THEN
+    RAISE EXCEPTION 'FALHOU: publicacao LLM antiga alterou a rodada atual';
+  END IF;
+
+  v_rejected := false;
+  BEGIN
+    INSERT INTO public.responses (
+      project_id, document_id, respondent_type, answers, is_latest,
+      is_partial, round_id
+    ) VALUES (
+      '71000000-0000-0000-0000-000000000001',
+      '72000000-0000-0000-0000-000000000001',
+      'humano', '{}'::jsonb, true, true, v_old_round
+    );
+  EXCEPTION WHEN serialization_failure THEN
+    v_rejected := true;
+  END;
+
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: response humana entrou em rodada historica';
+  END IF;
+  RAISE NOTICE 'OK: responses humanas e LLM antigas falham sem alterar latest';
 END $$;
 
 ROLLBACK;

--- a/frontend/supabase/tests/explicit_assignment_rounds.test.sql
+++ b/frontend/supabase/tests/explicit_assignment_rounds.test.sql
@@ -1,0 +1,138 @@
+-- Contrato das rodadas explicitas e do sorteio atomico.
+-- Executar apos `npx supabase db reset` com psql -v ON_ERROR_STOP=1.
+BEGIN;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('70000000-0000-0000-0000-000000000001', 'round-creator@example.test');
+
+DO $$
+DECLARE v_project_id uuid;
+BEGIN
+  v_project_id := public.create_project_with_initial_round(
+    'created atomically', NULL, '70000000-0000-0000-0000-000000000001', 'auto_review_llm');
+  IF NOT EXISTS (
+       SELECT 1 FROM public.project_members
+       WHERE project_members.project_id = v_project_id
+         AND user_id = '70000000-0000-0000-0000-000000000001'
+         AND role = 'coordenador'
+     ) OR NOT EXISTS (
+       SELECT 1 FROM public.projects
+       WHERE id = v_project_id AND current_round_id IS NOT NULL
+     ) THEN
+    RAISE EXCEPTION 'FALHOU: criacao atomica nao criou coordenador/rodada';
+  END IF;
+  RAISE NOTICE 'OK: projeto, coordenador e rodada inicial criados atomicamente';
+END $$;
+
+INSERT INTO public.projects (id, name) VALUES
+  ('71000000-0000-0000-0000-000000000001', 'round test A'),
+  ('71000000-0000-0000-0000-000000000002', 'round test B');
+
+INSERT INTO public.documents (id, project_id, text) VALUES
+  ('72000000-0000-0000-0000-000000000001', '71000000-0000-0000-0000-000000000001', 'doc A'),
+  ('72000000-0000-0000-0000-000000000002', '71000000-0000-0000-0000-000000000002', 'doc B');
+
+DO $$
+DECLARE n integer;
+BEGIN
+  SELECT count(*) INTO n FROM public.rounds
+  WHERE project_id IN ('71000000-0000-0000-0000-000000000001', '71000000-0000-0000-0000-000000000002')
+    AND label = 'Rodada inicial';
+  IF n <> 2 THEN RAISE EXCEPTION 'FALHOU: projetos novos nao criaram rodada inicial'; END IF;
+
+  BEGIN
+    UPDATE public.projects
+    SET current_round_id = (SELECT current_round_id FROM public.projects WHERE id = '71000000-0000-0000-0000-000000000002')
+    WHERE id = '71000000-0000-0000-0000-000000000001';
+    RAISE EXCEPTION 'FALHOU: current_round aceitou rodada de outro projeto';
+  EXCEPTION WHEN foreign_key_violation THEN NULL;
+  END;
+  RAISE NOTICE 'OK: rodada inicial e identidade canonica de projeto';
+END $$;
+
+DO $$
+DECLARE old_round uuid; result jsonb; new_round uuid;
+BEGIN
+  SELECT current_round_id INTO old_round FROM public.projects
+  WHERE id = '71000000-0000-0000-0000-000000000001';
+
+  INSERT INTO public.assignments (project_id, round_id, document_id, type, status)
+  VALUES ('71000000-0000-0000-0000-000000000001', old_round,
+          '72000000-0000-0000-0000-000000000001', 'codificacao', 'em_andamento');
+
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000001', 'codificacao', old_round,
+      'Rodada 2', false, '{}'::jsonb,
+      '[{"document_id":"72000000-0000-0000-0000-000000000001","user_id":null}]'::jsonb, false);
+    RAISE EXCEPTION 'FALHOU: abriu rodada sem confirmar trabalho aberto';
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM LIKE 'FALHOU:%' THEN RAISE; END IF;
+  END;
+
+  result := public.apply_lottery_assignments(
+    '71000000-0000-0000-0000-000000000001', 'codificacao', old_round,
+    'Rodada 2', true, '{"label":"Lote rodada 2","mode":"append","balancing":"round"}'::jsonb,
+    '[{"document_id":"72000000-0000-0000-0000-000000000001","user_id":null}]'::jsonb, false);
+  new_round := (result->>'round_id')::uuid;
+
+  IF (result->>'inserted')::int <> 1 OR new_round = old_round THEN
+    RAISE EXCEPTION 'FALHOU: retorno inesperado da nova rodada: %', result;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.assignments WHERE round_id = old_round AND status = 'em_andamento')
+     OR NOT EXISTS (SELECT 1 FROM public.assignments WHERE round_id = new_round AND status = 'pendente') THEN
+    RAISE EXCEPTION 'FALHOU: redistribuicao nao preservou historico/separou rodada nova';
+  END IF;
+  RAISE NOTICE 'OK: nova rodada redistribui sem ocupacao da rodada anterior';
+END $$;
+
+DO $$
+DECLARE current_round uuid; before_rounds int; before_batches int;
+BEGIN
+  SELECT current_round_id INTO current_round FROM public.projects
+  WHERE id = '71000000-0000-0000-0000-000000000002';
+  SELECT count(*) INTO before_rounds FROM public.rounds WHERE project_id = '71000000-0000-0000-0000-000000000002';
+  SELECT count(*) INTO before_batches FROM public.assignment_batches WHERE project_id = '71000000-0000-0000-0000-000000000002';
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000002', 'codificacao', current_round,
+      'Rodada vazia', true, '{}'::jsonb, '[]'::jsonb, false);
+    RAISE EXCEPTION 'FALHOU: sorteio vazio deveria abortar';
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM LIKE 'FALHOU:%' THEN RAISE; END IF;
+  END;
+  IF (SELECT count(*) FROM public.rounds WHERE project_id = '71000000-0000-0000-0000-000000000002') <> before_rounds
+     OR (SELECT count(*) FROM public.assignment_batches WHERE project_id = '71000000-0000-0000-0000-000000000002') <> before_batches
+     OR (SELECT current_round_id FROM public.projects WHERE id = '71000000-0000-0000-0000-000000000002') <> current_round THEN
+    RAISE EXCEPTION 'FALHOU: sorteio vazio deixou rodada/lote/ativacao parcial';
+  END IF;
+  RAISE NOTICE 'OK: zero inserts faz rollback completo';
+END $$;
+
+DO $$
+DECLARE round_a uuid; round_b uuid;
+BEGIN
+  SELECT current_round_id INTO round_a FROM public.projects WHERE id = '71000000-0000-0000-0000-000000000001';
+  SELECT current_round_id INTO round_b FROM public.projects WHERE id = '71000000-0000-0000-0000-000000000002';
+  BEGIN
+    INSERT INTO public.assignments (project_id, round_id, document_id, type)
+    VALUES ('71000000-0000-0000-0000-000000000001', round_b,
+            '72000000-0000-0000-0000-000000000001', 'codificacao');
+    RAISE EXCEPTION 'FALHOU: assignment aceitou rodada de outro projeto';
+  EXCEPTION WHEN foreign_key_violation THEN NULL;
+  END;
+
+  INSERT INTO public.assignments (project_id, round_id, document_id, type)
+  VALUES ('71000000-0000-0000-0000-000000000002', round_b,
+          '72000000-0000-0000-0000-000000000002', 'comparacao');
+  BEGIN
+    INSERT INTO public.assignments (project_id, round_id, document_id, type)
+    VALUES ('71000000-0000-0000-0000-000000000002', round_b,
+            '72000000-0000-0000-0000-000000000002', 'comparacao');
+    RAISE EXCEPTION 'FALHOU: duas comparacoes ativas na mesma rodada';
+  EXCEPTION WHEN unique_violation THEN NULL;
+  END;
+  RAISE NOTICE 'OK: FKs cross-project e comparacao ativa por rodada';
+END $$;
+
+ROLLBACK;

--- a/frontend/supabase/tests/response_round_serialization.test.sql
+++ b/frontend/supabase/tests/response_round_serialization.test.sql
@@ -1,0 +1,175 @@
+-- Prova concorrente da barreira entre escrita de responses e ativacao de rodada.
+-- As fixtures ficam commitadas para que as duas conexoes dblink as enxerguem;
+-- UUIDs reservados e o cleanup do topo tornam reexecucoes seguras apos falha.
+
+CREATE EXTENSION IF NOT EXISTS dblink WITH SCHEMA extensions;
+
+DELETE FROM public.projects
+WHERE id = '69000000-0000-0000-0000-000000000001';
+DELETE FROM auth.users
+WHERE id = '69000000-0000-0000-0000-000000000002';
+
+INSERT INTO auth.users (id, email) VALUES
+  ('69000000-0000-0000-0000-000000000002', 'round-serialization@example.test');
+
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('69000000-0000-0000-0000-000000000001', 'round serialization',
+   '69000000-0000-0000-0000-000000000002');
+
+INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
+  ('69000000-0000-0000-0000-000000000003',
+   '69000000-0000-0000-0000-000000000001', 'doc', 'texto',
+   'round-serialization-doc');
+
+INSERT INTO public.rounds (id, project_id, label) VALUES
+  ('69000000-0000-0000-0000-000000000004',
+   '69000000-0000-0000-0000-000000000001', 'Rodada seguinte'),
+  ('69000000-0000-0000-0000-000000000005',
+   '69000000-0000-0000-0000-000000000001', 'Rodada final');
+
+SELECT extensions.dblink_connect(
+  'round_writer',
+  'host=host.docker.internal port=54322 dbname=postgres user=postgres password=postgres'
+);
+SELECT extensions.dblink_connect(
+  'round_switcher',
+  'host=host.docker.internal port=54322 dbname=postgres user=postgres password=postgres'
+);
+
+-- O helper converte somente a rejeicao esperada em dado observavel. Qualquer
+-- outra excecao continua derrubando a suite.
+SELECT extensions.dblink_exec(
+  'round_writer',
+  $$CREATE FUNCTION pg_temp.try_stale_response() RETURNS text
+    LANGUAGE plpgsql AS $fn$
+    DECLARE v_old_round uuid;
+    BEGIN
+      SELECT id INTO STRICT v_old_round
+      FROM public.rounds
+      WHERE project_id = '69000000-0000-0000-0000-000000000001'
+        AND label = 'Rodada inicial';
+
+      INSERT INTO public.responses (
+        project_id, document_id, respondent_id, respondent_type,
+        respondent_name, answers, is_latest, is_partial, round_id
+      ) VALUES (
+        '69000000-0000-0000-0000-000000000001',
+        '69000000-0000-0000-0000-000000000003',
+        '69000000-0000-0000-0000-000000000002', 'humano', 'Writer',
+        '{"q1":"stale"}'::jsonb, true, true, v_old_round
+      );
+      RETURN 'unexpected-success';
+    EXCEPTION WHEN serialization_failure THEN
+      RETURN 'rejected-stale-round';
+    END;
+    $fn$;$$
+);
+
+-- 1. A troca ganha o lock: o save espera e, depois do commit, falha fechado.
+SELECT extensions.dblink_exec('round_switcher', 'BEGIN');
+SELECT extensions.dblink_exec(
+  'round_switcher',
+  $$UPDATE public.projects
+    SET current_round_id = '69000000-0000-0000-0000-000000000004'
+    WHERE id = '69000000-0000-0000-0000-000000000001'$$
+);
+SELECT extensions.dblink_send_query(
+  'round_writer',
+  'SELECT pg_temp.try_stale_response()'
+);
+SELECT pg_catalog.pg_sleep(0.2);
+
+DO $$
+BEGIN
+  IF extensions.dblink_is_busy('round_writer') <> 1 THEN
+    RAISE EXCEPTION 'FALHOU: save antigo nao esperou o lock da troca de rodada';
+  END IF;
+END;
+$$;
+
+SELECT extensions.dblink_exec('round_switcher', 'COMMIT');
+CREATE TEMP TABLE stale_save_result AS
+SELECT * FROM extensions.dblink_get_result('round_writer') AS result(outcome text);
+SELECT * FROM extensions.dblink_get_result('round_writer') AS result(outcome text);
+
+DO $$
+BEGIN
+  IF (SELECT outcome FROM stale_save_result) IS DISTINCT FROM 'rejected-stale-round'
+     OR EXISTS (
+       SELECT 1 FROM public.responses
+       WHERE project_id = '69000000-0000-0000-0000-000000000001'
+     ) THEN
+    RAISE EXCEPTION 'FALHOU: save antigo gravou depois da troca de rodada';
+  END IF;
+END;
+$$;
+
+-- 2. O save ganha o lock: a ativacao espera e so avanca depois do commit.
+UPDATE public.projects
+SET current_round_id = (
+  SELECT id FROM public.rounds
+  WHERE project_id = '69000000-0000-0000-0000-000000000001'
+    AND label = 'Rodada inicial'
+)
+WHERE id = '69000000-0000-0000-0000-000000000001';
+
+SELECT extensions.dblink_exec('round_writer', 'BEGIN');
+SELECT extensions.dblink_exec(
+  'round_writer',
+  $$INSERT INTO public.responses (
+      project_id, document_id, respondent_id, respondent_type,
+      respondent_name, answers, is_latest, is_partial, round_id
+    )
+    SELECT '69000000-0000-0000-0000-000000000001',
+           '69000000-0000-0000-0000-000000000003',
+           '69000000-0000-0000-0000-000000000002', 'humano', 'Writer',
+           '{"q1":"before-switch"}'::jsonb, true, true, project.current_round_id
+    FROM public.projects AS project
+    WHERE project.id = '69000000-0000-0000-0000-000000000001'$$
+);
+SELECT extensions.dblink_send_query(
+  'round_switcher',
+  $$UPDATE public.projects
+    SET current_round_id = '69000000-0000-0000-0000-000000000005'
+    WHERE id = '69000000-0000-0000-0000-000000000001'
+    RETURNING 'activated'::text$$
+);
+SELECT pg_catalog.pg_sleep(0.2);
+
+DO $$
+BEGIN
+  IF extensions.dblink_is_busy('round_switcher') <> 1 THEN
+    RAISE EXCEPTION 'FALHOU: ativacao nao esperou o save ja iniciado';
+  END IF;
+END;
+$$;
+
+SELECT extensions.dblink_exec('round_writer', 'COMMIT');
+CREATE TEMP TABLE activation_result AS
+SELECT * FROM extensions.dblink_get_result('round_switcher') AS result(outcome text);
+SELECT * FROM extensions.dblink_get_result('round_switcher') AS result(outcome text);
+
+DO $$
+BEGIN
+  IF (SELECT outcome FROM activation_result) IS DISTINCT FROM 'activated'
+     OR NOT EXISTS (
+       SELECT 1 FROM public.responses
+       WHERE project_id = '69000000-0000-0000-0000-000000000001'
+         AND answers = '{"q1":"before-switch"}'::jsonb
+     )
+     OR (SELECT current_round_id FROM public.projects
+         WHERE id = '69000000-0000-0000-0000-000000000001')
+        IS DISTINCT FROM '69000000-0000-0000-0000-000000000005'::uuid THEN
+    RAISE EXCEPTION 'FALHOU: save e ativacao nao produziram ordem linear';
+  END IF;
+  RAISE NOTICE 'OK: save e troca de rodada serializam nas duas ordens';
+END;
+$$;
+
+SELECT extensions.dblink_disconnect('round_writer');
+SELECT extensions.dblink_disconnect('round_switcher');
+
+DELETE FROM public.projects
+WHERE id = '69000000-0000-0000-0000-000000000001';
+DELETE FROM auth.users
+WHERE id = '69000000-0000-0000-0000-000000000002';


### PR DESCRIPTION
## Contexto\n\nPermite iniciar uma nova rodada dentro do sorteio e redistribuir os documentos entre pesquisadores, preservando as respostas e atribuições anteriores como histórico.\n\n## Mudanças\n\n- cria e ativa a nova rodada na mesma transação do sorteio;\n- exige confirmação quando a rodada atual ainda tem trabalho aberto;\n- vincula lotes, atribuições, respostas humanas e execuções LLM à rodada;\n- torna rodadas anteriores somente leitura na matriz e no formulário;\n- cria projetos novos já com a rodada inicial, de forma atômica;\n- inclui backfill fail-fast para os projetos existentes e invariantes por rodada no banco.\n\n## Validação\n\n- frontend: 198 arquivos / 2.171 testes;\n- backend: 280 testes;\n- TypeScript typecheck;\n- ESLint sem erros (5 warnings preexistentes);\n- Supabase reset local e 17 suítes SQL de gate.\n\n## Gates com ressalva\n\n- O smoke E2E remoto foi executado antes do push e teve 7 cenários aprovados, 1 ignorado e 3 falhas porque os projetos-fixture remotos ainda não possuem a rodada criada por esta migration; o gate foi pulado explicitamente no push após esse diagnóstico.\n- O fallow foi pulado explicitamente: marcou como novos limites de complexidade de funções preexistentes tocadas pela integração. O pre-commit react-doctor, Semgrep, mypy e os demais gates passaram.\n\n## Implantação\n\nA migração não foi aplicada ao Supabase remoto. O lote vazio já existente no projeto Zolgensma também não foi removido.