### PR TITLE
fix(sorteio): troca de rodada arquiva a rodada anterior sob SECURITY DEFINER

### DIFF
--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -163,6 +163,29 @@ const invariants: Invariant[] = [
     },
   },
   {
+    name: "response-is-latest-na-rodada-corrente",
+    motivation:
+      "a troca de rodada (#642/#645) arquiva a rodada anterior com is_latest = false no mesmo passo em que ativa a nova. Até 2026-08-04 esse UPDATE abortava com 42501 — SECURITY INVOKER contra o WITH CHECK de \"Users manage own responses\", que exige autoria do chamador — e nenhuma transição chegou a commitar. Com o arquivamento movido para start_project_round (SECURITY DEFINER), FAIL aqui = transição parcial: rodada nova ativa e resposta da anterior ainda corrente, que é o estado que faria a Comparação ler a rodada errada",
+    run: async () => {
+      const projects = await fetchAll<{ id: string; current_round_id: string | null }>(
+        "projects",
+        "id, current_round_id",
+      );
+      const currentRoundOf = new Map(projects.map((p) => [p.id, p.current_round_id]));
+      const rows = await fetchAll<{ id: string; project_id: string; round_id: string | null }>(
+        "responses",
+        "id, project_id, round_id",
+        (q) => q.eq("is_latest", true),
+      );
+      return rows
+        .filter((r) => r.round_id !== currentRoundOf.get(r.project_id))
+        .map((r) => ({
+          key: r.id,
+          detail: `is_latest na rodada ${r.round_id ?? "NULL"}; corrente do projeto ${r.project_id} é ${currentRoundOf.get(r.project_id) ?? "NULL"}`,
+        }));
+    },
+  },
+  {
     name: "comparacao-ativa-unica-por-documento",
     motivation:
       "invariante do índice assignments_one_active_comparacao_per_doc (#490/PR #496); FAIL aqui = índice dropado ou canal de escrita que o contorna",

--- a/frontend/supabase/migrations/20260804120000_start_project_round_definer.sql
+++ b/frontend/supabase/migrations/20260804120000_start_project_round_definer.sql
@@ -1,0 +1,346 @@
+-- A troca de rodada do sorteio (#642, refinada em #645) nunca funcionou em
+-- producao: `apply_lottery_assignments` e SECURITY INVOKER e o ramo de rodada
+-- nova executa `UPDATE responses SET is_latest = false` sobre TODA a rodada
+-- corrente, como o proprio coordenador.
+--
+-- A policy "Users manage own responses" (20260716155000) tem braco de
+-- coordenador apenas no USING. O WITH CHECK exige `respondent_type = 'humano'`
+-- E autoria do proprio chamador, de proposito: e a guarda do #483, que veda
+-- resposta atribuida ao LLM com autoria humana. Em UPDATE, USING decide quais
+-- linhas o chamador alcanca e WITH CHECK decide se a linha resultante pode
+-- existir sob a identidade dele — o coordenador alcanca as respostas alheias e
+-- reprova ao grava-las. Toda resposta de LLM e toda resposta humana de terceiro
+-- na rodada faz o sorteio abortar com 42501.
+--
+-- Nao ha perda de dado (a excecao reverte a transacao inteira), mas o efeito e
+-- que nenhuma troca de rodada chegou a commitar: na medicao de 2026-08-04, os 9
+-- projetos tinham exatamente uma rodada cada, todas 'Rodada inicial'.
+--
+-- Correcao: a transicao de rodada e uma operacao privilegiada e multi-tabela;
+-- expressar sua autorizacao como a intersecao das policies de quatro tabelas e
+-- o erro de desenho. Ela passa a viver numa funcao SECURITY DEFINER com gate
+-- explicito, como `publish_latest_llm_response` e
+-- `create_project_with_initial_round` (20260731120000) ja fazem. O WITH CHECK de
+-- `responses` fica intocado.
+
+-- `p_expected_active`/`p_expected_pending_scope` NULL significam "sem
+-- fotografia" (release anterior ao #645), nao zero. Receber as contagens ja
+-- decompostas — em vez do jsonb cru de `open_work_snapshot` — evita repetir
+-- aqui a validacao de forma que o chamador faz, e mantem a checagem de trabalho
+-- aberto valendo tambem para quem chame esta funcao direto pelo PostgREST.
+CREATE OR REPLACE FUNCTION public.start_project_round(
+  p_project_id uuid,
+  p_expected_round_id uuid,
+  p_label text,
+  p_expected_active integer,
+  p_expected_pending_scope integer,
+  p_confirm_active boolean,
+  p_confirm_pending_scope boolean
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_current_round_id uuid;
+  v_new_round_id uuid;
+  v_open_active integer;
+  v_open_pending_scope integer;
+  v_label text;
+BEGIN
+  -- SECURITY DEFINER ignora a RLS: sem este gate, `authenticated` trocaria a
+  -- rodada de qualquer projeto. Mesmo predicado da policy "Coordinators manage
+  -- rounds" (20260612090200), declarado uma vez.
+  IF NOT (
+    p_project_id IN (SELECT public.auth_user_coordinator_or_creator_project_ids())
+    OR public.is_master()
+  ) THEN
+    RAISE EXCEPTION 'apenas coordenadores podem iniciar uma rodada'
+      USING ERRCODE = '42501';
+  END IF;
+
+  v_label := pg_catalog.btrim(p_label);
+  IF v_label = '' OR v_label IS NULL THEN
+    RAISE EXCEPTION 'nome da rodada nao pode ser vazio' USING ERRCODE = '22023';
+  END IF;
+
+  -- Relock: no-op quando `apply_lottery_assignments` ja travou a linha nesta
+  -- transacao, e o que mantem a funcao correta se chamada isolada. A ordem
+  -- global de locks (projects -> documents) fica preservada nos dois casos.
+  SELECT project.current_round_id INTO v_current_round_id
+  FROM public.projects AS project
+  WHERE project.id = p_project_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'projeto inexistente ou inacessivel' USING ERRCODE = 'P0002';
+  END IF;
+  IF v_current_round_id IS DISTINCT FROM p_expected_round_id THEN
+    RAISE EXCEPTION 'a rodada atual mudou; recarregue o sorteio' USING ERRCODE = '40001';
+  END IF;
+
+  SELECT
+    COALESCE(sum(work.open_count) FILTER (WHERE work.scope_state = 'active'), 0)::integer,
+    COALESCE(sum(work.open_count) FILTER (WHERE work.scope_state = 'pending_scope'), 0)::integer
+  INTO v_open_active, v_open_pending_scope
+  FROM public.lottery_round_work_counts AS work
+  WHERE work.project_id = p_project_id
+    AND work.round_id = v_current_round_id;
+
+  IF p_expected_active IS NOT NULL
+     AND (v_open_active IS DISTINCT FROM p_expected_active
+          OR v_open_pending_scope IS DISTINCT FROM p_expected_pending_scope) THEN
+    RAISE EXCEPTION
+      'o trabalho aberto mudou (ativos: % -> %, revisao de escopo: % -> %); recarregue o sorteio',
+      p_expected_active, v_open_active,
+      p_expected_pending_scope, v_open_pending_scope
+      USING ERRCODE = '40001';
+  END IF;
+
+  IF v_open_active > 0 AND NOT COALESCE(p_confirm_active, false) THEN
+    RAISE EXCEPTION 'a rodada atual possui % trabalhos abertos em documentos ativos',
+      v_open_active USING ERRCODE = 'P0001';
+  END IF;
+  IF v_open_pending_scope > 0 AND NOT COALESCE(p_confirm_pending_scope, false) THEN
+    RAISE EXCEPTION
+      'a rodada atual possui % trabalhos abertos em revisao de escopo',
+      v_open_pending_scope USING ERRCODE = 'P0001';
+  END IF;
+
+  INSERT INTO public.rounds (project_id, label)
+  VALUES (p_project_id, v_label)
+  RETURNING id INTO v_new_round_id;
+
+  -- A ordem importa e nao pode ser invertida: o trigger
+  -- `responses_enforce_current_round_write` (20260731120000) rejeita com 40001
+  -- toda escrita de response cuja `round_id` difira da rodada corrente do
+  -- projeto. Arquivar enquanto `projects.current_round_id` ainda aponta para a
+  -- rodada antiga e o que faz estas linhas passarem. O
+  -- `archive_review_dependencies_on_response_change` (20260717120000) dispara
+  -- aqui e arquiva equivalencias, auto-revisoes e arbitragens dependentes.
+  UPDATE public.responses
+  SET is_latest = false
+  WHERE project_id = p_project_id
+    AND round_id = v_current_round_id
+    AND is_latest;
+
+  UPDATE public.projects
+  SET current_round_id = v_new_round_id,
+      round_strategy = 'manual'
+  WHERE id = p_project_id;
+
+  RETURN v_new_round_id;
+END;
+$$;
+
+-- O GRANT a `authenticated` e obrigatorio: a chamada parte de dentro de
+-- `apply_lottery_assignments`, que e SECURITY INVOKER, entao o EXECUTE e
+-- checado contra o papel da sessao, nao contra o dono da funcao.
+REVOKE ALL ON FUNCTION public.start_project_round(
+  uuid, uuid, text, integer, integer, boolean, boolean
+) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.start_project_round(
+  uuid, uuid, text, integer, integer, boolean, boolean
+) TO authenticated;
+
+-- Recriada a partir de 20260803140000 com uma unica diferenca: o bloco de
+-- transicao de rodada vira uma chamada a `start_project_round`. Continua
+-- SECURITY INVOKER — lote e atribuicoes tem braco de coordenador na RLS e
+-- devem continuar filtrados por ela —, e a atomicidade nao muda: tudo segue na
+-- mesma transacao, e qualquer excecao reverte rodada, arquivamento, lote e
+-- atribuicoes.
+CREATE OR REPLACE FUNCTION public.apply_lottery_assignments(
+  p_project_id uuid,
+  p_type text,
+  p_expected_round_id uuid,
+  p_new_round_label text,
+  p_confirm_open_work boolean,
+  p_batch jsonb,
+  p_assignments jsonb,
+  p_replace boolean
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_current_round_id uuid;
+  v_target_round_id uuid;
+  v_batch_id uuid;
+  v_created_by uuid;
+  v_inserted integer;
+  v_requested integer;
+  v_preserved integer;
+  v_expected_active integer;
+  v_expected_pending_scope integer;
+  v_open_work_snapshot jsonb;
+BEGIN
+  IF p_type NOT IN ('codificacao', 'comparacao') THEN
+    RAISE EXCEPTION 'tipo de sorteio invalido: %', p_type USING ERRCODE = '22023';
+  END IF;
+  IF jsonb_typeof(p_batch) IS DISTINCT FROM 'object' THEN
+    RAISE EXCEPTION 'batch deve ser um objeto JSON' USING ERRCODE = '22023';
+  END IF;
+  IF jsonb_typeof(p_assignments) IS DISTINCT FROM 'array' THEN
+    RAISE EXCEPTION 'assignments deve ser um array JSON' USING ERRCODE = '22023';
+  END IF;
+
+  v_requested := jsonb_array_length(p_assignments);
+  IF v_requested = 0 THEN
+    RAISE EXCEPTION 'assignments nao pode ser vazio' USING ERRCODE = '22023';
+  END IF;
+
+  v_open_work_snapshot := p_batch->'open_work_snapshot';
+  IF v_open_work_snapshot IS NOT NULL THEN
+    IF jsonb_typeof(v_open_work_snapshot) IS DISTINCT FROM 'object'
+       OR NOT (v_open_work_snapshot ? 'active_count')
+       OR NOT (v_open_work_snapshot ? 'pending_scope_count') THEN
+      RAISE EXCEPTION 'open_work_snapshot deve informar active_count e pending_scope_count'
+        USING ERRCODE = '22023';
+    END IF;
+
+    v_expected_active := (v_open_work_snapshot->>'active_count')::integer;
+    v_expected_pending_scope := (v_open_work_snapshot->>'pending_scope_count')::integer;
+    IF v_expected_active < 0 OR v_expected_pending_scope < 0 THEN
+      RAISE EXCEPTION 'contagens de trabalho aberto nao podem ser negativas'
+        USING ERRCODE = '22023';
+    END IF;
+  END IF;
+
+  v_created_by := public.clerk_uid();
+  IF v_created_by IS NULL THEN
+    RAISE EXCEPTION 'identidade autenticada indisponivel' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT project.current_round_id INTO v_current_round_id
+  FROM public.projects AS project
+  WHERE project.id = p_project_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'projeto inexistente ou inacessivel' USING ERRCODE = 'P0002';
+  END IF;
+  IF v_current_round_id IS DISTINCT FROM p_expected_round_id THEN
+    RAISE EXCEPTION 'a rodada atual mudou; recarregue o sorteio' USING ERRCODE = '40001';
+  END IF;
+
+  -- Ordem global: projects -> documents. O lock estabiliza o estado de escopo
+  -- antes de a contagem canonica ser relida e antes de qualquer escrita.
+  PERFORM 1
+  FROM public.documents AS document
+  WHERE document.project_id = p_project_id
+    AND document.excluded_at IS NULL
+  ORDER BY document.id
+  FOR UPDATE;
+
+  -- A pre-visualizacao so propoe documentos ativos. Revalidar o proprio
+  -- payload sob o lock torna impossivel criar fila para um documento excluido
+  -- ou colocado em revisao de escopo entre a pre-visualizacao e a gravacao.
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(p_assignments) AS proposed(entry)
+    LEFT JOIN public.documents AS document
+      ON document.id = (proposed.entry->>'document_id')::uuid
+     AND document.project_id = p_project_id
+     AND document.excluded_at IS NULL
+     AND document.exclusion_pending_at IS NULL
+    WHERE document.id IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'o escopo dos documentos mudou; recarregue o sorteio'
+      USING ERRCODE = '40001';
+  END IF;
+
+  v_target_round_id := v_current_round_id;
+  IF p_new_round_label IS NOT NULL THEN
+    IF p_type <> 'codificacao' THEN
+      RAISE EXCEPTION 'somente sorteio de codificacao pode iniciar rodada' USING ERRCODE = '22023';
+    END IF;
+
+    v_target_round_id := public.start_project_round(
+      p_project_id,
+      v_current_round_id,
+      p_new_round_label,
+      v_expected_active,
+      v_expected_pending_scope,
+      COALESCE(
+        (v_open_work_snapshot->>'confirm_active')::boolean,
+        p_confirm_open_work,
+        false
+      ),
+      COALESCE(
+        (v_open_work_snapshot->>'confirm_pending_scope')::boolean,
+        p_confirm_open_work,
+        false
+      )
+    );
+  END IF;
+
+  INSERT INTO public.assignment_batches (
+    project_id, round_id, type, created_by, researchers_per_doc,
+    docs_per_researcher, doc_subset_size, label, mode, balancing, filters
+  ) VALUES (
+    p_project_id,
+    v_target_round_id,
+    p_type,
+    v_created_by,
+    COALESCE((p_batch->>'researchers_per_doc')::integer, 2),
+    NULLIF(p_batch->>'docs_per_researcher', '')::integer,
+    NULLIF(p_batch->>'doc_subset_size', '')::integer,
+    NULLIF(p_batch->>'label', ''),
+    COALESCE(NULLIF(p_batch->>'mode', ''), CASE WHEN p_replace THEN 'replace' ELSE 'append' END),
+    COALESCE(NULLIF(p_batch->>'balancing', ''), 'history'),
+    p_batch->'filters'
+  ) RETURNING id INTO v_batch_id;
+
+  IF p_replace THEN
+    DELETE FROM public.assignments
+    WHERE project_id = p_project_id
+      AND round_id = v_target_round_id
+      AND status = 'pendente'
+      AND type = p_type;
+  END IF;
+
+  SELECT count(*) INTO v_preserved
+  FROM public.assignments
+  WHERE project_id = p_project_id
+    AND round_id = v_target_round_id
+    AND type = p_type;
+
+  INSERT INTO public.assignments (
+    project_id, round_id, document_id, user_id, batch_id, type, status, completed_at
+  )
+  SELECT p_project_id,
+         v_target_round_id,
+         (entry->>'document_id')::uuid,
+         (entry->>'user_id')::uuid,
+         v_batch_id,
+         p_type,
+         COALESCE(entry->>'status', 'pendente'),
+         (entry->>'completed_at')::timestamptz
+  FROM jsonb_array_elements(p_assignments) AS entry
+  ON CONFLICT DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  IF v_inserted <> v_requested THEN
+    RAISE EXCEPTION
+      'o conjunto do sorteio mudou; seriam criadas % de % atribuicoes; recarregue o sorteio',
+      v_inserted, v_requested
+      USING ERRCODE = '40001';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'round_id', v_target_round_id,
+    'batch_id', v_batch_id,
+    'inserted', v_inserted,
+    'preserved', v_preserved
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.apply_lottery_assignments(
+  uuid, text, uuid, text, boolean, jsonb, jsonb, boolean
+) FROM PUBLIC, anon, service_role;
+GRANT EXECUTE ON FUNCTION public.apply_lottery_assignments(
+  uuid, text, uuid, text, boolean, jsonb, jsonb, boolean
+) TO authenticated;

--- a/frontend/supabase/migrations/20260804120000_start_project_round_definer.sql
+++ b/frontend/supabase/migrations/20260804120000_start_project_round_definer.sql
@@ -28,6 +28,9 @@
 -- decompostas — em vez do jsonb cru de `open_work_snapshot` — evita repetir
 -- aqui a validacao de forma que o chamador faz, e mantem a checagem de trabalho
 -- aberto valendo tambem para quem chame esta funcao direto pelo PostgREST.
+-- A contrapartida e que a validacao de forma no chamador precisa recusar
+-- contagem nula: NULL aqui desliga a checagem de concorrencia otimista, entao
+-- so pode chegar de fotografia ausente, nunca de fotografia malformada.
 CREATE OR REPLACE FUNCTION public.start_project_round(
   p_project_id uuid,
   p_expected_round_id uuid,
@@ -64,9 +67,13 @@ BEGIN
     RAISE EXCEPTION 'nome da rodada nao pode ser vazio' USING ERRCODE = '22023';
   END IF;
 
-  -- Relock: no-op quando `apply_lottery_assignments` ja travou a linha nesta
-  -- transacao, e o que mantem a funcao correta se chamada isolada. A ordem
-  -- global de locks (projects -> documents) fica preservada nos dois casos.
+  -- Relock dos dois niveis: no-op quando `apply_lottery_assignments` ja travou
+  -- as mesmas linhas nesta transacao, e o que mantem a funcao correta se
+  -- chamada isolada pelo PostgREST — sem o lock de `documents`, a contagem
+  -- abaixo leria um escopo que outra transacao ainda pode mudar, e a
+  -- confirmacao dada sobre N trabalhos autorizaria silenciosamente outro N (a
+  -- corrida que o #645 fechou para o caminho da UI). A ordem global de locks
+  -- (projects -> documents) e a mesma nos dois casos.
   SELECT project.current_round_id INTO v_current_round_id
   FROM public.projects AS project
   WHERE project.id = p_project_id
@@ -78,6 +85,13 @@ BEGIN
   IF v_current_round_id IS DISTINCT FROM p_expected_round_id THEN
     RAISE EXCEPTION 'a rodada atual mudou; recarregue o sorteio' USING ERRCODE = '40001';
   END IF;
+
+  PERFORM 1
+  FROM public.documents AS document
+  WHERE document.project_id = p_project_id
+    AND document.excluded_at IS NULL
+  ORDER BY document.id
+  FOR UPDATE;
 
   SELECT
     COALESCE(sum(work.open_count) FILTER (WHERE work.scope_state = 'active'), 0)::integer,
@@ -118,6 +132,9 @@ BEGIN
   -- rodada antiga e o que faz estas linhas passarem. O
   -- `archive_review_dependencies_on_response_change` (20260717120000) dispara
   -- aqui e arquiva equivalencias, auto-revisoes e arbitragens dependentes.
+  -- Esse trigger casa por (project_id, document_id) SEM filtro de rodada, entao
+  -- o arquivamento tambem precisa preceder a criacao das atribuicoes da rodada
+  -- nova: inverter as duas apagaria arbitragens recem-criadas.
   UPDATE public.responses
   SET is_latest = false
   WHERE project_id = p_project_id
@@ -192,10 +209,16 @@ BEGIN
 
   v_open_work_snapshot := p_batch->'open_work_snapshot';
   IF v_open_work_snapshot IS NOT NULL THEN
+    -- Checar o tipo, e nao a presenca da chave: `jsonb ? 'k'` responde TRUE
+    -- para {"k": null}, e o cast de um JSON null devolve NULL, que
+    -- `start_project_round` interpreta como "sem fotografia" e usa para pular a
+    -- checagem de concorrencia otimista. Presenca da chave nao distingue
+    -- fotografia malformada de fotografia ausente; o tipo distingue.
     IF jsonb_typeof(v_open_work_snapshot) IS DISTINCT FROM 'object'
-       OR NOT (v_open_work_snapshot ? 'active_count')
-       OR NOT (v_open_work_snapshot ? 'pending_scope_count') THEN
-      RAISE EXCEPTION 'open_work_snapshot deve informar active_count e pending_scope_count'
+       OR jsonb_typeof(v_open_work_snapshot->'active_count') IS DISTINCT FROM 'number'
+       OR jsonb_typeof(v_open_work_snapshot->'pending_scope_count') IS DISTINCT FROM 'number' THEN
+      RAISE EXCEPTION
+        'open_work_snapshot deve informar active_count e pending_scope_count numericos'
         USING ERRCODE = '22023';
     END IF;
 

--- a/frontend/supabase/tests/explicit_assignment_rounds.test.sql
+++ b/frontend/supabase/tests/explicit_assignment_rounds.test.sql
@@ -75,6 +75,20 @@ INSERT INTO public.projects (id, name) VALUES
   ('71000000-0000-0000-0000-000000000001', 'round test A'),
   ('71000000-0000-0000-0000-000000000002', 'round test B');
 
+-- Os casos abaixo rodam como owner para isolar atomicidade das policies, mas a
+-- troca de rodada tem gate proprio dentro de `start_project_round`
+-- (20260804120000) — SECURITY DEFINER ignora RLS, entao a autorizacao e checada
+-- em codigo e vale para qualquer role. Sem membership o ator do JWT nao seria
+-- coordenador de projeto nenhum e todos os casos de rodada nova parariam no
+-- gate. A fixture apenas passa a declarar o que o caminho de producao sempre
+-- exigiu; a isolacao das policies continua valendo, porque o owner segue
+-- ignorando a RLS.
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('71000000-0000-0000-0000-000000000001',
+   '70000000-0000-0000-0000-000000000001', 'coordenador'),
+  ('71000000-0000-0000-0000-000000000002',
+   '70000000-0000-0000-0000-000000000001', 'coordenador');
+
 INSERT INTO public.documents (id, project_id, text) VALUES
   ('72000000-0000-0000-0000-000000000001', '71000000-0000-0000-0000-000000000001', 'doc A'),
   ('72000000-0000-0000-0000-000000000002', '71000000-0000-0000-0000-000000000002', 'doc B');
@@ -169,6 +183,9 @@ END $$;
 -- view do dialogo considera somente a rodada atual e documentos ativos.
 INSERT INTO public.projects (id, name) VALUES
   ('71000000-0000-0000-0000-000000000003', 'scope work contract');
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('71000000-0000-0000-0000-000000000003',
+   '70000000-0000-0000-0000-000000000001', 'coordenador');
 
 INSERT INTO public.documents
   (id, project_id, text, exclusion_pending_at, excluded_at)
@@ -643,6 +660,165 @@ BEGIN
     RAISE EXCEPTION 'FALHOU: RPC autenticada nao gravou lote/autoria esperados: %', v_result;
   END IF;
   RAISE NOTICE 'OK: RPC nova executa como authenticated sob RLS';
+END $$;
+
+-- Troca de rodada como authenticated. O caso acima roda com
+-- `p_new_round_label` NULL e so exercita a rodada corrente; o ramo de rodada
+-- nova escreve em `rounds` e `responses`, cujas policies nunca foram
+-- atravessadas por nenhum caso deste arquivo (os demais rodam como owner, que
+-- ignora RLS). Foi por essa fresta que o 42501 do #642/#645 chegou a producao.
+--
+-- O elemento discriminante e a resposta DE TERCEIRO e a DE LLM: o WITH CHECK de
+-- "Users manage own responses" exige `respondent_type = 'humano'` e autoria do
+-- chamador, entao um caso com apenas a resposta do proprio coordenador passaria
+-- mesmo sem o conserto e nao provaria nada.
+INSERT INTO public.projects (id, name) VALUES
+  ('71000000-0000-0000-0000-000000000006', 'authenticated round switch');
+INSERT INTO public.project_members (project_id, user_id, role) VALUES
+  ('71000000-0000-0000-0000-000000000006',
+   '70000000-0000-0000-0000-000000000001', 'coordenador'),
+  ('71000000-0000-0000-0000-000000000006',
+   '70000000-0000-0000-0000-000000000002', 'pesquisador');
+INSERT INTO public.documents (id, project_id, text) VALUES (
+  '72000000-0000-0000-0000-000000000008',
+  '71000000-0000-0000-0000-000000000006',
+  'round switch doc'
+);
+INSERT INTO public.responses (
+  project_id, document_id, respondent_id, respondent_type, answers, is_latest,
+  is_partial, round_id
+)
+SELECT
+  '71000000-0000-0000-0000-000000000006',
+  '72000000-0000-0000-0000-000000000008',
+  respondent.id,
+  respondent.kind,
+  '{"q1":"a"}'::jsonb,
+  true,
+  false,
+  project.current_round_id
+FROM public.projects AS project
+CROSS JOIN (VALUES
+  ('70000000-0000-0000-0000-000000000001'::uuid, 'humano'),
+  ('70000000-0000-0000-0000-000000000002'::uuid, 'humano'),
+  (NULL::uuid, 'llm')
+) AS respondent(id, kind)
+WHERE project.id = '71000000-0000-0000-0000-000000000006';
+
+CREATE TEMP TABLE authenticated_round_result (result jsonb NOT NULL);
+GRANT INSERT ON authenticated_round_result TO authenticated;
+-- Em producao `authenticated` tem os default privileges CRUD sobre as duas
+-- tabelas e so a RLS decide. Sem estes GRANTs o teste local falharia por
+-- privilegio de tabela ausente e nunca chegaria a avaliar a policy.
+GRANT SELECT, INSERT ON public.rounds TO authenticated;
+GRANT SELECT, UPDATE ON public.responses TO authenticated;
+
+SET LOCAL ROLE authenticated;
+INSERT INTO authenticated_round_result
+SELECT public.apply_lottery_assignments(
+  '71000000-0000-0000-0000-000000000006',
+  'codificacao',
+  (
+    SELECT current_round_id
+    FROM public.projects
+    WHERE id = '71000000-0000-0000-0000-000000000006'
+  ),
+  'Rodada 2',
+  false,
+  '{"open_work_snapshot":{"active_count":0,"pending_scope_count":0,"confirm_active":true,"confirm_pending_scope":true}}'::jsonb,
+  '[{"document_id":"72000000-0000-0000-0000-000000000008","user_id":"70000000-0000-0000-0000-000000000001"}]'::jsonb,
+  false
+);
+RESET ROLE;
+
+DO $$
+DECLARE
+  v_result jsonb;
+  v_new_round uuid;
+  v_stale integer;
+BEGIN
+  SELECT result INTO STRICT v_result FROM authenticated_round_result;
+  v_new_round := (v_result->>'round_id')::uuid;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.rounds
+    WHERE id = v_new_round
+      AND project_id = '71000000-0000-0000-0000-000000000006'
+      AND label = 'Rodada 2'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: rodada nova nao foi criada: %', v_result;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.projects
+    WHERE id = '71000000-0000-0000-0000-000000000006'
+      AND current_round_id = v_new_round
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: rodada nova nao foi ativada no projeto';
+  END IF;
+
+  -- O coracao do #642: arquivar a rodada anterior. Antes do conserto esta
+  -- contagem nunca chegava a ser feita — a RPC abortava com 42501.
+  SELECT count(*) INTO v_stale
+  FROM public.responses
+  WHERE project_id = '71000000-0000-0000-0000-000000000006'
+    AND round_id <> v_new_round
+    AND is_latest;
+  IF v_stale <> 0 THEN
+    RAISE EXCEPTION
+      'FALHOU: % responses da rodada anterior seguem is_latest', v_stale;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.assignments
+    WHERE project_id = '71000000-0000-0000-0000-000000000006'
+      AND round_id = v_new_round
+      AND document_id = '72000000-0000-0000-0000-000000000008'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: atribuicao nao caiu na rodada nova';
+  END IF;
+
+  RAISE NOTICE 'OK: coordenador troca de rodada arquivando responses alheias e de LLM';
+END $$;
+
+-- O gate de `start_project_round` nao pode depender da RLS das tabelas que ela
+-- escreve: SECURITY DEFINER as ignora. Um membro nao-coordenador do projeto
+-- (portanto capaz de enxerga-lo) deve receber 42501 da propria funcao. O
+-- mapping abaixo e o que faz a negativa vir do PAPEL: sem ele `clerk_uid()`
+-- seria NULL e o teste passaria por identidade ausente, discriminando outra
+-- coisa.
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+VALUES
+  ('round-researcher-clerk', '70000000-0000-0000-0000-000000000002', 1);
+
+DO $$
+DECLARE v_denied boolean := false;
+BEGIN
+  PERFORM pg_catalog.set_config(
+    'request.jwt.claims',
+    '{"sub":"round-researcher-clerk","supabase_uid":"70000000-0000-0000-0000-000000000002"}',
+    true
+  );
+  BEGIN
+    PERFORM public.start_project_round(
+      '71000000-0000-0000-0000-000000000006',
+      (SELECT current_round_id FROM public.projects
+       WHERE id = '71000000-0000-0000-0000-000000000006'),
+      'Rodada 3', NULL, NULL, true, true
+    );
+  EXCEPTION WHEN insufficient_privilege THEN
+    v_denied := true;
+  END;
+  PERFORM pg_catalog.set_config(
+    'request.jwt.claims',
+    '{"sub":"round-creator-clerk","supabase_uid":"70000000-0000-0000-0000-000000000001"}',
+    true
+  );
+  IF NOT v_denied THEN
+    RAISE EXCEPTION 'FALHOU: pesquisador iniciou rodada por chamada direta';
+  END IF;
+  RAISE NOTICE 'OK: start_project_round nega pesquisador com gate proprio';
 END $$;
 
 ROLLBACK;

--- a/frontend/supabase/tests/explicit_assignment_rounds.test.sql
+++ b/frontend/supabase/tests/explicit_assignment_rounds.test.sql
@@ -749,10 +749,15 @@ BEGIN
     RAISE EXCEPTION 'FALHOU: rodada nova nao foi criada: %', v_result;
   END IF;
 
+  -- `round_strategy` acompanha a ativacao: iniciar rodada pela mao tira o
+  -- projeto do versionamento automatico por schema. As duas colunas sao
+  -- escritas pelo mesmo UPDATE, entao afirmar so uma deixaria a outra livre
+  -- para sumir num refactor.
   IF NOT EXISTS (
     SELECT 1 FROM public.projects
     WHERE id = '71000000-0000-0000-0000-000000000006'
       AND current_round_id = v_new_round
+      AND round_strategy = 'manual'
   ) THEN
     RAISE EXCEPTION 'FALHOU: rodada nova nao foi ativada no projeto';
   END IF;
@@ -819,6 +824,131 @@ BEGIN
     RAISE EXCEPTION 'FALHOU: pesquisador iniciou rodada por chamada direta';
   END IF;
   RAISE NOTICE 'OK: start_project_round nega pesquisador com gate proprio';
+END $$;
+
+-- O gate tem dois bracos e todo caso acima autoriza pelo primeiro (membership
+-- 'coordenador'). O segundo — criador do projeto, ainda que sem membership —
+-- so existe porque a policy "Coordinators manage rounds" tambem o tem: o gate
+-- foi escrito para reproduzi-la inteira, e metade dela nao era exercitada por
+-- caso nenhum. Projeto sem `project_members` de proposito; a rodada inicial vem
+-- do trigger `projects_create_initial_round`.
+INSERT INTO public.projects (id, name, created_by) VALUES (
+  '71000000-0000-0000-0000-000000000007',
+  'creator round switch',
+  '70000000-0000-0000-0000-000000000001'
+);
+INSERT INTO public.documents (id, project_id, text) VALUES (
+  '72000000-0000-0000-0000-000000000009',
+  '71000000-0000-0000-0000-000000000007',
+  'creator switch doc'
+);
+-- Resposta de LLM: o arquivamento sob DEFINER precisa valer igual neste braco,
+-- e e ela que reprovaria no WITH CHECK se a transicao voltasse a ser INVOKER.
+INSERT INTO public.responses (
+  project_id, document_id, respondent_id, respondent_type, answers, is_latest,
+  is_partial, round_id
+)
+SELECT
+  '71000000-0000-0000-0000-000000000007',
+  '72000000-0000-0000-0000-000000000009',
+  NULL,
+  'llm',
+  '{"q1":"a"}'::jsonb,
+  true,
+  false,
+  project.current_round_id
+FROM public.projects AS project
+WHERE project.id = '71000000-0000-0000-0000-000000000007';
+
+CREATE TEMP TABLE creator_round_result (result jsonb NOT NULL);
+GRANT INSERT ON creator_round_result TO authenticated;
+
+SET LOCAL ROLE authenticated;
+INSERT INTO creator_round_result
+SELECT public.apply_lottery_assignments(
+  '71000000-0000-0000-0000-000000000007',
+  'codificacao',
+  (
+    SELECT current_round_id
+    FROM public.projects
+    WHERE id = '71000000-0000-0000-0000-000000000007'
+  ),
+  'Rodada do criador',
+  false,
+  '{"open_work_snapshot":{"active_count":0,"pending_scope_count":0,"confirm_active":true,"confirm_pending_scope":true}}'::jsonb,
+  '[{"document_id":"72000000-0000-0000-0000-000000000009","user_id":"70000000-0000-0000-0000-000000000001"}]'::jsonb,
+  false
+);
+RESET ROLE;
+
+DO $$
+DECLARE
+  v_result jsonb;
+  v_new_round uuid;
+BEGIN
+  SELECT result INTO STRICT v_result FROM creator_round_result;
+  v_new_round := (v_result->>'round_id')::uuid;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.projects
+    WHERE id = '71000000-0000-0000-0000-000000000007'
+      AND current_round_id = v_new_round
+      AND round_strategy = 'manual'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: criador nao ativou a rodada nova: %', v_result;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.responses
+    WHERE project_id = '71000000-0000-0000-0000-000000000007'
+      AND round_id <> v_new_round
+      AND is_latest
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: response de LLM da rodada anterior segue is_latest';
+  END IF;
+
+  RAISE NOTICE 'OK: criador sem membership troca de rodada pelo segundo braco do gate';
+END $$;
+
+-- `p_expected_active` NULL significa "sem fotografia" e desliga a checagem de
+-- concorrencia otimista. Quem decide se ha fotografia e a validacao de forma em
+-- `apply_lottery_assignments` — e `jsonb ? 'chave'` responde TRUE para
+-- {"chave": null}, entao uma fotografia com contagem nula atravessaria a
+-- validacao e chegaria como ausencia de fotografia, desligando em silencio a
+-- guarda que o #645 criou. O caso abaixo fixa que contagem nula e payload
+-- invalido, nao ausencia.
+DO $$
+DECLARE
+  v_rejected boolean := false;
+  v_rounds_before integer;
+BEGIN
+  SELECT count(*) INTO v_rounds_before
+  FROM public.rounds WHERE project_id = '71000000-0000-0000-0000-000000000006';
+
+  BEGIN
+    PERFORM public.apply_lottery_assignments(
+      '71000000-0000-0000-0000-000000000006',
+      'codificacao',
+      (SELECT current_round_id FROM public.projects
+       WHERE id = '71000000-0000-0000-0000-000000000006'),
+      'Rodada de fotografia nula',
+      false,
+      '{"open_work_snapshot":{"active_count":null,"pending_scope_count":0,"confirm_active":true,"confirm_pending_scope":true}}'::jsonb,
+      '[{"document_id":"72000000-0000-0000-0000-000000000008","user_id":"70000000-0000-0000-0000-000000000002"}]'::jsonb,
+      false
+    );
+  EXCEPTION WHEN invalid_parameter_value THEN
+    v_rejected := true;
+  END;
+
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'FALHOU: fotografia com contagem nula foi aceita como ausencia de fotografia';
+  END IF;
+  IF (SELECT count(*) FROM public.rounds
+      WHERE project_id = '71000000-0000-0000-0000-000000000006') <> v_rounds_before THEN
+    RAISE EXCEPTION 'FALHOU: payload invalido deixou rodada gravada';
+  END IF;
+  RAISE NOTICE 'OK: contagem nula na fotografia e payload invalido, nao ausencia';
 END $$;
 
 ROLLBACK;


### PR DESCRIPTION
## O que acontecia

A troca de rodada do sorteio — introduzida na #642 e refinada na #645 — **nunca funcionou em produção**. Quando uma coordenadora tentava sortear criando uma rodada nova, recebia:

```
new row violates row-level security policy for table "responses"
```

Não houve perda de dado: `apply_lottery_assignments` é uma transação única e a exceção reverte rodada, arquivamento, lote e atribuições.

## Medição em produção (2026-08-04, somente leitura)

| Evidência | Valor |
|---|---|
| Rodadas gravadas | 9 rodadas em 9 projetos — exatamente uma por projeto, todas `Rodada inicial` |
| Papel da coordenadora que relatou | `coordenador` nos dois projetos |
| `responses` com `is_latest` na rodada corrente (Zolgensma) | 265 humanas + 231 de LLM |

Nenhuma rodada tem rótulo de transição: confirma que nenhuma troca chegou a commitar. E o papel descarta identidade/RLS de coordenador como causa — o `INSERT INTO rounds` teria passado.

## Causa raiz

`apply_lottery_assignments` é `SECURITY INVOKER`, e o ramo de rodada nova executa três escritas como o próprio coordenador. A do meio é a que reprova:

```sql
UPDATE public.responses SET is_latest = false
WHERE project_id = p_project_id AND round_id = v_current_round_id AND is_latest;
```

A única policy de escrita em `responses` é `"Users manage own responses"`. Ela tem braço de coordenador **apenas no `USING`**; o `WITH CHECK` exige `respondent_type = 'humano'` **e** autoria do chamador.

Em `UPDATE`, `USING` decide quais linhas o chamador alcança e `WITH CHECK` decide se a linha resultante pode existir sob a identidade dele. O coordenador **alcança** as respostas alheias e **reprova ao gravá-las**: toda resposta de LLM e toda resposta humana de terceiro derruba a transação. No Zolgensma são 496 linhas, todas reprovando. Num projeto vazio o `UPDATE` casa zero linhas e passa — por isso o defeito só aparece com dado real.

Essa assimetria é deliberada: é a guarda da #483, que veda resposta atribuída ao LLM com autoria humana. **Não é ela que está errada.**

O erro de desenho é o ramo de rodada nova ter expressado a autorização de uma transição privilegiada e multi-tabela como a interseção das policies de quatro tabelas.

## Correção

A transição passa a viver em `public.start_project_round`, `SECURITY DEFINER` com gate de autorização explícito — o mesmo padrão que `publish_latest_llm_response` e `create_project_with_initial_round` já usam no repositório. O `WITH CHECK` de `responses` fica **intocado**.

`apply_lottery_assignments` continua `SECURITY INVOKER`: lote e atribuições têm braço de coordenador na RLS e devem continuar filtrados por ela. A atomicidade não muda — tudo segue na mesma transação.

Como `SECURITY DEFINER` ignora a RLS, o gate é obrigatório e vale para qualquer role. Ele repete, em código, o predicado da policy `"Coordinators manage rounds"`.

## Prova do vermelho

A suíte nova falha contra a `main` com exatamente o erro relatado, na linha exata:

```
ERROR:  new row violates row-level security policy for table "responses"
CONTEXT:  SQL statement "UPDATE public.responses SET is_latest = false ..."
PL/pgSQL function public.apply_lottery_assignments(...) line 150
```

O elemento discriminante é a resposta **de terceiro** e a **de LLM**: um caso com apenas a resposta do próprio coordenador passaria mesmo sem o conserto e não provaria nada.

## Por que o gate não pegou antes

O único caso de `explicit_assignment_rounds.test.sql` que rodava no papel `authenticated` passava `p_new_round_label` **NULL** — exercitava só o caminho da rodada corrente. Os demais rodam como owner, que ignora RLS. E os `GRANT`s do harness local cobriam `projects`, `documents`, `assignment_batches` e `assignments`, mas não `rounds` nem `responses`: as duas tabelas que só o ramo novo escreve. A lista de grants era um censo acidental da cobertura.

## Mudanças na fixture

Os projetos que trocam de rodada em `explicit_assignment_rounds.test.sql` não tinham coordenador — passavam porque o caminho não checava autorização nenhuma. Agora declaram o que produção sempre exigiu. A isolação das policies continua valendo: o owner segue ignorando a RLS.

## Verificação

- `npm run test:db` — 18 suítes de gate PASS; as 2 `RED*` são as conhecidas (#571/#572). A suíte de rodadas passa 13 casos, 2 deles novos.
- `npm run invariants` — 2 execuções contra produção. A invariante nova (`response-is-latest-na-rodada-corrente`) nasce verde, como esperado, já que nenhuma transição commitou. Os 2 FAILs são pré-existentes e rastreados (#623).
- Gates de pre-push: typecheck, vitest (2183 testes), e2e smoke, lint:types, fallow, semgrep, test:db — todos verdes.

## Antes de mergear

A migration precisa ser aplicada no remoto (`npx supabase db push`). Não há mudança de frontend: a assinatura da RPC é a mesma, então a ordem entre migration e deploy é indiferente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdAqftBfgGbvhWNrfgXkfT
