### PR TITLE
fix(fly): frontend passa a duas Machines always-on (#664)

### DIFF
--- a/.github/scripts/check-frontend-fly-machines.sh
+++ b/.github/scripts/check-frontend-fly-machines.sh
@@ -5,6 +5,12 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 fly_config="$repo_root/frontend/fly.toml"
 mode="${1:-}"
 
+# Cardinalidade contratada. Duas Machines eliminam o ponto único de falha por
+# host (#664): com uma só, perder o host derruba a produção e ela não se
+# recupera sozinha — em 2026-08-10 o host de gru ficou sem CPU livre e foi
+# preciso `machine clone` manual para outro host.
+readonly expected_machines=2
+
 if [[ "$mode" != "pre" && "$mode" != "post" ]]; then
   echo "uso: $0 pre|post" >&2
   exit 64
@@ -21,44 +27,63 @@ if ! machine_count="$(jq -er '
 fi
 
 if [[ "$mode" == "pre" ]]; then
-  if ((machine_count > 1)); then
-    echo "Deploy recusado: o frontend tem $machine_count Machines; reduza explicitamente para no máximo uma antes do deploy." >&2
+  if ((machine_count > expected_machines)); then
+    echo "Deploy recusado: o frontend tem $machine_count Machines; o contrato é $expected_machines. Reduza explicitamente antes do deploy." >&2
     exit 1
   fi
+  # Menos de $expected_machines é tolerado aqui de propósito: o `flyctl scale
+  # count` do workflow roda DEPOIS deste gate e é quem converge de volta para
+  # duas. Exigir a cardinalidade cheia já no preflight impediria o deploy de se
+  # auto-curar depois de perder uma Machine.
   echo "Preflight Fly aprovado: $machine_count Machine(s)."
   exit 0
 fi
 
-if ((machine_count != 1)); then
-  echo "Deploy inválido: esperado exatamente uma Machine do frontend, encontrado $machine_count." >&2
+if ((machine_count != expected_machines)); then
+  echo "Deploy inválido: esperado exatamente $expected_machines Machines do frontend, encontrado $machine_count." >&2
   exit 1
 fi
 
-if ! jq -e '
-  length == 1
-  and .[0].state == "started"
-  and .[0].region == "gru"
-  and .[0].config.guest.cpu_kind == "shared"
-  and .[0].config.guest.cpus == 1
-  and .[0].config.guest.memory_mb == 512
+# `all` quantifica sobre TODAS as Machines em vez de inspecionar .[0]: com mais
+# de uma, validar só a primeira aprovaria um deploy em que a segunda subiu
+# parada, em outra região ou com outro tamanho. O `length` não é redundante —
+# `all` sobre array vazio é true.
+if ! jq -e --argjson expected "$expected_machines" '
+  length == $expected
+  and all(.[];
+    .state == "started"
+    and .region == "gru"
+    and .config.guest.cpu_kind == "shared"
+    and .config.guest.cpus == 1
+    and .config.guest.memory_mb == 512)
 ' >/dev/null <<<"$machines_json"; then
-  echo "Deploy inválido: a Machine deve estar iniciada em gru com shared-cpu-1x e 512 MB." >&2
+  echo "Deploy inválido: todas as Machines devem estar iniciadas em gru com shared-cpu-1x e 512 MB." >&2
   exit 1
 fi
 
-machine_id="$(jq -er '.[0].id | select(type == "string" and length > 0)' <<<"$machines_json")"
+machine_ids_json="$(jq -er '[.[].id | select(type == "string" and length > 0)]' <<<"$machines_json")"
+if ! jq -e --argjson expected "$expected_machines" 'length == $expected' >/dev/null <<<"$machine_ids_json"; then
+  echo "Deploy inválido: não foi possível ler o id de todas as $expected_machines Machines." >&2
+  exit 1
+fi
 readonly health_attempts=12
 readonly health_interval_seconds=10
 
 for ((attempt = 1; attempt <= health_attempts; attempt += 1)); do
-  if checks_json="$(flyctl checks list -c "$fly_config" --json)" && jq -e --arg machine_id "$machine_id" '
-    type == "object"
-    and ((.[$machine_id] // null) as $checks
+  # `. as $by_machine` é necessário porque dentro de `all($ids[]; ...)` o `.`
+  # já é o id sob teste, não o mapa raiz. Uma Machine verde e outra vermelha
+  # não pode aprovar o deploy.
+  if checks_json="$(flyctl checks list -c "$fly_config" --json)" && jq -e --argjson ids "$machine_ids_json" '
+    . as $by_machine
+    | type == "object"
+    and all($ids[];
+      . as $id
+      | ($by_machine[$id] // null) as $checks
       | ($checks | type) == "array"
       and ($checks | length) > 0
       and all($checks[]; .status == "passing"))
   ' >/dev/null <<<"$checks_json"; then
-    echo "Postflight Fly aprovado: uma Machine saudável em gru, shared-cpu-1x/512 MB."
+    echo "Postflight Fly aprovado: $expected_machines Machines saudáveis em gru, shared-cpu-1x/512 MB."
     exit 0
   fi
 
@@ -68,5 +93,5 @@ for ((attempt = 1; attempt <= health_attempts; attempt += 1)); do
   fi
 done
 
-echo "Deploy inválido: a Machine não apresentou health check verde após $health_attempts tentativa(s)." >&2
+echo "Deploy inválido: as $expected_machines Machines não apresentaram health check verde após $health_attempts tentativa(s)." >&2
 exit 1

--- a/.github/scripts/check-frontend-fly-machines.sh
+++ b/.github/scripts/check-frontend-fly-machines.sh
@@ -10,6 +10,10 @@ mode="${1:-}"
 # recupera sozinha — em 2026-08-10 o host de gru ficou sem CPU livre e foi
 # preciso `machine clone` manual para outro host.
 readonly expected_machines=2
+# Região contratada, declarada aqui uma vez porque os dois modos dependem dela:
+# o postflight exige que as Machines estejam nela, e o preflight precisa recusar
+# o que estiver fora (ver a verificação logo abaixo).
+readonly expected_region="gru"
 
 if [[ "$mode" != "pre" && "$mode" != "post" ]]; then
   echo "uso: $0 pre|post" >&2
@@ -23,6 +27,18 @@ if ! machine_count="$(jq -er '
   end
 ' <<<"$machines_json")"; then
   echo "Não foi possível interpretar a lista de Machines do frontend." >&2
+  exit 1
+fi
+
+# Vale para os DOIS modos. No preflight não é redundante com a contagem: o
+# `flyctl machine list` enxerga todas as regiões, mas o `flyctl scale count` do
+# workflow é escopado em `--region $expected_region`. Uma Machine em gru mais
+# uma fora passaria pela contagem (2 <= 2) e a escala levaria gru de 1 para 2,
+# totalizando 3 — divergência criada DEPOIS do gate que existe para recusá-la, e
+# que travaria todo deploy seguinte no preflight. Recusar aqui custa exigir que
+# um `machine clone` de incidente fora de gru seja resolvido antes do deploy.
+if ! jq -e --arg region "$expected_region" 'all(.[]; .region == $region)' >/dev/null <<<"$machines_json"; then
+  echo "Deploy recusado: há Machine do frontend fora de $expected_region; a escala do workflow é escopada nessa região e não convergiria a cardinalidade total." >&2
   exit 1
 fi
 
@@ -46,18 +62,17 @@ fi
 
 # `all` quantifica sobre TODAS as Machines em vez de inspecionar .[0]: com mais
 # de uma, validar só a primeira aprovaria um deploy em que a segunda subiu
-# parada, em outra região ou com outro tamanho. O `length` não é redundante —
-# `all` sobre array vazio é true.
-if ! jq -e --argjson expected "$expected_machines" '
-  length == $expected
-  and all(.[];
+# parada ou com outro tamanho. A região não entra aqui — já foi verificada
+# acima, para os dois modos, e repeti-la abriria espaço para as duas definições
+# divergirem.
+if ! jq -e '
+  all(.[];
     .state == "started"
-    and .region == "gru"
     and .config.guest.cpu_kind == "shared"
     and .config.guest.cpus == 1
     and .config.guest.memory_mb == 512)
 ' >/dev/null <<<"$machines_json"; then
-  echo "Deploy inválido: todas as Machines devem estar iniciadas em gru com shared-cpu-1x e 512 MB." >&2
+  echo "Deploy inválido: todas as Machines devem estar iniciadas com shared-cpu-1x e 512 MB." >&2
   exit 1
 fi
 
@@ -83,7 +98,7 @@ for ((attempt = 1; attempt <= health_attempts; attempt += 1)); do
       and ($checks | length) > 0
       and all($checks[]; .status == "passing"))
   ' >/dev/null <<<"$checks_json"; then
-    echo "Postflight Fly aprovado: $expected_machines Machines saudáveis em gru, shared-cpu-1x/512 MB."
+    echo "Postflight Fly aprovado: $expected_machines Machines saudáveis em $expected_region, shared-cpu-1x/512 MB."
     exit 0
   fi
 

--- a/.github/scripts/test-frontend-fly-machine-contract.sh
+++ b/.github/scripts/test-frontend-fly-machine-contract.sh
@@ -99,9 +99,13 @@ ruby -ryaml -e '
 ' "$workflow"
 
 grep -Fq 'strategy = "bluegreen"' "$fly_config"
-grep -Fq 'auto_stop_machines = "stop"' "$fly_config"
+# Always-on é asserido aqui, e não só documentado no fly.toml, porque a volta
+# silenciosa do scale-to-zero foi o que tirou o site do ar em 2026-08-10: a
+# Machine parou por ociosidade e o host de gru não tinha CPU livre para
+# reacendê-la. Reintroduzir "stop"/0 tem que passar por esta linha.
+grep -Fq 'auto_stop_machines = "off"' "$fly_config"
 grep -Fq 'auto_start_machines = true' "$fly_config"
-grep -Fq 'min_machines_running = 0' "$fly_config"
+grep -Fq 'min_machines_running = 1' "$fly_config"
 grep -Fq 'swap_size_mb = 512' "$fly_config"
 grep -Fq 'size = "shared-cpu-1x"' "$fly_config"
 grep -Fq 'memory = "512mb"' "$fly_config"

--- a/.github/scripts/test-frontend-fly-machine-contract.sh
+++ b/.github/scripts/test-frontend-fly-machine-contract.sh
@@ -90,6 +90,14 @@ MACHINES_JSON="$(machines "$(machine machine-1)" "$(machine machine-2)" "$(machi
 expect_failure run_checker pre
 MACHINES_JSON='{"unexpected":"shape"}'
 expect_failure run_checker pre
+# Machine fora de gru dentro do teto de contagem: o preflight não pode aprovar.
+# O `flyctl scale count` é escopado em --region gru, então 1 em gru + 1 fora
+# passaria pela contagem (2 <= 2) e a escala levaria o total a 3 — divergência
+# criada depois do gate, que então travaria todo deploy seguinte.
+MACHINES_JSON="$(machines "$(machine machine-1)" "$(machine machine-2 started iad)")"
+expect_failure run_checker pre
+MACHINES_JSON="$(machines "$(machine machine-1 started iad)")"
+expect_failure run_checker pre
 
 MACHINES_JSON="$two_machines"
 CHECKS_JSON="$two_healthy"
@@ -156,6 +164,15 @@ ruby -ryaml -e '
   # Machine sozinho, e `scale count` destrói excedentes — antes do preflight,
   # apagaria a divergência que ele existe para recusar.
   abort("workflow sem ordem preflight -> scale -> deploy -> postflight") unless pre && scale && deploy && post && pre < scale && scale < deploy && deploy < post
+  # Os argumentos do scale carregam efeito em produção e por isso são asseridos
+  # um a um: sem `--yes` o comando pede confirmação e o job morre (runner do
+  # GitHub não tem TTY); sem `-a` explícito, o mesmo passo escalaria o app da
+  # API; sem `--region`, a Machine nova nasce onde o scheduler decidir, e o
+  # postflight exige gru.
+  scale_run = runs.fetch(scale)
+  ["--region gru", "--yes", "-a gui-analise-sistematica-frontend"].each do |arg|
+    abort("passo de escala sem #{arg}") unless scale_run.include?(arg)
+  end
   # --ha=false trava a cardinalidade em 1 do lado do flyctl e reintroduziria o
   # ponto único de falha do #664 sem tocar em nada que os outros gates leem.
   abort("--ha=false trava a cardinalidade em 1") if runs.any? { |run| run.include?("--ha=false") }

--- a/.github/scripts/test-frontend-fly-machine-contract.sh
+++ b/.github/scripts/test-frontend-fly-machine-contract.sh
@@ -27,14 +27,33 @@ exit 0
 EOF
 chmod +x "$tmp_dir/bin/sleep"
 
+# O id é parametrizado porque CHECKS_JSON é indexado por id: com dois elementos
+# de id igual, o caso "uma Machine saudável e outra não" seria indistinguível de
+# "as duas saudáveis" e o teste de health passaria a ser vácuo.
 machine() {
-  local state="${1:-started}"
-  local region="${2:-gru}"
-  local cpu_kind="${3:-shared}"
-  local cpus="${4:-1}"
-  local memory_mb="${5:-512}"
-  printf '[{"id":"machine-1","state":"%s","region":"%s","config":{"guest":{"cpu_kind":"%s","cpus":%s,"memory_mb":%s}}}]' \
-    "$state" "$region" "$cpu_kind" "$cpus" "$memory_mb"
+  local id="${1:-machine-1}"
+  local state="${2:-started}"
+  local region="${3:-gru}"
+  local cpu_kind="${4:-shared}"
+  local cpus="${5:-1}"
+  local memory_mb="${6:-512}"
+  printf '{"id":"%s","state":"%s","region":"%s","config":{"guest":{"cpu_kind":"%s","cpus":%s,"memory_mb":%s}}}' \
+    "$id" "$state" "$region" "$cpu_kind" "$cpus" "$memory_mb"
+}
+
+machines() {
+  local IFS=','
+  printf '[%s]' "$*"
+}
+
+# Mapa machine_id -> checks, na forma que `flyctl checks list --json` devolve.
+checks_for() {
+  local out='{}' id
+  for id in "$@"; do
+    out="$(jq -c --arg id "$id" \
+      '.[$id] = [{"name":"servicecheck-00-http-3000","status":"passing"}]' <<<"$out")"
+  done
+  printf '%s' "$out"
 }
 
 run_checker() {
@@ -54,35 +73,72 @@ expect_failure() {
 
 bash -n "$checker" "$0"
 
-MACHINES_JSON='[]'
+two_machines="$(machines "$(machine machine-1)" "$(machine machine-2)")"
+two_healthy="$(checks_for machine-1 machine-2)"
+
+# Preflight aceita 0..2: o `flyctl scale count 2` do workflow roda depois dele e
+# converge, então recusar 1 impediria o deploy de se auto-curar depois de perder
+# uma Machine. Acima do contrato, recusa.
 CHECKS_JSON='{}'
+MACHINES_JSON='[]'
 run_checker pre >/dev/null
-MACHINES_JSON="$(machine)"
+MACHINES_JSON="$(machines "$(machine machine-1)")"
 run_checker pre >/dev/null
-MACHINES_JSON="[$(machine | sed 's/^\[//; s/\]$//'),$(machine | sed 's/^\[//; s/\]$//')]"
+MACHINES_JSON="$two_machines"
+run_checker pre >/dev/null
+MACHINES_JSON="$(machines "$(machine machine-1)" "$(machine machine-2)" "$(machine machine-3)")"
 expect_failure run_checker pre
 MACHINES_JSON='{"unexpected":"shape"}'
 expect_failure run_checker pre
 
-MACHINES_JSON="$(machine)"
-CHECKS_JSON='{"machine-1":[{"name":"servicecheck-00-http-3000","status":"passing"}]}'
+MACHINES_JSON="$two_machines"
+CHECKS_JSON="$two_healthy"
 run_checker post >/dev/null
 
+# Cardinalidade: uma só deixou de bastar (#664), três também não.
+MACHINES_JSON="$(machines "$(machine machine-1)")"
+CHECKS_JSON="$(checks_for machine-1)"
+expect_failure run_checker post
+MACHINES_JSON="$(machines "$(machine machine-1)" "$(machine machine-2)" "$(machine machine-3)")"
+CHECKS_JSON="$(checks_for machine-1 machine-2 machine-3)"
+expect_failure run_checker post
+
+# Forma inválida na SEGUNDA Machine: prova que a validação quantifica sobre
+# todas em vez de inspecionar .[0].
+CHECKS_JSON="$two_healthy"
 for invalid_machine in \
-  "$(machine stopped)" \
-  "$(machine started iad)" \
-  "$(machine started gru performance)" \
-  "$(machine started gru shared 2)" \
-  "$(machine started gru shared 1 1024)"
+  "$(machine machine-2 stopped)" \
+  "$(machine machine-2 started iad)" \
+  "$(machine machine-2 started gru performance)" \
+  "$(machine machine-2 started gru shared 2)" \
+  "$(machine machine-2 started gru shared 1 1024)"
 do
-  MACHINES_JSON="$invalid_machine"
+  MACHINES_JSON="$(machines "$(machine machine-1)" "$invalid_machine")"
   expect_failure run_checker post
 done
 
-MACHINES_JSON="$(machine)"
+# ...e o espelho na primeira, para que trocar .[0] por .[1] também seja pego.
+for invalid_machine in \
+  "$(machine machine-1 stopped)" \
+  "$(machine machine-1 started iad)"
+do
+  MACHINES_JSON="$(machines "$invalid_machine" "$(machine machine-2)")"
+  expect_failure run_checker post
+done
+
+# Health por id. O caso decisivo é o mapa que cobre só a primeira Machine: é o
+# único que reprova uma implementação que leia o id de .[0] e nunca olhe a
+# segunda.
+MACHINES_JSON="$two_machines"
+CHECKS_JSON="$(checks_for machine-1)"
+expect_failure run_checker post
 CHECKS_JSON='{}'
 expect_failure run_checker post
-CHECKS_JSON='{"machine-1":[{"name":"servicecheck-00-http-3000","status":"critical"}]}'
+CHECKS_JSON="$(jq -c '.["machine-2"] = []' <<<"$two_healthy")"
+expect_failure run_checker post
+CHECKS_JSON="$(jq -c '.["machine-2"] = [{"name":"servicecheck-00-http-3000","status":"critical"}]' <<<"$two_healthy")"
+expect_failure run_checker post
+CHECKS_JSON="$(jq -c '.["machine-1"] = [{"name":"servicecheck-00-http-3000","status":"critical"}]' <<<"$two_healthy")"
 expect_failure run_checker post
 
 ruby -ryaml -e '
@@ -93,9 +149,16 @@ ruby -ryaml -e '
   steps = workflow.fetch("jobs").fetch("deploy").fetch("steps")
   runs = steps.filter_map { |step| step["run"] }
   pre = runs.index { |run| run.include?("check-frontend-fly-machines.sh pre") }
-  deploy = runs.index { |run| run.include?("flyctl deploy") && run.include?("--ha=false") }
+  scale = runs.index { |run| run.include?("flyctl scale count 2") }
+  deploy = runs.index { |run| run.include?("flyctl deploy") }
   post = runs.index { |run| run.include?("check-frontend-fly-machines.sh post") }
-  abort("workflow sem ordem preflight -> deploy -> postflight") unless pre && deploy && post && pre < deploy && deploy < post
+  # O scale fica entre preflight e deploy: `flyctl deploy` não cria a segunda
+  # Machine sozinho, e `scale count` destrói excedentes — antes do preflight,
+  # apagaria a divergência que ele existe para recusar.
+  abort("workflow sem ordem preflight -> scale -> deploy -> postflight") unless pre && scale && deploy && post && pre < scale && scale < deploy && deploy < post
+  # --ha=false trava a cardinalidade em 1 do lado do flyctl e reintroduziria o
+  # ponto único de falha do #664 sem tocar em nada que os outros gates leem.
+  abort("--ha=false trava a cardinalidade em 1") if runs.any? { |run| run.include?("--ha=false") }
 ' "$workflow"
 
 grep -Fq 'strategy = "bluegreen"' "$fly_config"
@@ -105,7 +168,7 @@ grep -Fq 'strategy = "bluegreen"' "$fly_config"
 # reacendê-la. Reintroduzir "stop"/0 tem que passar por esta linha.
 grep -Fq 'auto_stop_machines = "off"' "$fly_config"
 grep -Fq 'auto_start_machines = true' "$fly_config"
-grep -Fq 'min_machines_running = 1' "$fly_config"
+grep -Fq 'min_machines_running = 2' "$fly_config"
 grep -Fq 'swap_size_mb = 512' "$fly_config"
 grep -Fq 'size = "shared-cpu-1x"' "$fly_config"
 grep -Fq 'memory = "512mb"' "$fly_config"

--- a/.github/workflows/frontend-fly-deploy.yml
+++ b/.github/workflows/frontend-fly-deploy.yml
@@ -30,6 +30,20 @@ jobs:
         run: bash .github/scripts/check-frontend-fly-machines.sh pre
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_FRONTEND }}
+      - name: Convergir para duas Machines
+        working-directory: frontend
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_FRONTEND }}
+        # `flyctl deploy` não escala 1 -> 2 em app existente, então a segunda
+        # Machine precisa nascer de um passo declarativo — do contrário o
+        # postflight dependeria de alguém ter lembrado de rodar um comando.
+        # Idempotente: com as duas criadas, é no-op.
+        #
+        # Roda DEPOIS do preflight de propósito: `scale count` destrói
+        # excedentes, então antes dele apagaria em silêncio a divergência que o
+        # preflight existe para recusar — inclusive uma Machine clonada à mão
+        # durante um incidente, que foi o que restaurou o site em 2026-08-10.
+        run: flyctl scale count 2 --region gru --yes -a gui-analise-sistematica-frontend
       - name: flyctl deploy
         working-directory: frontend
         env:
@@ -43,7 +57,6 @@ jobs:
         run: |
           deploy_args=(
             --remote-only
-            --ha=false
             -a gui-analise-sistematica-frontend
             --build-arg "NEXT_DEPLOYMENT_ID=${GITHUB_SHA}"
             --build-secret "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${NEXT_SERVER_ACTIONS_ENCRYPTION_KEY}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,8 +77,9 @@ repos:
         pass_filenames: false
         require_serial: true
 
-      # O frontend pode escalar a zero, mas cada deploy deve convergir para uma
-      # unica Machine saudavel antes de o proxy poder para-la por ociosidade.
+      # O frontend roda com duas Machines sempre ligadas (#664): cada deploy
+      # deve convergir para essa cardinalidade e validar a saúde das duas, não
+      # só da primeira.
       - id: frontend-fly-machine-contract
         name: frontend Fly machine contract
         entry: .github/scripts/test-frontend-fly-machine-contract.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Para aplicar migrations pendentes: `npx supabase db push`
 
 ## Deploy
 
-Deploy e automatico a partir de merge no branch `main`. Frontend: em migracao Vercel → Fly.io (app `gui-analise-sistematica-frontend`); enquanto o cutover de dominio nao ocorre, Vercel ainda e a producao. Backend: Fly.io (app `gui-analise-sistematica-api`) via workflow quando ha mudanca em `backend/**`. A partir de 2026-04-20, **preferir branch + PR** ao push direto na main. Fluxo recomendado:
+Deploy e automatico a partir de merge no branch `main`. Frontend: Fly.io (app `gui-analise-sistematica-frontend`), servindo `dataframeit.com.br` — o cutover de dominio ja ocorreu, e foi a queda dessa app que tirou o site do ar em 2026-08-10. Backend: Fly.io (app `gui-analise-sistematica-api`) via workflow quando ha mudanca em `backend/**`. A partir de 2026-04-20, **preferir branch + PR** ao push direto na main. Fluxo recomendado:
 
 1. **Criar git worktree isolado** para a tarefa (ver secao "Workspace isolado" abaixo) — nao trabalhar no diretorio principal
 2. Criar branch descritiva (`feat/...`, `fix/...`, `perf/...`) na worktree

--- a/README.md
+++ b/README.md
@@ -136,14 +136,17 @@ fly secrets set CLERK_SECRET_KEY=sk_... \
   CLERK_WEBHOOK_SECRET=whsec_... \
   AUTO_REVIEW_RECONCILIATION_SECRET=the-same-long-random-secret \
   -a gui-analise-sistematica-frontend
-fly deploy -c fly.toml --ha=false -a gui-analise-sistematica-frontend   # fallback; o normal é via CI
+fly deploy -c fly.toml -a gui-analise-sistematica-frontend   # fallback; o normal é via CI
+fly scale count 2 --region gru -a gui-analise-sistematica-frontend   # só se o fallback rodar com menos de duas
 ```
 
 O endpoint de webhook do Clerk em produção é `https://dataframeit.com.br/api/webhooks/clerk`. Ele deve assinar e entregar `user.created`, `user.updated` e `user.deleted`; o signing secret correspondente fica em `CLERK_WEBHOOK_SECRET`. Ao ativar uma rota nova de reconciliação, configure esses três eventos somente depois que o frontend compatível estiver no ar e confirme uma entrega `2xx` de cada tipo — uma rota antiga pode responder `2xx` sem processar eventos que ainda não conhece.
 
 Mudanças que dependem de RPCs, constraints ou colunas novas seguem ordem estrita: backup e preflight, reparo de dados incompatíveis, migrations, verificação de pós-condições, deploy do frontend do mesmo SHA e smokes autenticados. Depois que o schema novo recebe escritas, o rollback suportado é roll-forward; não edite uma migration já registrada.
 
-O frontend opera com uma Machine `shared-cpu-1x` de 512 MB e 512 MB de swap. Quando fica ociosa, a Machine para; a primeira requisição seguinte a reinicia. O workflow recusa mais de uma Machine antes do deploy e valida cardinalidade, região, tamanho e health depois da atualização.
+O frontend opera com duas Machines `shared-cpu-1x` de 512 MB e 512 MB de swap cada, sempre ligadas. A segunda existe porque uma Machine única fica presa a um host: em 2026-08-10 o host de `gru` ficou sem CPU livre, a Machine não conseguiu voltar e o site ficou fora do ar até ser recriada à mão em outro host. O workflow converge a topologia com `flyctl scale count 2` depois do preflight, recusa mais de duas Machines antes do deploy e valida cardinalidade, região, tamanho e health **de cada uma** depois da atualização.
+
+A separação entre hosts é *best-effort* do scheduler do Fly e não é verificável pela CLI (nem `machine list --json` nem `machine status` expõem o host), então o contrato automatizado cobre a cardinalidade e a saúde, não a anti-afinidade. As duas Machines seguem em `gru`: isto não protege contra queda de região.
 
 ### Variáveis de ambiente
 

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -31,11 +31,26 @@ swap_size_mb = 512
 [http_service]
   internal_port = 3000
   force_https = true
-  # O backend so acorda esta aplicacao quando ha trabalho vencido na outbox.
-  # Fora disso, o proxy pode parar a unica Machine e reinicia-la sob demanda.
-  auto_stop_machines = "stop"
+  # Always-on: rollback do scale-to-zero habilitado no #644, na forma que
+  # aquele PR já previa ("restaurar auto_stop_machines = off e
+  # min_machines_running = 1, mantendo uma única Machine").
+  #
+  # Em 2026-08-10 a Machine parou por ociosidade e não conseguiu voltar: cada
+  # tentativa de acordá-la falhou com "could not reserve resource for machine:
+  # insufficient CPUs available to fulfill request on the current host" — o
+  # host de gru onde ela estava alocada ficou sem CPU livre. Como o proxy só
+  # tenta reacender sob demanda, o resultado foi um loop de start/crash e o
+  # site inteiro fora do ar até a Machine ser recriada em outro host.
+  #
+  # O custo do scale-to-zero, portanto, não é apenas o cold start medido: é
+  # depender da capacidade do host no instante de acordar. Com a Machine
+  # sempre ligada, esse instante deixa de existir no caminho crítico.
+  #
+  # auto_start_machines segue true de propósito: é a rede que reacende a
+  # Machine se ela parar por outro motivo (restart, manutenção do host).
+  auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
   [[http_service.checks]]
     grace_period = "10s"

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -50,7 +50,17 @@ swap_size_mb = 512
   # Machine se ela parar por outro motivo (restart, manutenção do host).
   auto_stop_machines = "off"
   auto_start_machines = true
-  min_machines_running = 1
+  # Duas Machines (#664). Manter a Machine acesa tira o "acordar" do caminho
+  # crítico, mas não desfaz a dependência de um único host: se ele reiniciar,
+  # entrar em manutenção ou ficar sem CPU no instante em que a Machine precise
+  # ser recriada, a produção cai de novo e não volta sozinha.
+  #
+  # Com auto_stop_machines = "off" este valor é inerte — min_machines_running
+  # só age quando o autostop está ligado. Ele fica aqui como declaração de
+  # intenção e como trava contra um retorno silencioso do scale-to-zero com
+  # cardinalidade 1. Quem de fato cria e mantém as duas é o `flyctl scale
+  # count 2` do workflow, verificado pelo postflight fail-closed.
+  min_machines_running = 2
 
   [[http_service.checks]]
     grace_period = "10s"

--- a/frontend/src/actions/__tests__/documents.test.ts
+++ b/frontend/src/actions/__tests__/documents.test.ts
@@ -30,11 +30,17 @@ const hoisted = vi.hoisted(() => ({
   resolveMemberUserId: vi.fn<(projectId: string) => Promise<string>>(
     async () => "canonical-member",
   ),
+  // Espiões, e não no-ops: QUAIS rotas são revalidadas é contrato observável —
+  // a fila de Atribuições depende do path para não servir do Router Cache um
+  // documento já excluído (#664).
+  revalidatePath: vi.fn<(path: string) => void>(),
+  revalidateTag: vi.fn<(tag: string, profile?: unknown) => void>(),
 }));
 
 vi.mock("next/cache", () => ({
-  revalidatePath: () => {},
-  revalidateTag: () => {},
+  revalidatePath: (path: string) => hoisted.revalidatePath(path),
+  revalidateTag: (tag: string, profile?: unknown) =>
+    hoisted.revalidateTag(tag, profile),
 }));
 vi.mock("@/lib/auth", () => ({
   getAuthUser: () => hoisted.getUser(),
@@ -90,6 +96,8 @@ beforeEach(() => {
   hoisted.isCoord.mockResolvedValue(true);
   hoisted.resolveMemberUserId.mockReset();
   hoisted.resolveMemberUserId.mockResolvedValue("canonical-member");
+  hoisted.revalidatePath.mockClear();
+  hoisted.revalidateTag.mockClear();
 });
 
 async function loadUpload() {
@@ -118,6 +126,10 @@ async function loadHardDelete() {
 
 async function loadBrowse() {
   return (await import("@/actions/documents")).getDocumentsForBrowse;
+}
+
+async function loadRevalidateCache() {
+  return (await import("@/actions/documents")).revalidateProjectDocumentsCache;
 }
 
 function insertedExternalIds(): (string | null)[] {
@@ -657,5 +669,39 @@ describe("hardDeleteDocuments", () => {
 
     expect(r).toEqual({ count: 1 });
     expect(writeCalls[0]).toMatchObject({ table: "documents", op: "delete" });
+  });
+});
+
+// A fila de Atribuições deixou de ter unstable_cache (#664) e passou a ser lida
+// direto do banco, mas o Router Cache do cliente ainda pode servir a
+// renderização anterior — sem revalidar o path, um documento recém-excluído
+// seguiria aparecendo como atribuível para o coordenador. Asserir a rota aqui,
+// e não só confiar no efeito colateral de qualquer revalidatePath invalidar o
+// Router Cache inteiro, é o que dá vermelho se a chamada for removida ou
+// trocada por uma revalidação de escopo mais estreito.
+describe("revalidateProjectDocumentsCache — rotas invalidadas", () => {
+  it("revalida config, Atribuições e a tag de progresso", async () => {
+    const revalidateProjectDocumentsCache = await loadRevalidateCache();
+
+    await revalidateProjectDocumentsCache("proj-1");
+
+    expect(hoisted.revalidatePath.mock.calls.map(([p]) => p)).toEqual([
+      "/projects/proj-1/config/documents",
+      "/projects/proj-1/analyze/assignments",
+    ]);
+    expect(hoisted.revalidateTag).toHaveBeenCalledWith(
+      "project-proj-1-progress",
+      { expire: 60 },
+    );
+  });
+
+  it("não revalida a tag `-documents`, que perdeu o produtor com o unstable_cache", async () => {
+    const revalidateProjectDocumentsCache = await loadRevalidateCache();
+
+    await revalidateProjectDocumentsCache("proj-1");
+
+    expect(hoisted.revalidateTag.mock.calls.map(([t]) => t)).not.toContain(
+      "project-proj-1-documents",
+    );
   });
 });

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -8,8 +8,6 @@ import {
   resolveProjectMemberActor,
 } from "@/lib/auth";
 import { revalidatePath, revalidateTag } from "next/cache";
-
-const TAG_PROFILE = Object.freeze({ expire: 300 });
 import { createHash } from "crypto";
 import { sanitizeStoredAnswers } from "@/lib/response-snapshot";
 import type { DocumentMetadata, PydanticField } from "@/lib/types";
@@ -232,7 +230,9 @@ async function filterActiveExternalIdConflicts<
 export async function revalidateProjectDocumentsCache(projectId: string) {
   try {
     revalidatePath(`/projects/${projectId}/config/documents`);
-    revalidateTag(`project-${projectId}-documents`, TAG_PROFILE);
+    // A tag `project-${projectId}-documents` saiu junto com o unstable_cache da
+    // página de Atribuições (#664): sem produtor, revalidá-la seria invalidar
+    // nada e sugerir uma garantia que não existe.
     revalidateTag(`project-${projectId}-progress`, { expire: 60 });
   } catch (e) {
     console.error("[revalidateProjectDocuments] falha ao revalidar cache", e);

--- a/frontend/src/actions/documents.ts
+++ b/frontend/src/actions/documents.ts
@@ -211,9 +211,9 @@ async function filterActiveExternalIdConflicts<
   return { rows: safe, skippedExisting, skippedInBatch };
 }
 
-// Revalida o cache de documentos do projeto: o path dinâmico de config, a tag
-// da página cacheada de assignments e a tag de progresso (contagens de docs) —
-// o mesmo conjunto que excludeDocuments/restoreDocuments/hardDeleteDocuments
+// Revalida o cache de documentos do projeto: os paths dinâmicos de config e de
+// Atribuições, mais a tag de progresso (contagens de docs) — o mesmo conjunto
+// que excludeDocuments/restoreDocuments/hardDeleteDocuments
 // revalidam. Fonte única usada tanto pelo último chunk de uploadDocuments quanto
 // pelo recovery do hook quando um upload em chunks falha no meio.
 // Best-effort: uma falha de revalidação de cache não pode propagar como erro da
@@ -232,7 +232,11 @@ export async function revalidateProjectDocumentsCache(projectId: string) {
     revalidatePath(`/projects/${projectId}/config/documents`);
     // A tag `project-${projectId}-documents` saiu junto com o unstable_cache da
     // página de Atribuições (#664): sem produtor, revalidá-la seria invalidar
-    // nada e sugerir uma garantia que não existe.
+    // nada e sugerir uma garantia que não existe. A rota entra aqui pelo path,
+    // e não pela tag: a lista passou a ser lida direto do banco, mas o Router
+    // Cache do cliente ainda pode servir uma renderização anterior — é o que
+    // faria um documento recém-excluído seguir aparecendo como atribuível.
+    revalidatePath(`/projects/${projectId}/analyze/assignments`);
     revalidateTag(`project-${projectId}-progress`, { expire: 60 });
   } catch (e) {
     console.error("[revalidateProjectDocuments] falha ao revalidar cache", e);

--- a/frontend/src/actions/project-comments.ts
+++ b/frontend/src/actions/project-comments.ts
@@ -118,8 +118,9 @@ export async function requestDocumentExclusion(
   // O doc some imediatamente das filas de codificação e da Comparação.
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/analyze/compare`);
-  // Fila de Assignments é lida via unstable_cache tagged (5min TTL) — sem
-  // isto o coordenador vê o doc como atribuível por até 5min após o pedido.
+  // A fila de Assignments é lida direto do banco (#664), mas a rota continua
+  // precisando de revalidatePath para o coordenador não ver o doc como
+  // atribuível a partir de uma renderização já em cache do Router.
   await revalidateProjectDocumentsCache(projectId);
   return { success: true };
 }

--- a/frontend/src/actions/project-comments.ts
+++ b/frontend/src/actions/project-comments.ts
@@ -119,8 +119,9 @@ export async function requestDocumentExclusion(
   revalidatePath(`/projects/${projectId}/analyze/code`);
   revalidatePath(`/projects/${projectId}/analyze/compare`);
   // A fila de Assignments é lida direto do banco (#664), mas a rota continua
-  // precisando de revalidatePath para o coordenador não ver o doc como
-  // atribuível a partir de uma renderização já em cache do Router.
+  // precisando de revalidatePath — que `revalidateProjectDocumentsCache` faz
+  // explicitamente pelo path — para o coordenador não ver o doc como atribuível
+  // a partir de uma renderização já em cache do Router.
   await revalidateProjectDocumentsCache(projectId);
   return { success: true };
 }

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/__tests__/page.test.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/__tests__/page.test.tsx
@@ -22,10 +22,6 @@ function makeClient() {
   };
 }
 
-vi.mock("next/cache", () => ({
-  unstable_cache: (callback: () => unknown) => callback,
-}));
-
 vi.mock("next/navigation", () => ({
   notFound: () => {
     throw new Error("NEXT_NOT_FOUND");

--- a/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/assignments/page.tsx
@@ -1,4 +1,3 @@
-import { unstable_cache } from "next/cache";
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { createSupabaseAdmin } from "@/lib/supabase/admin";
 import { getProjectAccessContext } from "@/lib/auth";
@@ -18,27 +17,27 @@ import {
   type MemberActivationLink,
 } from "@/components/members/member-list-utils";
 
-function getCachedDocuments(projectId: string) {
-  return unstable_cache(
-    async () => {
-      const supabase = createSupabaseAdmin();
-      const { data, error } = await supabase
-        .from("documents")
-        .select("id, external_id, title")
-        .eq("project_id", projectId)
-        .is("excluded_at", null)
-        .is("exclusion_pending_at", null)
-        .order("created_at", { ascending: true });
-      if (error) {
-        console.error(
-          `[assignments] getCachedDocuments falhou (projeto ${projectId}): ${error.message}`,
-        );
-      }
-      return data || [];
-    },
-    [`assignments-docs-${projectId}`],
-    { tags: [`project-${projectId}-documents`], revalidate: 300 },
-  )();
+// Leitura direta, sem unstable_cache: o cache do Next vive no processo, e o
+// revalidateTag da Server Action só invalida a instância que a atendeu. Com
+// duas Machines (#664), a outra continuaria servindo a lista antiga por até
+// 5 min — um documento excluído seguiria aparecendo como atribuível. A query
+// lê três colunas com filtro indexado por project_id; não cachear custa menos
+// que servir dado errado.
+async function listAssignableDocuments(projectId: string) {
+  const supabase = createSupabaseAdmin();
+  const { data, error } = await supabase
+    .from("documents")
+    .select("id, external_id, title")
+    .eq("project_id", projectId)
+    .is("excluded_at", null)
+    .is("exclusion_pending_at", null)
+    .order("created_at", { ascending: true });
+  if (error) {
+    console.error(
+      `[assignments] listAssignableDocuments falhou (projeto ${projectId}): ${error.message}`,
+    );
+  }
+  return data || [];
 }
 
 function requireQueryRows<T>(result: {
@@ -106,7 +105,7 @@ export default async function AssignmentsPage({
   const supabase = await createSupabaseServer();
 
   const [documents, memberState, { data: project }, { data: rounds }] = await Promise.all([
-    getCachedDocuments(id),
+    listAssignableDocuments(id),
     getMembers(supabase, id),
     supabase.from("projects").select("current_round_id").eq("id", id).single(),
     supabase.from("rounds").select("id, label, created_at").eq("project_id", id).order("created_at", { ascending: false }),


### PR DESCRIPTION
Empilhado sobre o #663 (base `fix/fly-frontend-always-on`).

## Por que

O #663 impede que a Machine pare por ociosidade, o que tira o "acordar" do caminho crítico. Ele não desfaz, porém, a dependência de um host único: se o host reiniciar, entrar em manutenção ou ficar sem CPU no instante em que a Machine precise ser recriada, a produção cai de novo e não se recupera sozinha — foi exatamente o que ocorreu em 2026-08-10, quando o site só voltou depois de um `flyctl machine clone` manual para outro host.

Duas Machines eliminam esse ponto único de falha. **Custo: ~US$ 3–4/mês** pela Machine adicional (o frontend passa de ~4 para ~7–8/mês). A economia foi o que motivou o scale-to-zero do #644, então o número fica registrado aqui de propósito: o tradeoff é explícito, e não um default.

## O que mudou

O #644 fixou cardinalidade 1 como contrato fail-closed em cinco pontos, que precisam mudar juntos:

1. **`frontend/fly.toml`** — `min_machines_running = 2`. Com `auto_stop_machines = "off"` este valor é **inerte** (ele só age quando o autostop está ligado); fica como declaração de intenção e trava contra o retorno silencioso do scale-to-zero com cardinalidade 1. Quem cria as duas é o passo de escala do workflow.
2. **`.github/workflows/frontend-fly-deploy.yml`** — sai o `--ha=false`, que travava a cardinalidade em 1 do lado do `flyctl`; entra um `flyctl scale count 2` idempotente **entre o preflight e o deploy**. `flyctl deploy` não escala 1→2 em app existente, então a segunda Machine precisa nascer de um passo declarativo, sob pena de o postflight depender de alguém ter lembrado de rodar um comando. A posição não é acidental: `scale count` destrói excedentes, então antes do preflight ele apagaria em silêncio a divergência que o gate existe para recusar — inclusive uma Machine clonada à mão durante um incidente, que foi o que restaurou o site em 2026-08-10.
3. **`.github/scripts/check-frontend-fly-machines.sh`** — a mudança é estrutural, não numérica. O postflight indexava `.[0]` na validação de forma e consultava a saúde apenas de `.[0].id`; trocar só o número produziria um gate que **passa com duas Machines validando uma**. Agora ele quantifica sobre todas, na forma e no health. O preflight aceita 0–2 de propósito, para que o deploy consiga se auto-curar depois de perder uma Machine — mas recusa qualquer Machine **fora de `gru`**, e não só o excedente de contagem: como o `scale count` é escopado por região, uma em gru mais uma fora passaria pelo teto (2 ≤ 2) e a escala levaria o total a 3, criando depois do gate exatamente a divergência que ele existe para recusar. A região passou a ser verificada uma vez, antes do branch `pre`/`post`, em vez de duas vezes em pontos que podem divergir.
4. **`.github/scripts/test-frontend-fly-machine-contract.sh`** — ids parametrizados (o `CHECKS_JSON` é indexado por id: com ids repetidos, o caso "uma saudável e outra não" seria indistinguível de "as duas saudáveis"), casos de 2 invertidos de falha para sucesso, e o caso decisivo em que só a primeira Machine aparece no mapa de checks.
5. **`README.md`** e o comentário do hook no `.pre-commit-config.yaml`.

## Cache cross-request removido

`getCachedDocuments` era o único `unstable_cache` do frontend. O cache vive no processo e o `revalidateTag` só invalida a instância que atendeu a Server Action — com duas Machines, a outra serviria a lista de documentos desatualizada por até 5 min, de modo que um documento excluído seguiria aparecendo como atribuível. A query lê três colunas com filtro indexado por `project_id`, então a correção é remover o cache, e não encurtar a janela. A tag `project-<id>-documents` perde o produtor e sai junto, com a constante `TAG_PROFILE` que só ela usava.

## Verificação

**Prova do vermelho por mutação** — oito mutações, todas mortas pelo contrato:

| Mutação | Como morreu |
|---|---|
| postflight valida forma só de `.[0]` | `comando deveria ter falhado: run_checker post` |
| health lê o id de `.[0]` | `não foi possível ler o id de todas as 2 Machines` |
| health checa só `$ids[0]` | `comando deveria ter falhado: run_checker post` |
| health `all` → `any` | idem |
| health ignora `.status` | idem |
| workflow sem o passo de scale | `workflow sem ordem preflight -> scale -> deploy -> postflight` |
| `--ha=false` de volta | `--ha=false trava a cardinalidade em 1` |
| `min_machines_running` de volta a 1 | grep do `fly.toml` |

As três mutações de health foram necessárias porque a primeira delas morria pelo *guard de contagem de ids*, e não pela verificação que interessa medir.

**Guarda anti-reintrodução do cache**: com o `vi.mock("next/cache")` removido e o `unstable_cache` ainda presente, o teste da página falha com `Invariant: incrementalCache missing in unstable_cache`. É red legítimo, não asserção sobre o mock.

Demais gates: `flyctl config validate --strict` (`Configuration is valid`); suíte completa do frontend (199 arquivos, 2183 testes); `typecheck`, `lint` (0 erros), `lint:types`, `fallow`, `semgrep`, smoke Playwright e todos os hooks de pre-commit e pre-push.

## Ordem de merge

O gate novo tolera o estado antigo (preflight aceita 0–2), mas o gate **antigo** recusa o estado novo (`> 1`). Escalar o remoto antes do merge criaria uma janela em que qualquer push em `frontend/**` morre no preflight com a produção saudável. Portanto: **mergear o #663 primeiro**, depois este PR, e deixar o próprio workflow convergir — preflight vê 1, o passo de escala cria a segunda, o bluegreen atualiza as duas, o postflight exige as duas verdes.

Se o `scale count` falhar por capacidade em `gru`, o job fica vermelho **antes** do deploy e a produção segue no release anterior, no ar. Se o bluegreen deixar Machines órfãs, o próximo preflight recusa — fail-closed; o runbook é listar, destruir as órfãs e rerodar.

**Rollback é pareado**: reverter só o código deixa 2 Machines contra o preflight antigo e travaria todo deploy futuro. O correto é `git revert` **mais** `flyctl scale count 1 --region gru --yes`.

## Limites, ditos explicitamente

- **Anti-afinidade de host não é garantida nem verificável.** Nem `machine list --json` nem `machine status` expõem o host, então o contrato automatizado cobre cardinalidade e saúde. A separação é best-effort do scheduler do Fly.
- **O preflight ficou mais estrito e isso tem custo operacional**: um `machine clone` de incidente que caia fora de `gru` trava o deploy até a Machine ser movida ou destruída. É a recusa desejada — sem ela, o mesmo estado levaria a produção a três Machines e travaria todo deploy seguinte de qualquer forma, só que depois de mutar a produção.
- **Continua tudo em `gru`**: isto não protege contra queda de região.
- **O bluegreen com 2 Machines cria 2 novas antes de remover as antigas**, com pico transitório de 4 — a mesma capacidade de host que faltou no incidente. Se isso passar a falhar, `strategy = "rolling"` é a troca de uma linha (com o grep do teste no mesmo commit).
- **Backend fora de escopo**: `gui-analise-sistematica-api` também tem uma Machine só, mas roda LLM em `BackgroundTasks` com `kill_timeout = "5m"` e mantém rate limit em memória do processo — duplicar instâncias ali muda comportamento, não só custo. Merece issue própria.

## Fora do escopo declarado, sinalizado

- `CLAUDE.md` afirmava que "Vercel ainda e a producao". A queda de 2026-08-10 — em que o site inteiro caiu por causa da Machine do Fly — prova que a linha está defasada e é ativamente perigosa durante um incidente. Corrigi em uma linha.
- Não incluí a limpeza das tags `project-<id>-members` e `project-<id>-progress`, que invalidam tags sem produtor (~12 chamadas, `getCachedMembers` não existe mais) e do comentário de `frontend/src/lib/cache.ts` que descreve esse produtor inexistente. São ~13 arquivos sem relação causal com escalar Machines, e misturá-los faria o revert deste PR arrastar limpeza de cache junto. Vale issue separada.

Closes #664

