### PR TITLE
fix(fly): remove marcador de conflito que invalidou o fly.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,24 @@ default_install_hook_types: [pre-commit, pre-push, post-checkout]
 default_stages: [pre-commit]
 
 repos:
+  # Marcador de conflito nao resolvido em qualquer arquivo versionado. Entrou
+  # depois de 2026-08-10: a resolucao de um merge deixou um `=======` orfao em
+  # frontend/fly.toml e nada barrou — o contrato de Machines le so as diretivas
+  # (com os comentarios removidos por sed), entao passou verde, e o defeito so
+  # apareceu no deploy, quando o `flyctl` recusou a config com "row 49 column 1".
+  # Fail-closed na producao funcionou (o preflight abortou antes de mutar nada),
+  # mas o custo foi um deploy vermelho por algo que um grep pega no commit.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      # --assume-in-merge porque o default so inspeciona quando o repo esta em
+      # estado de merge (MERGE_HEAD presente), e o marcador sobrevive ao commit
+      # de merge: quem o carrega adiante e o commit seguinte, ja fora desse
+      # estado. Um `=======` de exatamente sete sinais sozinho na linha e o
+      # padrao — colide com titulo setext de Markdown, que nao usamos.
+      - id: check-merge-conflict
+        args: [--assume-in-merge]
+
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.30.1
     hooks:

--- a/frontend/fly.toml
+++ b/frontend/fly.toml
@@ -46,22 +46,6 @@ swap_size_mb = 512
   # depender da capacidade do host no instante de acordar. Com a Machine
   # sempre ligada, esse instante deixa de existir no caminho crítico.
   #
-=======
-  # Always-on: rollback do scale-to-zero habilitado no #644, na forma que
-  # aquele PR já previa ("restaurar auto_stop_machines = off e
-  # min_machines_running = 1, mantendo uma única Machine").
-  #
-  # Em 2026-08-10 a Machine parou por ociosidade e não conseguiu voltar: cada
-  # tentativa de acordá-la falhou com "could not reserve resource for machine:
-  # insufficient CPUs available to fulfill request on the current host" — o
-  # host de gru onde ela estava alocada ficou sem CPU livre. Como o proxy só
-  # tenta reacender sob demanda, o resultado foi um loop de start/crash e o
-  # site inteiro fora do ar até a Machine ser recriada em outro host.
-  #
-  # O custo do scale-to-zero, portanto, não é apenas o cold start medido: é
-  # depender da capacidade do host no instante de acordar. Com a Machine
-  # sempre ligada, esse instante deixa de existir no caminho crítico.
-  #
   # auto_start_machines segue true de propósito: é a rede que reacende a
   # Machine se ela parar por outro motivo (restart, manutenção do host).
   #


### PR DESCRIPTION
Hotfix do merge do #666.

## O que quebrou

A resolução do merge deixou um `=======` órfão e o bloco de comentário do always-on duplicado em `frontend/fly.toml`. O primeiro deploy pós-merge morreu no preflight, antes de qualquer mutação:

```
Error: failed loading app config from .../frontend/fly.toml: row 49 column 1
```

**A produção não caiu.** O fail-closed funcionou como projetado: `flyctl deploy` e o passo de escala foram pulados, e o site seguiu no release anterior. O custo foi um deploy vermelho, não indisponibilidade.

## Por que nenhum gate pegou

O contrato de Machines lê o `fly.toml` apenas pelas diretivas, com os comentários removidos por `sed` antes do `grep -Fxq` — um marcador solto entre comentários não altera nenhuma asserção, então a suíte passou verde com o arquivo inválido. E o `check-merge-conflict` não existia na configuração.

A guarda entra agora com `--assume-in-merge`: o default do hook só inspeciona enquanto o repo está em estado de merge (`MERGE_HEAD` presente), mas o marcador **sobrevive** ao commit de merge — quem o carrega adiante é o commit seguinte, já fora desse estado. Sem o argumento, a guarda não pegaria justamente o caso que aconteceu aqui.

## Prova do vermelho

Rodado contra o `fly.toml` exatamente como ele foi para a `main` em `afbde9eb`:

```
probe-fly.toml:49: Merge conflict string '=======' found
```

Contra o arquivo corrigido, passa. `flyctl config validate --strict` volta a dizer `Configuration is valid`, e o contrato de Machines segue verde.

## Nota de processo

O gate `e2e-smoke` foi pulado com o escape que o próprio hook documenta (`SKIP=e2e-smoke`), com autorização explícita: este diff toca apenas `fly.toml` e `.pre-commit-config.yaml`, nenhum arquivo que o Playwright exercita, e o smoke vinha falhando por compilação a frio do dev server — vítima rotando entre specs a cada run. Os demais gates rodaram normalmente.