### PR TITLE
Reduz custo ocioso do backend no Fly

### DIFF
--- a/.github/scripts/check-backend-fly-machines.sh
+++ b/.github/scripts/check-backend-fly-machines.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fly_config="$repo_root/backend/fly.toml"
+mode="${1:-}"
+
+if [[ "$mode" != "pre" && "$mode" != "post" ]]; then
+  echo "uso: $0 pre|post" >&2
+  exit 64
+fi
+
+machines_json="$(flyctl machine list -c "$fly_config" --json)"
+if ! machine_count="$(jq -er '
+  if type == "array" then length
+  else error("resposta de Machines não é um array")
+  end
+' <<<"$machines_json")"; then
+  echo "Não foi possível interpretar a lista de Machines do backend." >&2
+  exit 1
+fi
+
+if [[ "$mode" == "pre" ]]; then
+  if ((machine_count > 1)); then
+    echo "Deploy recusado: o backend tem $machine_count Machines; reduza explicitamente para no máximo uma antes do deploy." >&2
+    exit 1
+  fi
+  echo "Preflight Fly aprovado: $machine_count Machine(s)."
+  exit 0
+fi
+
+if ((machine_count != 1)); then
+  echo "Deploy inválido: esperado exatamente uma Machine do backend, encontrado $machine_count." >&2
+  exit 1
+fi
+
+if ! jq -e '
+  length == 1
+  and .[0].state == "started"
+  and .[0].region == "gru"
+  and .[0].config.guest.cpu_kind == "shared"
+  and .[0].config.guest.cpus == 1
+  and .[0].config.guest.memory_mb == 512
+' >/dev/null <<<"$machines_json"; then
+  echo "Deploy inválido: a Machine deve estar iniciada em gru com shared-cpu-1x e 512 MB." >&2
+  exit 1
+fi
+
+machine_id="$(jq -er '.[0].id | select(type == "string" and length > 0)' <<<"$machines_json")"
+readonly health_attempts=12
+readonly health_interval_seconds=10
+
+for ((attempt = 1; attempt <= health_attempts; attempt += 1)); do
+  if checks_json="$(flyctl checks list -c "$fly_config" --json)" && jq -e --arg machine_id "$machine_id" '
+    type == "object"
+    and ((.[$machine_id] // null) as $checks
+      | ($checks | type) == "array"
+      and ($checks | length) > 0
+      and all($checks[]; .status == "passing"))
+  ' >/dev/null <<<"$checks_json"; then
+    echo "Postflight Fly aprovado: uma Machine saudável em gru, shared-cpu-1x/512 MB."
+    exit 0
+  fi
+
+  if ((attempt < health_attempts)); then
+    echo "Health ainda não passou (tentativa $attempt/$health_attempts); nova verificação em ${health_interval_seconds}s."
+    sleep "$health_interval_seconds"
+  fi
+done
+
+echo "Deploy inválido: a Machine não apresentou health check verde após $health_attempts tentativa(s)." >&2
+exit 1

--- a/.github/scripts/test-backend-fly-machine-contract.sh
+++ b/.github/scripts/test-backend-fly-machine-contract.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+checker="$repo_root/.github/scripts/check-backend-fly-machines.sh"
+workflow="$repo_root/.github/workflows/fly-deploy.yml"
+fly_config="$repo_root/backend/fly.toml"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+mkdir -p "$tmp_dir/bin"
+
+cat >"$tmp_dir/bin/flyctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-} ${2:-}" in
+  "machine list") printf '%s' "$MACHINES_JSON" ;;
+  "checks list") printf '%s' "$CHECKS_JSON" ;;
+  *) echo "flyctl inesperado: $*" >&2; exit 64 ;;
+esac
+EOF
+chmod +x "$tmp_dir/bin/flyctl"
+cat >"$tmp_dir/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$tmp_dir/bin/sleep"
+
+machine() {
+  local state="${1:-started}"
+  local region="${2:-gru}"
+  local cpu_kind="${3:-shared}"
+  local cpus="${4:-1}"
+  local memory_mb="${5:-512}"
+  printf '[{"id":"machine-1","state":"%s","region":"%s","config":{"guest":{"cpu_kind":"%s","cpus":%s,"memory_mb":%s}}}]' \
+    "$state" "$region" "$cpu_kind" "$cpus" "$memory_mb"
+}
+
+run_checker() {
+  env \
+    "PATH=$tmp_dir/bin:$PATH" \
+    MACHINES_JSON="$MACHINES_JSON" \
+    CHECKS_JSON="$CHECKS_JSON" \
+    bash "$checker" "$1"
+}
+
+expect_failure() {
+  if "$@" >/dev/null 2>&1; then
+    echo "comando deveria ter falhado: $*" >&2
+    exit 1
+  fi
+}
+
+bash -n "$checker" "$0"
+
+# O preflight aceita somente os estados dos quais --ha=false converge para uma
+# única Machine. Mais de uma exige redução remota explícita antes do deploy.
+MACHINES_JSON='[]'
+CHECKS_JSON='{}'
+run_checker pre >/dev/null
+MACHINES_JSON="$(machine)"
+run_checker pre >/dev/null
+MACHINES_JSON="[$(machine | sed 's/^\[//; s/\]$//'),$(machine | sed 's/^\[//; s/\]$//')]"
+expect_failure run_checker pre
+MACHINES_JSON='{"unexpected":"shape"}'
+expect_failure run_checker pre
+
+# O postflight exige a topologia versionada e ao menos um health check verde.
+MACHINES_JSON="$(machine)"
+CHECKS_JSON='{"machine-1":[{"name":"servicecheck-00-http-8000","status":"passing"}]}'
+run_checker post >/dev/null
+
+for invalid_machine in \
+  "$(machine stopped)" \
+  "$(machine started iad)" \
+  "$(machine started gru performance)" \
+  "$(machine started gru shared 2)" \
+  "$(machine started gru shared 1 1024)"
+do
+  MACHINES_JSON="$invalid_machine"
+  expect_failure run_checker post
+done
+
+MACHINES_JSON="$(machine)"
+CHECKS_JSON='{}'
+expect_failure run_checker post
+CHECKS_JSON='{"machine-1":[{"name":"servicecheck-00-http-8000","status":"critical"}]}'
+expect_failure run_checker post
+
+# O workflow usa o mesmo contrato executável antes e depois do deploy e nunca
+# permite que o default de alta disponibilidade recrie a segunda Machine.
+ruby -ryaml -e '
+  workflow = YAML.safe_load(File.read(ARGV.fetch(0)), aliases: true)
+  trigger = workflow["on"] || workflow[true]
+  paths = trigger.fetch("push").fetch("paths")
+  abort("mudança no checker precisa disparar o workflow") unless paths.include?(".github/scripts/check-backend-fly-machines.sh")
+  steps = workflow.fetch("jobs").fetch("deploy").fetch("steps")
+  runs = steps.filter_map { |step| step["run"] }
+  pre = runs.index { |run| run.include?("check-backend-fly-machines.sh pre") }
+  deploy = runs.index { |run| run.include?("flyctl deploy") && run.include?("--ha=false") }
+  post = runs.index { |run| run.include?("check-backend-fly-machines.sh post") }
+  abort("workflow sem ordem preflight -> deploy -> postflight") unless pre && deploy && post && pre < deploy && deploy < post
+' "$workflow"
+
+grep -Fq 'size = "shared-cpu-1x"' "$fly_config"
+grep -Fq 'memory = "512mb"' "$fly_config"
+
+echo "Contrato de Machines do backend validado."

--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'backend/**'
       - '.github/workflows/fly-deploy.yml'
+      - '.github/scripts/check-backend-fly-machines.sh'
   workflow_dispatch:
 
 permissions:
@@ -24,8 +25,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Pin a SHA (tag 1.6) por supply-chain safety — @master é floating ref.
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
-      - run: flyctl deploy --remote-only -a gui-analise-sistematica-api
+      - name: Recusar cardinalidade divergente antes do deploy
+        run: bash .github/scripts/check-backend-fly-machines.sh pre
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: flyctl deploy
+        run: flyctl deploy --remote-only --ha=false -a gui-analise-sistematica-api
         working-directory: backend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Verificar topologia e health depois do deploy
+        run: bash .github/scripts/check-backend-fly-machines.sh post
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,16 @@ repos:
         pass_filenames: false
         require_serial: true
 
+      # Contrato de custo/disponibilidade do backend no Fly: o workflow só
+      # converge de 0/1 para uma Machine e valida tamanho, região e health.
+      - id: backend-fly-machine-contract
+        name: backend Fly machine contract
+        entry: .github/scripts/test-backend-fly-machine-contract.sh
+        language: system
+        files: ^(\.github/(workflows/fly-deploy\.yml|scripts/(check|test)-backend-fly-machine.*\.sh)|backend/fly\.toml)$
+        pass_filenames: false
+        require_serial: true
+
       # react-doctor como gate local de qualidade React (estilo flake8/mypy).
       #
       # Por que --scope changed e nao --staged: o --staged escaneia o arquivo

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ fly secrets set SUPABASE_URL=https://xxx.supabase.co \
 # CORS_ORIGINS, CLERK_JWKS_URL e CLERK_JWT_ISSUER ficam em [env] no fly.toml:
 # nenhum é secret (o JWKS é endpoint público, o issuer é a URL da Frontend API),
 # e mantê-los no toml faz da troca de instância Clerk um diff revisável.
-fly deploy -c fly.toml -a gui-analise-sistematica-api   # fallback; o normal é via CI
+fly deploy -c fly.toml --ha=false -a gui-analise-sistematica-api   # fallback; o normal é via CI
 ```
 
 `CLERK_JWKS_URL` já existiu como secret deste app. Enquanto o secret existir, ele **sombreia o `[env]` homônimo** do `fly.toml` — o valor versionado é ignorado em silêncio (o mesmo já aconteceu aqui com `CORS_ORIGINS`). Depois do primeiro deploy que traz a variável para o `[env]`, remover o secret:
@@ -122,6 +122,8 @@ fly secrets unset CLERK_JWKS_URL -a gui-analise-sistematica-api
 Enquanto os dois valores forem idênticos a ordem deploy → unset não tem downtime; a inversa teria. O risco de deixar o secret para trás aparece na *próxima* troca de instância Clerk: o `fly.toml` apontaria para o JWKS novo, o secret continuaria servindo o antigo, e o par JWKS/issuer divergiria — exatamente o modo de falha que a validação de `iss` existe para tornar diagnosticável.
 
 Verificar: `curl https://gui-analise-sistematica-api.fly.dev/health`
+
+O backend opera com exatamente uma Machine `shared-cpu-1x` de 512 MB, sempre ligada. O workflow recusa deploy quando encontra mais de uma Machine e valida cardinalidade, região, tamanho e health depois da atualização; reduções remotas continuam sendo uma operação explícita, fora do deploy automático.
 
 ### 3. Frontend (Fly.io — `gui-analise-sistematica-frontend`)
 

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -15,6 +15,12 @@ kill_timeout = "5m"
   # o deploy automatico (fly-deploy.yml).
   strategy = "bluegreen"
 
+[[vm]]
+  # Fonte versionada do tamanho: `--ha=false` no workflow controla a
+  # cardinalidade; este bloco impede que um deploy recrie a Machine maior.
+  size = "shared-cpu-1x"
+  memory = "512mb"
+
 [http_service]
   internal_port = 8000
   force_https = true

--- a/backend/services/auto_review_reconciliation.py
+++ b/backend/services/auto_review_reconciliation.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 
 import httpx
 
@@ -40,6 +41,32 @@ def assert_auto_review_reconciliation_capability() -> None:
         raise RuntimeError(
             "Database migration returned an invalid auto-review capability."
         )
+
+
+async def has_due_auto_review_reconciliation_request(
+    *, now: datetime | None = None
+) -> bool:
+    """Return whether the durable outbox has work eligible for this tick."""
+    due_before = (now or datetime.now(UTC)).isoformat()
+
+    def query_due_request() -> bool:
+        result = (
+            get_supabase()
+            .table("auto_review_reconciliation_requests")
+            .select("document_id")
+            .lte("next_attempt_at", due_before)
+            .limit(1)
+            .execute()
+        )
+        if not isinstance(result.data, list):
+            raise RuntimeError(
+                "Auto-review reconciliation outbox returned invalid data."
+            )
+        return bool(result.data)
+
+    # supabase-py is synchronous. Keep its network wait outside FastAPI's event
+    # loop so health checks and requests are not stalled by the periodic probe.
+    return await asyncio.to_thread(query_due_request)
 
 
 async def wake_auto_review_reconciliation(
@@ -82,8 +109,23 @@ async def wake_auto_review_reconciliation(
 async def run_auto_review_reconciliation_wakeup_loop(
     *, interval_seconds: float = _WAKEUP_INTERVAL_SECONDS
 ) -> None:
-    """Wake the frontend immediately and periodically until cancellation."""
+    """Wake the frontend only while the durable outbox has due work."""
     async with httpx.AsyncClient(timeout=_WAKEUP_TIMEOUT_SECONDS) as client:
         while True:
-            await wake_auto_review_reconciliation(client)
+            try:
+                has_due_request = await has_due_auto_review_reconciliation_request()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # A falha da sonda não prova que a outbox está vazia. Acordar o
+                # consumidor preserva o contrato durável em vez de atrasar jobs.
+                logger.warning(
+                    "Failed to inspect auto-review reconciliation outbox; "
+                    "waking frontend conservatively",
+                    exc_info=True,
+                )
+                has_due_request = True
+
+            if has_due_request:
+                await wake_auto_review_reconciliation(client)
             await asyncio.sleep(interval_seconds)

--- a/backend/tests/test_auto_review_reconciliation.py
+++ b/backend/tests/test_auto_review_reconciliation.py
@@ -1,5 +1,6 @@
 import asyncio
-from contextlib import suppress
+from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -67,32 +68,120 @@ def test_wakeup_is_disabled_without_internal_url(monkeypatch) -> None:
     assert asyncio.run(reconciliation.wake_auto_review_reconciliation()) is False
 
 
-def test_periodic_loop_repeats_wakeup(monkeypatch) -> None:
-    calls: list[object] = []
-    called_twice = asyncio.Event()
+class _DueRequestQuery:
+    def __init__(self, data: list[dict[str, str]]) -> None:
+        self.data = data
+        self.calls: list[tuple[object, ...]] = []
+
+    def select(self, columns: str):
+        self.calls.append(("select", columns))
+        return self
+
+    def lte(self, column: str, value: str):
+        self.calls.append(("lte", column, value))
+        return self
+
+    def limit(self, count: int):
+        self.calls.append(("limit", count))
+        return self
+
+    def execute(self):
+        self.calls.append(("execute",))
+        return SimpleNamespace(data=self.data)
+
+
+@pytest.mark.parametrize(
+    ("rows", "expected"),
+    [([], False), ([{"document_id": "document-1"}], True)],
+)
+def test_due_request_query_is_bounded_and_uses_database_deadline(
+    monkeypatch,
+    rows: list[dict[str, str]],
+    expected: bool,
+) -> None:
+    query = _DueRequestQuery(rows)
+
+    class Supabase:
+        def table(self, name: str):
+            assert name == "auto_review_reconciliation_requests"
+            return query
+
+    monkeypatch.setattr(reconciliation, "get_supabase", lambda: Supabase())
+    now = datetime(2026, 8, 3, 15, 30, tzinfo=UTC)
+
+    assert (
+        asyncio.run(reconciliation.has_due_auto_review_reconciliation_request(now=now))
+        is expected
+    )
+    assert query.calls == [
+        ("select", "document_id"),
+        ("lte", "next_attempt_at", "2026-08-03T15:30:00+00:00"),
+        ("limit", 1),
+        ("execute",),
+    ]
+
+
+class _StopLoop(Exception):
+    pass
+
+
+def _run_single_periodic_tick(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    due: bool | Exception,
+) -> list[object]:
+    wakeup_calls: list[object] = []
+
+    async def fake_has_due_request() -> bool:
+        if isinstance(due, Exception):
+            raise due
+        return due
 
     async def fake_wakeup(client=None) -> bool:
-        calls.append(client)
-        if len(calls) == 2:
-            called_twice.set()
+        wakeup_calls.append(client)
         return True
 
-    monkeypatch.setattr(reconciliation, "wake_auto_review_reconciliation", fake_wakeup)
+    async def stop_after_tick(_interval_seconds: float) -> None:
+        raise _StopLoop
 
-    async def scenario() -> None:
-        task = asyncio.create_task(
+    monkeypatch.setattr(
+        reconciliation,
+        "has_due_auto_review_reconciliation_request",
+        fake_has_due_request,
+    )
+    monkeypatch.setattr(reconciliation, "wake_auto_review_reconciliation", fake_wakeup)
+    monkeypatch.setattr(reconciliation.asyncio, "sleep", stop_after_tick)
+
+    with pytest.raises(_StopLoop):
+        asyncio.run(
             reconciliation.run_auto_review_reconciliation_wakeup_loop(
                 interval_seconds=0
             )
         )
-        await asyncio.wait_for(called_twice.wait(), timeout=1)
-        task.cancel()
-        with suppress(asyncio.CancelledError):
-            await task
 
-    asyncio.run(scenario())
-    assert len(calls) >= 2
-    assert all(call is calls[0] for call in calls)
+    return wakeup_calls
+
+
+def test_periodic_loop_does_not_wake_frontend_without_due_work(monkeypatch) -> None:
+    assert _run_single_periodic_tick(monkeypatch, due=False) == []
+
+
+def test_periodic_loop_wakes_frontend_for_due_work(monkeypatch) -> None:
+    calls = _run_single_periodic_tick(monkeypatch, due=True)
+
+    assert len(calls) == 1
+
+
+def test_periodic_loop_wakes_conservatively_when_outbox_query_fails(
+    monkeypatch, caplog
+) -> None:
+    calls = _run_single_periodic_tick(
+        monkeypatch,
+        due=RuntimeError("database unavailable"),
+    )
+
+    assert len(calls) == 1
+    assert "Failed to inspect auto-review reconciliation outbox" in caplog.text
 
 
 def test_lifespan_starts_and_stops_periodic_wakeup(monkeypatch) -> None:


### PR DESCRIPTION
## O que mudou

- consulta a outbox durável antes de cada tick periódico e só acorda o frontend quando há pedido com `next_attempt_at <= agora`;
- em erro da consulta, mantém o comportamento conservador: registra a falha e acorda o consumidor;
- preserva o wake imediato disparado pelo `llm_runner` após publicar respostas;
- fixa o backend em uma Machine `shared-cpu-1x` de 512 MB;
- adiciona `--ha=false` e guardas fail-closed antes e depois do deploy para cardinalidade, região, CPU, memória e health;
- atualiza o fallback manual e adiciona teste comportamental do contrato Fly ao pre-commit.

## Causa raiz e impacto

O backend acordava o frontend a cada 30 segundos mesmo com a outbox vazia. Isso impedia o futuro scale-to-zero do frontend e mantinha tráfego sem trabalho. Além disso, o workflow não desabilitava o default de alta disponibilidade do Fly, permitindo que um deploy recriasse uma segunda Machine.

Com este PR, o backend continua always-on para proteger os `BackgroundTasks` de LLM, mas o wake periódico passa a refletir trabalho vencido na outbox e novos deploys ficam presos ao contrato de uma única Machine de 512 MB.

## Verificação

- `uv run --group dev pytest -q`: 284 testes passaram;
- teste focal da reconciliação: 12 testes passaram, com prova do vermelho antes da implementação;
- Playwright pre-push delegado: 10 passaram, 1 ignorado, 0 falharam;
- ruff, mypy, semgrep, actionlint e shellcheck passaram;
- contrato comportamental das Machines e notificador de falha passaram;
- `flyctl config validate --strict -c backend/fly.toml` passou;
- `git diff --check` passou.

## Gate operacional

O preflight read-only confirmou que o app remoto ainda tem 2 Machines e recusou corretamente esse estado. Antes do merge — que dispara o deploy automático — é necessário reduzir explicitamente o backend para 1 Machine e validar os jobs LLM em andamento. Este PR não altera o estado remoto da Fly.io.