### PR TITLE
Corrige contagem de trabalho aberto e sorteios vazios

### DIFF
--- a/frontend/src/actions/__tests__/assignments.test.ts
+++ b/frontend/src/actions/__tests__/assignments.test.ts
@@ -51,6 +51,12 @@ import {
   smartRandomize,
   type LotteryParams,
 } from "../assignments";
+import { LOTTERY_EMPTY_MESSAGES } from "@/lib/lottery-utils";
+
+const ROUND_RESULTS: TableResults = {
+  rounds: { data: { id: "round-1", label: "Rodada inicial" } },
+  lottery_round_work_counts: { data: [] },
+};
 
 beforeEach(() => {
   serverTableResults = undefined;
@@ -63,6 +69,7 @@ beforeEach(() => {
 describe("getLotteryDocStats", () => {
   it("mapeia as linhas da view lottery_doc_stats para LotteryDocStats[]", async () => {
     serverTableResults = {
+      ...ROUND_RESULTS,
       lottery_doc_stats: {
         data: [
           {
@@ -73,7 +80,7 @@ describe("getLotteryDocStats", () => {
             has_llm_response: true,
             active_codificacao: 1,
             active_comparacao: 0,
-            has_any_assignment_ever: true,
+            has_assignment_in_current_round: true,
             batch_ids: ["b1", "b2"],
           },
           {
@@ -84,7 +91,7 @@ describe("getLotteryDocStats", () => {
             has_llm_response: false,
             active_codificacao: 0,
             active_comparacao: 0,
-            has_any_assignment_ever: false,
+            has_assignment_in_current_round: false,
             batch_ids: null,
           },
         ],
@@ -108,7 +115,7 @@ describe("getLotteryDocStats", () => {
         humanCodingCount: 2,
         hasLlmResponse: true,
         activeAssignments: { codificacao: 1, comparacao: 0 },
-        hasAnyAssignmentEver: true,
+        hasAssignmentInCurrentRound: true,
         batchIds: ["b1", "b2"],
       },
       {
@@ -118,16 +125,45 @@ describe("getLotteryDocStats", () => {
         humanCodingCount: 0,
         hasLlmResponse: false,
         activeAssignments: { codificacao: 0, comparacao: 0 },
-        hasAnyAssignmentEver: false,
+        hasAssignmentInCurrentRound: false,
         batchIds: [],
       },
     ]);
     expect(result.minResponsesForComparison).toBe(2);
     expect(result.automationMode).toBe("compare_llm");
+    expect(result.currentRoundId).toBe("round-1");
+    expect(result.currentRoundLabel).toBe("Rodada inicial");
+    expect(result.activeOpenAssignmentCount).toBe(0);
+    expect(result.pendingScopeAssignmentCount).toBe(0);
+  });
+
+  it("separa trabalho ativo de documentos ainda em revisão de escopo", async () => {
+    serverTableResults = {
+      ...ROUND_RESULTS,
+      lottery_doc_stats: { data: [] },
+      assignment_batches: { data: [] },
+      projects: {
+        data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" },
+      },
+      lottery_round_work_counts: {
+        data: [
+          { assignment_type: "codificacao", scope_state: "active", open_count: 3 },
+          { assignment_type: "comparacao", scope_state: "active", open_count: 2 },
+          { assignment_type: "codificacao", scope_state: "pending_scope", open_count: 4 },
+        ],
+      },
+    };
+
+    const result = await getLotteryDocStats("p1");
+
+    expect(result.error).toBeUndefined();
+    expect(result.activeOpenAssignmentCount).toBe(5);
+    expect(result.pendingScopeAssignmentCount).toBe(4);
   });
 
   it("não consulta responses nem assignments crus (regressão da issue #182)", async () => {
     serverTableResults = {
+      ...ROUND_RESULTS,
       lottery_doc_stats: { data: [] },
       assignment_batches: { data: [] },
       projects: { data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" } },
@@ -136,6 +172,7 @@ describe("getLotteryDocStats", () => {
     await getLotteryDocStats("p1");
 
     expect(fromCalls).toContain("lottery_doc_stats");
+    expect(fromCalls).toContain("lottery_round_work_counts");
     expect(fromCalls).not.toContain("responses");
     expect(fromCalls).not.toContain("assignments");
   });
@@ -144,6 +181,7 @@ describe("getLotteryDocStats", () => {
 describe("previewLottery", () => {
   it("caminho feliz: distribui documentos elegíveis a partir da view + assignments brutos", async () => {
     serverTableResults = {
+      ...ROUND_RESULTS,
       project_members: { data: [{ user_id: "u1" }] },
       lottery_doc_stats: {
         data: [
@@ -155,7 +193,7 @@ describe("previewLottery", () => {
             has_llm_response: false,
             active_codificacao: 0,
             active_comparacao: 0,
-            has_any_assignment_ever: false,
+            has_assignment_in_current_round: false,
             batch_ids: [],
           },
         ],
@@ -163,6 +201,7 @@ describe("previewLottery", () => {
       assignment_batches: { data: [] },
       projects: { data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" } },
       assignments: { data: [] },
+      responses: { data: [] },
     };
 
     const result = await previewLottery({
@@ -183,6 +222,158 @@ describe("previewLottery", () => {
     expect(fromCalls).toContain("lottery_doc_stats");
     expect(fromCalls).toContain("assignments");
   });
+
+  it("falha fechado quando não consegue ler as atribuições existentes", async () => {
+    serverTableResults = {
+      ...ROUND_RESULTS,
+      project_members: { data: [{ user_id: "u1" }] },
+      lottery_doc_stats: {
+        data: [
+          {
+            id: "d1",
+            external_id: null,
+            title: "Doc 1",
+            human_coding_count: 0,
+            has_llm_response: false,
+            active_codificacao: 0,
+            active_comparacao: 0,
+            has_assignment_in_current_round: false,
+            batch_ids: [],
+          },
+        ],
+      },
+      assignment_batches: { data: [] },
+      projects: {
+        data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" },
+      },
+      assignments: { data: null, error: { message: "timeout" } },
+      responses: { data: [] },
+    };
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "codificacao",
+      mode: "append",
+      balancing: "round",
+      researchersPerDoc: 1,
+      participantIds: ["u1"],
+    });
+
+    expect(result.error).toBe(
+      "Erro ao ler as atribuições existentes do sorteio: timeout",
+    );
+    expect(rpcCalls).toHaveLength(0);
+  });
+
+  it("explica quando a capacidade total dos participantes já acabou", async () => {
+    serverTableResults = {
+      ...ROUND_RESULTS,
+      project_members: { data: [{ user_id: "u1" }] },
+      lottery_doc_stats: {
+        data: [
+          {
+            id: "d1",
+            external_id: null,
+            title: "Doc 1",
+            human_coding_count: 0,
+            has_llm_response: false,
+            active_codificacao: 0,
+            active_comparacao: 0,
+            has_assignment_in_current_round: false,
+            batch_ids: [],
+          },
+          {
+            id: "d2",
+            external_id: null,
+            title: "Doc 2",
+            human_coding_count: 1,
+            has_llm_response: false,
+            active_codificacao: 1,
+            active_comparacao: 0,
+            has_assignment_in_current_round: true,
+            batch_ids: ["b0"],
+          },
+        ],
+      },
+      assignment_batches: { data: [] },
+      projects: {
+        data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" },
+      },
+      assignments: {
+        data: [
+          { document_id: "d2", user_id: "u1", status: "concluido", type: "codificacao", round_id: "round-1" },
+        ],
+      },
+      responses: { data: [] },
+    };
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "codificacao",
+      mode: "append",
+      balancing: "round",
+      researchersPerDoc: 1,
+      docsPerResearcher: 1,
+      participantIds: ["u1"],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.preview).toMatchObject({
+      totalNew: 0,
+      emptyReason: "capacity_exhausted",
+      unfilledSlots: 1,
+    });
+  });
+
+  it("atribuições de documentos fora do escopo não consomem capacidade", async () => {
+    serverTableResults = {
+      ...ROUND_RESULTS,
+      project_members: { data: [{ user_id: "u1" }] },
+      lottery_doc_stats: {
+        data: [
+          {
+            id: "active-doc",
+            external_id: null,
+            title: "Documento ativo",
+            human_coding_count: 0,
+            has_llm_response: false,
+            active_codificacao: 0,
+            active_comparacao: 0,
+            has_assignment_in_current_round: false,
+            batch_ids: [],
+          },
+        ],
+      },
+      assignment_batches: { data: [] },
+      projects: {
+        data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" },
+      },
+      assignments: {
+        data: [
+          { document_id: "excluded-doc", user_id: "u1", status: "em_andamento", type: "codificacao", round_id: "round-1" },
+          { document_id: "pending-scope-doc", user_id: "u1", status: "pendente", type: "codificacao", round_id: "round-1" },
+        ],
+      },
+      responses: { data: [] },
+    };
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "codificacao",
+      mode: "append",
+      balancing: "history",
+      researchersPerDoc: 1,
+      docsPerResearcher: 1,
+      participantIds: ["u1"],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.preview).toMatchObject({
+      totalNew: 1,
+      totalPreserved: 0,
+      participants: [{ userId: "u1", existing: 0, newDocs: 1 }],
+    });
+  });
 });
 
 // Regressão da issue #490: o sorteio de Comparação herdava o default 2 do
@@ -193,6 +384,7 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
   // número de revisores fosse honrado, sobrariam candidatos para uma 2ª vaga.
   function comparisonFixture(assignments: unknown[] = []): TableResults {
     return {
+      ...ROUND_RESULTS,
       project_members: { data: [{ user_id: "u1" }, { user_id: "u2" }, { user_id: "u3" }] },
       lottery_doc_stats: {
         data: [
@@ -204,7 +396,7 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
             has_llm_response: false,
             active_codificacao: 0,
             active_comparacao: 0,
-            has_any_assignment_ever: true,
+            has_assignment_in_current_round: true,
             batch_ids: [],
           },
         ],
@@ -212,10 +404,11 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
       assignment_batches: { data: [] },
       projects: { data: { min_responses_for_comparison: 2, automation_mode: null, current_round_id: "round-1" } },
       assignments: { data: assignments },
+      responses: { data: [] },
     };
   }
 
-  it("ignora researchersPerDoc forjado no payload e atribui um único revisor", async () => {
+  it("recusa researchersPerDoc forjado no payload de comparação antes de consultar o banco", async () => {
     serverTableResults = comparisonFixture();
 
     const result = await previewLottery({
@@ -223,19 +416,15 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
       type: "comparacao",
       mode: "append",
       balancing: "round",
-      // A união discriminada proíbe este campo no braço "comparacao": o cast é o
-      // teste. Server Action é endpoint HTTP público e o projeto não valida com
-      // zod — o contrato sob prova é o server IGNORAR o que o client pediu, e
-      // não confiar no type-check que só existe em tempo de compilação.
+      // A união discriminada proíbe este campo no braço "comparacao": o cast é
+      // o teste da validação runtime na fronteira da Server Action.
       researchersPerDoc: 2,
       participantIds: ["u1", "u2", "u3"],
     } as unknown as LotteryParams);
 
-    expect(result.error).toBeUndefined();
-    expect(result.preview?.totalNew).toBe(1);
-    expect(
-      result.preview?.participants.filter((p) => p.newDocs > 0),
-    ).toHaveLength(1);
+    expect(result.error).toContain("Configuração do sorteio inválida");
+    expect(fromCalls).toHaveLength(0);
+    expect(rpcCalls).toHaveLength(0);
   });
 
   it("comparação nunca sorteia o codificador do próprio documento", async () => {
@@ -314,10 +503,8 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
       type: "comparacao",
       mode: "append",
       balancing: "round",
-      // Forjado: é este pedido que, honrado, abriria a 2ª vaga do documento.
-      researchersPerDoc: 2,
       participantIds: ["u1", "u2", "u3"],
-    } as unknown as LotteryParams);
+    });
 
     // O documento passa nos filtros (o coordenador não filtrou nada), mas a vaga
     // está ocupada pela comparação ativa: a prévia mostra zero elegíveis em vez
@@ -325,6 +512,50 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
     expect(result.error).toBeUndefined();
     expect(result.preview?.eligibleDocs).toBe(0);
     expect(result.preview?.totalNew).toBe(0);
+    expect(result.preview?.emptyReason).toBe("all_slots_filled");
+  });
+
+  it("não chama a RPC quando todas as vagas já estão ocupadas", async () => {
+    serverTableResults = comparisonFixture([
+      { document_id: "d1", user_id: "u1", status: "pendente", type: "comparacao", round_id: "round-1" },
+    ]);
+
+    const result = await smartRandomize({
+      projectId: "p1",
+      type: "comparacao",
+      mode: "append",
+      balancing: "round",
+      participantIds: ["u1", "u2", "u3"],
+    });
+
+    expect(result.error).toBe(LOTTERY_EMPTY_MESSAGES.all_slots_filled);
+    expect(rpcCalls).toHaveLength(0);
+    expect(writeCalls).toHaveLength(0);
+  });
+
+  it("explica quando todos os pares disponíveis são vetados", async () => {
+    serverTableResults = {
+      ...comparisonFixture(),
+      project_members: { data: [{ user_id: "u1" }] },
+      responses: {
+        data: [{ document_id: "d1", respondent_id: "u1", round_id: "round-1" }],
+      },
+    };
+
+    const result = await previewLottery({
+      projectId: "p1",
+      type: "comparacao",
+      mode: "append",
+      balancing: "round",
+      participantIds: ["u1"],
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.preview).toMatchObject({
+      totalNew: 0,
+      emptyReason: "no_available_pairs",
+      unfilledSlots: 1,
+    });
   });
 
   it("smartRandomize grava um assignment e registra researchers_per_doc 1 no lote", async () => {
@@ -334,16 +565,15 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
       // insert...select("id").single() do lote deste sorteio.
       assignment_batches: [{ data: [] }, { data: { id: "b1" } }],
     };
-    rpcResults = { apply_lottery_assignments: { data: 1 } };
+    rpcResults = { apply_lottery_assignments: { data: { inserted: 1 } } };
 
     const result = await smartRandomize({
       projectId: "p1",
       type: "comparacao",
       mode: "append",
       balancing: "round",
-      researchersPerDoc: 2, // forjado — a gravação tem de refletir o efetivo (1)
       participantIds: ["u1", "u2", "u3"],
-    } as unknown as LotteryParams);
+    });
 
     expect(result.error).toBeUndefined();
     expect(result.count).toBe(1);
@@ -353,6 +583,70 @@ describe("sorteio de comparação: um revisor por documento (#490)", () => {
     expect((rpc?.args as { p_assignments: unknown[] }).p_assignments).toHaveLength(1);
 
     expect((rpc?.args as { p_batch: unknown }).p_batch).toMatchObject({ researchers_per_doc: 1 });
+  });
+
+  it("nova rodada envia contagens e confirmações separadas no snapshot transacional", async () => {
+    serverTableResults = {
+      ...comparisonFixture(),
+      project_members: { data: [{ user_id: "u1" }] },
+      lottery_doc_stats: {
+        data: [
+          {
+            id: "d1",
+            external_id: "EXT-1",
+            title: "Doc 1",
+            human_coding_count: 2,
+            has_llm_response: false,
+            active_codificacao: 1,
+            active_comparacao: 0,
+            has_assignment_in_current_round: true,
+            batch_ids: ["old-batch"],
+          },
+        ],
+      },
+      lottery_round_work_counts: {
+        data: [
+          { assignment_type: "codificacao", scope_state: "active", open_count: 2 },
+          { assignment_type: "comparacao", scope_state: "pending_scope", open_count: 3 },
+        ],
+      },
+      responses: { data: [] },
+    };
+    rpcResults = {
+      apply_lottery_assignments: { data: { inserted: 1, round_id: "round-2" } },
+    };
+
+    const result = await smartRandomize({
+      projectId: "p1",
+      type: "codificacao",
+      mode: "append",
+      balancing: "round",
+      researchersPerDoc: 1,
+      participantIds: ["u1"],
+      target: {
+        kind: "new",
+        expectedRoundId: "round-1",
+        roundLabel: "Rodada 2",
+        confirmActiveWork: true,
+        confirmPendingScopeWork: true,
+      },
+    });
+
+    expect(result).toMatchObject({ count: 1 });
+    const rpc = rpcCalls.find((call) => call.fn === "apply_lottery_assignments");
+    expect(rpc?.args).toMatchObject({
+      p_expected_round_id: "round-1",
+      p_new_round_label: "Rodada 2",
+      p_confirm_open_work: true,
+      p_batch: {
+        open_work_snapshot: {
+          active_count: 2,
+          pending_scope_count: 3,
+          confirm_active: true,
+          confirm_pending_scope: true,
+        },
+      },
+    });
   });
 });
 
@@ -386,6 +680,11 @@ describe("status inicial do assignment de codificação (#521)", () => {
   // o mesmo par que já tem response humana.
   function codingFixture(responseRows: unknown[], answerRows: unknown[]): TableResults {
     return {
+      ...ROUND_RESULTS,
+      rounds: [
+        { data: { id: "round-1", label: "Rodada inicial" } },
+        { data: [{ id: "round-1", label: "Rodada inicial" }] },
+      ],
       project_members: { data: [{ user_id: "u1" }] },
       lottery_doc_stats: {
         data: [
@@ -397,7 +696,7 @@ describe("status inicial do assignment de codificação (#521)", () => {
             has_llm_response: false,
             active_codificacao: 0,
             active_comparacao: 0,
-            has_any_assignment_ever: false,
+            has_assignment_in_current_round: false,
             batch_ids: [],
           },
         ],
@@ -427,7 +726,7 @@ describe("status inicial do assignment de codificação (#521)", () => {
   }
 
   beforeEach(() => {
-    rpcResults = { apply_lottery_assignments: { data: 1 } };
+    rpcResults = { apply_lottery_assignments: { data: { inserted: 1 } } };
   });
 
   it("sorteio manda 'concluido' + completed_at quando o sorteado já codificou o documento", async () => {

--- a/frontend/src/actions/assignments.ts
+++ b/frontend/src/actions/assignments.ts
@@ -13,11 +13,13 @@ import {
   resolveWeight,
   resolveCap,
   resolveResearchersPerDoc,
+  LOTTERY_EMPTY_MESSAGES,
   type LotteryBalancing,
   type LotteryDocStats,
   type LotteryFilters,
   type LotteryMode,
   type LotteryParticipant,
+  type LotteryEmptyReason,
 } from "@/lib/lottery-utils";
 import { MEMBERS_TAG_PROFILE, membersTag } from "@/lib/cache";
 import { errorMessage } from "@/lib/utils";
@@ -28,6 +30,7 @@ import {
 import type { ResponseRoundFields, RoundContext } from "@/lib/rounds";
 import type { SupabaseServerClient } from "@/lib/supabase/server";
 import type { AnswerFieldHashes, PydanticField, Round } from "@/lib/types";
+import { z } from "zod";
 
 // --- Status inicial do assignment de codificação (issue #521) ---
 
@@ -88,13 +91,13 @@ interface InitialStatusInputs {
  * qualquer escrita.
  */
 function requireData<T>(
-  result: { data: T | null; error: { message: string } | null },
+  result: { data: T; error: { message: string } | null },
   context: string,
-): T {
-  if (result.error || !result.data) {
+): NonNullable<T> {
+  if (result.error || result.data == null) {
     throw new Error(`${context}: ${result.error?.message ?? "resposta vazia"}`);
   }
-  return result.data;
+  return result.data as NonNullable<T>;
 }
 
 async function loadRounds(
@@ -449,7 +452,8 @@ interface LotteryParamsBase {
         kind: "new";
         expectedRoundId: string;
         roundLabel: string;
-        confirmOpenWork: boolean;
+        confirmActiveWork: boolean;
+        confirmPendingScopeWork: boolean;
       };
 }
 
@@ -458,22 +462,133 @@ interface LotteryParamsBase {
  * construível — o braço `comparacao` não tem o campo. A regra é um revisor de
  * comparação por documento (ver COMPARISON_REVIEWERS_PER_DOC, issue #490).
  *
- * ATENÇÃO: isto é garantia de COMPILAÇÃO, para o client. Server Action é
- * endpoint HTTP público e o projeto não valida com zod — um payload forjado
- * chega com `{ type: "comparacao", researchersPerDoc: 5 }` sem passar por
- * type-check nenhum. As garantias de runtime são `resolveResearchersPerDoc` em
- * computeLottery (que ignora o valor recebido) e, no banco, o índice
- * assignments_one_active_comparacao_per_doc. O `researchersPerDoc?: never`
- * existe só para o excess property check pegar o literal no client.
+ * A união também é validada em runtime na fronteira da Server Action: um
+ * payload forjado de comparação com `researchersPerDoc` é recusado antes de
+ * qualquer leitura ou escrita. O índice do banco segue como última barreira.
  */
 export type LotteryParams =
   | (LotteryParamsBase & { type: "codificacao"; researchersPerDoc: number })
   | (LotteryParamsBase & { type: "comparacao"; researchersPerDoc?: never });
 
+const lotteryFiltersSchema = z
+  .object({
+    maxHumanCodings: z.number().int().nonnegative().optional(),
+    assignmentFilter: z.enum(["any", "noActiveOfType", "neverAssigned"]).optional(),
+    batchFilter: z
+      .object({
+        exclude: z.array(z.string().min(1)).optional(),
+        only: z.string().min(1).optional(),
+      })
+      .strict()
+      .optional(),
+    manualDocIds: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+  .superRefine((filters, ctx) => {
+    if (filters.batchFilter?.only && filters.batchFilter.exclude?.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Os filtros de lote são mutuamente exclusivos.",
+      });
+    }
+  });
+
+const lotteryTargetSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("current"),
+      expectedRoundId: z.string().min(1),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("new"),
+      expectedRoundId: z.string().min(1),
+      roundLabel: z.string().trim().min(1),
+      confirmActiveWork: z.boolean(),
+      confirmPendingScopeWork: z.boolean(),
+    })
+    .strict(),
+]);
+
+const lotteryParamsBaseSchema = z
+  .object({
+    projectId: z.string().min(1),
+    mode: z.enum(["append", "replace"]),
+    balancing: z.enum(["round", "history"]),
+    seed: z.number().int().min(0).max(2 ** 31 - 1).optional(),
+    docsPerResearcher: z.number().int().positive().optional(),
+    docSubsetSize: z.number().int().positive().optional(),
+    label: z.string().optional(),
+    filters: lotteryFiltersSchema.optional(),
+    participantIds: z.array(z.string().min(1)).min(1),
+    participantSettings: z
+      .record(
+        z.string(),
+        z
+          .object({
+            weight: z.number().positive().optional(),
+            cap: z.number().int().positive().nullable().optional(),
+          })
+          .strict(),
+      )
+      .optional(),
+    target: lotteryTargetSchema.optional(),
+  })
+  .strict();
+
+const lotteryParamsSchema = z.discriminatedUnion("type", [
+  lotteryParamsBaseSchema.extend({
+    type: z.literal("codificacao"),
+    researchersPerDoc: z.number().int().positive(),
+  }),
+  lotteryParamsBaseSchema.extend({
+    type: z.literal("comparacao"),
+    researchersPerDoc: z.never().optional(),
+  }),
+]);
+
+function validateLotteryParams(params: LotteryParams): LotteryParams {
+  const result = lotteryParamsSchema.safeParse(params);
+  if (!result.success) {
+    throw new Error(
+      `Configuração do sorteio inválida: ${result.error.issues[0]?.message ?? "revise os campos"}`,
+    );
+  }
+  return result.data as LotteryParams;
+}
+
+async function validateAndAuthorizeLottery(
+  params: LotteryParams,
+): Promise<
+  | { ok: true; params: LotteryParams }
+  | { ok: false; error: string }
+> {
+  let validatedParams: LotteryParams;
+  try {
+    validatedParams = validateLotteryParams(params);
+  } catch (error) {
+    return {
+      ok: false,
+      error: errorMessage(error) || "Configuração do sorteio inválida",
+    };
+  }
+
+  const gate = await requireCoordinator(
+    validatedParams.projectId,
+    "Apenas coordenadores podem sortear atribuições.",
+  );
+  return gate.ok
+    ? { ok: true, params: validatedParams }
+    : { ok: false, error: gate.error };
+}
+
 interface LotteryAssignment {
   document_id: string;
   user_id: string;
 }
+
+type NonEmptyLotteryAssignments = [LotteryAssignment, ...LotteryAssignment[]];
 
 export interface LotteryPreview {
   participants: { userId: string; existing: number; newDocs: number }[];
@@ -481,6 +596,10 @@ export interface LotteryPreview {
   totalPreserved: number;
   /** nº de docs elegíveis pós-filtros (pré-subset) */
   eligibleDocs: number;
+  /** vagas pedidas que não puderam ser preenchidas */
+  unfilledSlots: number;
+  /** presente somente quando nenhuma atribuição nova é possível */
+  emptyReason?: LotteryEmptyReason;
   /** semente usada; o dialog a reenvia em smartRandomize (research D13) */
   seed: number;
   targetRoundLabel?: string;
@@ -494,7 +613,8 @@ interface LotteryDocStatsResult {
   automationMode: string | null;
   currentRoundId: string | null;
   currentRoundLabel: string | null;
-  openAssignmentCount: number;
+  activeOpenAssignmentCount: number;
+  pendingScopeAssignmentCount: number;
 }
 
 interface LotteryData extends LotteryDocStatsResult {
@@ -510,39 +630,74 @@ interface LotteryData extends LotteryDocStatsResult {
 
 /**
  * Stats por documento a partir da view `lottery_doc_stats` (issue #182):
- * agrega humanCodingCount/hasLlmResponse/activeAssignments/hasAnyAssignmentEver/
+ * agrega humanCodingCount/hasLlmResponse/activeAssignments/atribuição na rodada/
  * batchIds em Postgres, bounded pelo nº de documentos ativos do projeto — sem
  * tocar responses/assignments crus.
  */
 async function fetchLotteryDocStats(projectId: string): Promise<LotteryDocStatsResult> {
   const supabase = await createSupabaseServer();
 
-  const [{ data: docs }, { data: batches }, { data: project }, { data: rounds }] = await Promise.all([
-    supabase
-      .from("lottery_doc_stats")
-      .select(
-        "id, external_id, title, human_coding_count, has_llm_response, active_codificacao, active_comparacao, has_any_assignment_ever, batch_ids"
-      )
-      .eq("project_id", projectId),
-    supabase
-      .from("assignment_batches")
-      .select("id, label, created_at, round_id")
-      .eq("project_id", projectId)
-      .order("created_at", { ascending: false }),
-    supabase
+  const project = requireData(
+    await supabase
       .from("projects")
       .select("min_responses_for_comparison, automation_mode, current_round_id")
       .eq("id", projectId)
       .single(),
+    "Erro ao ler a rodada atual do projeto",
+  );
+  const currentRoundId = project.current_round_id as string | null;
+  if (!currentRoundId) {
+    return {
+      docs: [],
+      batches: [],
+      minResponsesForComparison: project.min_responses_for_comparison ?? 2,
+      automationMode: project.automation_mode ?? null,
+      currentRoundId: null,
+      currentRoundLabel: null,
+      activeOpenAssignmentCount: 0,
+      pendingScopeAssignmentCount: 0,
+    };
+  }
+
+  const [docsResult, batchesResult, roundResult, workCountsResult] = await Promise.all([
+    supabase
+      .from("lottery_doc_stats")
+      .select(
+        "id, external_id, title, human_coding_count, has_llm_response, active_codificacao, active_comparacao, has_assignment_in_current_round, batch_ids"
+      )
+      .eq("project_id", projectId),
+    supabase
+      .from("assignment_batches")
+      .select("id, label, created_at")
+      .eq("project_id", projectId)
+      .eq("round_id", currentRoundId)
+      .order("created_at", { ascending: false }),
     supabase
       .from("rounds")
       .select("id, label")
       .eq("project_id", projectId)
+      .eq("id", currentRoundId)
+      .single(),
+    supabase
+      .from("lottery_round_work_counts")
+      .select("assignment_type, scope_state, open_count")
+      .eq("project_id", projectId)
+      .eq("round_id", currentRoundId),
   ]);
-  const currentRound = (rounds ?? []).find((round) => round.id === project?.current_round_id);
+  const docs = requireData(docsResult, "Erro ao ler os documentos do sorteio");
+  const batches = requireData(batchesResult, "Erro ao ler os lotes do sorteio");
+  const currentRound = requireData(roundResult, "Erro ao ler a rodada atual");
+  const workCounts = requireData(
+    workCountsResult,
+    "Erro ao contar o trabalho aberto da rodada",
+  );
+  const countByScope = (scopeState: "active" | "pending_scope") =>
+    workCounts
+      .filter((row) => row.scope_state === scopeState)
+      .reduce((total, row) => total + Number(row.open_count), 0);
 
   return {
-    docs: (docs || []).map((d) => ({
+    docs: docs.map((d) => ({
       id: d.id,
       externalId: d.external_id,
       title: d.title,
@@ -552,22 +707,20 @@ async function fetchLotteryDocStats(projectId: string): Promise<LotteryDocStatsR
         codificacao: d.active_codificacao,
         comparacao: d.active_comparacao,
       },
-      hasAnyAssignmentEver: d.has_any_assignment_ever,
+      hasAssignmentInCurrentRound: d.has_assignment_in_current_round,
       batchIds: d.batch_ids || [],
     })),
-    batches: (batches || []).filter((b) => b.round_id === project?.current_round_id).map((b) => ({
+    batches: batches.map((b) => ({
       id: b.id,
       label: b.label,
       createdAt: b.created_at,
     })),
-    minResponsesForComparison: project?.min_responses_for_comparison ?? 2,
-    automationMode: project?.automation_mode ?? null,
-    currentRoundId: project?.current_round_id ?? null,
-    currentRoundLabel: currentRound?.label ?? null,
-    openAssignmentCount: (docs || []).reduce(
-      (total, d) => total + d.active_codificacao + d.active_comparacao,
-      0,
-    ),
+    minResponsesForComparison: project.min_responses_for_comparison ?? 2,
+    automationMode: project.automation_mode ?? null,
+    currentRoundId,
+    currentRoundLabel: currentRound.label ?? null,
+    activeOpenAssignmentCount: countByScope("active"),
+    pendingScopeAssignmentCount: countByScope("pending_scope"),
   };
 }
 
@@ -581,7 +734,7 @@ async function fetchLotteryDocStats(projectId: string): Promise<LotteryDocStatsR
 async function fetchLotteryData(projectId: string): Promise<LotteryData> {
   const supabase = await createSupabaseServer();
 
-  const [stats, { data: assignments }, { data: humanCoders }] = await Promise.all([
+  const [stats, assignmentsResult, humanCodersResult] = await Promise.all([
     fetchLotteryDocStats(projectId),
     supabase
       .from("assignments")
@@ -603,17 +756,25 @@ async function fetchLotteryData(projectId: string): Promise<LotteryData> {
       .eq("is_latest", true)
       .not("respondent_id", "is", null),
   ]);
+  const assignments = requireData(
+    assignmentsResult,
+    "Erro ao ler as atribuições existentes do sorteio",
+  );
+  const humanCoders = requireData(
+    humanCodersResult,
+    "Erro ao ler as codificações humanas do sorteio",
+  );
 
   return {
     ...stats,
-    assignmentRows: (assignments || []).map((a) => ({
+    assignmentRows: assignments.map((a) => ({
       document_id: a.document_id,
       user_id: a.user_id,
       status: a.status,
       type: a.type,
       round_id: a.round_id ?? stats.currentRoundId ?? "",
     })),
-    humanCoderRows: (humanCoders || []).flatMap((r) =>
+    humanCoderRows: humanCoders.flatMap((r) =>
       r.respondent_id
         ? [
             {
@@ -650,11 +811,11 @@ export async function getLotteryDocStats(
   }
 }
 
-async function computeLottery(params: LotteryParams): Promise<{
-  newAssignments: LotteryAssignment[];
+interface LotteryComputationCommon {
   preservedCount: number;
   preservedByUser: Record<string, number>;
   eligibleCount: number;
+  unfilledSlots: number;
   seed: number;
   batchData: Record<string, unknown>;
   /** tipo normalizado aqui — quem grava reusa em vez de renormalizar */
@@ -662,31 +823,42 @@ async function computeLottery(params: LotteryParams): Promise<{
   /** fase 1 do status inicial (#521): responses humanas leves do projeto */
   humanCoderRows: HumanCoderRow[];
   target: NonNullable<LotteryParams["target"]>;
-}> {
+}
+
+type LotteryComputation =
+  | (LotteryComputationCommon & {
+      kind: "ready";
+      newAssignments: NonEmptyLotteryAssignments;
+    })
+  | (LotteryComputationCommon & {
+      kind: "empty";
+      newAssignments: [];
+      emptyReason: LotteryEmptyReason;
+    });
+
+async function computeLottery(params: LotteryParams): Promise<LotteryComputation> {
   const supabase = await createSupabaseServer();
-  // Normaliza em vez de confiar no literal: o payload chega por HTTP e não passa
-  // por zod. Qualquer coisa que não seja "comparacao" é codificação.
+  // `validateLotteryParams` tornou o discriminante confiável antes de chegar
+  // aqui; a normalização serve apenas para estreitar o tipo compartilhado.
   const assignmentType =
     params.type === "comparacao" ? "comparacao" : "codificacao";
-  // Para comparação o valor pedido é ignorado (sempre 1) — a união discriminada
-  // já proíbe o campo no client, e este é o guard para quem vem de fora dela.
   const researchersPerDoc = resolveResearchersPerDoc(
     assignmentType,
     (params as { researchersPerDoc?: number }).researchersPerDoc,
   );
   const filters = params.filters || {};
 
-  if (filters.batchFilter?.only && filters.batchFilter?.exclude?.length) {
-    throw new Error("Os filtros de lote são mutuamente exclusivos.");
-  }
-
-  const [{ data: members }, data] = await Promise.all([
+  const [membersResult, data] = await Promise.all([
     supabase
       .from("project_members")
       .select("user_id")
       .eq("project_id", params.projectId),
     fetchLotteryData(params.projectId),
   ]);
+  const members = requireData(
+    membersResult,
+    "Erro ao ler os participantes do sorteio",
+  );
 
   const target = params.target ?? {
     kind: "current" as const,
@@ -705,7 +877,7 @@ async function computeLottery(params: LotteryParams): Promise<{
 
   // Pool de participantes: deduplicado e validado contra project_members
   // (qualquer role) — defesa em profundidade além do RLS (research D5)
-  const memberIds = new Set((members || []).map((m) => m.user_id));
+  const memberIds = new Set(members.map((m) => m.user_id));
   const uniqueIds = [...new Set(params.participantIds)];
   const participantIds = uniqueIds.filter((id) => memberIds.has(id));
   if (!participantIds.length || participantIds.length !== uniqueIds.length) {
@@ -724,7 +896,7 @@ async function computeLottery(params: LotteryParams): Promise<{
         humanCodingCount: 0,
         hasLlmResponse: false,
         activeAssignments: { codificacao: 0, comparacao: 0 },
-        hasAnyAssignmentEver: false,
+        hasAssignmentInCurrentRound: false,
         batchIds: [],
       }))
     : data.docs;
@@ -756,9 +928,13 @@ async function computeLottery(params: LotteryParams): Promise<{
       ? ["pendente", "em_andamento", "concluido"]
       : ["em_andamento", "concluido"]
   );
+  const activeDocIds = new Set(data.docs.map((doc) => doc.id));
   const currentRoundRows = startsNewRound
     ? []
-    : data.assignmentRows.filter((a) => a.round_id === data.currentRoundId);
+    : data.assignmentRows.filter(
+        (a) =>
+          a.round_id === data.currentRoundId && activeDocIds.has(a.document_id),
+      );
   const preserved = currentRoundRows.filter(
     (a) => a.type === assignmentType && preservedStatuses.has(a.status),
   );
@@ -809,7 +985,9 @@ async function computeLottery(params: LotteryParams): Promise<{
   // que não ocupe mais a vaga do documento.
   const loadRows =
     params.balancing === "history"
-      ? data.assignmentRows.filter((a) => a.type === assignmentType)
+      ? data.assignmentRows.filter(
+          (a) => a.type === assignmentType && activeDocIds.has(a.document_id),
+        )
       : preserved;
   const preservedByUser: Record<string, number> = {};
   for (const a of loadRows) {
@@ -829,6 +1007,11 @@ async function computeLottery(params: LotteryParams): Promise<{
   if (params.docSubsetSize && params.docSubsetSize < eligibleDocIds.length) {
     eligibleDocIds = shuffleWithRng(eligibleDocIds, rng).slice(0, params.docSubsetSize);
   }
+  const requestedSlots = eligibleDocIds.reduce(
+    (total, documentId) =>
+      total + Math.max(0, researchersPerDoc - (docAssignedCount[documentId] || 0)),
+    0,
+  );
 
   // Matriz de co-ocorrência a partir do conjunto preservado
   const coOccurrence: Record<string, Record<string, number>> = {};
@@ -896,6 +1079,13 @@ async function computeLottery(params: LotteryParams): Promise<{
     label: params.label || null,
     mode: params.mode,
     balancing: params.balancing,
+    open_work_snapshot: {
+      active_count: data.activeOpenAssignmentCount,
+      pending_scope_count: data.pendingScopeAssignmentCount,
+      confirm_active: target.kind === "new" && target.confirmActiveWork,
+      confirm_pending_scope:
+        target.kind === "new" && target.confirmPendingScopeWork,
+    },
     filters: {
       ...filters,
       participantIds,
@@ -905,31 +1095,52 @@ async function computeLottery(params: LotteryParams): Promise<{
     },
   };
 
-  return {
-    newAssignments,
+  const common: LotteryComputationCommon = {
     preservedCount: preserved.length,
     preservedByUser,
     eligibleCount,
+    unfilledSlots: Math.max(0, requestedSlots - newAssignments.length),
     seed,
     batchData,
     assignmentType,
     humanCoderRows: data.humanCoderRows,
     target,
   };
+  if (newAssignments.length > 0) {
+    return {
+      ...common,
+      kind: "ready",
+      newAssignments: newAssignments as NonEmptyLotteryAssignments,
+    };
+  }
+
+  const emptyReason: LotteryEmptyReason =
+    eligibleDocIds.length === 0
+      ? "all_slots_filled"
+      : participants.every((participant) => participant.capacity <= 0)
+        ? "capacity_exhausted"
+        : "no_available_pairs";
+  return { ...common, kind: "empty", newAssignments: [], emptyReason };
 }
 
 export async function previewLottery(
   params: LotteryParams,
 ): Promise<{ preview?: LotteryPreview; error?: string }> {
-  const gate = await requireCoordinator(
-    params.projectId,
-    "Apenas coordenadores podem sortear atribuições.",
-  );
-  if (!gate.ok) return { error: gate.error };
+  const request = await validateAndAuthorizeLottery(params);
+  if (!request.ok) return { error: request.error };
+  const validatedParams = request.params;
 
   try {
-    const { newAssignments, preservedCount, preservedByUser, eligibleCount, seed, target } =
-      await computeLottery(params);
+    const computation = await computeLottery(validatedParams);
+    const {
+      newAssignments,
+      preservedCount,
+      preservedByUser,
+      eligibleCount,
+      unfilledSlots,
+      seed,
+      target,
+    } = computation;
 
     const newCounts: Record<string, number> = {};
     for (const a of newAssignments) {
@@ -938,7 +1149,7 @@ export async function previewLottery(
 
     return {
       preview: {
-        participants: [...new Set(params.participantIds)].map((userId) => ({
+        participants: [...new Set(validatedParams.participantIds)].map((userId) => ({
           userId,
           existing: preservedByUser[userId] || 0,
           newDocs: newCounts[userId] || 0,
@@ -946,6 +1157,9 @@ export async function previewLottery(
         totalNew: newAssignments.length,
         totalPreserved: preservedCount,
         eligibleDocs: eligibleCount,
+        unfilledSlots,
+        emptyReason:
+          computation.kind === "empty" ? computation.emptyReason : undefined,
         seed,
         targetRoundLabel:
           target.kind === "new"
@@ -961,11 +1175,9 @@ export async function previewLottery(
 export async function smartRandomize(
   params: LotteryParams,
 ): Promise<{ count?: number; preserved?: number; error?: string }> {
-  const gate = await requireCoordinator(
-    params.projectId,
-    "Apenas coordenadores podem sortear atribuições.",
-  );
-  if (!gate.ok) return { error: gate.error };
+  const request = await validateAndAuthorizeLottery(params);
+  if (!request.ok) return { error: request.error };
+  const validatedParams = request.params;
 
   const supabase = await createSupabaseServer();
 
@@ -975,8 +1187,12 @@ export async function smartRandomize(
   // Operação crítica: computeLottery + registro do lote + RPC transacional. Só
   // um erro aqui (nada gravado, ou gravação abortada) deve virar { error }.
   try {
+    const computation = await computeLottery(validatedParams);
+    if (computation.kind === "empty") {
+      return { error: LOTTERY_EMPTY_MESSAGES[computation.emptyReason] };
+    }
     const { newAssignments, preservedCount, batchData, assignmentType, humanCoderRows, target } =
-      await computeLottery(params);
+      computation;
 
     // Status inicial por linha (#521): um documento já codificado por completo
     // pelo próprio sorteado nasce 'concluido', não 'pendente'. Calculado ANTES
@@ -992,7 +1208,7 @@ export async function smartRandomize(
         ? new Map<string, InitialCodingStatus>()
         : await resolveInitialCodingStatuses(
             supabase,
-            params.projectId,
+            validatedParams.projectId,
             newAssignments.flatMap((a) => {
               const response = responsesByPair.get(pairKey(a.document_id, a.user_id));
               return response ? [response] : [];
@@ -1016,27 +1232,26 @@ export async function smartRandomize(
     const { data: result, error: rpcError } = await supabase.rpc(
       "apply_lottery_assignments",
       {
-        p_project_id: params.projectId,
+        p_project_id: validatedParams.projectId,
         p_type: assignmentType,
         p_expected_round_id: target.expectedRoundId,
         p_new_round_label:
           target.kind === "new" ? target.roundLabel.trim() : null,
         p_confirm_open_work:
-          target.kind === "new" && target.confirmOpenWork,
+          target.kind === "new" &&
+          target.confirmActiveWork &&
+          target.confirmPendingScopeWork,
         p_batch: batchData,
         p_assignments: assignmentRows,
-        p_replace: params.mode === "replace",
+        p_replace: validatedParams.mode === "replace",
       },
     );
     if (rpcError) {
       throw new Error(`Erro ao gravar as atribuições do sorteio: ${rpcError.message}`);
     }
 
-    // Contagem REAL do RPC, não o tamanho do que se pretendia gravar: o
-    // ON CONFLICT DO NOTHING pula linhas quando o gatilho automático cria a
-    // comparação do documento entre a leitura do computeLottery (fora da
-    // transação) e este INSERT. Reportar o pretendido faria o coordenador ver
-    // um número que não está no banco.
+    // A RPC exige correspondência exata entre proposta e inserção. Qualquer
+    // conflito concorrente reverte o lote inteiro com 40001.
     const rpcResult = result as { inserted?: number } | null;
     count = rpcResult?.inserted ?? newAssignments.length;
     preserved = preservedCount;
@@ -1051,7 +1266,7 @@ export async function smartRandomize(
     // Persiste o peso/limite usado por participante (decisão: editar no diálogo,
     // mas assumir continuidade no próximo sorteio). Uma falha aqui só afeta o
     // default da próxima vez.
-    const settingsEntries = Object.entries(params.participantSettings ?? {});
+    const settingsEntries = Object.entries(validatedParams.participantSettings ?? {});
     if (settingsEntries.length > 0) {
       const results = await Promise.all(
         settingsEntries.map(([userId, cfg]) =>
@@ -1061,7 +1276,7 @@ export async function smartRandomize(
               assignment_weight: resolveWeight(cfg.weight),
               assignment_cap: resolveCap(cfg.cap),
             })
-            .eq("project_id", params.projectId)
+            .eq("project_id", validatedParams.projectId)
             .eq("user_id", userId),
         ),
       );
@@ -1071,12 +1286,12 @@ export async function smartRandomize(
           `[lottery] falha ao persistir peso/limite por membro: ${failed.error.message}`,
         );
       }
-      revalidateTag(membersTag(params.projectId), MEMBERS_TAG_PROFILE);
+      revalidateTag(membersTag(validatedParams.projectId), MEMBERS_TAG_PROFILE);
     }
 
-    revalidatePath(`/projects/${params.projectId}/analyze/assignments`);
-    revalidatePath(`/projects/${params.projectId}/analyze/code`);
-    revalidatePath(`/projects/${params.projectId}/analyze/compare`);
+    revalidatePath(`/projects/${validatedParams.projectId}/analyze/assignments`);
+    revalidatePath(`/projects/${validatedParams.projectId}/analyze/code`);
+    revalidatePath(`/projects/${validatedParams.projectId}/analyze/compare`);
   } catch (e) {
     console.error(`[lottery] falha nos efeitos pós-sorteio: ${errorMessage(e)}`);
   }

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -51,6 +51,7 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
     participantCount,
     eligibleCount,
     blockedMessage,
+    canPreview,
     canSubmit,
     preview,
     estimatedPerParticipant,
@@ -272,6 +273,7 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
             run={{
               previewing,
               loading,
+              canPreview,
               canSubmit,
               onPreview: () => void handlePreview(),
               onRandomize: () => void handleRandomize(),

--- a/frontend/src/components/assignments/LotteryDialog.tsx
+++ b/frontend/src/components/assignments/LotteryDialog.tsx
@@ -40,7 +40,9 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
   const params = useLotteryParams();
   const {
     type, setType, targetKind, setTargetKind, roundLabel, setRoundLabel,
-    confirmOpenWork, setConfirmOpenWork, mode, setMode, label, setLabel,
+    confirmActiveWork, setConfirmActiveWork,
+    confirmPendingScopeWork, setConfirmPendingScopeWork,
+    mode, setMode, label, setLabel,
     setPreviewState,
   } = params;
 
@@ -140,7 +142,8 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
               value={targetKind}
               onValueChange={(value) => {
                 setTargetKind(value as "current" | "new");
-                setConfirmOpenWork(false);
+                setConfirmActiveWork(false);
+                setConfirmPendingScopeWork(false);
               }}
               className="space-y-1"
             >
@@ -165,15 +168,29 @@ export function LotteryDialog({ projectId, members }: LotteryDialogProps) {
                   value={roundLabel}
                   onChange={(event) => setRoundLabel(event.target.value)}
                 />
-                {(stats?.openAssignmentCount ?? 0) > 0 && (
+                {(stats?.activeOpenAssignmentCount ?? 0) > 0 && (
                   <div className="flex items-start gap-2 rounded-md border p-3">
                     <Checkbox
-                      id="confirm-open-work"
-                      checked={confirmOpenWork}
-                      onCheckedChange={(checked) => setConfirmOpenWork(checked === true)}
+                      id="confirm-active-work"
+                      checked={confirmActiveWork}
+                      onCheckedChange={(checked) => setConfirmActiveWork(checked === true)}
                     />
-                    <Label htmlFor="confirm-open-work" className="font-normal leading-snug">
-                      Confirmo iniciar a nova rodada apesar de {stats?.openAssignmentCount} atribuições em andamento ou pendentes na rodada atual.
+                    <Label htmlFor="confirm-active-work" className="font-normal leading-snug">
+                      Confirmo iniciar a nova rodada apesar de {stats?.activeOpenAssignmentCount} atribuições ativas em andamento ou pendentes na rodada atual.
+                    </Label>
+                  </div>
+                )}
+                {(stats?.pendingScopeAssignmentCount ?? 0) > 0 && (
+                  <div className="flex items-start gap-2 rounded-md border p-3">
+                    <Checkbox
+                      id="confirm-pending-scope-work"
+                      checked={confirmPendingScopeWork}
+                      onCheckedChange={(checked) =>
+                        setConfirmPendingScopeWork(checked === true)
+                      }
+                    />
+                    <Label htmlFor="confirm-pending-scope-work" className="font-normal leading-snug">
+                      Confirmo iniciar a nova rodada apesar de {stats?.pendingScopeAssignmentCount} atribuições ligadas a documentos ainda em revisão de escopo. Se o pedido for rejeitado depois, esses documentos precisarão entrar em um novo sorteio da rodada atual.
                     </Label>
                   </div>
                 )}

--- a/frontend/src/components/assignments/LotteryEligibilitySection.tsx
+++ b/frontend/src/components/assignments/LotteryEligibilitySection.tsx
@@ -137,7 +137,7 @@ export function LotteryEligibilitySection({
               {isComparacao ? "comparação" : "codificação"}
             </SelectItem>
             <SelectItem value="neverAssigned">
-              Nunca atribuído
+              Ainda não atribuído nesta rodada
             </SelectItem>
           </SelectContent>
         </Select>

--- a/frontend/src/components/assignments/LotteryPreviewSection.tsx
+++ b/frontend/src/components/assignments/LotteryPreviewSection.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import type { LotteryPreview } from "@/actions/assignments";
+import { LOTTERY_EMPTY_MESSAGES } from "@/lib/lottery-utils";
 import type { LotteryMember } from "./lottery-dialog-types";
 
 // Seção "Prévia + Confirmar" do LotteryDialog: botão de prévia, tabela de
@@ -42,6 +43,16 @@ export function LotteryPreviewSection({
             {preview.totalNew} novas atribuições ·{" "}
             {preview.totalPreserved} preservadas
           </p>
+          {preview.emptyReason && (
+            <p className="text-xs text-destructive" role="alert">
+              {LOTTERY_EMPTY_MESSAGES[preview.emptyReason]}
+            </p>
+          )}
+          {!preview.emptyReason && preview.unfilledSlots > 0 && (
+            <p className="text-xs text-muted-foreground">
+              {preview.unfilledSlots} vagas não puderam ser preenchidas com os participantes e limites atuais.
+            </p>
+          )}
           <div className="max-h-40 overflow-y-auto">
             <table className="w-full text-xs">
               <thead>

--- a/frontend/src/components/assignments/LotteryPreviewSection.tsx
+++ b/frontend/src/components/assignments/LotteryPreviewSection.tsx
@@ -18,6 +18,7 @@ export function LotteryPreviewSection({
   run: {
     previewing: boolean;
     loading: boolean;
+    canPreview: boolean;
     canSubmit: boolean;
     onPreview: () => void;
     onRandomize: () => void;
@@ -31,7 +32,7 @@ export function LotteryPreviewSection({
       <Button
         variant="outline"
         onClick={run.onPreview}
-        disabled={run.previewing || !run.canSubmit}
+        disabled={run.previewing || !run.canPreview}
         className="w-full"
       >
         {run.previewing ? "Calculando..." : "Visualizar prévia"}

--- a/frontend/src/components/assignments/__tests__/LotteryPreviewSection.test.tsx
+++ b/frontend/src/components/assignments/__tests__/LotteryPreviewSection.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LotteryPreview } from "@/actions/assignments";
+import { LotteryPreviewSection } from "../LotteryPreviewSection";
+
+const emptyPreview: LotteryPreview = {
+  participants: [{ userId: "u1", existing: 1, newDocs: 0 }],
+  totalNew: 0,
+  totalPreserved: 1,
+  eligibleDocs: 1,
+  unfilledSlots: 1,
+  seed: 4242,
+  emptyReason: "capacity_exhausted",
+};
+
+afterEach(cleanup);
+
+describe("LotteryPreviewSection", () => {
+  it("mantém a prévia acionável quando o resultado vazio bloqueia o sorteio", () => {
+    render(
+      <LotteryPreviewSection
+        preview={emptyPreview}
+        members={[{ userId: "u1", name: "Ana", role: "pesquisador" }]}
+        run={{
+          previewing: false,
+          loading: false,
+          canPreview: true,
+          canSubmit: false,
+          onPreview: vi.fn(),
+          onRandomize: vi.fn(),
+        }}
+      />,
+    );
+
+    const previewButton = screen.getByRole("button", { name: "Visualizar prévia" });
+    const randomizeButton = screen.getByRole("button", { name: "Sortear" });
+
+    expect((previewButton as HTMLButtonElement).disabled).toBe(false);
+    expect((randomizeButton as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
+++ b/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, cleanup } from "@testing-library/react";
 import { previewLottery, smartRandomize } from "@/actions/assignments";
 import type { LotteryPreview } from "@/actions/assignments";
-import type { LotteryDocStats } from "@/lib/lottery-utils";
+import {
+  LOTTERY_EMPTY_MESSAGES,
+  type LotteryDocStats,
+} from "@/lib/lottery-utils";
 import { useLotteryParams } from "../useLotteryParams";
 import { useLotteryRun } from "../useLotteryRun";
 import type { LotteryMember, LotteryStats } from "../lottery-dialog-types";
@@ -25,7 +28,7 @@ function doc(id: string, overrides?: Partial<LotteryDocStats>): LotteryDocStats 
     humanCodingCount: 0,
     hasLlmResponse: false,
     activeAssignments: { codificacao: 0, comparacao: 0 },
-    hasAnyAssignmentEver: false,
+    hasAssignmentInCurrentRound: false,
     batchIds: [],
     ...overrides,
   };
@@ -44,7 +47,8 @@ const stats: LotteryStats = {
   automationMode: null,
   currentRoundId: "round-1",
   currentRoundLabel: "Rodada inicial",
-  openAssignmentCount: 0,
+  activeOpenAssignmentCount: 0,
+  pendingScopeAssignmentCount: 0,
 };
 
 const previewResult: LotteryPreview = {
@@ -52,12 +56,13 @@ const previewResult: LotteryPreview = {
   totalNew: 2,
   totalPreserved: 0,
   eligibleDocs: 3,
+  unfilledSlots: 0,
   seed: 4242,
 };
 
 // Integra useLotteryParams + useLotteryRun como no LotteryDialog real —
 // o contrato sob teste é o casamento prévia↔configuração (research D13).
-function setup(statsOverride: LotteryStats = stats) {
+function setup(statsOverride: LotteryStats | null = stats) {
   return renderHook(() => {
     const params = useLotteryParams();
     const run = useLotteryRun({
@@ -82,6 +87,13 @@ afterEach(() => {
 });
 
 describe("useLotteryRun", () => {
+  it("não confunde carregamento ou erro de stats com ausência de rodada", () => {
+    const { result } = setup(null);
+
+    expect(result.current.run.blockedMessage).toBeNull();
+    expect(result.current.run.canSubmit).toBe(false);
+  });
+
   it("deriva contagens: pesquisadores participam por default, coordenador não", () => {
     const { result } = setup();
     expect(result.current.run.participantCount).toBe(2);
@@ -112,6 +124,67 @@ describe("useLotteryRun", () => {
       result.current.params.setResearchersPerDoc(3);
     });
     expect(result.current.run.preview).toBeNull();
+  });
+
+  it("prévia vazia bloqueia o submit e não chama a Server Action", async () => {
+    mockPreview.mockResolvedValueOnce({
+      preview: {
+        ...previewResult,
+        participants: [{ userId: "u1", existing: 1, newDocs: 0 }],
+        totalNew: 0,
+        unfilledSlots: 1,
+        emptyReason: "capacity_exhausted",
+      },
+    });
+    const { result } = setup();
+
+    await act(() => result.current.run.handlePreview());
+
+    expect(result.current.run.canSubmit).toBe(false);
+    expect(result.current.run.blockedMessage).toBe(
+      LOTTERY_EMPTY_MESSAGES.capacity_exhausted,
+    );
+    await act(() => result.current.run.handleRandomize());
+    expect(mockRandomize).not.toHaveBeenCalled();
+  });
+
+  it("trocar o alvo invalida a prévia e exige confirmações separadas", async () => {
+    const statsWithOpenWork: LotteryStats = {
+      ...stats,
+      activeOpenAssignmentCount: 2,
+      pendingScopeAssignmentCount: 3,
+    };
+    const { result } = setup(statsWithOpenWork);
+    await act(() => result.current.run.handlePreview());
+
+    act(() => {
+      result.current.params.setTargetKind("new");
+      result.current.params.setRoundLabel("Rodada 2");
+    });
+
+    expect(result.current.run.preview).toBeNull();
+    expect(result.current.run.blockedMessage).toBe(
+      "Confirme a abertura da nova rodada com trabalho ativo ainda aberto.",
+    );
+    act(() => result.current.params.setConfirmActiveWork(true));
+    expect(result.current.run.blockedMessage).toBe(
+      "Confirme a abertura da nova rodada com documentos ainda em revisão de escopo.",
+    );
+    act(() => result.current.params.setConfirmPendingScopeWork(true));
+    expect(result.current.run.blockedMessage).toBeNull();
+
+    await act(() => result.current.run.handleRandomize());
+    expect(mockRandomize).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        target: {
+          kind: "new",
+          expectedRoundId: "round-1",
+          roundLabel: "Rodada 2",
+          confirmActiveWork: true,
+          confirmPendingScopeWork: true,
+        },
+      }),
+    );
   });
 
   it("o rótulo não invalida a prévia, mas entra no submit", async () => {

--- a/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
+++ b/frontend/src/components/assignments/__tests__/useLotteryRun.test.ts
@@ -91,6 +91,7 @@ describe("useLotteryRun", () => {
     const { result } = setup(null);
 
     expect(result.current.run.blockedMessage).toBeNull();
+    expect(result.current.run.canPreview).toBe(false);
     expect(result.current.run.canSubmit).toBe(false);
   });
 
@@ -98,10 +99,11 @@ describe("useLotteryRun", () => {
     const { result } = setup();
     expect(result.current.run.participantCount).toBe(2);
     expect(result.current.run.eligibleCount).toBe(3);
+    expect(result.current.run.canPreview).toBe(true);
     expect(result.current.run.canSubmit).toBe(true);
   });
 
-  it("bloqueia quando os filtros zeram os elegíveis", () => {
+  it("bloqueia prévia e submit quando os filtros zeram os elegíveis", async () => {
     const { result } = setup();
     act(() => {
       // "Sem nenhuma codificação" + docs com codificação → só d1 e d3;
@@ -112,7 +114,11 @@ describe("useLotteryRun", () => {
     expect(result.current.run.blockedMessage).toBe(
       "Nenhum documento passa nos filtros atuais.",
     );
+    expect(result.current.run.canPreview).toBe(false);
     expect(result.current.run.canSubmit).toBe(false);
+
+    await act(() => result.current.run.handlePreview());
+    expect(mockPreview).not.toHaveBeenCalled();
   });
 
   it("mudar a configuração invalida a prévia (e a seed) por derivação", async () => {
@@ -126,7 +132,7 @@ describe("useLotteryRun", () => {
     expect(result.current.run.preview).toBeNull();
   });
 
-  it("prévia vazia bloqueia o submit e não chama a Server Action", async () => {
+  it("permite recalcular uma prévia vazia e só libera o submit após encontrar vagas", async () => {
     mockPreview.mockResolvedValueOnce({
       preview: {
         ...previewResult,
@@ -144,8 +150,17 @@ describe("useLotteryRun", () => {
     expect(result.current.run.blockedMessage).toBe(
       LOTTERY_EMPTY_MESSAGES.capacity_exhausted,
     );
+    expect(result.current.run.canPreview).toBe(true);
     await act(() => result.current.run.handleRandomize());
     expect(mockRandomize).not.toHaveBeenCalled();
+
+    await act(() => result.current.run.handlePreview());
+
+    expect(mockPreview).toHaveBeenCalledTimes(2);
+    expect(result.current.run.preview).toEqual(previewResult);
+    expect(result.current.run.blockedMessage).toBeNull();
+    expect(result.current.run.canPreview).toBe(true);
+    expect(result.current.run.canSubmit).toBe(true);
   });
 
   it("trocar o alvo invalida a prévia e exige confirmações separadas", async () => {

--- a/frontend/src/components/assignments/lottery-dialog-types.ts
+++ b/frontend/src/components/assignments/lottery-dialog-types.ts
@@ -23,7 +23,8 @@ export interface LotteryStats {
   automationMode: string | null;
   currentRoundId?: string | null;
   currentRoundLabel?: string | null;
-  openAssignmentCount?: number;
+  activeOpenAssignmentCount?: number;
+  pendingScopeAssignmentCount?: number;
 }
 
 export type CodingsFilterMode = "all" | "none" | "atMost";

--- a/frontend/src/components/assignments/useLotteryParams.ts
+++ b/frontend/src/components/assignments/useLotteryParams.ts
@@ -16,7 +16,8 @@ export function useLotteryParams() {
   const [type, setType] = useState<"codificacao" | "comparacao">("codificacao");
   const [targetKind, setTargetKind] = useState<"current" | "new">("current");
   const [roundLabel, setRoundLabel] = useState("");
-  const [confirmOpenWork, setConfirmOpenWork] = useState(false);
+  const [confirmActiveWork, setConfirmActiveWork] = useState(false);
+  const [confirmPendingScopeWork, setConfirmPendingScopeWork] = useState(false);
 
   // Distribuição
   const [researchersPerDoc, setResearchersPerDoc] = useState(2);
@@ -71,8 +72,10 @@ export function useLotteryParams() {
     setTargetKind,
     roundLabel,
     setRoundLabel,
-    confirmOpenWork,
-    setConfirmOpenWork,
+    confirmActiveWork,
+    setConfirmActiveWork,
+    confirmPendingScopeWork,
+    setConfirmPendingScopeWork,
     researchersPerDoc,
     setResearchersPerDoc,
     docsPerResearcherEnabled,

--- a/frontend/src/components/assignments/useLotteryRun.ts
+++ b/frontend/src/components/assignments/useLotteryRun.ts
@@ -99,18 +99,16 @@ function getNewRoundBlockedMessage({
   });
 }
 
-function getLotteryBlockedMessage({
+function getLotteryConfigBlockedMessage({
   stats,
   newRoundMessage,
   participantCount,
   eligibleCount,
-  emptyReason,
 }: {
   stats: LotteryStats | null;
   newRoundMessage: string | null;
   participantCount: number;
   eligibleCount: number | null;
-  emptyReason?: LotteryEmptyReason;
 }): string | null {
   if (stats !== null && !stats.currentRoundId) {
     return "O projeto não tem uma rodada atual.";
@@ -122,6 +120,21 @@ function getLotteryBlockedMessage({
   if (eligibleCount === 0) {
     return "Nenhum documento passa nos filtros atuais.";
   }
+  return null;
+}
+
+function isLotteryPreviewEnabled(
+  stats: LotteryStats | null,
+  configBlockedMessage: string | null,
+): boolean {
+  return stats !== null && configBlockedMessage === null;
+}
+
+function getLotteryBlockedMessage(
+  configBlockedMessage: string | null,
+  emptyReason: LotteryEmptyReason | undefined,
+): string | null {
+  if (configBlockedMessage) return configBlockedMessage;
   return emptyReason ? LOTTERY_EMPTY_MESSAGES[emptyReason] : null;
 }
 
@@ -132,6 +145,29 @@ function isLotterySubmitEnabled(
 ): boolean {
   if (!stats || blockedMessage) return false;
   return previewTotal !== 0;
+}
+
+async function runLotteryAction({
+  enabled,
+  blockedMessage,
+  setRunning,
+  action,
+}: {
+  enabled: boolean;
+  blockedMessage: string | null;
+  setRunning: (running: boolean) => void;
+  action: () => Promise<void>;
+}): Promise<void> {
+  if (!enabled) {
+    if (blockedMessage) toast.error(blockedMessage);
+    return;
+  }
+  setRunning(true);
+  try {
+    await action();
+  } finally {
+    setRunning(false);
+  }
 }
 
 // Derivações e ações do sorteio (elegibilidade, prévia, submit) sobre o
@@ -282,14 +318,18 @@ export function useLotteryRun({
     confirmActiveWork,
     confirmPendingScopeWork,
   });
-  const blockedMessage = getLotteryBlockedMessage({
+  const configBlockedMessage = getLotteryConfigBlockedMessage({
     stats,
     newRoundMessage,
     participantCount: participantIds.length,
     eligibleCount,
-    emptyReason: preview?.emptyReason,
   });
+  const blockedMessage = getLotteryBlockedMessage(
+    configBlockedMessage,
+    preview?.emptyReason,
+  );
 
+  const canPreview = isLotteryPreviewEnabled(stats, configBlockedMessage);
   const canSubmit = isLotterySubmitEnabled(
     stats,
     blockedMessage,
@@ -330,41 +370,39 @@ export function useLotteryRun({
       : { ...base, type: "codificacao", researchersPerDoc: researchersPerDocEffective };
   };
 
-  const handlePreview = async () => {
-    setPreviewing(true);
-    try {
-      const result = await previewLottery(buildParams(false));
-      if (result.error) {
-        toast.error(result.error);
-      } else if (result.preview) {
-        setPreviewState({ key: configKey, preview: result.preview });
-      }
-    } finally {
-      setPreviewing(false);
-    }
-  };
+  const handlePreview = () =>
+    runLotteryAction({
+      enabled: canPreview,
+      blockedMessage: configBlockedMessage,
+      setRunning: setPreviewing,
+      action: async () => {
+        const result = await previewLottery(buildParams(false));
+        if (result.error) {
+          toast.error(result.error);
+        } else if (result.preview) {
+          setPreviewState({ key: configKey, preview: result.preview });
+        }
+      },
+    });
 
-  const handleRandomize = async () => {
-    if (blockedMessage) {
-      toast.error(blockedMessage);
-      return;
-    }
-    setLoading(true);
-    try {
-      const result = await smartRandomize(buildParams(true));
-      if (result.error) {
-        toast.error(result.error);
-      } else {
-        toast.success(
-          `${result.count} novas atribuições criadas! (${result.preserved} preservadas)`
-        );
-        setPreviewState(null);
-        onLotteryDone();
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
+  const handleRandomize = () =>
+    runLotteryAction({
+      enabled: canSubmit,
+      blockedMessage,
+      setRunning: setLoading,
+      action: async () => {
+        const result = await smartRandomize(buildParams(true));
+        if (result.error) {
+          toast.error(result.error);
+        } else {
+          toast.success(
+            `${result.count} novas atribuições criadas! (${result.preserved} preservadas)`
+          );
+          setPreviewState(null);
+          onLotteryDone();
+        }
+      },
+    });
 
   const docsConsidered =
     eligibleCount === null
@@ -385,6 +423,7 @@ export function useLotteryRun({
     participantCount: participantIds.length,
     eligibleCount,
     blockedMessage,
+    canPreview,
     canSubmit,
     preview,
     estimatedPerParticipant,

--- a/frontend/src/components/assignments/useLotteryRun.ts
+++ b/frontend/src/components/assignments/useLotteryRun.ts
@@ -7,6 +7,8 @@ import {
   resolveWeight,
   resolveCap,
   resolveResearchersPerDoc,
+  LOTTERY_EMPTY_MESSAGES,
+  type LotteryEmptyReason,
   type LotteryFilters,
 } from "@/lib/lottery-utils";
 import { toast } from "sonner";
@@ -17,6 +19,120 @@ import {
   isParticipant,
   weightValue,
 } from "./lottery-participant-values";
+
+function countEligibleDocs({
+  stats,
+  type,
+  targetKind,
+  filters,
+}: {
+  stats: LotteryStats | null;
+  type: "codificacao" | "comparacao";
+  targetKind: "current" | "new";
+  filters: LotteryFilters;
+}): number | null {
+  if (!stats) return null;
+  let candidates = targetKind === "new"
+    ? stats.docs.map((doc) => ({
+        ...doc,
+        humanCodingCount: 0,
+        hasLlmResponse: false,
+        activeAssignments: { codificacao: 0, comparacao: 0 },
+        hasAssignmentInCurrentRound: false,
+        batchIds: [],
+      }))
+    : stats.docs;
+  if (type === "comparacao") {
+    candidates = filterComparisonEligible(
+      candidates,
+      stats.automationMode,
+      stats.minResponsesForComparison,
+    );
+  }
+  return filterEligibleDocs(candidates, type, filters).length;
+}
+
+function getOpenWorkBlockedMessage({
+  stats,
+  confirmActiveWork,
+  confirmPendingScopeWork,
+}: {
+  stats: LotteryStats | null;
+  confirmActiveWork: boolean;
+  confirmPendingScopeWork: boolean;
+}): string | null {
+  const hasActiveWork = (stats?.activeOpenAssignmentCount ?? 0) > 0;
+  if (hasActiveWork && !confirmActiveWork) {
+    return "Confirme a abertura da nova rodada com trabalho ativo ainda aberto.";
+  }
+  const hasPendingScope = (stats?.pendingScopeAssignmentCount ?? 0) > 0;
+  if (hasPendingScope && !confirmPendingScopeWork) {
+    return "Confirme a abertura da nova rodada com documentos ainda em revisão de escopo.";
+  }
+  return null;
+}
+
+function getNewRoundBlockedMessage({
+  stats,
+  type,
+  targetKind,
+  roundLabel,
+  confirmActiveWork,
+  confirmPendingScopeWork,
+}: {
+  stats: LotteryStats | null;
+  type: "codificacao" | "comparacao";
+  targetKind: "current" | "new";
+  roundLabel: string;
+  confirmActiveWork: boolean;
+  confirmPendingScopeWork: boolean;
+}): string | null {
+  if (targetKind !== "new") return null;
+  if (type !== "codificacao") {
+    return "Uma nova rodada começa com um sorteio de codificação.";
+  }
+  if (!roundLabel.trim()) return "Informe o nome da nova rodada.";
+  return getOpenWorkBlockedMessage({
+    stats,
+    confirmActiveWork,
+    confirmPendingScopeWork,
+  });
+}
+
+function getLotteryBlockedMessage({
+  stats,
+  newRoundMessage,
+  participantCount,
+  eligibleCount,
+  emptyReason,
+}: {
+  stats: LotteryStats | null;
+  newRoundMessage: string | null;
+  participantCount: number;
+  eligibleCount: number | null;
+  emptyReason?: LotteryEmptyReason;
+}): string | null {
+  if (stats !== null && !stats.currentRoundId) {
+    return "O projeto não tem uma rodada atual.";
+  }
+  if (newRoundMessage) return newRoundMessage;
+  if (participantCount === 0) {
+    return "Nenhum participante selecionado.";
+  }
+  if (eligibleCount === 0) {
+    return "Nenhum documento passa nos filtros atuais.";
+  }
+  return emptyReason ? LOTTERY_EMPTY_MESSAGES[emptyReason] : null;
+}
+
+function isLotterySubmitEnabled(
+  stats: LotteryStats | null,
+  blockedMessage: string | null,
+  previewTotal: number | undefined,
+): boolean {
+  if (!stats || blockedMessage) return false;
+  return previewTotal !== 0;
+}
 
 // Derivações e ações do sorteio (elegibilidade, prévia, submit) sobre o
 // estado do formulário (useLotteryParams). Lê os campos de `params`
@@ -44,7 +160,8 @@ export function useLotteryRun({
     type,
     targetKind,
     roundLabel,
-    confirmOpenWork,
+    confirmActiveWork,
+    confirmPendingScopeWork,
     researchersPerDoc,
     docsPerResearcherEnabled,
     docsPerResearcher,
@@ -130,10 +247,13 @@ export function useLotteryRun({
   // Prévia + semente (research D13): a seed da última prévia é reaproveitada
   // ao sortear; a prévia é guardada junto da configuração que a gerou, então
   // qualquer mudança de configuração a invalida (e à seed) por derivação.
-  // O rótulo fica de fora: não afeta o resultado do sorteio, e é lido em
-  // buildParams na hora do submit
+  // O rótulo do lote fica de fora: não afeta o resultado e é lido em
+  // buildParams. O alvo e o nome da rodada entram porque mudam a operação.
   const configKey = JSON.stringify({
     type,
+    targetKind,
+    currentRoundId: stats?.currentRoundId ?? null,
+    roundLabel: targetKind === "new" ? roundLabel.trim() : null,
     researchersPerDoc: researchersPerDocEffective,
     docsPerResearcherEnabled,
     docsPerResearcher,
@@ -149,44 +269,32 @@ export function useLotteryRun({
   const seed = preview?.seed ?? null;
 
   // Contagem de elegíveis ao vivo, com a mesma função pura do server
-  const eligibleCount = useMemo(() => {
-    if (!stats) return null;
-    let candidates = targetKind === "new"
-      ? stats.docs.map((doc) => ({
-          ...doc,
-          humanCodingCount: 0,
-          hasLlmResponse: false,
-          activeAssignments: { codificacao: 0, comparacao: 0 },
-          hasAnyAssignmentEver: false,
-          batchIds: [],
-        }))
-      : stats.docs;
-    if (isComparacao) {
-      candidates = filterComparisonEligible(
-        candidates,
-        stats.automationMode,
-        stats.minResponsesForComparison,
-      );
-    }
-    return filterEligibleDocs(candidates, type, filters).length;
-  }, [stats, type, isComparacao, filters, targetKind]);
+  const eligibleCount = useMemo(
+    () => countEligibleDocs({ stats, type, targetKind, filters }),
+    [stats, type, filters, targetKind],
+  );
 
-  const blockedMessage =
-    !stats?.currentRoundId
-      ? "O projeto não tem uma rodada atual."
-      : targetKind === "new" && type !== "codificacao"
-        ? "Uma nova rodada começa com um sorteio de codificação."
-        : targetKind === "new" && !roundLabel.trim()
-          ? "Informe o nome da nova rodada."
-        : targetKind === "new" && (stats.openAssignmentCount ?? 0) > 0 && !confirmOpenWork
-            ? "Confirme a abertura da nova rodada com trabalho ainda aberto."
-            : participantIds.length === 0
-      ? "Nenhum participante selecionado."
-      : eligibleCount === 0
-        ? "Nenhum documento passa nos filtros atuais."
-        : null;
+  const newRoundMessage = getNewRoundBlockedMessage({
+    stats,
+    type,
+    targetKind,
+    roundLabel,
+    confirmActiveWork,
+    confirmPendingScopeWork,
+  });
+  const blockedMessage = getLotteryBlockedMessage({
+    stats,
+    newRoundMessage,
+    participantCount: participantIds.length,
+    eligibleCount,
+    emptyReason: preview?.emptyReason,
+  });
 
-  const canSubmit = !blockedMessage && stats !== null;
+  const canSubmit = isLotterySubmitEnabled(
+    stats,
+    blockedMessage,
+    preview?.totalNew,
+  );
 
   const buildParams = (withSeed: boolean): LotteryParams => {
     const base = {
@@ -207,7 +315,8 @@ export function useLotteryRun({
             kind: "new" as const,
             expectedRoundId: stats?.currentRoundId ?? "",
             roundLabel: roundLabel.trim(),
-            confirmOpenWork,
+            confirmActiveWork,
+            confirmPendingScopeWork,
           }
         : {
             kind: "current" as const,
@@ -236,6 +345,10 @@ export function useLotteryRun({
   };
 
   const handleRandomize = async () => {
+    if (blockedMessage) {
+      toast.error(blockedMessage);
+      return;
+    }
     setLoading(true);
     try {
       const result = await smartRandomize(buildParams(true));

--- a/frontend/src/components/assignments/useLotteryStats.ts
+++ b/frontend/src/components/assignments/useLotteryStats.ts
@@ -29,7 +29,8 @@ export function useLotteryStats(projectId: string, open: boolean) {
               automationMode: s.automationMode ?? null,
               currentRoundId: s.currentRoundId ?? null,
               currentRoundLabel: s.currentRoundLabel ?? null,
-              openAssignmentCount: s.openAssignmentCount ?? 0,
+              activeOpenAssignmentCount: s.activeOpenAssignmentCount ?? 0,
+              pendingScopeAssignmentCount: s.pendingScopeAssignmentCount ?? 0,
             },
             error: false,
           });

--- a/frontend/src/lib/__tests__/lottery-utils.test.ts
+++ b/frontend/src/lib/__tests__/lottery-utils.test.ts
@@ -20,7 +20,7 @@ function doc(overrides: Partial<LotteryDocStats> & { id: string }): LotteryDocSt
     humanCodingCount: 0,
     hasLlmResponse: false,
     activeAssignments: { codificacao: 0, comparacao: 0 },
-    hasAnyAssignmentEver: false,
+    hasAssignmentInCurrentRound: false,
     batchIds: [],
     ...overrides,
   };
@@ -68,17 +68,17 @@ describe("filterEligibleDocs", () => {
       doc({
         id: "cod-ativa",
         activeAssignments: { codificacao: 1, comparacao: 0 },
-        hasAnyAssignmentEver: true,
+        hasAssignmentInCurrentRound: true,
       }),
       doc({
         id: "comp-ativa",
         activeAssignments: { codificacao: 0, comparacao: 1 },
-        hasAnyAssignmentEver: true,
+        hasAssignmentInCurrentRound: true,
       }),
       doc({
         id: "ja-teve",
         activeAssignments: { codificacao: 0, comparacao: 0 },
-        hasAnyAssignmentEver: true,
+        hasAssignmentInCurrentRound: true,
       }),
     ];
 
@@ -196,7 +196,7 @@ describe("filterEligibleDocs", () => {
         id: "ativa",
         humanCodingCount: 0,
         activeAssignments: { codificacao: 1, comparacao: 0 },
-        hasAnyAssignmentEver: true,
+        hasAssignmentInCurrentRound: true,
         batchIds: ["b2"],
       }),
       doc({ id: "lote-excluido", humanCodingCount: 0, batchIds: ["b1"] }),

--- a/frontend/src/lib/lottery-utils.ts
+++ b/frontend/src/lib/lottery-utils.ts
@@ -6,6 +6,19 @@
 export type LotteryMode = "append" | "replace";
 export type LotteryBalancing = "round" | "history";
 export type AssignmentFilter = "any" | "noActiveOfType" | "neverAssigned";
+export type LotteryEmptyReason =
+  | "all_slots_filled"
+  | "capacity_exhausted"
+  | "no_available_pairs";
+
+export const LOTTERY_EMPTY_MESSAGES: Record<LotteryEmptyReason, string> = {
+  all_slots_filled:
+    "Todos os documentos selecionados já têm o número solicitado de atribuições nesta rodada. Para redistribuir o trabalho, inicie uma nova rodada.",
+  capacity_exhausted:
+    "Os participantes selecionados atingiram os limites de documentos configurados. Aumente ou remova os limites para continuar.",
+  no_available_pairs:
+    "Não há novos pares possíveis entre os documentos e participantes selecionados. Revise os participantes ou inicie uma nova rodada.",
+};
 
 export interface LotteryFilters {
   /** undefined = todos; 0 = sem nenhuma codificação; N = no máximo N */
@@ -26,7 +39,8 @@ export interface LotteryDocStats {
   hasLlmResponse: boolean;
   /** pendente + em_andamento, por tipo */
   activeAssignments: { codificacao: number; comparacao: number };
-  hasAnyAssignmentEver: boolean;
+  /** existe ao menos uma atribuição do documento na rodada atual */
+  hasAssignmentInCurrentRound: boolean;
   batchIds: string[];
 }
 
@@ -168,7 +182,7 @@ export function filterEligibleDocs(
   if (assignmentFilter === "noActiveOfType") {
     result = result.filter((d) => d.activeAssignments[type] === 0);
   } else if (assignmentFilter === "neverAssigned") {
-    result = result.filter((d) => !d.hasAnyAssignmentEver);
+    result = result.filter((d) => !d.hasAssignmentInCurrentRound);
   }
 
   if (filters.batchFilter?.only) {

--- a/frontend/supabase/migrations/20260803140000_lottery_scope_work_contract.sql
+++ b/frontend/supabase/migrations/20260803140000_lottery_scope_work_contract.sql
@@ -1,0 +1,347 @@
+-- Unifica o contrato de trabalho aberto usado pela pre-visualizacao e pela
+-- aplicacao do sorteio. A contagem pertence a uma rodada e distingue
+-- documentos ativos daqueles cuja exclusao ainda aguarda decisao; documentos
+-- ja excluidos preservam o historico, mas nao bloqueiam uma rodada nova.
+
+CREATE OR REPLACE VIEW public.lottery_round_work_counts
+WITH (security_invoker = true) AS
+SELECT
+  assignment.project_id,
+  assignment.round_id,
+  assignment.type AS assignment_type,
+  CASE
+    WHEN document.exclusion_pending_at IS NULL THEN 'active'
+    ELSE 'pending_scope'
+  END AS scope_state,
+  count(*)::integer AS open_count
+FROM public.assignments AS assignment
+JOIN public.documents AS document
+  ON document.id = assignment.document_id
+ AND document.project_id = assignment.project_id
+WHERE assignment.status IN ('pendente', 'em_andamento')
+  AND document.excluded_at IS NULL
+GROUP BY
+  assignment.project_id,
+  assignment.round_id,
+  assignment.type,
+  CASE
+    WHEN document.exclusion_pending_at IS NULL THEN 'active'
+    ELSE 'pending_scope'
+  END;
+
+REVOKE ALL ON public.lottery_round_work_counts FROM PUBLIC, anon;
+GRANT SELECT ON public.lottery_round_work_counts TO authenticated, service_role;
+
+CREATE INDEX IF NOT EXISTS idx_assignments_open_work_by_round
+  ON public.assignments (project_id, round_id, document_id, type)
+  WHERE status IN ('pendente', 'em_andamento');
+
+-- O nome anterior dizia "alguma vez", mas a elegibilidade do sorteio passou a
+-- ser por rodada. Renomear antes do CREATE OR REPLACE preserva dependencias da
+-- view sem manter duas representacoes concorrentes da mesma informacao.
+ALTER VIEW public.lottery_doc_stats
+  RENAME COLUMN has_any_assignment_ever TO has_assignment_in_current_round;
+
+CREATE OR REPLACE VIEW public.lottery_doc_stats
+WITH (security_invoker = true) AS
+SELECT
+  document.id,
+  document.project_id,
+  document.external_id,
+  document.title,
+  COALESCE(response_stats.human_coding_count, 0)::integer AS human_coding_count,
+  COALESCE(response_stats.has_llm_response, false) AS has_llm_response,
+  COALESCE(assignment_stats.active_codificacao, 0)::integer AS active_codificacao,
+  COALESCE(assignment_stats.active_comparacao, 0)::integer AS active_comparacao,
+  COALESCE(assignment_stats.has_assignment_in_current_round, false)
+    AS has_assignment_in_current_round,
+  COALESCE(assignment_stats.batch_ids, ARRAY[]::uuid[]) AS batch_ids
+FROM public.documents AS document
+JOIN public.projects AS project ON project.id = document.project_id
+LEFT JOIN LATERAL (
+  SELECT
+    count(DISTINCT response.respondent_id)
+      FILTER (WHERE response.respondent_type = 'humano') AS human_coding_count,
+    bool_or(response.respondent_type = 'llm') AS has_llm_response
+  FROM public.responses AS response
+  WHERE response.document_id = document.id
+    AND response.project_id = document.project_id
+    AND response.round_id = project.current_round_id
+    AND response.is_latest = true
+) AS response_stats ON true
+LEFT JOIN LATERAL (
+  SELECT
+    count(*) FILTER (
+      WHERE assignment.type = 'codificacao'
+        AND assignment.status IN ('pendente', 'em_andamento')
+    ) AS active_codificacao,
+    count(*) FILTER (
+      WHERE assignment.type = 'comparacao'
+        AND assignment.status IN ('pendente', 'em_andamento')
+    ) AS active_comparacao,
+    count(*) > 0 AS has_assignment_in_current_round,
+    array_agg(DISTINCT assignment.batch_id)
+      FILTER (WHERE assignment.batch_id IS NOT NULL) AS batch_ids
+  FROM public.assignments AS assignment
+  WHERE assignment.document_id = document.id
+    AND assignment.project_id = document.project_id
+    AND assignment.round_id = project.current_round_id
+) AS assignment_stats ON true
+WHERE document.excluded_at IS NULL
+  AND document.exclusion_pending_at IS NULL;
+
+REVOKE ALL ON public.lottery_doc_stats FROM PUBLIC, anon;
+GRANT SELECT ON public.lottery_doc_stats TO authenticated, service_role;
+
+-- O payload novo carrega a fotografia das contagens exibidas ao coordenador.
+-- A RPC repete a leitura depois de travar projeto e documentos, impedindo que
+-- uma confirmacao dada sobre N trabalhos autorize silenciosamente outro N.
+-- `p_confirm_open_work` permanece apenas como compatibilidade com a release
+-- anterior, que ainda nao envia `open_work_snapshot`.
+CREATE OR REPLACE FUNCTION public.apply_lottery_assignments(
+  p_project_id uuid,
+  p_type text,
+  p_expected_round_id uuid,
+  p_new_round_label text,
+  p_confirm_open_work boolean,
+  p_batch jsonb,
+  p_assignments jsonb,
+  p_replace boolean
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_current_round_id uuid;
+  v_target_round_id uuid;
+  v_batch_id uuid;
+  v_created_by uuid;
+  v_inserted integer;
+  v_requested integer;
+  v_preserved integer;
+  v_open_active integer := 0;
+  v_open_pending_scope integer := 0;
+  v_expected_active integer;
+  v_expected_pending_scope integer;
+  v_confirm_active boolean;
+  v_confirm_pending_scope boolean;
+  v_open_work_snapshot jsonb;
+  v_has_snapshot boolean := false;
+  v_label text;
+BEGIN
+  IF p_type NOT IN ('codificacao', 'comparacao') THEN
+    RAISE EXCEPTION 'tipo de sorteio invalido: %', p_type USING ERRCODE = '22023';
+  END IF;
+  IF jsonb_typeof(p_batch) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'batch deve ser um objeto JSON' USING ERRCODE = '22023';
+  END IF;
+  IF jsonb_typeof(p_assignments) IS DISTINCT FROM 'array' THEN
+    RAISE EXCEPTION 'assignments deve ser um array JSON' USING ERRCODE = '22023';
+  END IF;
+
+  v_requested := jsonb_array_length(p_assignments);
+  IF v_requested = 0 THEN
+    RAISE EXCEPTION 'assignments nao pode ser vazio' USING ERRCODE = '22023';
+  END IF;
+
+  v_open_work_snapshot := p_batch->'open_work_snapshot';
+  IF v_open_work_snapshot IS NOT NULL THEN
+    IF jsonb_typeof(v_open_work_snapshot) IS DISTINCT FROM 'object'
+       OR NOT (v_open_work_snapshot ? 'active_count')
+       OR NOT (v_open_work_snapshot ? 'pending_scope_count') THEN
+      RAISE EXCEPTION 'open_work_snapshot deve informar active_count e pending_scope_count'
+        USING ERRCODE = '22023';
+    END IF;
+
+    v_expected_active := (v_open_work_snapshot->>'active_count')::integer;
+    v_expected_pending_scope := (v_open_work_snapshot->>'pending_scope_count')::integer;
+    IF v_expected_active < 0 OR v_expected_pending_scope < 0 THEN
+      RAISE EXCEPTION 'contagens de trabalho aberto nao podem ser negativas'
+        USING ERRCODE = '22023';
+    END IF;
+    v_has_snapshot := true;
+  END IF;
+
+  v_created_by := public.clerk_uid();
+  IF v_created_by IS NULL THEN
+    RAISE EXCEPTION 'identidade autenticada indisponivel' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT project.current_round_id INTO v_current_round_id
+  FROM public.projects AS project
+  WHERE project.id = p_project_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'projeto inexistente ou inacessivel' USING ERRCODE = 'P0002';
+  END IF;
+  IF v_current_round_id IS DISTINCT FROM p_expected_round_id THEN
+    RAISE EXCEPTION 'a rodada atual mudou; recarregue o sorteio' USING ERRCODE = '40001';
+  END IF;
+
+  -- Ordem global: projects -> documents. O lock estabiliza o estado de escopo
+  -- antes de a contagem canonica ser relida e antes de qualquer escrita.
+  PERFORM 1
+  FROM public.documents AS document
+  WHERE document.project_id = p_project_id
+    AND document.excluded_at IS NULL
+  ORDER BY document.id
+  FOR UPDATE;
+
+  -- A pre-visualizacao so propoe documentos ativos. Revalidar o proprio
+  -- payload sob o lock torna impossivel criar fila para um documento excluido
+  -- ou colocado em revisao de escopo entre a pre-visualizacao e a gravacao.
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(p_assignments) AS proposed(entry)
+    LEFT JOIN public.documents AS document
+      ON document.id = (proposed.entry->>'document_id')::uuid
+     AND document.project_id = p_project_id
+     AND document.excluded_at IS NULL
+     AND document.exclusion_pending_at IS NULL
+    WHERE document.id IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'o escopo dos documentos mudou; recarregue o sorteio'
+      USING ERRCODE = '40001';
+  END IF;
+
+  v_target_round_id := v_current_round_id;
+  IF p_new_round_label IS NOT NULL THEN
+    IF p_type <> 'codificacao' THEN
+      RAISE EXCEPTION 'somente sorteio de codificacao pode iniciar rodada' USING ERRCODE = '22023';
+    END IF;
+    v_label := btrim(p_new_round_label);
+    IF v_label = '' THEN
+      RAISE EXCEPTION 'nome da rodada nao pode ser vazio' USING ERRCODE = '22023';
+    END IF;
+
+    SELECT
+      COALESCE(sum(work.open_count) FILTER (WHERE work.scope_state = 'active'), 0)::integer,
+      COALESCE(sum(work.open_count) FILTER (WHERE work.scope_state = 'pending_scope'), 0)::integer
+    INTO v_open_active, v_open_pending_scope
+    FROM public.lottery_round_work_counts AS work
+    WHERE work.project_id = p_project_id
+      AND work.round_id = v_current_round_id;
+
+    IF v_has_snapshot
+       AND (v_open_active IS DISTINCT FROM v_expected_active
+            OR v_open_pending_scope IS DISTINCT FROM v_expected_pending_scope) THEN
+      RAISE EXCEPTION
+        'o trabalho aberto mudou (ativos: % -> %, revisao de escopo: % -> %); recarregue o sorteio',
+        v_expected_active, v_open_active,
+        v_expected_pending_scope, v_open_pending_scope
+        USING ERRCODE = '40001';
+    END IF;
+
+    v_confirm_active := COALESCE(
+      (v_open_work_snapshot->>'confirm_active')::boolean,
+      p_confirm_open_work,
+      false
+    );
+    v_confirm_pending_scope := COALESCE(
+      (v_open_work_snapshot->>'confirm_pending_scope')::boolean,
+      p_confirm_open_work,
+      false
+    );
+
+    IF v_open_active > 0 AND NOT v_confirm_active THEN
+      RAISE EXCEPTION 'a rodada atual possui % trabalhos abertos em documentos ativos',
+        v_open_active USING ERRCODE = 'P0001';
+    END IF;
+    IF v_open_pending_scope > 0 AND NOT v_confirm_pending_scope THEN
+      RAISE EXCEPTION
+        'a rodada atual possui % trabalhos abertos em revisao de escopo',
+        v_open_pending_scope USING ERRCODE = 'P0001';
+    END IF;
+
+    INSERT INTO public.rounds (project_id, label)
+    VALUES (p_project_id, v_label)
+    RETURNING id INTO v_target_round_id;
+
+    UPDATE public.responses
+    SET is_latest = false
+    WHERE project_id = p_project_id
+      AND round_id = v_current_round_id
+      AND is_latest;
+
+    UPDATE public.projects
+    SET current_round_id = v_target_round_id,
+        round_strategy = 'manual'
+    WHERE id = p_project_id;
+  END IF;
+
+  INSERT INTO public.assignment_batches (
+    project_id, round_id, type, created_by, researchers_per_doc,
+    docs_per_researcher, doc_subset_size, label, mode, balancing, filters
+  ) VALUES (
+    p_project_id,
+    v_target_round_id,
+    p_type,
+    v_created_by,
+    COALESCE((p_batch->>'researchers_per_doc')::integer, 2),
+    NULLIF(p_batch->>'docs_per_researcher', '')::integer,
+    NULLIF(p_batch->>'doc_subset_size', '')::integer,
+    NULLIF(p_batch->>'label', ''),
+    COALESCE(NULLIF(p_batch->>'mode', ''), CASE WHEN p_replace THEN 'replace' ELSE 'append' END),
+    COALESCE(NULLIF(p_batch->>'balancing', ''), 'history'),
+    p_batch->'filters'
+  ) RETURNING id INTO v_batch_id;
+
+  IF p_replace THEN
+    DELETE FROM public.assignments
+    WHERE project_id = p_project_id
+      AND round_id = v_target_round_id
+      AND status = 'pendente'
+      AND type = p_type;
+  END IF;
+
+  SELECT count(*) INTO v_preserved
+  FROM public.assignments
+  WHERE project_id = p_project_id
+    AND round_id = v_target_round_id
+    AND type = p_type;
+
+  INSERT INTO public.assignments (
+    project_id, round_id, document_id, user_id, batch_id, type, status, completed_at
+  )
+  SELECT p_project_id,
+         v_target_round_id,
+         (entry->>'document_id')::uuid,
+         (entry->>'user_id')::uuid,
+         v_batch_id,
+         p_type,
+         COALESCE(entry->>'status', 'pendente'),
+         (entry->>'completed_at')::timestamptz
+  FROM jsonb_array_elements(p_assignments) AS entry
+  ON CONFLICT DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  IF v_inserted <> v_requested THEN
+    RAISE EXCEPTION
+      'o conjunto do sorteio mudou; seriam criadas % de % atribuicoes; recarregue o sorteio',
+      v_inserted, v_requested
+      USING ERRCODE = '40001';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'round_id', v_target_round_id,
+    'batch_id', v_batch_id,
+    'inserted', v_inserted,
+    'preserved', v_preserved
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.apply_lottery_assignments(
+  uuid, text, uuid, text, boolean, jsonb, jsonb, boolean
+) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.apply_lottery_assignments(
+  uuid, text, uuid, text, boolean, jsonb, jsonb, boolean
+) TO authenticated;
+
+REVOKE ALL ON FUNCTION public.apply_lottery_assignments(
+  uuid, text, uuid, jsonb, boolean
+) FROM PUBLIC, anon, authenticated, service_role;
+DROP FUNCTION public.apply_lottery_assignments(uuid, text, uuid, jsonb, boolean);

--- a/frontend/supabase/migrations/20260803204000_lottery_doc_stats_compat_alias.sql
+++ b/frontend/supabase/migrations/20260803204000_lottery_doc_stats_compat_alias.sql
@@ -1,0 +1,60 @@
+-- Mantem o contrato legado durante o deploy em duas etapas: esta migration de
+-- compatibilidade entra antes do frontend novo, portanto ambas as versoes
+-- precisam ler a mesma informacao de ocupacao da rodada atual.
+
+CREATE OR REPLACE VIEW public.lottery_doc_stats
+WITH (security_invoker = true) AS
+WITH canonical AS (
+  SELECT
+    document.id,
+    document.project_id,
+    document.external_id,
+    document.title,
+    COALESCE(response_stats.human_coding_count, 0)::integer AS human_coding_count,
+    COALESCE(response_stats.has_llm_response, false) AS has_llm_response,
+    COALESCE(assignment_stats.active_codificacao, 0)::integer AS active_codificacao,
+    COALESCE(assignment_stats.active_comparacao, 0)::integer AS active_comparacao,
+    COALESCE(assignment_stats.has_assignment_in_current_round, false)
+      AS has_assignment_in_current_round,
+    COALESCE(assignment_stats.batch_ids, ARRAY[]::uuid[]) AS batch_ids
+  FROM public.documents AS document
+  JOIN public.projects AS project ON project.id = document.project_id
+  LEFT JOIN LATERAL (
+    SELECT
+      count(DISTINCT response.respondent_id)
+        FILTER (WHERE response.respondent_type = 'humano') AS human_coding_count,
+      bool_or(response.respondent_type = 'llm') AS has_llm_response
+    FROM public.responses AS response
+    WHERE response.document_id = document.id
+      AND response.project_id = document.project_id
+      AND response.round_id = project.current_round_id
+      AND response.is_latest = true
+  ) AS response_stats ON true
+  LEFT JOIN LATERAL (
+    SELECT
+      count(*) FILTER (
+        WHERE assignment.type = 'codificacao'
+          AND assignment.status IN ('pendente', 'em_andamento')
+      ) AS active_codificacao,
+      count(*) FILTER (
+        WHERE assignment.type = 'comparacao'
+          AND assignment.status IN ('pendente', 'em_andamento')
+      ) AS active_comparacao,
+      count(*) > 0 AS has_assignment_in_current_round,
+      array_agg(DISTINCT assignment.batch_id)
+        FILTER (WHERE assignment.batch_id IS NOT NULL) AS batch_ids
+    FROM public.assignments AS assignment
+    WHERE assignment.document_id = document.id
+      AND assignment.project_id = document.project_id
+      AND assignment.round_id = project.current_round_id
+  ) AS assignment_stats ON true
+  WHERE document.excluded_at IS NULL
+    AND document.exclusion_pending_at IS NULL
+)
+SELECT
+  canonical.*,
+  canonical.has_assignment_in_current_round AS has_any_assignment_ever
+FROM canonical;
+
+REVOKE ALL ON public.lottery_doc_stats FROM PUBLIC, anon;
+GRANT SELECT ON public.lottery_doc_stats TO authenticated, service_role;

--- a/frontend/supabase/tests/atomic_replace_rpcs.test.sql
+++ b/frontend/supabase/tests/atomic_replace_rpcs.test.sql
@@ -34,6 +34,10 @@ INSERT INTO public.documents (id, project_id, external_id, title, text, text_has
 -- arquivo (a review logo abaixo e o assignment em seguida).
 INSERT INTO auth.users (id, email) VALUES
   ('77777777-7777-7777-7777-777777777777', 'atomic-replace-respondent@example.test');
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+VALUES
+  ('atomic-replace-clerk', '77777777-7777-7777-7777-777777777777', 1);
 
 INSERT INTO public.responses (id, project_id, document_id, respondent_id, respondent_type, answers) VALUES
   ('44444444-4444-4444-4444-444444444444', '11111111-1111-1111-1111-111111111111', '22222222-2222-2222-2222-222222222222', '77777777-7777-7777-7777-777777777777', 'humano', '{"campo":"x"}');
@@ -173,13 +177,22 @@ END $$;
 
 -- ----- #181: apply_lottery_assignments(replace) descarta pendentes do tipo + insere -----
 DO $$
-DECLARE n_pend int;
+DECLARE n_pend int; v_round_id uuid;
 BEGIN
+  PERFORM set_config(
+    'request.jwt.claims',
+    '{"sub":"atomic-replace-clerk","supabase_uid":"77777777-7777-7777-7777-777777777777"}',
+    true
+  );
+  SELECT current_round_id INTO v_round_id
+  FROM public.projects WHERE id = '11111111-1111-1111-1111-111111111111';
+
   -- Pendente antiga (em D2) que deve ser descartada pelo modo replace.
   INSERT INTO public.assignments (project_id, document_id, status, type)
     VALUES ('11111111-1111-1111-1111-111111111111', '33333333-3333-3333-3333-333333333333', 'pendente', 'codificacao');
   PERFORM public.apply_lottery_assignments(
-    '11111111-1111-1111-1111-111111111111'::uuid, 'codificacao', NULL,
+    '11111111-1111-1111-1111-111111111111'::uuid, 'codificacao', v_round_id,
+    NULL, false, '{}'::jsonb,
     '[{"document_id":"22222222-2222-2222-2222-222222222222","user_id":null}]'::jsonb,
     true
   );
@@ -195,14 +208,23 @@ END $$;
 -- ficava eternamente pendente na fila: nada promove um assignment criado DEPOIS
 -- da response.
 DO $$
-DECLARE r_status text; r_done timestamptz; r_default text; r_default_done timestamptz;
+DECLARE
+  r_status text;
+  r_done timestamptz;
+  r_default text;
+  r_default_done timestamptz;
+  v_round_id uuid;
 BEGIN
+  SELECT current_round_id INTO v_round_id
+  FROM public.projects WHERE id = '11111111-1111-1111-1111-111111111111';
+
   -- Este DELETE limpa a fixture de assignments dos blocos anteriores, então
   -- este bloco tem de continuar sendo o ÚLTIMO: um caso novo inserido abaixo
   -- herdaria a tabela vazia e passaria por vácuo, sem sinal nenhum.
   DELETE FROM public.assignments WHERE project_id = '11111111-1111-1111-1111-111111111111';
   PERFORM public.apply_lottery_assignments(
-    '11111111-1111-1111-1111-111111111111'::uuid, 'codificacao', NULL,
+    '11111111-1111-1111-1111-111111111111'::uuid, 'codificacao', v_round_id,
+    NULL, false, '{}'::jsonb,
     '[{"document_id":"22222222-2222-2222-2222-222222222222","user_id":null,
        "status":"concluido","completed_at":"2026-07-20T10:00:00Z"},
       {"document_id":"33333333-3333-3333-3333-333333333333","user_id":null}]'::jsonb,

--- a/frontend/supabase/tests/explicit_assignment_rounds.test.sql
+++ b/frontend/supabase/tests/explicit_assignment_rounds.test.sql
@@ -97,6 +97,14 @@ BEGIN
   RAISE NOTICE 'OK: rodada inicial e identidade canonica de projeto';
 END $$;
 
+-- As RPCs de escrita derivam a autoria do JWT, inclusive quando o teste roda
+-- como owner para isolar atomicidade das demais policies.
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"round-creator-clerk","supabase_uid":"70000000-0000-0000-0000-000000000001"}',
+  true
+);
+
 DO $$
 DECLARE old_round uuid; result jsonb; new_round uuid;
 BEGIN
@@ -145,7 +153,7 @@ BEGIN
       '71000000-0000-0000-0000-000000000002', 'codificacao', current_round,
       'Rodada vazia', true, '{}'::jsonb, '[]'::jsonb, false);
     RAISE EXCEPTION 'FALHOU: sorteio vazio deveria abortar';
-  EXCEPTION WHEN raise_exception THEN
+  EXCEPTION WHEN invalid_parameter_value THEN
     IF SQLERRM LIKE 'FALHOU:%' THEN RAISE; END IF;
   END;
   IF (SELECT count(*) FROM public.rounds WHERE project_id = '71000000-0000-0000-0000-000000000002') <> before_rounds
@@ -154,6 +162,297 @@ BEGIN
     RAISE EXCEPTION 'FALHOU: sorteio vazio deixou rodada/lote/ativacao parcial';
   END IF;
   RAISE NOTICE 'OK: zero inserts faz rollback completo';
+END $$;
+
+-- A mesma fonte canonica alimenta a pre-visualizacao e a validacao
+-- transacional. O historico permanece consultavel por round_id, enquanto a
+-- view do dialogo considera somente a rodada atual e documentos ativos.
+INSERT INTO public.projects (id, name) VALUES
+  ('71000000-0000-0000-0000-000000000003', 'scope work contract');
+
+INSERT INTO public.documents
+  (id, project_id, text, exclusion_pending_at, excluded_at)
+VALUES
+  ('72000000-0000-0000-0000-000000000003', '71000000-0000-0000-0000-000000000003', 'active doc', NULL, NULL),
+  ('72000000-0000-0000-0000-000000000004', '71000000-0000-0000-0000-000000000003', 'pending scope doc', now(), NULL),
+  ('72000000-0000-0000-0000-000000000005', '71000000-0000-0000-0000-000000000003', 'excluded doc', NULL, now());
+
+-- Linhas da rodada inicial viram historia sem serem apagadas. A response
+-- humana continua is_latest=true de proposito: so o filtro por round_id pode
+-- impedi-la de contaminar lottery_doc_stats.
+INSERT INTO public.responses (
+  project_id, document_id, respondent_id, respondent_type, answers
+) VALUES (
+  '71000000-0000-0000-0000-000000000003',
+  '72000000-0000-0000-0000-000000000003',
+  '70000000-0000-0000-0000-000000000001',
+  'humano',
+  '{}'::jsonb
+);
+INSERT INTO public.assignments (project_id, document_id, type, status)
+VALUES (
+  '71000000-0000-0000-0000-000000000003',
+  '72000000-0000-0000-0000-000000000003',
+  'codificacao',
+  'em_andamento'
+);
+
+INSERT INTO public.rounds (id, project_id, label)
+VALUES (
+  '73000000-0000-0000-0000-000000000003',
+  '71000000-0000-0000-0000-000000000003',
+  'Rodada atual'
+);
+UPDATE public.projects
+SET current_round_id = '73000000-0000-0000-0000-000000000003',
+    round_strategy = 'manual'
+WHERE id = '71000000-0000-0000-0000-000000000003';
+
+INSERT INTO public.responses (
+  project_id, document_id, respondent_type, respondent_name, answers
+) VALUES (
+  '71000000-0000-0000-0000-000000000003',
+  '72000000-0000-0000-0000-000000000003',
+  'llm',
+  'scope-contract/test',
+  '{}'::jsonb
+);
+INSERT INTO public.assignments (project_id, document_id, type, status) VALUES
+  ('71000000-0000-0000-0000-000000000003', '72000000-0000-0000-0000-000000000003', 'codificacao', 'em_andamento'),
+  ('71000000-0000-0000-0000-000000000003', '72000000-0000-0000-0000-000000000004', 'arbitragem', 'pendente'),
+  ('71000000-0000-0000-0000-000000000003', '72000000-0000-0000-0000-000000000005', 'comparacao', 'em_andamento'),
+  ('71000000-0000-0000-0000-000000000003', '72000000-0000-0000-0000-000000000003', 'arbitragem', 'concluido');
+
+DO $$
+DECLARE
+  v_initial_round uuid;
+  v_active_count integer;
+  v_pending_count integer;
+  v_human_count integer;
+  v_has_llm boolean;
+  v_active_coding integer;
+  v_active_comparison integer;
+  v_has_assignment boolean;
+BEGIN
+  SELECT round.id INTO STRICT v_initial_round
+  FROM public.rounds AS round
+  WHERE round.project_id = '71000000-0000-0000-0000-000000000003'
+    AND round.id <> '73000000-0000-0000-0000-000000000003';
+
+  SELECT
+    COALESCE(sum(work.open_count) FILTER (WHERE work.scope_state = 'active'), 0),
+    COALESCE(sum(work.open_count) FILTER (WHERE work.scope_state = 'pending_scope'), 0)
+  INTO v_active_count, v_pending_count
+  FROM public.lottery_round_work_counts AS work
+  WHERE work.project_id = '71000000-0000-0000-0000-000000000003'
+    AND work.round_id = '73000000-0000-0000-0000-000000000003';
+
+  IF v_active_count <> 1 OR v_pending_count <> 1 THEN
+    RAISE EXCEPTION
+      'FALHOU: contagem canonica esperava active=1/pending_scope=1, recebeu %/%',
+      v_active_count, v_pending_count;
+  END IF;
+  IF NOT EXISTS (
+       SELECT 1 FROM public.lottery_round_work_counts
+       WHERE project_id = '71000000-0000-0000-0000-000000000003'
+         AND round_id = '73000000-0000-0000-0000-000000000003'
+         AND assignment_type = 'arbitragem'
+         AND scope_state = 'pending_scope'
+         AND open_count = 1
+     ) OR EXISTS (
+       SELECT 1 FROM public.lottery_round_work_counts
+       WHERE project_id = '71000000-0000-0000-0000-000000000003'
+         AND round_id = '73000000-0000-0000-0000-000000000003'
+         AND assignment_type = 'comparacao'
+     ) THEN
+    RAISE EXCEPTION 'FALHOU: tipos abertos ou documento excluido foram classificados incorretamente';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.lottery_round_work_counts
+    WHERE project_id = '71000000-0000-0000-0000-000000000003'
+      AND round_id = v_initial_round
+      AND assignment_type = 'codificacao'
+      AND scope_state = 'active'
+      AND open_count = 1
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: fonte canonica perdeu o historico por rodada';
+  END IF;
+
+  SELECT
+    stats.human_coding_count,
+    stats.has_llm_response,
+    stats.active_codificacao,
+    stats.active_comparacao,
+    stats.has_assignment_in_current_round
+  INTO
+    v_human_count,
+    v_has_llm,
+    v_active_coding,
+    v_active_comparison,
+    v_has_assignment
+  FROM public.lottery_doc_stats AS stats
+  WHERE stats.id = '72000000-0000-0000-0000-000000000003';
+
+  IF v_human_count <> 0 OR NOT v_has_llm OR v_active_coding <> 1
+     OR v_active_comparison <> 0 OR NOT v_has_assignment THEN
+    RAISE EXCEPTION 'FALHOU: lottery_doc_stats misturou rodadas: human=%, llm=%, coding=%, comparison=%, assigned=%',
+      v_human_count, v_has_llm, v_active_coding, v_active_comparison, v_has_assignment;
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.lottery_doc_stats
+    WHERE id IN (
+      '72000000-0000-0000-0000-000000000004',
+      '72000000-0000-0000-0000-000000000005'
+    )
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: lottery_doc_stats expos documento pendente ou excluido';
+  END IF;
+  RAISE NOTICE 'OK: contagens por escopo e estatisticas por rodada usam o contrato canonico';
+END $$;
+
+DO $$
+DECLARE
+  v_round_id uuid := '73000000-0000-0000-0000-000000000003';
+  v_before_rounds integer;
+  v_before_batches integer;
+  v_result jsonb;
+  v_rejected boolean;
+  v_batch_creator uuid;
+BEGIN
+  SELECT count(*) INTO v_before_rounds
+  FROM public.rounds WHERE project_id = '71000000-0000-0000-0000-000000000003';
+  SELECT count(*) INTO v_before_batches
+  FROM public.assignment_batches WHERE project_id = '71000000-0000-0000-0000-000000000003';
+
+  v_rejected := false;
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000003', 'codificacao', v_round_id,
+      'Rodada com snapshot obsoleto', false,
+      '{"open_work_snapshot":{"active_count":2,"pending_scope_count":1,"confirm_active":true,"confirm_pending_scope":true}}'::jsonb,
+      '[{"document_id":"72000000-0000-0000-0000-000000000003","user_id":null}]'::jsonb,
+      false
+    );
+  EXCEPTION WHEN serialization_failure THEN
+    v_rejected := true;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: RPC aceitou snapshot de trabalho aberto obsoleto';
+  END IF;
+
+  v_rejected := false;
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000003', 'codificacao', v_round_id,
+      NULL, false, '{}'::jsonb,
+      '[{"document_id":"72000000-0000-0000-0000-000000000005","user_id":null}]'::jsonb,
+      false
+    );
+  EXCEPTION WHEN serialization_failure THEN
+    v_rejected := true;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: RPC criou fila para documento excluido';
+  END IF;
+
+  v_rejected := false;
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000003', 'codificacao', v_round_id,
+      'Rodada sem confirmar ativos', true,
+      '{"open_work_snapshot":{"active_count":1,"pending_scope_count":1,"confirm_active":false,"confirm_pending_scope":true}}'::jsonb,
+      '[{"document_id":"72000000-0000-0000-0000-000000000003","user_id":null}]'::jsonb,
+      false
+    );
+  EXCEPTION WHEN raise_exception THEN
+    v_rejected := true;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: confirmacao unica sobrepos confirm_active=false';
+  END IF;
+
+  v_rejected := false;
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000003', 'codificacao', v_round_id,
+      'Rodada sem confirmar pendentes de escopo', true,
+      '{"open_work_snapshot":{"active_count":1,"pending_scope_count":1,"confirm_active":true,"confirm_pending_scope":false}}'::jsonb,
+      '[{"document_id":"72000000-0000-0000-0000-000000000003","user_id":null}]'::jsonb,
+      false
+    );
+  EXCEPTION WHEN raise_exception THEN
+    v_rejected := true;
+  END;
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: confirmacao unica sobrepos confirm_pending_scope=false';
+  END IF;
+
+  IF (SELECT count(*) FROM public.rounds WHERE project_id = '71000000-0000-0000-0000-000000000003') <> v_before_rounds
+     OR (SELECT count(*) FROM public.assignment_batches WHERE project_id = '71000000-0000-0000-0000-000000000003') <> v_before_batches THEN
+    RAISE EXCEPTION 'FALHOU: validacao de snapshot/confirmacao deixou escrita parcial';
+  END IF;
+
+  v_result := public.apply_lottery_assignments(
+    '71000000-0000-0000-0000-000000000003', 'codificacao', v_round_id,
+    'Rodada confirmada', false,
+    '{"created_by":"70000000-0000-0000-0000-000000000002","open_work_snapshot":{"active_count":1,"pending_scope_count":1,"confirm_active":true,"confirm_pending_scope":true}}'::jsonb,
+    '[{"document_id":"72000000-0000-0000-0000-000000000003","user_id":null}]'::jsonb,
+    false
+  );
+
+  SELECT batch.created_by INTO v_batch_creator
+  FROM public.assignment_batches AS batch
+  WHERE batch.id = (v_result->>'batch_id')::uuid;
+  IF (v_result->>'inserted')::integer <> 1
+     OR v_batch_creator IS DISTINCT FROM '70000000-0000-0000-0000-000000000001'::uuid THEN
+    RAISE EXCEPTION 'FALHOU: resultado/autoria canonica inesperados: %, %', v_result, v_batch_creator;
+  END IF;
+  RAISE NOTICE 'OK: snapshot e confirmacoes sao revalidados; autoria vem do JWT';
+END $$;
+
+-- ON CONFLICT nao pode transformar uma proposta de duas atribuicoes num lote
+-- parcial de uma. O erro 40001 reverte inclusive a linha que chegou a inserir.
+INSERT INTO public.projects (id, name) VALUES
+  ('71000000-0000-0000-0000-000000000004', 'partial insert rollback');
+INSERT INTO public.documents (id, project_id, text) VALUES
+  ('72000000-0000-0000-0000-000000000006', '71000000-0000-0000-0000-000000000004', 'conflicting doc');
+INSERT INTO public.assignments (project_id, document_id, user_id, type, status)
+VALUES (
+  '71000000-0000-0000-0000-000000000004',
+  '72000000-0000-0000-0000-000000000006',
+  '70000000-0000-0000-0000-000000000001',
+  'codificacao',
+  'pendente'
+);
+
+DO $$
+DECLARE
+  v_round_id uuid;
+  v_before_batches integer;
+  v_rejected boolean := false;
+BEGIN
+  SELECT current_round_id INTO v_round_id
+  FROM public.projects WHERE id = '71000000-0000-0000-0000-000000000004';
+  SELECT count(*) INTO v_before_batches
+  FROM public.assignment_batches WHERE project_id = '71000000-0000-0000-0000-000000000004';
+
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000004', 'codificacao', v_round_id,
+      NULL, false, '{}'::jsonb,
+      '[{"document_id":"72000000-0000-0000-0000-000000000006","user_id":"70000000-0000-0000-0000-000000000001"},{"document_id":"72000000-0000-0000-0000-000000000006","user_id":"70000000-0000-0000-0000-000000000002"}]'::jsonb,
+      false
+    );
+  EXCEPTION WHEN serialization_failure THEN
+    v_rejected := true;
+  END;
+
+  IF NOT v_rejected
+     OR (SELECT count(*) FROM public.assignments WHERE project_id = '71000000-0000-0000-0000-000000000004') <> 1
+     OR (SELECT count(*) FROM public.assignment_batches WHERE project_id = '71000000-0000-0000-0000-000000000004') <> v_before_batches THEN
+    RAISE EXCEPTION 'FALHOU: conflito parcial nao reverteu lote e assignments';
+  END IF;
+  RAISE NOTICE 'OK: insercao parcial falha com 40001 e rollback completo';
 END $$;
 
 DO $$
@@ -277,6 +576,64 @@ BEGIN
     RAISE EXCEPTION 'FALHOU: response humana entrou em rodada historica';
   END IF;
   RAISE NOTICE 'OK: responses humanas e LLM antigas falham sem alterar latest';
+END $$;
+
+-- A assinatura nova tambem precisa funcionar com o mesmo role usado pelo
+-- PostgREST. Rodar apenas como owner provaria atomicidade, mas nao a composicao
+-- real de SECURITY INVOKER com RLS e autoria derivada do JWT.
+INSERT INTO public.projects (id, name) VALUES
+  ('71000000-0000-0000-0000-000000000005', 'authenticated lottery');
+INSERT INTO public.project_members (project_id, user_id, role) VALUES (
+  '71000000-0000-0000-0000-000000000005',
+  '70000000-0000-0000-0000-000000000001',
+  'coordenador'
+);
+INSERT INTO public.documents (id, project_id, text) VALUES (
+  '72000000-0000-0000-0000-000000000007',
+  '71000000-0000-0000-0000-000000000005',
+  'authenticated doc'
+);
+CREATE TEMP TABLE authenticated_lottery_result (result jsonb NOT NULL);
+GRANT INSERT ON authenticated_lottery_result TO authenticated;
+-- O Supabase local nao reproduz os default privileges CRUD do remoto (limite
+-- ja documentado em rls_audit.test.sql). Conceder apenas o necessario dentro
+-- desta transacao permite testar as policies e o SECURITY INVOKER reais.
+GRANT SELECT, UPDATE ON public.documents TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.assignment_batches TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.assignments TO authenticated;
+
+SET LOCAL ROLE authenticated;
+INSERT INTO authenticated_lottery_result
+SELECT public.apply_lottery_assignments(
+  '71000000-0000-0000-0000-000000000005',
+  'codificacao',
+  (
+    SELECT current_round_id
+    FROM public.projects
+    WHERE id = '71000000-0000-0000-0000-000000000005'
+  ),
+  NULL,
+  false,
+  '{"open_work_snapshot":{"active_count":0,"pending_scope_count":0,"confirm_active":false,"confirm_pending_scope":false}}'::jsonb,
+  '[{"document_id":"72000000-0000-0000-0000-000000000007","user_id":"70000000-0000-0000-0000-000000000001"}]'::jsonb,
+  false
+);
+RESET ROLE;
+
+DO $$
+DECLARE v_result jsonb;
+BEGIN
+  SELECT result INTO STRICT v_result FROM authenticated_lottery_result;
+  IF (v_result->>'inserted')::integer <> 1
+     OR NOT EXISTS (
+       SELECT 1
+       FROM public.assignment_batches AS batch
+       WHERE batch.id = (v_result->>'batch_id')::uuid
+         AND batch.created_by = '70000000-0000-0000-0000-000000000001'
+     ) THEN
+    RAISE EXCEPTION 'FALHOU: RPC autenticada nao gravou lote/autoria esperados: %', v_result;
+  END IF;
+  RAISE NOTICE 'OK: RPC nova executa como authenticated sob RLS';
 END $$;
 
 ROLLBACK;

--- a/frontend/supabase/tests/explicit_assignment_rounds.test.sql
+++ b/frontend/supabase/tests/explicit_assignment_rounds.test.sql
@@ -233,6 +233,7 @@ DECLARE
   v_active_coding integer;
   v_active_comparison integer;
   v_has_assignment boolean;
+  v_has_assignment_legacy boolean;
 BEGIN
   SELECT round.id INTO STRICT v_initial_round
   FROM public.rounds AS round
@@ -283,13 +284,15 @@ BEGIN
     stats.has_llm_response,
     stats.active_codificacao,
     stats.active_comparacao,
-    stats.has_assignment_in_current_round
+    stats.has_assignment_in_current_round,
+    stats.has_any_assignment_ever
   INTO
     v_human_count,
     v_has_llm,
     v_active_coding,
     v_active_comparison,
-    v_has_assignment
+    v_has_assignment,
+    v_has_assignment_legacy
   FROM public.lottery_doc_stats AS stats
   WHERE stats.id = '72000000-0000-0000-0000-000000000003';
 
@@ -297,6 +300,11 @@ BEGIN
      OR v_active_comparison <> 0 OR NOT v_has_assignment THEN
     RAISE EXCEPTION 'FALHOU: lottery_doc_stats misturou rodadas: human=%, llm=%, coding=%, comparison=%, assigned=%',
       v_human_count, v_has_llm, v_active_coding, v_active_comparison, v_has_assignment;
+  END IF;
+  IF v_has_assignment_legacy IS DISTINCT FROM v_has_assignment THEN
+    RAISE EXCEPTION
+      'FALHOU: alias legado divergiu da ocupacao canonica: legado=%, canonico=%',
+      v_has_assignment_legacy, v_has_assignment;
   END IF;
   IF EXISTS (
     SELECT 1 FROM public.lottery_doc_stats
@@ -307,7 +315,7 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'FALHOU: lottery_doc_stats expos documento pendente ou excluido';
   END IF;
-  RAISE NOTICE 'OK: contagens por escopo e estatisticas por rodada usam o contrato canonico';
+  RAISE NOTICE 'OK: estatisticas por rodada e alias legado usam o contrato canonico';
 END $$;
 
 DO $$
@@ -598,6 +606,7 @@ GRANT INSERT ON authenticated_lottery_result TO authenticated;
 -- O Supabase local nao reproduz os default privileges CRUD do remoto (limite
 -- ja documentado em rls_audit.test.sql). Conceder apenas o necessario dentro
 -- desta transacao permite testar as policies e o SECURITY INVOKER reais.
+GRANT SELECT, UPDATE ON public.projects TO authenticated;
 GRANT SELECT, UPDATE ON public.documents TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.assignment_batches TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON public.assignments TO authenticated;

--- a/frontend/supabase/tests/rls_audit.test.sql
+++ b/frontend/supabase/tests/rls_audit.test.sql
@@ -166,19 +166,25 @@ BEGIN
     RAISE EXCEPTION 'FALHOU contrato: grants de replace_and_add_documents';
   END IF;
 
+  IF to_regprocedure(
+       'public.apply_lottery_assignments(uuid,text,uuid,jsonb,boolean)'
+     ) IS NOT NULL THEN
+    RAISE EXCEPTION 'FALHOU contrato: overload legada de apply_lottery_assignments ainda existe';
+  END IF;
+
   IF has_function_privilege(
        'anon',
-       'public.apply_lottery_assignments(uuid,text,uuid,jsonb,boolean)',
+       'public.apply_lottery_assignments(uuid,text,uuid,text,boolean,jsonb,jsonb,boolean)',
        'EXECUTE'
      )
      OR has_function_privilege(
        'service_role',
-       'public.apply_lottery_assignments(uuid,text,uuid,jsonb,boolean)',
+       'public.apply_lottery_assignments(uuid,text,uuid,text,boolean,jsonb,jsonb,boolean)',
        'EXECUTE'
      )
      OR NOT has_function_privilege(
        'authenticated',
-       'public.apply_lottery_assignments(uuid,text,uuid,jsonb,boolean)',
+       'public.apply_lottery_assignments(uuid,text,uuid,text,boolean,jsonb,jsonb,boolean)',
        'EXECUTE'
      ) THEN
     RAISE EXCEPTION 'FALHOU contrato: grants de apply_lottery_assignments';


### PR DESCRIPTION
## Problema

O bloqueio para iniciar uma nova rodada contava atribuições abertas sem considerar o estado de escopo do documento. No projeto Zolgensma, 8 atribuições em andamento pertenciam a documentos já excluídos: precisavam permanecer no histórico, mas não eram trabalho acionável e não deveriam impedir uma nova rodada.

Havia uma segunda lacuna no mesmo fluxo: documentos podiam passar pelos filtros da interface e, ainda assim, o algoritmo produzir zero pares distribuíveis. O frontend enviava esse lote vazio para a RPC e o banco respondia com erro.

## O que mudou

- cria a fonte canônica lottery_round_work_counts, por projeto, rodada, tipo e estado de escopo;
- torna lottery_doc_stats explicitamente limitada à rodada atual;
- separa a confirmação de trabalho ativo da confirmação de documentos ainda em revisão de escopo;
- mantém documentos excluídos no histórico, sem usá-los para ocupação, equilíbrio ou capacidade do sorteio;
- valida o payload das Server Actions com Zod e falha fechado quando uma leitura necessária do Supabase falha;
- representa o cálculo como ready com lista não vazia ou empty com causa específica;
- impede o submit de prévias vazias e explica se todas as vagas estão ocupadas, se a capacidade acabou ou se não há pares disponíveis;
- mantém Visualizar prévia acionável após resultado vazio, permitindo recalcular mudanças externas sem reabrir o diálogo;
- endurece a RPC: autoria derivada do JWT, payload não vazio, snapshot revalidado sob lock, documento ainda ativo e inserção integral ou rollback com SQLSTATE 40001;
- remove a overload legada de 5 argumentos.

## Compatibilidade de deploy

A migration 20260803140000 já havia sido aplicada antes do frontend e renomeou a coluna da view. A migration posterior 20260803204000 restaura has_any_assignment_ever como alias derivado de has_assignment_in_current_round, de modo que o frontend antigo e o novo leiam a mesma informação durante o deploy em duas etapas.

As duas migrations estão aplicadas no Supabase remoto. Uma consulta PostgREST com os dois nomes e limit=0 respondeu HTTP 200 antes do merge.

## Impacto

No estado remoto verificado após a migration original, Zolgensma passou a reportar 0 atribuições ativas e 0 em revisão de escopo. As mesmas 8 atribuições continuam preservadas nos documentos excluídos.

## Validação

- 199 arquivos e 2.183 testes Vitest passaram;
- 18 suítes SQL de gate passaram; as 2 RED conhecidas continuam rastreadas em #571 e #572;
- typecheck, build de produção e ESLint tipado passaram;
- smoke Playwright autenticado do pre-push passou;
- React Doctor, Fallow, Semgrep e gitleaks passaram sem achados novos;
- migration reset local, aplicação remota e contrato PostgREST dos dois aliases foram verificados.