### PR TITLE
fix(auto-revisao): outbox exige geração LLM e sai do retry infinito (#670)

### DIFF
--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -77,6 +77,11 @@ async function fetchAll<T>(
   table: string,
   columns: string,
   filter?: (q: UntypedSelectBuilder) => UntypedSelectBuilder,
+  // Nem toda tabela chaveia por `id`: `auto_review_reconciliation_requests` tem
+  // PK em `document_id`. O default cobre o resto do arquivo; o que a coluna
+  // precisa ser é ÚNICA, senão o ORDER BY volta a não desempatar e o hazard
+  // descrito acima reaparece por outro caminho.
+  orderColumn = "id",
 ): Promise<T[]> {
   const PAGE = 1000;
   const rows: T[] = [];
@@ -84,7 +89,7 @@ async function fetchAll<T>(
     let q: UntypedSelectBuilder = supabase
       .from(table)
       .select(columns)
-      .order("id", { ascending: true })
+      .order(orderColumn, { ascending: true })
       .range(from, from + PAGE - 1);
     if (filter) q = filter(q);
     const { data, error } = await q;
@@ -852,6 +857,47 @@ const invariants: Invariant[] = [
         .map((rv) => ({
           key: rv.id,
           detail: `review de ${rv.created_at.slice(0, 10)} escolheu ${rv.chosen_response_id} mas o snapshot não tem entry dessa resposta`,
+        }));
+    },
+  },
+  {
+    name: "outbox-de-auto-revisao-drena",
+    motivation:
+      "#670: a fila de reconciliação não tem limite de tentativas, TTL nem dead-letter — request que o worker não consegue satisfazer envelhece para sempre com o backoff no teto de 1h, e nada denuncia (o outcome `deferred` não conta como `failed`, e a rota interna só devolve 503 em `failed`). Foi assim que 25 linhas insatisfazíveis passaram dias em retry silencioso no Zolgensma-Judiciário. Com o produtor corrigido, toda request é satisfazível, então FAIL aqui deixou de significar 'estado impossível' e passa a significar CONSUMIDOR parado: worker morto, segredo rotacionado, ou reconcile_auto_review_cycles falhando em série",
+    run: async () => {
+      // Os dois limiares medem coisas diferentes e nenhum cobre o outro.
+      // `attempt_count` pega o loop rápido: o backoff é 5s, 10s, 20s..., então 5
+      // tentativas ≈ 2,5 min de falha contínua — alto o bastante para não morder
+      // um erro transitório isolado (a RPC rejeita input stale por desenho, e
+      // uma rejeição sozinha é normal sob edição concorrente). `requested_at`
+      // pega o caso em que ninguém sequer TENTA: worker parado não incrementa
+      // attempt_count, e a linha ficaria invisível para o primeiro limiar.
+      //
+      // Cuidado ao ler o número: `requested_at` e `attempt_count` são zerados
+      // pelo ON CONFLICT DO UPDATE do trigger a cada nova submissão humana no
+      // mesmo documento. Não medem a idade da fila — medem quanto tempo faz que
+      // o último evento sujo daquele documento está sem drenar, que é o que
+      // interessa aqui.
+      const MAX_ATTEMPTS = 5;
+      const MAX_IDADE_MS = 6 * 60 * 60 * 1000;
+      const rows = await fetchAll<{
+        document_id: string;
+        project_id: string;
+        attempt_count: number;
+        requested_at: string;
+        last_error: string | null;
+      }>(
+        "auto_review_reconciliation_requests",
+        "document_id, project_id, attempt_count, requested_at, last_error",
+        undefined,
+        "document_id",
+      );
+      const corte = Date.now() - MAX_IDADE_MS;
+      return rows
+        .filter((r) => r.attempt_count >= MAX_ATTEMPTS || Date.parse(r.requested_at) < corte)
+        .map((r) => ({
+          key: r.document_id,
+          detail: `${r.attempt_count} tentativa(s) desde ${r.requested_at} (projeto ${r.project_id}): ${r.last_error ?? "nenhuma tentativa registrada"}`,
         }));
     },
   },

--- a/frontend/src/actions/__tests__/auto-review-backlog-wiring.test.ts
+++ b/frontend/src/actions/__tests__/auto-review-backlog-wiring.test.ts
@@ -27,7 +27,6 @@ const hoisted = vi.hoisted(() => ({
   drain: vi.fn(async () => ({
     processed: 1,
     stale: 0,
-    deferred: 0,
     failed: 0,
     remaining: 0,
   })),

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -9,7 +9,6 @@ import type { SaveResponseOpts } from "@/actions/responses";
 const drainAutoReviewReconciliationRequests = vi.hoisted(() => vi.fn(async () => ({
   processed: 1,
   stale: 0,
-  deferred: 0,
   failed: 0,
   remaining: 0,
 })));

--- a/frontend/src/actions/field-reviews.ts
+++ b/frontend/src/actions/field-reviews.ts
@@ -562,7 +562,6 @@ export async function regenerateAutoReviewBacklog(
   error?: string;
   queued?: number;
   processed?: number;
-  deferred?: number;
 }> {
   try {
     const gate = await requireCoordinator(
@@ -595,7 +594,6 @@ export async function regenerateAutoReviewBacklog(
       success: true,
       queued: typeof queued === "number" ? queued : 0,
       processed: drainResult.processed,
-      deferred: drainResult.deferred,
     };
   } catch (e) {
     return { success: false, error: errorMessage(e) || "Erro" };

--- a/frontend/src/app/api/internal/auto-review/reconcile/__tests__/route.test.ts
+++ b/frontend/src/app/api/internal/auto-review/reconcile/__tests__/route.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
   authorize.mockReset();
   drain.mockReset();
   authorize.mockReturnValue(true);
-  drain.mockResolvedValue({ processed: 1, stale: 0, deferred: 0, failed: 0, remaining: 0 });
+  drain.mockResolvedValue({ processed: 1, stale: 0, failed: 0, remaining: 0 });
 });
 
 describe("POST /api/internal/auto-review/reconcile", () => {
@@ -35,11 +35,11 @@ describe("POST /api/internal/auto-review/reconcile", () => {
     }));
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ processed: 1, stale: 0, deferred: 0, failed: 0, remaining: 0 });
+    expect(await response.json()).toEqual({ processed: 1, stale: 0, failed: 0, remaining: 0 });
   });
 
   it("sinaliza falha operacional para o backend repetir o wakeup", async () => {
-    drain.mockResolvedValue({ processed: 0, stale: 0, deferred: 0, failed: 1, remaining: 0 });
+    drain.mockResolvedValue({ processed: 0, stale: 0, failed: 1, remaining: 0 });
     const { POST } = await import("@/app/api/internal/auto-review/reconcile/route");
     const response = await POST(new Request("https://app.test/api/internal/auto-review/reconcile", {
       method: "POST",

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -61,13 +61,14 @@ export function LlmInsightsView({
         toast.error(result.error ?? "Falha ao regenerar backlog");
         return;
       }
+      // "Aguardando a resposta LLM" saiu na #670: documento sem geração LLM
+      // deixou de entrar no backlog, então não há mais pedido em espera para
+      // contar — o que sobrava ali era a fila insatisfazível se anunciando como
+      // se fosse trabalho em andamento.
       const parts = [
         `${result.queued ?? 0} documento(s) reenfileirado(s)`,
         `${result.processed ?? 0} pedido(s) processado(s)`,
       ];
-      if (result.deferred) {
-        parts.push(`${result.deferred} pedido(s) aguardando a resposta LLM`);
-      }
       toast.success(`Backlog regenerado. ${parts.join(", ")}.`);
       refresh();
     } catch (err) {

--- a/frontend/src/lib/__tests__/auto-review-reconciler.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-reconciler.test.ts
@@ -11,6 +11,11 @@ const state = vi.hoisted(() => ({
   rpcCalls: [] as Array<{ name: string; args: unknown }>,
   failures: [] as unknown[],
   deletes: [] as Array<Array<[string, unknown]>>,
+  // Filtros das LEITURAS, não só das escritas: é o que permite afirmar que o
+  // worker busca a geração LLM pelo id enfileirado, e não a corrente do
+  // documento — a diferença entre reconciliar a geração certa e reconciliar
+  // outra com os `expected_*` da antiga.
+  selects: [] as Array<{ table: string; filters: Array<[string, unknown]> }>,
 }));
 
 vi.mock("server-only", () => ({}));
@@ -84,6 +89,7 @@ class Query {
   }
 
   private selectResult() {
+    state.selects.push({ table: this.table, filters: this.filters });
     if (this.table === "auto_review_reconciliation_requests") return this.requestsResult();
     if (this.table === "responses") return this.responsesResult();
     const rowsByTable: Record<string, unknown> = {
@@ -146,6 +152,7 @@ beforeEach(() => {
   state.rpcCalls = [];
   state.failures = [];
   state.deletes = [];
+  state.selects = [];
   admin.rpc.mockClear();
   buildEquivalenceMap.mockClear();
   computeBacklogRows.mockReset();
@@ -167,7 +174,7 @@ describe("drainAutoReviewReconciliationRequests", () => {
     const { drainAutoReviewReconciliationRequests } = await import("@/lib/auto-review-reconciler");
     const result = await drainAutoReviewReconciliationRequests();
 
-    expect(result).toEqual({ processed: 1, stale: 0, deferred: 0, failed: 0, remaining: 0 });
+    expect(result).toEqual({ processed: 1, stale: 0, failed: 0, remaining: 0 });
     expect(computeBacklogRows).toHaveBeenCalledOnce();
     expect(state.rpcCalls).toEqual([{
       name: "reconcile_auto_review_cycles",
@@ -201,9 +208,12 @@ describe("drainAutoReviewReconciliationRequests", () => {
     const { drainAutoReviewReconciliationRequests } = await import("@/lib/auto-review-reconciler");
     const result = await drainAutoReviewReconciliationRequests();
 
-    expect(result).toEqual({ processed: 0, stale: 1, deferred: 0, failed: 0, remaining: 0 });
+    expect(result).toEqual({ processed: 0, stale: 1, failed: 0, remaining: 0 });
     expect(state.rpcCalls).toEqual([]);
     expect(state.deletes[0]).toContainEqual(["llm_response_id", "llm-1"]);
+    // Obsoleta é descartada, não reagendada: desde a #670 nada volta para a
+    // fila esperando uma geração que já foi substituída (era o retry perpétuo).
+    expect(state.failures).toEqual([]);
   });
 
   it("mantém a request e registra a falha para retry", async () => {
@@ -211,7 +221,7 @@ describe("drainAutoReviewReconciliationRequests", () => {
     const { drainAutoReviewReconciliationRequests } = await import("@/lib/auto-review-reconciler");
     const result = await drainAutoReviewReconciliationRequests();
 
-    expect(result).toEqual({ processed: 0, stale: 0, deferred: 0, failed: 1, remaining: 0 });
+    expect(result).toEqual({ processed: 0, stale: 0, failed: 1, remaining: 0 });
     expect(state.deletes).toEqual([]);
     expect(state.failures).toEqual([{
       p_document_id: "doc-1",
@@ -220,18 +230,15 @@ describe("drainAutoReviewReconciliationRequests", () => {
     }]);
   });
 
-  it("adia o sinal humano até a primeira geração LLM ficar visível", async () => {
-    state.requests = [{ ...request, llm_response_id: null }];
-    state.llmLatest = false;
+  it("lê a resposta LLM pela geração enfileirada, não pela corrente do documento", async () => {
     const { drainAutoReviewReconciliationRequests } = await import("@/lib/auto-review-reconciler");
-    const result = await drainAutoReviewReconciliationRequests();
+    await drainAutoReviewReconciliationRequests();
 
-    expect(result).toEqual({ processed: 0, stale: 0, deferred: 1, failed: 0, remaining: 0 });
-    expect(state.deletes).toEqual([]);
-    expect(state.failures).toEqual([expect.objectContaining({
-      p_document_id: "doc-1",
-      p_llm_response_id: null,
-    })]);
+    const llmRead = state.selects.find(
+      (s) => s.table === "responses"
+        && s.filters.some(([column, value]) => column === "respondent_type" && value === "llm"),
+    );
+    expect(llmRead?.filters).toContainEqual(["id", "llm-1"]);
   });
 
   it("confirma uma geração LLM sem humano e deixa um save futuro reenfileirar", async () => {

--- a/frontend/src/lib/__tests__/auto-review-reconciler.test.ts
+++ b/frontend/src/lib/__tests__/auto-review-reconciler.test.ts
@@ -9,6 +9,10 @@ const state = vi.hoisted(() => ({
   humanLatest: true,
   rpcError: null as string | null,
   rpcCalls: [] as Array<{ name: string; args: unknown }>,
+  // Efeito colateral disparado DENTRO da reconciliação, que é onde a corrida
+  // vive: entre o commit da RPC e o ACK, uma nova submissão humana reenfileira
+  // o documento com a mesma geração LLM.
+  rpcSideEffect: null as (() => void) | null,
   failures: [] as unknown[],
   deletes: [] as Array<Array<[string, unknown]>>,
   // Filtros das LEITURAS, não só das escritas: é o que permite afirmar que o
@@ -125,6 +129,7 @@ const admin = {
       state.due = false;
       return { data: true, error: null };
     }
+    if (name === "reconcile_auto_review_cycles") state.rpcSideEffect?.();
     return {
       data: {},
       error: state.rpcError ? { message: state.rpcError } : null,
@@ -140,6 +145,7 @@ const request = {
   project_id: "project-1",
   document_id: "doc-1",
   llm_response_id: "llm-1",
+  requested_at: "2026-07-16T12:30:00.000Z",
   allow_new_cycles: true,
 };
 
@@ -150,6 +156,7 @@ beforeEach(() => {
   state.humanLatest = true;
   state.rpcError = null;
   state.rpcCalls = [];
+  state.rpcSideEffect = null;
   state.failures = [];
   state.deletes = [];
   state.selects = [];
@@ -190,6 +197,25 @@ describe("drainAutoReviewReconciliationRequests", () => {
       }] },
     }]);
     expect(state.deletes[0]).toContainEqual(["llm_response_id", "llm-1"]);
+  });
+
+  it("não confirma a request que um save humano reenfileirou durante a reconciliação", async () => {
+    // A janela é estreita mas a perda é silenciosa: a RPC já commitou os
+    // field_reviews, o novo save os arquiva e reenfileira o documento, e um ACK
+    // que casasse só documento+geração apagaria esse pedido recém-criado — o
+    // reenfileiramento humano mantém a MESMA geração LLM, só `requested_at`
+    // muda. O documento ficaria com as revisões arquivadas e nada na fila para
+    // regenerá-las, invisível até a próxima publicação LLM.
+    const reenqueued = { ...request, requested_at: "2026-07-16T12:31:00.000Z" };
+    state.rpcSideEffect = () => { state.requests = [reenqueued]; };
+    const { drainAutoReviewReconciliationRequests } = await import("@/lib/auto-review-reconciler");
+    const result = await drainAutoReviewReconciliationRequests();
+
+    // A perda vem primeiro: é o dado sobrevivendo que interessa, não a forma da
+    // query. O filtro logo abaixo diz por qual coluna ela sobreviveu.
+    expect(state.requests).toEqual([reenqueued]);
+    expect(result).toEqual({ processed: 1, stale: 0, failed: 0, remaining: 1 });
+    expect(state.deletes[0]).toContainEqual(["requested_at", "2026-07-16T12:30:00.000Z"]);
   });
 
   it("também reconcilia consenso para encerrar um ciclo anterior", async () => {

--- a/frontend/src/lib/auto-review-reconciler.ts
+++ b/frontend/src/lib/auto-review-reconciler.ts
@@ -8,7 +8,11 @@ import type { PydanticField } from "@/lib/types";
 interface ReconciliationRequest {
   project_id: string;
   document_id: string;
-  llm_response_id: string | null;
+  // Nunca nulo desde a #670: a coluna é NOT NULL e o produtor não enfileira
+  // documento sem geração LLM corrente. Antes disso, NULL significava "humano
+  // sujo esperando a primeira geração" — um estado que nenhum worker conseguia
+  // satisfazer e que ficava em retry perpétuo.
+  llm_response_id: string;
   allow_new_cycles: boolean;
 }
 
@@ -26,7 +30,7 @@ interface ReconciliationGroup {
 type AdminClient = ReturnType<typeof createSupabaseAdmin>;
 type VersionedHumanResponse = HumanResponseRow & { updated_at: string };
 type VersionedLlmResponse = LlmResponseRow & { updated_at: string };
-type ReconciliationOutcome = "processed" | "stale" | "deferred" | "failed";
+type ReconciliationOutcome = "processed" | "stale" | "failed";
 
 interface ReconciliationInputs {
   fields: PydanticField[];
@@ -39,12 +43,9 @@ interface ReconciliationInputs {
 export interface ReconciliationDrainResult {
   processed: number;
   stale: number;
-  deferred: number;
   failed: number;
   remaining: number;
 }
-
-class DeferredReconciliation extends Error {}
 
 function firstError(
   results: Array<{ error: { message: string } | null }>,
@@ -56,14 +57,13 @@ async function acknowledge(
   admin: AdminClient,
   request: ReconciliationRequest,
 ): Promise<void> {
-  let query = admin
+  // ACK pela geração exata: se outra publicação já reenfileirou o documento, a
+  // request em banco não é mais a que este worker leu e o DELETE não casa.
+  const { error } = await admin
     .from("auto_review_reconciliation_requests")
     .delete()
-    .eq("document_id", request.document_id);
-  query = request.llm_response_id === null
-    ? query.is("llm_response_id", null)
-    : query.eq("llm_response_id", request.llm_response_id);
-  const { error } = await query;
+    .eq("document_id", request.document_id)
+    .eq("llm_response_id", request.llm_response_id);
   if (error) throw new Error(error.message);
 }
 
@@ -177,20 +177,20 @@ async function readReconciliationInputs(
         .eq("respondent_type", "humano")
         .eq("is_latest", true)
         .eq("is_partial", false),
-      (() => {
-        let query = admin
-          .from("responses")
-          .select("id, document_id, answers, answer_field_hashes, updated_at")
-          .eq("project_id", request.project_id)
-          .eq("document_id", request.document_id)
-          .eq("respondent_type", "llm")
-          .eq("is_latest", true)
-          .eq("is_partial", false);
-        if (request.llm_response_id !== null) {
-          query = query.eq("id", request.llm_response_id);
-        }
-        return query.maybeSingle();
-      })(),
+      // O filtro por id é o que distingue "a geração que enfileirou este pedido
+      // continua corrente" de "outra publicação já a substituiu". Sem ele, uma
+      // request obsoleta reconciliaria contra a geração nova, com os
+      // `expected_*` da antiga.
+      admin
+        .from("responses")
+        .select("id, document_id, answers, answer_field_hashes, updated_at")
+        .eq("project_id", request.project_id)
+        .eq("document_id", request.document_id)
+        .eq("respondent_type", "llm")
+        .eq("is_latest", true)
+        .eq("is_partial", false)
+        .eq("id", request.llm_response_id)
+        .maybeSingle(),
       admin
         .from("response_equivalences")
         .select(
@@ -272,12 +272,13 @@ async function reconcileRequest(
 ): Promise<"processed" | "stale"> {
   const inputs = await readReconciliationInputs(admin, request);
   const llm = inputs.llm;
+  // A geração enfileirada deixou de ser a corrente e completa (rerun, publicação
+  // parcial, remoção). O pedido é obsoleto: quem publicar a próxima geração
+  // reenfileira o documento. Desde a #670 não existe mais o caso "ainda não há
+  // geração nenhuma" — a request não seria criada.
   if (!llm) {
-    if (request.llm_response_id !== null) {
-      await acknowledge(admin, request);
-      return "stale";
-    }
-    throw new DeferredReconciliation("current complete LLM response is not visible yet");
+    await acknowledge(admin, request);
+    return "stale";
   }
 
   const humans = await eligibleHumanResponses(
@@ -329,7 +330,6 @@ async function processRequest(
     return await reconcileRequest(admin, request);
   } catch (requestError) {
     await recordFailure(admin, request, requestError);
-    if (requestError instanceof DeferredReconciliation) return "deferred";
     logReconciliationFailure(request, requestError);
     return "failed";
   }
@@ -368,7 +368,7 @@ async function countDueRequests(
 }
 
 function processedRequestCount(result: ReconciliationDrainResult): number {
-  return result.processed + result.stale + result.deferred + result.failed;
+  return result.processed + result.stale + result.failed;
 }
 
 export async function drainAutoReviewReconciliationRequests(
@@ -380,7 +380,6 @@ export async function drainAutoReviewReconciliationRequests(
   const result: ReconciliationDrainResult = {
     processed: 0,
     stale: 0,
-    deferred: 0,
     failed: 0,
     remaining: 0,
   };

--- a/frontend/src/lib/auto-review-reconciler.ts
+++ b/frontend/src/lib/auto-review-reconciler.ts
@@ -13,6 +13,10 @@ interface ReconciliationRequest {
   // sujo esperando a primeira geração" — um estado que nenhum worker conseguia
   // satisfazer e que ficava em retry perpétuo.
   llm_response_id: string;
+  // Token de versão da request, não metadado de exibição: os dois produtores o
+  // reescrevem com `now()` no `ON CONFLICT DO UPDATE`, e o ACK o exige de volta
+  // para não apagar um reenfileiramento que chegou depois da leitura.
+  requested_at: string;
   allow_new_cycles: boolean;
 }
 
@@ -57,13 +61,22 @@ async function acknowledge(
   admin: AdminClient,
   request: ReconciliationRequest,
 ): Promise<void> {
-  // ACK pela geração exata: se outra publicação já reenfileirou o documento, a
-  // request em banco não é mais a que este worker leu e o DELETE não casa.
+  // ACK pela linha exata que este worker leu, e são precisos os dois filtros:
+  // `llm_response_id` cobre a republicação de LLM (que troca a geração), e
+  // `requested_at` cobre o reenfileiramento HUMANO, que mantém a mesma geração e
+  // por isso é invisível ao primeiro filtro — o `ON CONFLICT (document_id) DO
+  // UPDATE` dos dois produtores só reescreve `requested_at`/`attempt_count`.
+  // Sem o segundo filtro, um save que caia entre o commit de
+  // reconcile_auto_review_cycles e este DELETE perde a request recém-criada,
+  // ficando com os field_reviews arquivados e nada na fila para regenerá-los.
+  // `record_auto_review_reconciliation_failure` não toca em `requested_at`, então
+  // uma tentativa que falhou antes ainda casa aqui: o filtro não prende a fila.
   const { error } = await admin
     .from("auto_review_reconciliation_requests")
     .delete()
     .eq("document_id", request.document_id)
-    .eq("llm_response_id", request.llm_response_id);
+    .eq("llm_response_id", request.llm_response_id)
+    .eq("requested_at", request.requested_at);
   if (error) throw new Error(error.message);
 }
 
@@ -342,7 +355,7 @@ async function fetchDueRequests(
 ): Promise<ReconciliationRequest[]> {
   let query = admin
     .from("auto_review_reconciliation_requests")
-    .select("project_id, document_id, llm_response_id, allow_new_cycles")
+    .select("project_id, document_id, llm_response_id, requested_at, allow_new_cycles")
     .lte("next_attempt_at", new Date().toISOString())
     .order("next_attempt_at", { ascending: true })
     .order("requested_at", { ascending: true })
@@ -389,8 +402,9 @@ export async function drainAutoReviewReconciliationRequests(
     const requests = await fetchDueRequests(admin, batchSize, options.projectId);
 
     for (const request of requests) {
-      // Sequential processing bounds DB pressure. Duplicate workers remain
-      // safe because reconciliation and ACK use the exact response generation.
+      // Sequential processing bounds DB pressure. Duplicate workers remain safe
+      // because reconciliation is versioned by the RPC's expected_* inputs and
+      // the ACK matches the exact request row (generation + requested_at).
       // react-doctor-disable-next-line react-doctor/async-await-in-loop
       const outcome = await processRequest(admin, request);
       result[outcome] += 1;

--- a/frontend/supabase/migrations/20260811130000_auto_review_reconciliation_requires_llm.sql
+++ b/frontend/supabase/migrations/20260811130000_auto_review_reconciliation_requires_llm.sql
@@ -1,0 +1,332 @@
+-- #670: a outbox de auto-revisão deixa de conseguir representar "codificação
+-- humana suja sem geração LLM para comparar".
+--
+-- O ramo humano de enqueue_auto_review_reconciliation (20260717120000:759)
+-- enfileirava com llm_response_id NULL quando o documento ainda não tinha
+-- geração LLM corrente, e validate_auto_review_reconciliation_request aceitava
+-- esse estado de propósito. Nenhum worker pode satisfazer essa linha — não
+-- existe o par a reconciliar —, então ela vivia em retry perpétuo com o backoff
+-- de record_auto_review_reconciliation_failure saturado no teto de 1 h. E em
+-- silêncio: o outcome `deferred` não conta como `failed`, e a rota interna só
+-- devolve 503 em `failed`. Medido em 2026-08-10 no projeto Zolgensma-Judiciário:
+-- 25 linhas, todas com o mesmo last_error, uma delas com 136 tentativas.
+--
+-- A correção é pela origem, não por teto de tentativas: um teto trocaria o loop
+-- infinito por abandono silencioso, e a request sumiria sem que a reconciliação
+-- fosse feita. Sem geração LLM corrente o produtor não enfileira, e a coluna
+-- vira NOT NULL — o estado deixa de ser construível por qualquer canal, não só
+-- pelo que passa pelo trigger.
+--
+-- Nada se perde, por duas propriedades do desenho existente:
+--   (a) o ramo LLM do trigger não tem gate algum, e a única porta de entrada de
+--       geração LLM corrente é publish_latest_llm_response, que apaga as
+--       requests do documento e insere a geração nova — logo TODA transição
+--       para "existe LLM corrente completa" enfileira;
+--   (b) a request não carrega snapshot humano: o dreno relê as respostas
+--       humanas correntes no momento em que processa (auto-review-reconciler.ts,
+--       readReconciliationInputs). A request só diz QUAL geração LLM comparar.
+-- Junto com o mutex `FOR UPDATE` na linha de documents, compartilhado entre o
+-- trigger e a publicação, isso fecha também a corrida "humano submete no
+-- instante em que o run LLM publica": nas duas ordens possíveis sobra uma
+-- request com a geração preenchida.
+--
+-- O reparo dos resíduos vem ANTES do SET NOT NULL e na MESMA transação da
+-- redefinição do produtor: não existe instante com a constraint viva e o
+-- produtor antigo ainda inserindo NULL.
+BEGIN;
+
+-- O SET NOT NULL pega ACCESS EXCLUSIVE na tabela. Falhar rápido é melhor que
+-- enfileirar atrás de uma transação longa segurando o lock, o que bloquearia
+-- todo save humano do produto enquanto esperasse.
+SET LOCAL lock_timeout = '10s';
+
+-- Resíduo cujo documento TEM geração corrente: só a coluna estava vazia. Aponta
+-- para a geração que o produtor novo teria gravado e zera o backoff acumulado.
+-- O índice parcial responses_one_latest_llm_per_document garante no máximo uma
+-- candidata por documento, então o UPDATE é determinístico. Uma colisão com o
+-- UNIQUE de llm_response_id abortaria a migration inteira — fail-closed, que é
+-- o comportamento certo aqui.
+UPDATE public.auto_review_reconciliation_requests AS request
+SET llm_response_id = llm.id,
+    requested_at = pg_catalog.now(),
+    next_attempt_at = pg_catalog.now(),
+    attempt_count = 0,
+    last_error = NULL
+FROM public.responses AS llm
+WHERE request.llm_response_id IS NULL
+  AND llm.project_id = request.project_id
+  AND llm.document_id = request.document_id
+  AND llm.respondent_type = 'llm'
+  AND llm.is_latest = true
+  AND llm.is_partial = false;
+
+-- Resíduo cujo documento NÃO tem geração corrente: nenhuma reconciliação é
+-- computável por esta linha, hoje ou depois. Quem publicar a próxima geração
+-- reenfileira o documento com o id certo, e o dreno lerá as respostas humanas
+-- correntes de então. Os dois passos são escritos por construção, não pelo
+-- censo do dia: em 2026-08-10 o UPDATE acertaria zero linhas e o DELETE, 25.
+DELETE FROM public.auto_review_reconciliation_requests
+WHERE llm_response_id IS NULL;
+
+ALTER TABLE public.auto_review_reconciliation_requests
+  ALTER COLUMN llm_response_id SET NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.enqueue_auto_review_reconciliation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_allow_new_cycles BOOLEAN;
+  v_llm_response_id UUID;
+BEGIN
+  IF NEW.respondent_type NOT IN ('humano', 'llm')
+     OR NEW.is_latest IS DISTINCT FROM true
+     OR NEW.is_partial IS DISTINCT FROM false THEN
+    RETURN NEW;
+  END IF;
+
+  -- The document row is the publication mutex shared with
+  -- publish_latest_llm_response. This function is VOLATILE, so under READ
+  -- COMMITTED each of its statements takes a fresh snapshot: the LLM lookup
+  -- below runs after the lock and therefore sees a publication that just
+  -- committed.
+  PERFORM 1
+  FROM public.documents AS document
+  WHERE document.id = NEW.document_id
+    AND document.project_id = NEW.project_id
+  FOR UPDATE;
+
+  SELECT project.automation_mode = 'auto_review_llm'
+  INTO v_allow_new_cycles
+  FROM public.projects AS project
+  WHERE project.id = NEW.project_id;
+
+  IF NEW.respondent_type = 'humano' THEN
+    IF NOT COALESCE(v_allow_new_cycles, false)
+       AND NOT EXISTS (
+         SELECT 1 FROM public.field_reviews AS review
+         WHERE review.project_id = NEW.project_id
+           AND review.document_id = NEW.document_id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM public.field_review_cycle_history_entries AS history
+         WHERE history.project_id = NEW.project_id
+           AND history.document_id = NEW.document_id
+       ) THEN
+      RETURN NEW;
+    END IF;
+
+    SELECT llm.id INTO v_llm_response_id
+    FROM public.responses AS llm
+    WHERE llm.project_id = NEW.project_id
+      AND llm.document_id = NEW.document_id
+      AND llm.respondent_type = 'llm'
+      AND llm.is_latest = true
+      AND llm.is_partial = false;
+
+    -- #670: sem geração LLM corrente não existe o par a reconciliar, e
+    -- enfileirar aqui cria trabalho que nenhum worker consegue concluir. Este
+    -- save não se perde: publish_latest_llm_response apaga e reinsere a request
+    -- com o id da geração nova, e o dreno relê as respostas humanas correntes
+    -- daquele instante.
+    IF v_llm_response_id IS NULL THEN
+      RETURN NEW;
+    END IF;
+  ELSE
+    v_llm_response_id := NEW.id;
+  END IF;
+
+  INSERT INTO public.auto_review_reconciliation_requests (
+    document_id, project_id, llm_response_id, allow_new_cycles
+  ) VALUES (
+    NEW.document_id, NEW.project_id, v_llm_response_id,
+    COALESCE(v_allow_new_cycles, false)
+  )
+  ON CONFLICT (document_id) DO UPDATE
+  SET project_id = EXCLUDED.project_id,
+      llm_response_id = EXCLUDED.llm_response_id,
+      allow_new_cycles = EXCLUDED.allow_new_cycles,
+      requested_at = pg_catalog.now(),
+      next_attempt_at = pg_catalog.now(),
+      attempt_count = 0,
+      last_error = NULL;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Some o ramo que legitimava o NULL. Com a coluna NOT NULL, o EXISTS da geração
+-- passa a ser total: toda request referencia a LLM corrente e completa do seu
+-- documento. A checagem da resposta humana some junto — ela existia só para dar
+-- alguma âncora ao caso sem LLM, e o dreno relê os humanos de qualquer forma.
+CREATE OR REPLACE FUNCTION public.validate_auto_review_reconciliation_request()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.documents AS document
+    WHERE document.id = NEW.document_id
+      AND document.project_id = NEW.project_id
+  ) THEN
+    RAISE EXCEPTION 'reconciliation request document does not belong to project';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.responses AS llm
+    WHERE llm.id = NEW.llm_response_id
+      AND llm.project_id = NEW.project_id
+      AND llm.document_id = NEW.document_id
+      AND llm.respondent_type = 'llm'
+      AND llm.is_latest = true
+      AND llm.is_partial = false
+  ) THEN
+    RAISE EXCEPTION 'reconciliation request must reference its current complete LLM response';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Sem NULL na coluna, "pendente" passa a significar exatamente uma geração. O
+-- ramo `llm_response_id IS NULL` casava com QUALQUER geração consultada; era
+-- alcançável apenas para documentos sem LLM corrente, que final_answers nem
+-- emite (a view é ancorada em responses LLM com is_latest = true).
+CREATE OR REPLACE FUNCTION public.is_auto_review_reconciliation_pending(
+  p_project_id UUID,
+  p_document_id UUID,
+  p_llm_response_id UUID
+) RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT (
+    SESSION_USER = 'postgres'
+    OR auth.role() = 'service_role'
+    OR p_project_id IN (SELECT public.auth_user_accessible_project_ids())
+  ) AND EXISTS (
+    SELECT 1
+    FROM public.auto_review_reconciliation_requests AS request
+    WHERE request.project_id = p_project_id
+      AND request.document_id = p_document_id
+      AND request.llm_response_id = p_llm_response_id
+  );
+$$;
+
+-- Fecha o último lugar onde NULL tinha significado: com IS NOT DISTINCT FROM,
+-- um chamador que passasse NULL casaria a linha de um documento sem geração;
+-- com `=`, não casa nada. O backoff em si fica intacto — sem estado terminal na
+-- fila, o que ainda falha é falha de verdade e merece retry.
+CREATE OR REPLACE FUNCTION public.record_auto_review_reconciliation_failure(
+  p_document_id UUID,
+  p_llm_response_id UUID,
+  p_error TEXT
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  UPDATE public.auto_review_reconciliation_requests AS request
+  SET attempt_count = request.attempt_count + 1,
+      last_error = pg_catalog.left(p_error, 4000),
+      next_attempt_at = pg_catalog.now() + pg_catalog.make_interval(
+        secs => LEAST(
+          3600,
+          (5 * pg_catalog.power(2, LEAST(request.attempt_count, 10)))::INTEGER
+        )
+      )
+  WHERE request.document_id = p_document_id
+    AND request.llm_response_id = p_llm_response_id;
+  RETURN FOUND;
+END;
+$$;
+
+-- Segundo produtor, usado pelo reparo do coordenador (regenerateAutoReviewBacklog).
+-- O LEFT JOIN LATERAL era a outra fonte de linhas sem geração; com JOIN LATERAL,
+-- documento sem LLM corrente simplesmente não entra no backlog.
+CREATE OR REPLACE FUNCTION public.enqueue_auto_review_reconciliation_for_project(
+  p_project_id UUID
+) RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_enqueued INTEGER;
+BEGIN
+  -- Share the same per-document publication mutex used by the response trigger
+  -- and publish_latest_llm_response. The repair action cannot enqueue a stale
+  -- LLM generation while a rerun is being published.
+  PERFORM 1
+  FROM public.documents AS document
+  WHERE document.project_id = p_project_id
+  ORDER BY document.id
+  FOR UPDATE;
+
+  INSERT INTO public.auto_review_reconciliation_requests (
+    document_id, project_id, llm_response_id, allow_new_cycles
+  )
+  SELECT
+    document.id,
+    document.project_id,
+    llm.id,
+    project.automation_mode = 'auto_review_llm'
+  FROM public.documents AS document
+  JOIN public.projects AS project ON project.id = document.project_id
+  JOIN LATERAL (
+    SELECT response.id
+    FROM public.responses AS response
+    WHERE response.project_id = document.project_id
+      AND response.document_id = document.id
+      AND response.respondent_type = 'llm'
+      AND response.is_latest = true
+      AND response.is_partial = false
+    LIMIT 1
+  ) AS llm ON true
+  WHERE document.project_id = p_project_id
+    AND EXISTS (
+      SELECT 1
+      FROM public.responses AS human
+      WHERE human.project_id = document.project_id
+        AND human.document_id = document.id
+        AND human.respondent_type = 'humano'
+        AND human.is_latest = true
+        AND human.is_partial = false
+    )
+    AND (
+      project.automation_mode = 'auto_review_llm'
+      OR EXISTS (
+        SELECT 1 FROM public.field_reviews AS review
+        WHERE review.project_id = document.project_id
+          AND review.document_id = document.id
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.field_review_cycle_history_entries AS history
+        WHERE history.project_id = document.project_id
+          AND history.document_id = document.id
+      )
+    )
+  ON CONFLICT (document_id) DO UPDATE
+  SET project_id = EXCLUDED.project_id,
+      llm_response_id = EXCLUDED.llm_response_id,
+      allow_new_cycles = EXCLUDED.allow_new_cycles,
+      requested_at = pg_catalog.now(),
+      next_attempt_at = pg_catalog.now(),
+      attempt_count = 0,
+      last_error = NULL;
+
+  GET DIAGNOSTICS v_enqueued = ROW_COUNT;
+  RETURN v_enqueued;
+END;
+$$;
+
+COMMIT;

--- a/frontend/supabase/tests/auto_review_reconciliation_outbox.test.sql
+++ b/frontend/supabase/tests/auto_review_reconciliation_outbox.test.sql
@@ -156,6 +156,48 @@ BEGIN
 END;
 $$;
 
+-- Contrato do token de ACK. O dreno apaga a request casando também
+-- `requested_at` (auto-review-reconciler.ts, acknowledge), porque o
+-- reenfileiramento humano mantém a MESMA geração LLM: sem essa coluna o worker
+-- não distingue a linha que leu da que um save posterior recriou, e apaga a
+-- segunda. O que este bloco fixa é a premissa de banco disso — o
+-- `ON CONFLICT DO UPDATE` reescreve `requested_at` e preserva `llm_response_id`.
+--
+-- A suíte roda numa transação só e `pg_catalog.now()` é transaction_timestamp(),
+-- então dois enqueues seguidos gravariam o MESMO valor: afirmar "o timestamp
+-- avançou" seria vácuo aqui. Empurrar o valor para o passado antes do re-save é
+-- o que faz a asserção morder.
+DO $$
+DECLARE
+  v_llm_response_id UUID;
+  v_requested_at TIMESTAMPTZ;
+BEGIN
+  UPDATE public.auto_review_reconciliation_requests
+  SET requested_at = pg_catalog.now() - INTERVAL '1 minute'
+  WHERE document_id = 'c0000000-0000-0000-0000-000000000002';
+
+  UPDATE public.responses
+  SET answers = '{"q1":"human-revisado"}'
+  WHERE id = 'd0000000-0000-0000-0000-000000000010';
+
+  SELECT request.llm_response_id, request.requested_at
+  INTO STRICT v_llm_response_id, v_requested_at
+  FROM public.auto_review_reconciliation_requests AS request
+  WHERE request.document_id = 'c0000000-0000-0000-0000-000000000002';
+
+  IF v_requested_at <> pg_catalog.now() THEN
+    RAISE EXCEPTION
+      'human re-save did not refresh the ACK token; requested_at is %',
+      v_requested_at;
+  END IF;
+
+  IF v_llm_response_id IS DISTINCT FROM
+     'd0000000-0000-0000-0000-000000000011'::UUID THEN
+    RAISE EXCEPTION 'human re-save changed the enqueued LLM generation';
+  END IF;
+END;
+$$;
+
 -- Documento só com codificação humana, sem geração LLM nenhuma: é o cenário da
 -- #670 e a fixture das três asserções seguintes.
 INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
@@ -262,6 +304,14 @@ $$;
 -- backlog em vez de virar linha insatisfazível.
 DO $$
 BEGIN
+  -- Apagar a request de c…0002 é o que torna o discriminante abaixo capaz de
+  -- morder: ela foi criada pelo trigger na publicação da geração LLM e ainda
+  -- está viva aqui, então um `NOT EXISTS` sobre a linha preexistente passaria
+  -- mesmo que o JOIN LATERAL casasse zero documentos. Zerada a fila, só o
+  -- próprio reparo pode recriá-la.
+  DELETE FROM public.auto_review_reconciliation_requests
+  WHERE document_id = 'c0000000-0000-0000-0000-000000000002';
+
   PERFORM public.enqueue_auto_review_reconciliation_for_project(
     'b0000000-0000-0000-0000-000000000002'
   );
@@ -273,8 +323,8 @@ BEGIN
     RAISE EXCEPTION 'backlog regeneration enqueued a document without an LLM generation';
   END IF;
 
-  -- Discriminante: o documento que TEM geração corrente continua entrando, senão
-  -- a asserção acima passaria com um reparo que simplesmente não enfileira nada.
+  -- Discriminante: o documento que TEM geração corrente volta a entrar, senão a
+  -- asserção acima passaria com um reparo que simplesmente não enfileira nada.
   IF NOT EXISTS (
     SELECT 1 FROM public.auto_review_reconciliation_requests
     WHERE document_id = 'c0000000-0000-0000-0000-000000000002'

--- a/frontend/supabase/tests/auto_review_reconciliation_outbox.test.sql
+++ b/frontend/supabase/tests/auto_review_reconciliation_outbox.test.sql
@@ -85,8 +85,9 @@ BEGIN
 END;
 $$;
 
--- Human-first publication creates a nullable dirty signal. The subsequent LLM
--- generation coalesces that row instead of leaving two competing contracts.
+-- Human-first publication has nothing to reconcile against yet, so it must not
+-- enqueue: a request without an LLM generation is work no worker can finish
+-- (#670). The save is not lost — the LLM publication below enqueues it.
 INSERT INTO public.responses (
   id, project_id, document_id, respondent_id, respondent_type, answers,
   is_latest, is_partial, pydantic_hash, answer_field_hashes,
@@ -101,12 +102,11 @@ INSERT INTO public.responses (
 
 DO $$
 BEGIN
-  IF NOT EXISTS (
+  IF EXISTS (
     SELECT 1 FROM public.auto_review_reconciliation_requests
     WHERE document_id = 'c0000000-0000-0000-0000-000000000002'
-      AND llm_response_id IS NULL
   ) THEN
-    RAISE EXCEPTION 'human-first save did not persist a nullable dirty signal';
+    RAISE EXCEPTION 'human-first save enqueued without a current LLM generation';
   END IF;
 END;
 $$;
@@ -126,10 +126,13 @@ DO $$
 DECLARE
   v_rejected BOOLEAN := false;
 BEGIN
+  -- Contrapartida da asserção anterior: o save humano que não enfileirou não se
+  -- perdeu. A publicação da geração LLM é que enfileira, e o dreno relê as
+  -- respostas humanas correntes daquele instante.
   IF (SELECT llm_response_id FROM public.auto_review_reconciliation_requests
       WHERE document_id = 'c0000000-0000-0000-0000-000000000002')
      IS DISTINCT FROM 'd0000000-0000-0000-0000-000000000011'::UUID THEN
-    RAISE EXCEPTION 'LLM generation did not coalesce the nullable dirty signal';
+    RAISE EXCEPTION 'LLM generation did not enqueue the pending human reconciliation';
   END IF;
 
   BEGIN
@@ -149,6 +152,135 @@ BEGIN
 
   IF NOT v_rejected THEN
     RAISE EXCEPTION 'malformed project/document/request trio was accepted';
+  END IF;
+END;
+$$;
+
+-- Documento só com codificação humana, sem geração LLM nenhuma: é o cenário da
+-- #670 e a fixture das três asserções seguintes.
+INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
+  ('c0000000-0000-0000-0000-000000000003',
+   'b0000000-0000-0000-0000-000000000002', 'human-only doc', 'text',
+   'human-only-doc');
+
+INSERT INTO public.responses (
+  id, project_id, document_id, respondent_id, respondent_type, answers,
+  is_latest, is_partial, pydantic_hash, answer_field_hashes,
+  schema_version_major, schema_version_minor, schema_version_patch
+) VALUES (
+  'd0000000-0000-0000-0000-000000000013',
+  'b0000000-0000-0000-0000-000000000002',
+  'c0000000-0000-0000-0000-000000000003',
+  'a0000000-0000-0000-0000-000000000001', 'humano', '{"q1":"human-only"}',
+  true, false, 'schema-hash', '{"q1":"q1-hash"}', 1, 0, 0
+);
+
+-- #670: é o NOT NULL da coluna que torna "request sem geração para comparar" um
+-- estado inconstruível. O guard do trigger sozinho protegeria só o caminho que
+-- passa por ele; a constraint protege qualquer canal de escrita, inclusive os
+-- que ainda não existem. Asserção estrutural porque a comportamental abaixo não
+-- consegue distinguir a constraint do validate: BEFORE trigger roda ANTES da
+-- checagem de NOT NULL, então é sempre o validate que responde primeiro.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_attribute AS column_meta
+    WHERE column_meta.attrelid = 'public.auto_review_reconciliation_requests'::REGCLASS
+      AND column_meta.attname = 'llm_response_id'
+      AND column_meta.attnotnull
+  ) THEN
+    RAISE EXCEPTION 'llm_response_id still admits NULL';
+  END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+  v_rejected BOOLEAN := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.auto_review_reconciliation_requests (
+      document_id, project_id, llm_response_id, allow_new_cycles
+    ) VALUES (
+      'c0000000-0000-0000-0000-000000000003',
+      'b0000000-0000-0000-0000-000000000002', NULL, true
+    );
+  EXCEPTION
+    WHEN not_null_violation THEN
+      v_rejected := true;
+    WHEN raise_exception THEN
+      IF SQLERRM <> 'reconciliation request must reference its current complete LLM response' THEN
+        RAISE;
+      END IF;
+      v_rejected := true;
+  END;
+
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'request without an LLM generation was accepted';
+  END IF;
+END;
+$$;
+
+-- A geração precisa ser a CORRENTE, não qualquer uma do documento: uma request
+-- apontando para geração superada faria o dreno reconciliar contra respostas
+-- que a publicação seguinte já substituiu.
+INSERT INTO public.responses (
+  id, project_id, document_id, respondent_type, answers, justifications,
+  is_latest, is_partial, pydantic_hash, answer_field_hashes,
+  schema_version_major, schema_version_minor, schema_version_patch
+) VALUES (
+  'd0000000-0000-0000-0000-000000000012',
+  'b0000000-0000-0000-0000-000000000002',
+  'c0000000-0000-0000-0000-000000000002', 'llm', '{"q1":"llm-superseded"}', NULL,
+  false, false, 'schema-hash', '{"q1":"q1-hash"}', 1, 0, 0
+);
+
+DO $$
+DECLARE
+  v_rejected BOOLEAN := false;
+BEGIN
+  BEGIN
+    UPDATE public.auto_review_reconciliation_requests
+    SET llm_response_id = 'd0000000-0000-0000-0000-000000000012'
+    WHERE document_id = 'c0000000-0000-0000-0000-000000000002';
+  EXCEPTION WHEN raise_exception THEN
+    IF SQLERRM <> 'reconciliation request must reference its current complete LLM response' THEN
+      RAISE;
+    END IF;
+    v_rejected := true;
+  END;
+
+  IF NOT v_rejected THEN
+    RAISE EXCEPTION 'request pointing at a superseded LLM generation was accepted';
+  END IF;
+END;
+$$;
+
+-- O reparo do coordenador (regenerateAutoReviewBacklog) é o SEGUNDO produtor e
+-- precisa do mesmo contrato: documento sem geração LLM corrente fica fora do
+-- backlog em vez de virar linha insatisfazível.
+DO $$
+BEGIN
+  PERFORM public.enqueue_auto_review_reconciliation_for_project(
+    'b0000000-0000-0000-0000-000000000002'
+  );
+
+  IF EXISTS (
+    SELECT 1 FROM public.auto_review_reconciliation_requests
+    WHERE document_id = 'c0000000-0000-0000-0000-000000000003'
+  ) THEN
+    RAISE EXCEPTION 'backlog regeneration enqueued a document without an LLM generation';
+  END IF;
+
+  -- Discriminante: o documento que TEM geração corrente continua entrando, senão
+  -- a asserção acima passaria com um reparo que simplesmente não enfileira nada.
+  IF NOT EXISTS (
+    SELECT 1 FROM public.auto_review_reconciliation_requests
+    WHERE document_id = 'c0000000-0000-0000-0000-000000000002'
+      AND llm_response_id = 'd0000000-0000-0000-0000-000000000011'
+  ) THEN
+    RAISE EXCEPTION 'backlog regeneration dropped a document with a current LLM generation';
   END IF;
 END;
 $$;


### PR DESCRIPTION
Closes #670

**Tier 1** (migration + write path) — `revisão: integral`.

## O problema

Em projeto com `automation_mode='auto_review_llm'`, toda submissão humana completa enfileirava uma request de reconciliação. Sem geração LLM corrente no documento, a linha nascia com `llm_response_id NULL` — estado que o trigger de validação aceitava de propósito e que nenhum worker consegue satisfazer, porque não existe o par a reconciliar. O dreno lançava `DeferredReconciliation`, o backoff saturava no teto de 1 h, e nada removia a linha. Silencioso por construção: `deferred` não conta como `failed`, e a rota interna só devolve 503 em `failed`.

## Censo de produção (2026-08-10, read-only)

- **25 linhas** na fila, todas com `llm_response_id NULL`, todas no projeto `00779233` (Zolgensma-Judiciário);
- `last_error` idêntico nas 25; `attempt_count` de 8 a 136; a mais recente enfileirada 5 minutos antes de a issue ser aberta — **a fila ainda estava crescendo**;
- **zero** respostas LLM para os 25 documentos, então o expurgo não perde trabalho.

Duas correções ao que a issue afirma: `requested_at` e `attempt_count` são zerados pelo `ON CONFLICT DO UPDATE` a cada nova submissão humana no mesmo documento, então nenhum dos dois mede a idade da fila — medem quanto tempo faz que o último evento sujo daquele documento está sem drenar. Por isso o censo de hoje (25 linhas desde 06/08, máximo de 136 tentativas) não bate com o do corpo da issue (24 linhas desde 17/07, máximo de 949), sem que nada tenha se resolvido no meio.

## A correção

Pela origem, não por teto de tentativas — um teto trocaria o loop infinito por abandono silencioso, e a request sumiria sem que a reconciliação fosse feita. Sem geração LLM corrente o produtor não enfileira, e a coluna vira `NOT NULL`: o estado deixa de ser construível por **qualquer** canal de escrita, não só pelo que passa pelo trigger.

Nada se perde, por duas propriedades do desenho já existente:

1. o ramo LLM do trigger não tem gate algum, e a única porta de entrada de geração corrente é `publish_latest_llm_response`, que apaga as requests do documento e insere a nova — logo **toda** transição para "existe LLM corrente completa" enfileira;
2. a request não carrega snapshot humano: o dreno relê as respostas humanas correntes no momento em que processa. A request só diz *qual* geração LLM comparar.

Somado ao mutex `FOR UPDATE` na linha de `documents`, compartilhado entre trigger e publicação, isso cobre também a corrida "humano submete no instante em que o run LLM publica": nas duas ordens possíveis sobra uma request com a geração preenchida.

`final_answers` não perde fail-closed: a view é ancorada em `responses` LLM com `is_latest = true`, então documento sem geração não gera linha nenhuma — o ramo `llm_response_id IS NULL` de `is_auto_review_reconciliation_pending` só era alcançável para documentos que a view não emite.

Com o estado impossível eliminado, o outcome `deferred` some do reconciliador, da rota e do toast de regeneração de backlog. Contador cravado em zero mentiria para quem lê o JSON e manteria um ramo morto vivo na UI. O corpo da resposta da rota encolhe; o único consumidor (`backend/services/auto_review_reconciliation.py`) faz `raise_for_status()` e descarta o corpo.

## Correção vinda da revisão: o ACK também casa `requested_at`

O `acknowledge` do dreno apagava a request por `(document_id, llm_response_id)`. Isso discrimina republicação de LLM, que troca a geração, mas **não** discrimina re-submissão humana: o `ON CONFLICT (document_id) DO UPDATE` dos dois produtores mantém o mesmo `llm_response_id` e só reescreve `requested_at`.

A janela é estreita e a perda é silenciosa. O worker lê `req(D, L1)`; `reconcile_auto_review_cycles` commita com o humano `H@t1`; antes do round-trip do DELETE a pesquisadora salva de novo, `archive_review_dependencies_on_response_change` arquiva os `field_reviews` recém-criados e o trigger reenfileira `req(D, L1)`; o ACK apaga essa linha nova. O documento fica com revisões arquivadas e nada na fila para regenerá-las — invisível até a próxima publicação LLM ou uma regeneração manual de backlog.

A janela *antes* do commit já era fechada: os `expected_*` da RPC levantam `auto-review reconciliation inputs changed; retry required`, o outcome vira `failed` e a request sobrevive. Faltava a janela **entre o commit e o DELETE**. O comportamento é idêntico na `main` — não é regressão desta branch; o que a branch acrescentava era o comentário declarando o ACK coberto contra reenfileiramento, verdade apenas no caso LLM.

Não precisa de migration: a coluna existe desde a `20260717120000`, e `record_auto_review_reconciliation_failure` não a toca — uma tentativa que falhou antes ainda casa o ACK, então o filtro novo não prende fila.

**Também da revisão**: o discriminante do bloco de regeneração de backlog era vácuo. A request de `c…0002` sobrevivia da publicação anterior, então um reparo que não enfileirasse nada ainda passaria no `NOT EXISTS`. A fila passa a ser zerada antes do `PERFORM`. Medido com um mutante "o reparo enfileira zero": **passa** no teste antigo (exit 0) e **cai** no novo (exit 3, `backlog regeneration dropped a document with a current LLM generation`).

**Asserção nova do contrato do token**: o `ON CONFLICT DO UPDATE` reescreve `requested_at` e preserva `llm_response_id`. Como a suíte roda numa transação só e `now()` é `transaction_timestamp()`, afirmar "o timestamp avançou" seria vácuo — o valor é empurrado para o passado antes do re-save. Mutante que remove o reset mata a asserção.

**Round-trip do `+00:00`** verificado contra PostgREST real (par Postgres+PostgREST efêmero, isolado do container compartilhado), com discriminante de token deslocado: `URL.searchParams` codifica o `+` como `%2B` e o filtro casa a linha exata. Sem isso o DELETE nunca casaria e a fila travaria — falha silenciosa cara demais para aceitar só com mock.

## Verificação

**Invariante nova** `outbox-de-auto-revisao-drena`, escrita **antes** da migration e rodada contra produção: **FAIL com 25 violações**. Os dois limiares (`attempt_count >= 5` ou idade > 6 h) foram provados mordendo **independentemente** — 22 violações só pela idade, 25 só pelas tentativas; nenhum é código morto. Recusei de propósito a invariante "nenhuma request com NULL": é a constraint reescrita noutro canal, degenerada pela construção do produtor.

**Asserções SQL contra o schema de `main`**, cada uma medida individualmente (a suíte para na primeira falha e esconderia as demais):

| Asserção | Contra `main` |
|---|---|
| human-first não enfileira | 🔴 vermelha |
| `llm_response_id` é `NOT NULL` | 🔴 vermelha |
| backlog não enfileira doc sem LLM | 🔴 vermelha |
| `INSERT` com NULL é rejeitado | ⚠️ inalcançável em `main` (lá o doc já enfileira, e o conflito de PK vem antes) |
| validate rejeita geração superada | ⚪ já verde em `main` — **cobertura nova de guard preexistente**, não prova de vermelho |

**Mutação manual** (uma por vez, revertendo). Vale registrar *quem* matou cada uma, porque duas morreram pela camada de baixo e não pela asserção escrita para elas:

| Mutação | Morreu por |
|---|---|
| remover o `RETURN NEW` sem geração LLM | `validate`/`NOT NULL` (defesa em profundidade) |
| remover o `SET NOT NULL` | asserção estrutural (`pg_attribute.attnotnull`) |
| `JOIN LATERAL` → `LEFT JOIN LATERAL` | `validate`/`NOT NULL` |
| remover a checagem de geração no `validate` | asserção de geração superada |
| remover `.eq(\"id\", …)` de `readReconciliationInputs` | o teste vitest escrito para ela |
| ACK sem casar a geração exata | dois testes preexistentes |

**Sem cobertura, declarado**: a remoção do `IS NULL OR` em `is_auto_review_reconciliation_pending` e a troca `IS NOT DISTINCT FROM` → `=` em `record_..._failure` não são mutáveis com observação — os dois ramos só eram alcançáveis com linha NULL, que a constraint tornou inconstruível. São remoção de código morto guardada pelo `NOT NULL`, e não vou fingir cobertura que não existe.

**Gates** (remedidos após mergear a `main` com o #673): `test:db` 19 PASS / 0 FAIL (os 2 RED* são os conhecidos #571/#572), vitest 2.186 testes, typecheck, lint:types, e2e smoke, fallow, semgrep, react-doctor — todos verdes no pre-push.

## Ordem de deploy — cumprida

A migration `20260811130000` **já está aplicada em produção** (confirmado em 2026-08-13 por `supabase migration list --linked`). A restrição era real: o TS novo com o schema velho é incompatível — `readReconciliationInputs` emitiria `.eq("id", null)` sobre uma linha `llm_response_id NULL`. Com o schema novo e o TS ainda publicado nada quebra: `llm_response_id` nunca é nulo e o ramo `deferred` fica inalcançável.

O prefixo é `20260811130000`, depois da `20260811120000` do #673 — que já foi mergeado e está incorporado nesta branch, então a ordem está resolvida em disco, não só por convenção de nome.

