### PR TITLE
fix(fly): frontend volta a always-on — scale-to-zero derrubou o site

### DIFF
--- a/.github/scripts/check-frontend-fly-machines.sh
+++ b/.github/scripts/check-frontend-fly-machines.sh
@@ -46,6 +46,25 @@ if ! jq -e '
   exit 1
 fi
 
+# O autostop é conferido na config APLICADA, e não só no fly.toml, porque foi
+# por aí que o site caiu em 2026-08-10 e por aí que ele voltou: a Machine foi
+# recriada com `machine clone` (que herda a config da origem, ainda com
+# autostop ligado) e só depois corrigida com `machine update --autostop=off`,
+# tudo fora do fluxo de deploy. O grep do fly.toml prova a intenção declarada;
+# esta asserção prova o que a Machine de fato tem.
+#
+# `== false` é fail-closed de propósito: o flyctl serializa "off" como booleano
+# false, então as formas string ("stop", "suspend"), o true e o campo ausente
+# (null) reprovam todos.
+if ! jq -e '
+  (.[0].config.services | type) == "array"
+  and (.[0].config.services | length) > 0
+  and all(.[0].config.services[]; .autostop == false and .autostart == true)
+' >/dev/null <<<"$machines_json"; then
+  echo "Deploy inválido: a Machine precisa estar com autostop desligado e autostart ligado." >&2
+  exit 1
+fi
+
 machine_id="$(jq -er '.[0].id | select(type == "string" and length > 0)' <<<"$machines_json")"
 readonly health_attempts=12
 readonly health_interval_seconds=10

--- a/.github/scripts/test-frontend-fly-machine-contract.sh
+++ b/.github/scripts/test-frontend-fly-machine-contract.sh
@@ -27,14 +27,19 @@ exit 0
 EOF
 chmod +x "$tmp_dir/bin/sleep"
 
+# autostop/autostart sao emitidos como JSON cru (nao entre aspas) porque o
+# flyctl serializa "off" como o booleano false; passar a string "stop" aqui
+# reproduz a outra forma que a API aceita para o mesmo campo.
 machine() {
   local state="${1:-started}"
   local region="${2:-gru}"
   local cpu_kind="${3:-shared}"
   local cpus="${4:-1}"
   local memory_mb="${5:-512}"
-  printf '[{"id":"machine-1","state":"%s","region":"%s","config":{"guest":{"cpu_kind":"%s","cpus":%s,"memory_mb":%s}}}]' \
-    "$state" "$region" "$cpu_kind" "$cpus" "$memory_mb"
+  local autostop="${6:-false}"
+  local autostart="${7:-true}"
+  printf '[{"id":"machine-1","state":"%s","region":"%s","config":{"guest":{"cpu_kind":"%s","cpus":%s,"memory_mb":%s},"services":[{"internal_port":3000,"autostop":%s,"autostart":%s}]}}]' \
+    "$state" "$region" "$cpu_kind" "$cpus" "$memory_mb" "$autostop" "$autostart"
 }
 
 run_checker() {
@@ -73,7 +78,13 @@ for invalid_machine in \
   "$(machine started iad)" \
   "$(machine started gru performance)" \
   "$(machine started gru shared 2)" \
-  "$(machine started gru shared 1 1024)"
+  "$(machine started gru shared 1 1024)" \
+  "$(machine started gru shared 1 512 true)" \
+  "$(machine started gru shared 1 512 '"stop"')" \
+  "$(machine started gru shared 1 512 '"suspend"')" \
+  "$(machine started gru shared 1 512 false false)" \
+  "$(machine | jq -c '[.[0] | .config.services = []]')" \
+  "$(machine | jq -c '[.[0] | del(.config.services)]')"
 do
   MACHINES_JSON="$invalid_machine"
   expect_failure run_checker post
@@ -98,16 +109,30 @@ ruby -ryaml -e '
   abort("workflow sem ordem preflight -> deploy -> postflight") unless pre && deploy && post && pre < deploy && deploy < post
 ' "$workflow"
 
-grep -Fq 'strategy = "bluegreen"' "$fly_config"
+# A comparação é por linha inteira e sobre o fly.toml já sem comentários: o
+# arquivo documenta em prosa os valores que estas asserções rejeitam (o bloco
+# do always-on cita "min_machines_running = 1"), então um grep de substring
+# passaria a casar a documentação em vez da diretiva e aprovaria justamente a
+# mudança que deveria barrar. O -Fx também dispensa escapar os metacaracteres
+# de regex que aparecem nos valores.
+fly_directives="$(sed 's/#.*//; s/[[:space:]]*$//; s/^[[:space:]]*//' "$fly_config")"
+
+assert_directive() {
+  grep -Fxq "$1" <<<"$fly_directives" && return 0
+  echo "frontend/fly.toml sem a diretiva esperada: $1" >&2
+  exit 1
+}
+
+assert_directive 'strategy = "bluegreen"'
 # Always-on é asserido aqui, e não só documentado no fly.toml, porque a volta
 # silenciosa do scale-to-zero foi o que tirou o site do ar em 2026-08-10: a
 # Machine parou por ociosidade e o host de gru não tinha CPU livre para
 # reacendê-la. Reintroduzir "stop"/0 tem que passar por esta linha.
-grep -Fq 'auto_stop_machines = "off"' "$fly_config"
-grep -Fq 'auto_start_machines = true' "$fly_config"
-grep -Fq 'min_machines_running = 1' "$fly_config"
-grep -Fq 'swap_size_mb = 512' "$fly_config"
-grep -Fq 'size = "shared-cpu-1x"' "$fly_config"
-grep -Fq 'memory = "512mb"' "$fly_config"
+assert_directive 'auto_stop_machines = "off"'
+assert_directive 'auto_start_machines = true'
+assert_directive 'min_machines_running = 1'
+assert_directive 'swap_size_mb = 512'
+assert_directive 'size = "shared-cpu-1x"'
+assert_directive 'memory = "512mb"'
 
 echo "Contrato de Machines do frontend validado."

--- a/.github/scripts/test-frontend-fly-machine-contract.sh
+++ b/.github/scripts/test-frontend-fly-machine-contract.sh
@@ -99,9 +99,13 @@ ruby -ryaml -e '
 ' "$workflow"
 
 grep -Fq 'strategy = "bluegreen"' "$fly_config"
-grep -Fq 'auto_stop_machines = "stop"' "$fly_config"
+# Always-on é asserido aqui, e não só documentado no fly.toml, porque a volta
+# silenciosa do scale-to-zero foi o que tirou o site do ar em 2026-08-10: a
+# Machine parou por ociosidade e o host de gru não tinha CPU livre para
+# reacendê-la. Reintroduzir "stop"/0 tem que passar por esta linha.
+grep -Fq 'auto_stop_machines = "off"' "$fly_config"
 grep -Fq 'auto_start_machines = true' "$fly_config"
-grep -Fq 'min_machines_running = 0' "$fly_config"
+grep -Fq 'min_machines_running = 1' "$fly_config"
 grep -Fq 'swap_size_mb = 512' "$fly_config"
 grep -Fq 'size = "shared-cpu-1x"' "$fly_config"
 grep -Fq 'memory = "512mb"' "$fly_config"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,8 +77,10 @@ repos:
         pass_filenames: false
         require_serial: true
 
-      # O frontend pode escalar a zero, mas cada deploy deve convergir para uma
-      # unica Machine saudavel antes de o proxy poder para-la por ociosidade.
+      # O frontend e always-on desde 2026-08-10, quando a Machine parou por
+      # ociosidade e nao voltou (o host de gru estava sem CPU livre). Cada
+      # deploy deve convergir para uma unica Machine saudavel e com o autostop
+      # desligado — tanto no fly.toml quanto na config aplicada.
       - id: frontend-fly-machine-contract
         name: frontend Fly machine contract
         entry: .github/scripts/test-frontend-fly-machine-contract.sh

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -31,11 +31,26 @@ swap_size_mb = 512
 [http_service]
   internal_port = 3000
   force_https = true
-  # O backend so acorda esta aplicacao quando ha trabalho vencido na outbox.
-  # Fora disso, o proxy pode parar a unica Machine e reinicia-la sob demanda.
-  auto_stop_machines = "stop"
+  # Always-on: rollback do scale-to-zero habilitado no #644, na forma que
+  # aquele PR já previa ("restaurar auto_stop_machines = off e
+  # min_machines_running = 1, mantendo uma única Machine").
+  #
+  # Em 2026-08-10 a Machine parou por ociosidade e não conseguiu voltar: cada
+  # tentativa de acordá-la falhou com "could not reserve resource for machine:
+  # insufficient CPUs available to fulfill request on the current host" — o
+  # host de gru onde ela estava alocada ficou sem CPU livre. Como o proxy só
+  # tenta reacender sob demanda, o resultado foi um loop de start/crash e o
+  # site inteiro fora do ar até a Machine ser recriada em outro host.
+  #
+  # O custo do scale-to-zero, portanto, não é apenas o cold start medido: é
+  # depender da capacidade do host no instante de acordar. Com a Machine
+  # sempre ligada, esse instante deixa de existir no caminho crítico.
+  #
+  # auto_start_machines segue true de propósito: é a rede que reacende a
+  # Machine se ela parar por outro motivo (restart, manutenção do host).
+  auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [[http_service.checks]]
     grace_period = "10s"

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -48,6 +48,12 @@ swap_size_mb = 512
   #
   # auto_start_machines segue true de propósito: é a rede que reacende a
   # Machine se ela parar por outro motivo (restart, manutenção do host).
+  #
+  # Quem sustenta a disponibilidade aqui é o auto_stop_machines sozinho.
+  # min_machines_running só é honrado quando o autostop está ligado — ele diz
+  # quantas Machines a lógica de parada por ociosidade preserva, e com "off"
+  # ninguém para nada. Fica em 1 como intenção declarada para o dia em que o
+  # autostop voltar, não como piso ativo de Machines.
   auto_stop_machines = "off"
   auto_start_machines = true
   min_machines_running = 1


### PR DESCRIPTION
## O que mudou

- `frontend/fly.toml`: `auto_stop_machines = "off"` e `min_machines_running = 1`, revertendo o scale-to-zero habilitado no #644;
- o contrato comportamental (`.github/scripts/test-frontend-fly-machine-contract.sh`) passa a asserir os valores de always-on, para que a volta do scale-to-zero não seja silenciosa;
- mantém intactos o `bluegreen`, o `--ha=false`, o preflight/postflight de cardinalidade e a topologia `shared-cpu-1x`/512 MB que o #644 introduziu.

## Causa raiz e impacto

O #644 configurou o frontend para parar a única Machine quando ociosa e reiniciá-la sob demanda. Em 2026-08-10, por volta das 15:47Z, a Machine parou e não conseguiu voltar. Cada tentativa do proxy falhou com:

```
machines API returned an error: "could not reserve resource for machine:
insufficient CPUs available to fulfill request on the current host"
```

O host de `gru` onde a Machine estava alocada ficou sem CPU livre. Como o proxy só reacende sob demanda, o resultado foi um loop de `start` → `crash` (`exit_code=0`, `oom_killed=false`, `requested_stop=false`) e **o site inteiro fora do ar** — `dataframeit.com.br` e `gui-analise-sistematica-frontend.fly.dev/api/health` davam timeout. O backend seguiu saudável o tempo todo.

Não foi cold start lento nem OOM (o 512 MB + swap do #364 seguem valendo), e não foi regressão de código: a Machine rodava a imagem do v110 havia seis dias.

Este é exatamente o rollback que o #644 já previa no corpo do PR — "restaurar `auto_stop_machines = off` e `min_machines_running = 1`, mantendo uma única Machine" — antecipado para o caso de o cold start ser inadequado. O que ocorreu foi mais grave: não foi lentidão ao acordar, foi impossibilidade de acordar.

A leitura que fica: o custo do scale-to-zero não é apenas o cold start medido, é **depender da capacidade do host no instante de acordar**. Com a Machine sempre ligada, esse instante sai do caminho crítico. O tradeoff de custo que motivou o #644 continua real e foi reavaliado à luz da queda.

`auto_start_machines` segue `true` de propósito: é a rede que reacende a Machine se ela parar por outro motivo (restart, manutenção do host).

## Verificação

- **Prova do vermelho** do contrato: com o `fly.toml` de `origin/main` (scale-to-zero) o teste falha (`exit=1`); com o desta branch, passa (`exit=0`). A asserção discrimina de fato, em vez de passar dos dois lados;
- `flyctl config validate --strict -c frontend/fly.toml`: `Configuration is valid`;
- hook `frontend Fly machine contract` no pre-commit: passou;
- semgrep no pre-push: passou (demais gates sem arquivos no escopo deste diff).

## Estado operacional (já aplicado, antes deste PR)

A produção foi restaurada fora do fluxo de PR, porque o site estava fora do ar:

1. `flyctl machine clone` da Machine travada — o clone subiu saudável em outro host, o que confirmou que o problema era capacidade do host e não a aplicação;
2. `flyctl machine destroy` da Machine presa;
3. `flyctl machine update --autostop=off` na Machine restante, para não repetir a parada por ociosidade enquanto este PR não é merjado.

Estado remoto agora: **uma** Machine `started` em `gru`, `shared-cpu-1x`/512 MB, health `passing`, `autostop=off` — coerente com o postflight do #644 e com o `fly.toml` desta branch. `https://dataframeit.com.br` responde 200.

Refs #644