### PR TITLE
fix(db): referência a response carrega o documento (#625, #628)

### DIFF
--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -40,6 +40,7 @@ TESTS_DIR="supabase/tests"
 # pgTAP — roda por `supabase test db`.
 PGTAP_SUITES=(
   responses_llm_actor_integrity
+  response_references_document_scoped
 )
 
 # Suítes de gate (fail-closed): qualquer falha aqui derruba o exit code.

--- a/frontend/supabase/migrations/20260805120000_response_references_document_scoped.sql
+++ b/frontend/supabase/migrations/20260805120000_response_references_document_scoped.sql
@@ -1,0 +1,185 @@
+-- Toda referência a `responses` passa a carregar o documento (issues #625, #628).
+--
+-- Quatro colunas apontam para uma resposta sem dizer de qual documento ela é:
+-- reviews.chosen_response_id, response_equivalences.response_a_id/_b_id e
+-- field_reviews.human_response_id/llm_response_id. A FK de coluna única garante
+-- que a resposta EXISTE; não garante que ela pertence ao documento da linha que
+-- a referencia. O estado "veredito do documento A escolhendo resposta do
+-- documento B" era construível, e foi construído: a #623 reparou 3 vereditos
+-- gravados no campo/documento errado, produzidos em 27/07 com o defeito ativo.
+--
+-- A #603 (FKs compostas project-scoped) NÃO fecha isso. Duas respostas do mesmo
+-- projeto e de documentos diferentes satisfazem qualquer FK que só carregue
+-- project_id — que é exatamente a forma do bug. O escopo certo é o documento,
+-- que é estritamente mais estreito e já implica o projeto.
+--
+-- A invariante `review-chosen-response-do-mesmo-documento`
+-- (frontend/scripts/invariants/check-invariants.ts) existe justamente porque
+-- "FK garante existência, não coerência". Ela continua valendo como detector do
+-- histórico; daqui para a frente o estado deixa de ser construível.
+--
+-- Medição em produção (2026-08-04, harness/2026-08-04-fk-document-scoped/,
+-- read-only, 1.179 responses / 1.482 reviews / 325 equivalences / 535
+-- field_reviews): ZERO violações vivas nas cinco colunas, zero document_id nulo
+-- em responses e reviews, com controle provando que o detector acusaria um par
+-- forjado. Ou seja: o resíduo da #628 já foi reparado pela #623 — esta migration
+-- fecha uma garantia ausente, não conserta estrago em curso. Por isso as
+-- restrições entram VALIDADAS, e não NOT VALID: não há histórico a tolerar.
+
+BEGIN;
+
+-- Estabiliza o conjunto entre o preflight e as restrições, fechando a janela
+-- entre medir e restringir. Mesmo protocolo de
+-- 20260727120000_responses_one_latest_human_per_document.sql.
+LOCK TABLE
+  public.responses,
+  public.reviews,
+  public.response_equivalences,
+  public.field_reviews
+IN SHARE ROW EXCLUSIVE MODE;
+
+-- ========== Preflight: abortar nomeando o resíduo, nunca sanear =============
+--
+-- Não há reparo automático possível aqui, e a diferença importa: repontar a
+-- referência para uma resposta "parecida" do documento certo é inventar qual
+-- resposta a revisora quis escolher — falsificação de veredito. Apagar a linha
+-- destrói revisão humana. Ambos exigem decisão caso a caso, que foi como a #623
+-- tratou os 3 vereditos: identificados um a um, com a autora consultada.
+--
+-- Demover/apagar linha destas tabelas também não é inerte: o trigger
+-- archive_review_dependencies_on_response_change (20260717120000) APAGA
+-- field_reviews e response_equivalences cujo snapshot ficou obsoleto. Sanear
+-- dentro de um `db push` esconderia isso.
+DO $preflight$
+DECLARE
+  v_offenders TEXT;
+BEGIN
+  SELECT pg_catalog.string_agg(offender.descricao, '; ' ORDER BY offender.descricao)
+    INTO v_offenders
+  FROM (
+    SELECT pg_catalog.format(
+             'reviews %s (doc %s) escolhe response %s do doc %s',
+             review.id, review.document_id, review.chosen_response_id,
+             chosen.document_id) AS descricao
+    FROM public.reviews AS review
+    JOIN public.responses AS chosen ON chosen.id = review.chosen_response_id
+    WHERE review.chosen_response_id IS NOT NULL
+      AND review.document_id IS DISTINCT FROM chosen.document_id
+
+    UNION ALL
+
+    SELECT pg_catalog.format(
+             'response_equivalences %s (doc %s) une responses dos docs %s e %s',
+             equivalence.id, equivalence.document_id,
+             side_a.document_id, side_b.document_id) AS descricao
+    FROM public.response_equivalences AS equivalence
+    JOIN public.responses AS side_a ON side_a.id = equivalence.response_a_id
+    JOIN public.responses AS side_b ON side_b.id = equivalence.response_b_id
+    WHERE equivalence.document_id IS DISTINCT FROM side_a.document_id
+       OR equivalence.document_id IS DISTINCT FROM side_b.document_id
+
+    UNION ALL
+
+    SELECT pg_catalog.format(
+             'field_reviews %s (doc %s, campo %s) aponta responses dos docs %s e %s',
+             field_review.id, field_review.document_id, field_review.field_name,
+             human.document_id, llm.document_id) AS descricao
+    FROM public.field_reviews AS field_review
+    JOIN public.responses AS human ON human.id = field_review.human_response_id
+    JOIN public.responses AS llm ON llm.id = field_review.llm_response_id
+    WHERE field_review.document_id IS DISTINCT FROM human.document_id
+       OR field_review.document_id IS DISTINCT FROM llm.document_id
+  ) AS offender;
+
+  IF v_offenders IS NOT NULL THEN
+    RAISE EXCEPTION
+      'referência a response cruzando documento: %', v_offenders
+      USING ERRCODE = '23503',
+            HINT = 'Não há reparo automático: repontar inventa a escolha da revisora e apagar destrói revisão humana. Decidir caso a caso, como na issue #623.';
+  END IF;
+END;
+$preflight$;
+
+-- reviews.document_id nulo tornaria a FK composta abaixo inerte para a linha:
+-- FK MATCH SIMPLE (o default) não verifica NADA quando QUALQUER coluna da chave
+-- é nula. Sem esta guarda a restrição existiria sem restringir — o mesmo modo de
+-- falha que o CHECK de autoria de 20260727120000:117-128 evita no índice único.
+-- Produção mede 0 nulos em 1.482 linhas. As demais tabelas já nascem NOT NULL.
+DO $preflight_null$
+DECLARE
+  v_offenders TEXT;
+BEGIN
+  SELECT pg_catalog.string_agg(review.id::text, ', ' ORDER BY review.id)
+    INTO v_offenders
+  FROM public.reviews AS review
+  WHERE review.document_id IS NULL;
+
+  IF v_offenders IS NOT NULL THEN
+    RAISE EXCEPTION 'reviews sem document_id: %', v_offenders
+      USING ERRCODE = '23502',
+            HINT = 'Um veredito sem documento não tem escopo; identifique o documento antes de aplicar.';
+  END IF;
+END;
+$preflight_null$;
+
+ALTER TABLE public.reviews ALTER COLUMN document_id SET NOT NULL;
+
+-- ========== O alvo composto ================================================
+--
+-- Redundante em teoria — `id` já é PK, então (document_id, id) é único por
+-- construção. Existe porque o Postgres exige que as colunas referenciadas por
+-- uma FK sejam cobertas por uma restrição única; é o preço de expressar "esta
+-- resposta, deste documento" como chave.
+ALTER TABLE public.responses
+  ADD CONSTRAINT responses_document_id_id_key UNIQUE (document_id, id);
+
+-- ========== reviews ========================================================
+--
+-- DROP e ADD no MESMO ALTER TABLE, deliberadamente: duas FKs entre o mesmo par
+-- de tabelas fazem o PostgREST devolver PGRST201 (relacionamento ambíguo) em
+-- qualquer embed que passe a existir. Hoje `chosen_response_id` é lida só como
+-- coluna crua (5 páginas, verificado), então nenhum embed quebra — mas deixar a
+-- FK antiga viva plantaria a ambiguidade para o primeiro embed futuro.
+--
+-- Sem ON DELETE: preserva o NO ACTION original de 001_initial_schema.sql:161. O
+-- contrato está documentado em 20260629120000:94 e 20260716120000:101 ("FK
+-- chosen_response_id -> responses sem CASCADE"), e as RPCs de replace apagam
+-- reviews ANTES de responses justamente por causa dele. Trocar para CASCADE aqui
+-- faria vereditos sumirem em silêncio quando uma resposta é substituída.
+ALTER TABLE public.reviews
+  DROP CONSTRAINT IF EXISTS reviews_chosen_response_id_fkey,
+  ADD CONSTRAINT reviews_document_chosen_response_fk
+    FOREIGN KEY (document_id, chosen_response_id)
+    REFERENCES public.responses (document_id, id);
+
+-- ========== response_equivalences ==========================================
+--
+-- ON DELETE CASCADE preservado das FKs originais (20260504000000:20-21): apagar
+-- uma resposta dissolve os pares que a incluíam.
+ALTER TABLE public.response_equivalences
+  DROP CONSTRAINT IF EXISTS response_equivalences_response_a_id_fkey,
+  DROP CONSTRAINT IF EXISTS response_equivalences_response_b_id_fkey,
+  ADD CONSTRAINT response_equivalences_document_response_a_fk
+    FOREIGN KEY (document_id, response_a_id)
+    REFERENCES public.responses (document_id, id) ON DELETE CASCADE,
+  ADD CONSTRAINT response_equivalences_document_response_b_fk
+    FOREIGN KEY (document_id, response_b_id)
+    REFERENCES public.responses (document_id, id) ON DELETE CASCADE;
+
+-- ========== field_reviews ==================================================
+--
+-- ON DELETE CASCADE preservado de 20260513000001:23-24. Aqui a amarra vale
+-- dobrado: field_reviews é a tabela da arbitragem, onde um par (humano, LLM)
+-- cruzando documento faria a arbitragem comparar respostas de textos diferentes
+-- — e o veredito resultante seria gravado como se fosse do documento da linha.
+ALTER TABLE public.field_reviews
+  DROP CONSTRAINT IF EXISTS field_reviews_human_response_id_fkey,
+  DROP CONSTRAINT IF EXISTS field_reviews_llm_response_id_fkey,
+  ADD CONSTRAINT field_reviews_document_human_response_fk
+    FOREIGN KEY (document_id, human_response_id)
+    REFERENCES public.responses (document_id, id) ON DELETE CASCADE,
+  ADD CONSTRAINT field_reviews_document_llm_response_fk
+    FOREIGN KEY (document_id, llm_response_id)
+    REFERENCES public.responses (document_id, id) ON DELETE CASCADE;
+
+COMMIT;

--- a/frontend/supabase/tests/response_references_document_scoped.test.sql
+++ b/frontend/supabase/tests/response_references_document_scoped.test.sql
@@ -1,0 +1,367 @@
+-- Contrato das referências a `responses`: toda coluna que aponta para uma
+-- resposta carrega o documento dela (issues #625, #628; migration
+-- 20260805120000_response_references_document_scoped.sql).
+--
+-- As cinco colunas NÃO estavam no mesmo estado antes desta migration, e a
+-- estrutura do arquivo reflete isso:
+--
+--  * `reviews.chosen_response_id` não tinha guarda NENHUMA — e é exatamente
+--    onde a #623 encontrou 3 vereditos gravados no documento errado, em
+--    produção. Para ela, a FK é garantia nova.
+--  * `response_equivalences` e `field_reviews` já eram protegidas por trigger
+--    (`snapshot_response_equivalence_answers`, `snapshot_field_review_cycle`),
+--    e por isso produção nunca acusou violação nelas. Ali a FK é DEFESA EM
+--    PROFUNDIDADE: não depende de o trigger sobreviver a uma migration futura
+--    — risco concreto, documentado na #602, onde guards por trigger tiveram de
+--    ser retirados por efeito colateral.
+--
+-- Consequência para o teste: nessas duas tabelas o trigger recusa ANTES da
+-- checagem da FK, então uma asserção ingênua passaria idêntica se a FK não
+-- existisse. Por isso cada uma tem DOIS casos — um fixando o comportamento
+-- vigente (recusa por trigger) e outro com o trigger desabilitado dentro da
+-- transação, que é o único que de fato mede a FK.
+--
+-- Os demais casos e o que cada um impede:
+--
+--  * POSITIVO (referência dentro do mesmo documento passa): sem ele, uma FK que
+--    recusasse TUDO faria os negativos passarem e o contrato seria vácuo.
+--  * NULO em `reviews.chosen_response_id`: 294 das 1.482 reviews de produção
+--    não escolhem resposta — veredito sem escolha é legítimo. Uma FK composta
+--    que recusasse NULL quebraria a Comparação inteira; MATCH SIMPLE é o que
+--    permite isso, e o caso fixa a permissão.
+--  * `reviews.document_id` NOT NULL: é ELE que faz a FK valer, porque MATCH
+--    SIMPLE não verifica nada quando qualquer coluna da chave é nula. Sem a
+--    restrição de nulidade a FK existiria sem restringir — mesmo modo de falha
+--    que o CHECK de autoria de 20260727120000:117-128 evita no índice único.
+--
+-- Como rodar (após `npx supabase start` e `npx supabase db reset`):
+--   psql "$(npx supabase status -o env | grep DB_URL | cut -d= -f2- | tr -d '"')" \
+--     -v ON_ERROR_STOP=1 -f supabase/tests/response_references_document_scoped.test.sql
+--
+-- Validar pelo exit code, não por contar OKs na saída.
+-- A transação termina em ROLLBACK e não deixa fixtures no banco local.
+
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS pgtap WITH SCHEMA extensions;
+
+SELECT plan(12);
+
+CREATE OR REPLACE FUNCTION pg_temp.rejected_constraint(statement TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  actual_constraint TEXT;
+BEGIN
+  EXECUTE statement;
+  RETURN NULL;
+EXCEPTION WHEN OTHERS THEN
+  GET STACKED DIAGNOSTICS actual_constraint = CONSTRAINT_NAME;
+  RETURN actual_constraint;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION pg_temp.rejected_sqlstate(statement TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  actual_sqlstate TEXT;
+BEGIN
+  EXECUTE statement;
+  RETURN NULL;
+EXCEPTION WHEN OTHERS THEN
+  GET STACKED DIAGNOSTICS actual_sqlstate = RETURNED_SQLSTATE;
+  RETURN actual_sqlstate;
+END;
+$$;
+
+-- ========== Fixtures ========================================================
+-- O trigger de auth cria os profiles que sustentam reviewer_id/respondent_id.
+INSERT INTO auth.users (id, email) VALUES
+  ('62510000-0000-0000-0000-000000000001', 'coordenadora-625@example.test'),
+  ('62510000-0000-0000-0000-000000000002', 'pesquisadora-625@example.test');
+
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+SELECT id::TEXT, id, 1
+FROM auth.users
+WHERE id::TEXT LIKE '62510000-0000-0000-0000-%';
+
+INSERT INTO public.projects (id, name, created_by) VALUES (
+  '62520000-0000-0000-0000-000000000001',
+  'referencias document-scoped',
+  '62510000-0000-0000-0000-000000000001'
+);
+
+-- DOIS documentos no MESMO projeto: é essa a configuração que a FK
+-- project-scoped da #603 deixaria passar e que esta migration fecha.
+INSERT INTO public.documents (id, project_id, title, text) VALUES
+  ('62530000-0000-0000-0000-00000000000A',
+   '62520000-0000-0000-0000-000000000001', 'documento A', 'texto A'),
+  ('62530000-0000-0000-0000-00000000000B',
+   '62520000-0000-0000-0000-000000000001', 'documento B', 'texto B');
+
+-- Uma resposta humana e uma LLM por documento.
+INSERT INTO public.responses
+  (id, project_id, document_id, respondent_type, respondent_id, answers, is_latest)
+VALUES
+  ('62540000-0000-0000-000a-0000000000aa',
+   '62520000-0000-0000-0000-000000000001',
+   '62530000-0000-0000-0000-00000000000A',
+   'humano', '62510000-0000-0000-0000-000000000002', '{"q1": "a"}'::jsonb, true),
+  ('62540000-0000-0000-000b-0000000000aa',
+   '62520000-0000-0000-0000-000000000001',
+   '62530000-0000-0000-0000-00000000000B',
+   'humano', '62510000-0000-0000-0000-000000000002', '{"q1": "b"}'::jsonb, true),
+  ('62540000-0000-0000-000a-0000000000cc',
+   '62520000-0000-0000-0000-000000000001',
+   '62530000-0000-0000-0000-00000000000A',
+   'llm', NULL, '{"q1": "a-llm"}'::jsonb, true),
+  ('62540000-0000-0000-000b-0000000000cc',
+   '62520000-0000-0000-0000-000000000001',
+   '62530000-0000-0000-0000-00000000000B',
+   'llm', NULL, '{"q1": "b-llm"}'::jsonb, true);
+
+-- ========== reviews.chosen_response_id ======================================
+
+-- O caso da #625/#628: veredito do documento A escolhendo resposta do B.
+-- Mesmo projeto, mesma pessoa, mesmo campo — só o documento diverge.
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.reviews
+      (project_id, document_id, field_name, reviewer_id, verdict, chosen_response_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q1', '62510000-0000-0000-0000-000000000001', 'humano',
+       '62540000-0000-0000-000b-0000000000aa')
+  $$),
+  'reviews_document_chosen_response_fk',
+  'review do doc A não pode escolher response do doc B'
+);
+
+-- Positivo: sem ele os negativos passariam mesmo com uma FK que recusa tudo.
+--
+-- `field_name` PRÓPRIO, e não o 'q1' do caso acima, de propósito: reviews tem
+-- UNIQUE(project_id, document_id, field_name, reviewer_id), então reusar 'q1'
+-- acoplaria este caso ao anterior — no estado SEM a migration o INSERT de cima
+-- tem sucesso e este colidiria por unicidade, falhando por um motivo que nada
+-- tem a ver com o contrato sob teste. Cada caso responde por si.
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.reviews
+      (project_id, document_id, field_name, reviewer_id, verdict, chosen_response_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q1_positivo', '62510000-0000-0000-0000-000000000001', 'humano',
+       '62540000-0000-0000-000a-0000000000aa')
+  $$),
+  NULL,
+  'review do doc A escolhe response do doc A'
+);
+
+-- Veredito sem escolha continua legítimo (294 linhas assim em produção).
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.reviews
+      (project_id, document_id, field_name, reviewer_id, verdict, chosen_response_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000B',
+       'q1', '62510000-0000-0000-0000-000000000001', 'ambiguo', NULL)
+  $$),
+  NULL,
+  'chosen_response_id NULL continua permitido'
+);
+
+-- É o NOT NULL que faz a FK valer: com document_id nulo, MATCH SIMPLE não
+-- verificaria a chave e a referência cruzada entraria pela porta dos fundos.
+SELECT is(
+  pg_temp.rejected_sqlstate($$
+    INSERT INTO public.reviews
+      (project_id, document_id, field_name, reviewer_id, verdict, chosen_response_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       NULL,
+       'q1', '62510000-0000-0000-0000-000000000001', 'humano',
+       '62540000-0000-0000-000b-0000000000aa')
+  $$),
+  '23502',
+  'review sem document_id é recusada (senão a FK ficaria inerte)'
+);
+
+-- UPDATE também é coberto: a FK vale para toda escrita, não só INSERT. Sem
+-- este caso, um caminho que repontasse o veredito depois de criado passaria.
+INSERT INTO public.reviews
+  (id, project_id, document_id, field_name, reviewer_id, verdict, chosen_response_id)
+VALUES
+  ('62550000-0000-0000-0000-000000000001',
+   '62520000-0000-0000-0000-000000000001',
+   '62530000-0000-0000-0000-00000000000B',
+   'q2', '62510000-0000-0000-0000-000000000001', 'humano',
+   '62540000-0000-0000-000b-0000000000aa');
+
+SELECT is(
+  pg_temp.rejected_constraint($$
+    UPDATE public.reviews
+    SET chosen_response_id = '62540000-0000-0000-000a-0000000000aa'
+    WHERE id = '62550000-0000-0000-0000-000000000001'
+  $$),
+  'reviews_document_chosen_response_fk',
+  'repontar veredito para response de outro documento é recusado'
+);
+
+-- ========== response_equivalences ===========================================
+--
+-- Aqui a FK é DEFESA EM PROFUNDIDADE, não garantia nova: o trigger
+-- `snapshot_response_equivalence_answers` já recusa o par cruzado desde
+-- 20260504000000. Por isso são dois casos, e não um.
+--
+-- O primeiro fixa o comportamento visível hoje (quem recusa é o trigger, que
+-- roda antes da checagem da FK). O segundo é o que de fato mede a FK: com o
+-- trigger desabilitado dentro desta transação, a FK precisa recusar sozinha.
+-- Sem o segundo caso, esta seção passaria idêntica se a FK não existisse — um
+-- verde vácuo quanto ao que a migration acrescenta.
+
+SELECT is(
+  pg_temp.rejected_sqlstate($$
+    INSERT INTO public.response_equivalences
+      (project_id, document_id, field_name, response_a_id, response_b_id, reviewer_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q1',
+       '62540000-0000-0000-000a-0000000000aa',
+       '62540000-0000-0000-000b-0000000000cc',
+       '62510000-0000-0000-0000-000000000001')
+  $$),
+  'P0001',
+  'equivalência cruzada é recusada pelo trigger (comportamento vigente)'
+);
+
+ALTER TABLE public.response_equivalences
+  DISABLE TRIGGER snapshot_response_equivalence_answers;
+
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.response_equivalences
+      (project_id, document_id, field_name, response_a_id, response_b_id, reviewer_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q1',
+       '62540000-0000-0000-000a-0000000000aa',
+       '62540000-0000-0000-000b-0000000000cc',
+       '62510000-0000-0000-0000-000000000001')
+  $$),
+  'response_equivalences_document_response_b_fk',
+  'sem o trigger, a FK recusa a equivalência cruzada sozinha'
+);
+
+ALTER TABLE public.response_equivalences
+  ENABLE TRIGGER snapshot_response_equivalence_answers;
+
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.response_equivalences
+      (project_id, document_id, field_name, response_a_id, response_b_id, reviewer_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q1',
+       '62540000-0000-0000-000a-0000000000aa',
+       '62540000-0000-0000-000a-0000000000cc',
+       '62510000-0000-0000-0000-000000000001')
+  $$),
+  NULL,
+  'equivalência entre responses do mesmo documento passa'
+);
+
+-- ========== field_reviews ===================================================
+
+-- Aqui a amarra vale dobrado: um par (humano, LLM) cruzando documento faria a
+-- arbitragem comparar respostas de textos diferentes, e o veredito seria
+-- gravado como se fosse do documento da linha.
+--
+-- Mesma estrutura de dois casos da seção anterior, e pelo mesmo motivo: o
+-- trigger `snapshot_field_review_cycle` já recusa o par cruzado ("field review
+-- responses must match its project, document, and reviewer"), então só com ele
+-- desabilitado é possível provar que a FK morde por conta própria.
+SELECT is(
+  pg_temp.rejected_sqlstate($$
+    INSERT INTO public.field_reviews
+      (project_id, document_id, field_name, human_response_id, llm_response_id,
+       self_reviewer_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q1',
+       '62540000-0000-0000-000b-0000000000aa',
+       '62540000-0000-0000-000a-0000000000cc',
+       '62510000-0000-0000-0000-000000000002')
+  $$),
+  'P0001',
+  'field_review cruzado é recusado pelo trigger (comportamento vigente)'
+);
+
+ALTER TABLE public.field_reviews DISABLE TRIGGER snapshot_field_review_cycle;
+
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.field_reviews
+      (project_id, document_id, field_name, human_response_id, llm_response_id,
+       self_reviewer_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q1',
+       '62540000-0000-0000-000b-0000000000aa',
+       '62540000-0000-0000-000a-0000000000cc',
+       '62510000-0000-0000-0000-000000000002')
+  $$),
+  'field_reviews_document_human_response_fk',
+  'sem o trigger, a FK recusa human_response de outro documento'
+);
+
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.field_reviews
+      (project_id, document_id, field_name, human_response_id, llm_response_id,
+       self_reviewer_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q2',
+       '62540000-0000-0000-000a-0000000000aa',
+       '62540000-0000-0000-000b-0000000000cc',
+       '62510000-0000-0000-0000-000000000002')
+  $$),
+  'field_reviews_document_llm_response_fk',
+  'sem o trigger, a FK recusa llm_response de outro documento'
+);
+
+ALTER TABLE public.field_reviews ENABLE TRIGGER snapshot_field_review_cycle;
+
+SELECT is(
+  pg_temp.rejected_constraint($$
+    INSERT INTO public.field_reviews
+      (project_id, document_id, field_name, human_response_id, llm_response_id,
+       self_reviewer_id)
+    VALUES
+      ('62520000-0000-0000-0000-000000000001',
+       '62530000-0000-0000-0000-00000000000A',
+       'q3',
+       '62540000-0000-0000-000a-0000000000aa',
+       '62540000-0000-0000-000a-0000000000cc',
+       '62510000-0000-0000-0000-000000000002')
+  $$),
+  NULL,
+  'field_review com os dois lados do mesmo documento passa'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
Primeiro item do épico #648 (Trilha 2 — identidade referencial).

## O problema

Cinco colunas apontavam para uma resposta sem dizer de qual documento ela é: `reviews.chosen_response_id`, `response_equivalences.response_a_id/_b_id` e `field_reviews.human_response_id/llm_response_id`. A FK de coluna única garante que a resposta **existe**; não garante que ela pertence ao documento da linha que a referencia.

## As cinco não estavam no mesmo estado

Isso mudou o desenho do PR e do teste, e vale explicitar:

- **`reviews.chosen_response_id` não tinha guarda nenhuma.** É exatamente onde a #623 encontrou 3 vereditos gravados no documento errado, em produção, em 27/07. Para ela, a FK composta é **garantia nova**.
- **`response_equivalences` e `field_reviews` já eram protegidas por trigger** (`snapshot_response_equivalence_answers`, `snapshot_field_review_cycle`) — o que explica por que a medição não achou violação nelas. Ali a FK é **defesa em profundidade**: não depende de o trigger sobreviver a uma migration futura, risco concreto documentado na #602, onde guards por trigger tiveram de ser retirados por efeito colateral.

## Por que a #603 não resolvia isto

FKs project-scoped não fecham o caso: duas respostas do **mesmo projeto** e de documentos diferentes satisfazem qualquer FK que só carregue `project_id` — e é essa a forma do bug. O escopo certo é o documento, estritamente mais estreito e que já implica o projeto. A #603 continua valendo para o isolamento cross-project, que é uma garantia diferente (comentado lá).

## `reviews.document_id` vira NOT NULL

É ele que faz a FK valer: FK `MATCH SIMPLE` (o default) **não verifica nada** quando qualquer coluna da chave é nula. Sem a restrição, a FK existiria sem restringir — mesmo modo de falha que o CHECK de autoria de `20260727120000:117-128` evita no índice único.

## Medição em produção (read-only, 2026-08-04)

Sobre 1.179 responses, 1.482 reviews, 325 equivalences e 535 field_reviews:

```
chosen_response_id inexistente:                 0
chosen_response de OUTRO documento:             0
equivalência com lado de outro documento:       0
field_reviews.human_response_id de outro doc:   0
field_reviews.llm_response_id de outro doc:     0
responses.document_id NULL:                     0
reviews.document_id NULL:                       0
reviews.chosen_response_id NULL:              294  (legítimo — veredito sem escolha)
```

Com controle provando que o detector morde (um par forjado seria acusado), então o zero não é vácuo.

**O resíduo que a #628 afirma estar ativo já fora reparado pela #623** — a premissa da issue estava desatualizada, e registrei isso lá. Por isso as restrições entram **validadas**, e não `NOT VALID`: não há histórico a tolerar, e adiar a validação só deixaria a garantia pela metade.

## Verificação

**Prova do vermelho.** Sem a migration, falham exatamente os **6 casos negativos** e passam os **4 positivos/permissivos** — o que mostra que o teste mede as constraints, e não outra coisa.

**Mutação como juiz.** Dropar as FKs deixa vermelhos os casos 1, 5, 7, 10 e 11, e mantém verdes o 6 e o 9 — estes medem o *trigger*, que a mutação não tocou. É precisamente por isso que as duas tabelas com trigger têm **dois casos cada**, o segundo com o trigger desabilitado dentro da transação: sem ele, aquelas seções passariam idênticas se a FK não existisse, e o verde seria vácuo quanto ao que este PR acrescenta.

Um detalhe de higiene que a primeira execução revelou: o caso positivo de `reviews` usa `field_name` próprio, porque reusar o `q1` do caso negativo o acoplava ao anterior via `UNIQUE(project_id, document_id, field_name, reviewer_id)` — no estado sem a migration o INSERT de cima tem sucesso e o de baixo falhava por unicidade, ou seja, por um motivo alheio ao contrato.

**Suíte completa de banco**: 19 PASS, 0 FAIL de gate, 2 KNOWN_RED já rastreadas (#571, #572).

## Aplicação

Migration **não** roda no merge. Aplicar com `npx supabase db push` e, em seguida, `npm run invariants` (obrigação de tier 1). O preflight aborta nomeando o resíduo em vez de sanear — mexer nessas tabelas dispara `archive_review_dependencies_on_response_change`, que APAGA `field_reviews`/`response_equivalences`, e isso não pode ser efeito colateral silencioso de um `db push`.

Closes #628
