### PR TITLE
fix(db): cria llm_runs.round_id, que o backend escreve desde o #642

### DIFF
--- a/.github/workflows/database-tests.yml
+++ b/.github/workflows/database-tests.yml
@@ -59,6 +59,8 @@ jobs:
         run: npm run test:db:column-guard
       - name: Unicidade da resposta humana corrente
         run: npm run test:db:responses-human-latest
+      - name: Rodada da execução LLM
+        run: npm run test:db:llm-runs-round
 
       # As fixtures destes precisam estar commitadas (duas conexões dblink veem
       # o mesmo estado), então eles sujam o banco e ficam por último.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "test:db:unmark-equivalence": "npm run test:db:psql -- supabase/tests/unmark_equivalence_atomic.test.sql",
     "test:db:arbitration-reopen": "npm run test:db:psql -- supabase/tests/arbitration_reopen.test.sql",
     "test:db:rls-audit": "npm run test:db:psql -- supabase/tests/rls_audit.test.sql",
+    "test:db:llm-runs-round": "npm run test:db:psql -- supabase/tests/llm_runs_round.test.sql",
     "test:db:psql": "bash scripts/run-sql-test.sh",
     "test:watch": "vitest",
     "test:e2e": "playwright test",

--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -50,6 +50,7 @@ GATE_SUITES=(
   atomic_replace_rpcs
   explicit_assignment_rounds
   llm_rate_limit
+  llm_runs_round
   member_permission_rpcs
   project_members_column_guard
   responses_one_latest_human

--- a/frontend/supabase/migrations/20260811120000_llm_runs_round_id.sql
+++ b/frontend/supabase/migrations/20260811120000_llm_runs_round_id.sql
@@ -1,0 +1,54 @@
+-- llm_runs.round_id: a coluna que o backend escreve desde o #642 e que nenhuma
+-- migration criou.
+--
+-- O #642 (20260731120000_explicit_assignment_rounds.sql) deu rodada explicita a
+-- `assignments`, `assignment_batches` e `responses`, e no mesmo commit
+-- `_persist_run_snapshot` (backend/services/llm_runner.py) passou a gravar
+-- `round_id` em `llm_runs` — tabela que aquela migration nao menciona uma unica
+-- vez. Como essa funcao re-lanca a excecao de proposito ("nao engolir erro"), o
+-- PGRST204 abortava a run inteira antes do primeiro documento. Medicao de
+-- 2026-08-11: 1 run desde o deploy do #642, falhada; ultima bem sucedida em
+-- 2026-07-02.
+--
+-- A coluna nasce NOT NULL como as tres tabelas irmas. Run sem rodada ja era
+-- inutil na pratica: `publish_latest_llm_response` recusa `round_id` nulo, entao
+-- ela nunca chegaria a publicar resposta. O NOT NULL apenas antecipa a falha
+-- para antes de gastar token de provider.
+
+ALTER TABLE public.llm_runs
+  ADD COLUMN round_id uuid;
+
+-- Runs historicas herdam a rodada atual do projeto — mesmo criterio do backfill
+-- de responses/assignments em 20260731120000, onde a "Rodada inicial" representa
+-- retroativamente todo o historico anterior as rodadas.
+UPDATE public.llm_runs AS run
+SET round_id = project.current_round_id
+FROM public.projects AS project
+WHERE project.id = run.project_id;
+
+-- FK composta, e nao `REFERENCES rounds(id)`: a simples aceitaria uma run de um
+-- projeto carimbada com rodada de outro. Ancora na UNIQUE (project_id, id) que
+-- 20260731120000 criou em `rounds` justamente para servir de alvo a essas FKs.
+--
+-- Sem `ON DELETE` (NO ACTION) de proposito: `llm_runs.project_id` e
+-- `rounds.project_id` ja cascateiam de `projects`, e a checagem de integridade
+-- de uma FK NO ACTION roda no fim do statement, quando o cascade ja removeu a
+-- run. Trocar por RESTRICT quebraria a exclusao de projeto (checagem imediata).
+ALTER TABLE public.llm_runs
+  ALTER COLUMN round_id SET NOT NULL,
+  ADD CONSTRAINT llm_runs_project_round_fk
+    FOREIGN KEY (project_id, round_id)
+    REFERENCES public.rounds(project_id, id);
+
+-- `_persist_run_insert` cria a linha no POST /api/llm/run sem `round_id`: a
+-- rodada so e lida depois, ja dentro do background task. Sem preenchimento
+-- automatico o NOT NULL inverteria o bug — o INSERT passaria a falhar com 23502
+-- e a run ficaria invisivel na aba Execucoes, exatamente o que a docstring
+-- daquela funcao diz querer evitar.
+--
+-- A funcao ja existe desde 20260731120000 e serve sem alteracao: le
+-- `NEW.project_id`, so preenche quando `NEW.round_id IS NULL` e nunca sobrescreve
+-- valor explicito — o UPDATE do snapshot continua mandando na rodada final.
+CREATE TRIGGER llm_runs_fill_current_round
+BEFORE INSERT ON public.llm_runs
+FOR EACH ROW EXECUTE FUNCTION public.fill_current_round_id();

--- a/frontend/supabase/migrations/20260811120000_llm_runs_round_id.sql
+++ b/frontend/supabase/migrations/20260811120000_llm_runs_round_id.sql
@@ -18,6 +18,46 @@
 ALTER TABLE public.llm_runs
   ADD COLUMN round_id uuid;
 
+-- Preflight, na mesma idiomatica fail-fast de 20260731120000: o backfill abaixo
+-- carimba a rodada CORRENTE em toda run historica, e isso so e verdade sob a
+-- premissa daquela migration — "a Rodada inicial representa retroativamente
+-- todo o historico". A diferenca e que a premissa deixou de ser automatica em
+-- 20260804120000: ate ali nenhuma troca de rodada chegava a commitar (o proprio
+-- cabecalho daquela migration mede os 9 projetos com exatamente uma rodada
+-- cada), e a partir dali passou a commitar. Num projeto que ja trocou de
+-- rodada, o historico anterior a troca nao pertence a corrente, e carimba-lo
+-- assim seria mentira silenciosa.
+--
+-- A clausula `count(*) > 1` e carga, nao decoracao: as "Rodada inicial" foram
+-- todas criadas pelo backfill do #642 em 2026-07-31, depois das runs que elas
+-- representam. Medicao de 2026-08-13 contra producao — sem essa clausula o
+-- preflight abortaria 8 das 9 runs existentes; com ela, nenhuma, e a unica run
+-- de projeto multi-rodada (Zolgensma-Judiciario, segunda rodada em 2026-08-05,
+-- run em 2026-08-10) e legitimamente da rodada corrente.
+--
+-- O que este bloco NAO cobre: projeto com `current_round_id IS NULL` some no
+-- JOIN e passa batido aqui — ele aborta adiante, no SET NOT NULL. Esse estado
+-- continua representavel e tem issue propria; torna-lo irrepresentavel exige
+-- CONSTRAINT TRIGGER deferida, porque `create_initial_project_round` e AFTER
+-- INSERT (logo NOT NULL na coluna quebraria a criacao de projeto) e CHECK nao
+-- aceita DEFERRABLE no Postgres.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.llm_runs AS run
+    JOIN public.projects AS project ON project.id = run.project_id
+    JOIN public.rounds AS current_round ON current_round.id = project.current_round_id
+    WHERE run.started_at < current_round.created_at
+      AND (
+        SELECT count(*) FROM public.rounds AS project_round
+        WHERE project_round.project_id = run.project_id
+      ) > 1
+  ) THEN
+    RAISE EXCEPTION 'llm_runs round_id: run anterior a rodada corrente em projeto multi-rodada; derive o backfill dos dados reais';
+  END IF;
+END $$;
+
 -- Runs historicas herdam a rodada atual do projeto — mesmo criterio do backfill
 -- de responses/assignments em 20260731120000, onde a "Rodada inicial" representa
 -- retroativamente todo o historico anterior as rodadas.

--- a/frontend/supabase/migrations/20260811120000_llm_runs_round_id.sql
+++ b/frontend/supabase/migrations/20260811120000_llm_runs_round_id.sql
@@ -37,7 +37,7 @@ ALTER TABLE public.llm_runs
 --
 -- O que este bloco NAO cobre: projeto com `current_round_id IS NULL` some no
 -- JOIN e passa batido aqui — ele aborta adiante, no SET NOT NULL. Esse estado
--- continua representavel e tem issue propria; torna-lo irrepresentavel exige
+-- continua representavel (ver issue #687); torna-lo irrepresentavel exige
 -- CONSTRAINT TRIGGER deferida, porque `create_initial_project_round` e AFTER
 -- INSERT (logo NOT NULL na coluna quebraria a criacao de projeto) e CHECK nao
 -- aceita DEFERRABLE no Postgres.

--- a/frontend/supabase/tests/llm_runs_round.test.sql
+++ b/frontend/supabase/tests/llm_runs_round.test.sql
@@ -1,0 +1,197 @@
+-- Contrato de `llm_runs.round_id`, a coluna que o backend escreve desde o #642
+-- e que nenhuma migration criava: toda run de LLM morria com PGRST204 em
+-- `_persist_run_snapshot` antes do primeiro documento.
+--
+-- As assercoes (b) e (c) sao replay dos dois writes reais de
+-- backend/services/llm_runner.py — o INSERT que nasce sem rodada e o UPDATE do
+-- snapshot que a grava. Sem elas o arquivo seria so leitura de catalogo, e
+-- catalogo nao reproduz o bug: o que quebrou em producao foi um UPDATE.
+--
+-- Roda numa transacao e nao deixa fixture no banco local.
+
+BEGIN;
+
+-- (a) Catalogo. Vem primeiro para que a ausencia da coluna produza uma
+-- mensagem legivel em vez do 42703 cru que os blocos seguintes levantariam.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_attribute AS attribute
+    WHERE attribute.attrelid = 'public.llm_runs'::regclass
+      AND attribute.attname = 'round_id'
+      AND attribute.atttypid = 'uuid'::regtype
+      AND attribute.attnotnull
+      AND NOT attribute.attisdropped
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: llm_runs.round_id nao existe como uuid NOT NULL';
+  END IF;
+
+  -- FK composta, nao `REFERENCES rounds(id)`: a simples aceitaria run de um
+  -- projeto carimbada com rodada de outro.
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_constraint AS constraint_row
+    WHERE constraint_row.conrelid = 'public.llm_runs'::regclass
+      AND constraint_row.confrelid = 'public.rounds'::regclass
+      AND constraint_row.contype = 'f'
+      AND pg_catalog.pg_get_constraintdef(constraint_row.oid)
+        ILIKE '%FOREIGN KEY (project_id, round_id) REFERENCES rounds(project_id, id)%'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: llm_runs nao ancora (project_id, round_id) em rounds';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_trigger AS trigger_row
+    JOIN pg_catalog.pg_proc AS proc ON proc.oid = trigger_row.tgfoid
+    WHERE trigger_row.tgrelid = 'public.llm_runs'::regclass
+      AND NOT trigger_row.tgisinternal
+      AND proc.proname = 'fill_current_round_id'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: llm_runs nao preenche a rodada corrente no INSERT';
+  END IF;
+
+  RAISE NOTICE 'OK: catalogo tem round_id NOT NULL, FK composta e trigger';
+END;
+$$;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('7c000000-0000-0000-0000-000000000001', 'llm-runs-round@example.test');
+
+-- A trigger `projects_create_initial_round` cria a rodada de cada projeto.
+INSERT INTO public.projects (id, name, created_by) VALUES
+  ('7c100000-0000-0000-0000-000000000001', 'run com rodada corrente',
+   '7c000000-0000-0000-0000-000000000001'),
+  ('7c100000-0000-0000-0000-000000000002', 'projeto vizinho',
+   '7c000000-0000-0000-0000-000000000001'),
+  ('7c100000-0000-0000-0000-000000000003', 'projeto sem rodada',
+   '7c000000-0000-0000-0000-000000000001');
+
+-- (b) Replay de `_persist_run_insert`: o POST /api/llm/run cria a linha sem
+-- `round_id` porque a rodada so e lida depois, ja dentro do background task.
+-- Sem o preenchimento automatico o NOT NULL inverteria o bug — o INSERT
+-- passaria a falhar e a run ficaria invisivel na aba Execucoes.
+INSERT INTO public.llm_runs (job_id, project_id, filter_mode, status, phase, heartbeat_at)
+VALUES (
+  '7c200000-0000-0000-0000-000000000001',
+  '7c100000-0000-0000-0000-000000000001',
+  'all', 'running', 'loading', now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.llm_runs AS run
+    JOIN public.projects AS project ON project.id = run.project_id
+    WHERE run.job_id = '7c200000-0000-0000-0000-000000000001'
+      AND run.round_id = project.current_round_id
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: INSERT sem round_id nao herdou a rodada corrente';
+  END IF;
+  RAISE NOTICE 'OK: run nasce carimbada com a rodada corrente do projeto';
+END;
+$$;
+
+-- (c) Replay de `_persist_run_snapshot` (llm_runner.py:216-227) — o write que
+-- produzia o PGRST204 em producao. As demais colunas do payload acompanham
+-- porque e o UPDATE inteiro que precisa passar, nao so a coluna nova.
+UPDATE public.llm_runs
+SET llm_provider = 'google',
+    llm_model = 'gemini-2.5-flash',
+    document_count = 3,
+    pydantic_code = 'class Resposta(BaseModel): pass',
+    round_id = (
+      SELECT current_round_id FROM public.projects
+      WHERE id = '7c100000-0000-0000-0000-000000000001'
+    )
+WHERE job_id = '7c200000-0000-0000-0000-000000000001';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.llm_runs AS run
+    JOIN public.projects AS project ON project.id = run.project_id
+    WHERE run.job_id = '7c200000-0000-0000-0000-000000000001'
+      AND run.round_id = project.current_round_id
+      AND run.llm_model = 'gemini-2.5-flash'
+      AND run.document_count = 3
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: snapshot da execucao nao gravou rodada e metadados';
+  END IF;
+  RAISE NOTICE 'OK: snapshot da execucao grava a rodada junto dos metadados';
+END;
+$$;
+
+-- (d) O NOT NULL morde de fato, nao so no catalogo. A trigger cobre INSERT;
+-- projeto sem rodada corrente e UPDATE para NULL continuam barrados.
+UPDATE public.projects
+SET current_round_id = NULL
+WHERE id = '7c100000-0000-0000-0000-000000000003';
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.llm_runs (job_id, project_id, status, phase)
+    VALUES (
+      '7c200000-0000-0000-0000-000000000002',
+      '7c100000-0000-0000-0000-000000000003',
+      'running', 'loading'
+    );
+    RAISE EXCEPTION 'TESTE FALHOU: run de projeto sem rodada foi aceita';
+  EXCEPTION
+    WHEN not_null_violation THEN
+      NULL;
+  END;
+
+  BEGIN
+    UPDATE public.llm_runs
+    SET round_id = NULL
+    WHERE job_id = '7c200000-0000-0000-0000-000000000001';
+    RAISE EXCEPTION 'TESTE FALHOU: run existente ficou sem rodada';
+  EXCEPTION
+    WHEN not_null_violation THEN
+      NULL;
+  END;
+
+  RAISE NOTICE 'OK: run sem rodada e irrepresentavel no INSERT e no UPDATE';
+END;
+$$;
+
+-- (e) A FK composta recusa rodada de outro projeto; e o cascade de `projects`
+-- continua funcionando apesar de a FK ser NO ACTION — a checagem de integridade
+-- roda no fim do statement, quando o cascade ja removeu a run.
+DO $$
+DECLARE
+  v_foreign_round uuid;
+BEGIN
+  SELECT current_round_id INTO STRICT v_foreign_round
+  FROM public.projects WHERE id = '7c100000-0000-0000-0000-000000000002';
+
+  BEGIN
+    UPDATE public.llm_runs
+    SET round_id = v_foreign_round
+    WHERE job_id = '7c200000-0000-0000-0000-000000000001';
+    RAISE EXCEPTION 'TESTE FALHOU: run aceitou rodada de outro projeto';
+  EXCEPTION
+    WHEN foreign_key_violation THEN
+      NULL;
+  END;
+
+  DELETE FROM public.projects
+  WHERE id = '7c100000-0000-0000-0000-000000000001';
+
+  IF EXISTS (
+    SELECT 1 FROM public.llm_runs
+    WHERE job_id = '7c200000-0000-0000-0000-000000000001'
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: exclusao do projeto nao removeu a execucao';
+  END IF;
+
+  RAISE NOTICE 'OK: rodada e do proprio projeto e o cascade sobrevive a FK';
+END;
+$$;
+
+ROLLBACK;

--- a/frontend/supabase/tests/llm_runs_round.test.sql
+++ b/frontend/supabase/tests/llm_runs_round.test.sql
@@ -7,6 +7,12 @@
 -- snapshot que a grava. Sem elas o arquivo seria so leitura de catalogo, e
 -- catalogo nao reproduz o bug: o que quebrou em producao foi um UPDATE.
 --
+-- (c) e (c2) gravam uma rodada que NAO e a corrente de proposito. As duas
+-- escritas de `fill_current_round_id` convergiam para o mesmo valor que a
+-- trigger ja tinha carimbado em (b), e escrita que repete o valor existente nao
+-- e observavel: em 2026-08-13 remover `round_id` do SET de (c) deixava a suite
+-- verde. Uma rodada distinta e o unico valor que so o write sob teste produz.
+--
 -- Roda numa transacao e nao deixa fixture no banco local.
 
 BEGIN;
@@ -94,18 +100,33 @@ BEGIN
 END;
 $$;
 
+-- Segunda rodada do mesmo projeto, sem promove-la a corrente. Ela existe para
+-- que (c) tenha um valor que so o proprio UPDATE consiga produzir: enquanto o
+-- snapshot gravava a rodada corrente, ele repetia o carimbo que a trigger de
+-- (b) ja tinha posto, e remover `round_id` do SET deixava a suite verde —
+-- medido em 2026-08-13, exatamente a mutacao correspondente ao write que
+-- quebrou em producao.
+INSERT INTO public.rounds (id, project_id, label) VALUES
+  ('7c300000-0000-0000-0000-000000000001',
+   '7c100000-0000-0000-0000-000000000001', 'Rodada 2');
+
 -- (c) Replay de `_persist_run_snapshot` (llm_runner.py:216-227) — o write que
 -- produzia o PGRST204 em producao. As demais colunas do payload acompanham
 -- porque e o UPDATE inteiro que precisa passar, nao so a coluna nova.
+--
+-- A rodada gravada e deliberadamente diferente da corrente, e nao um capricho
+-- do teste: o INSERT nasce no POST /api/llm/run e o snapshot roda depois, ja
+-- no background task, relendo `current_round_id` (llm_runner.py:1216 e :1262).
+-- Se o coordenador trocar a rodada nesse intervalo, a run migra — e o comentario
+-- da migration chama isso de "o UPDATE do snapshot continua mandando na rodada
+-- final". Nao ha guarda contra esse UPDATE: `enforce_current_response_round_write`
+-- protege `responses`, nao `llm_runs`.
 UPDATE public.llm_runs
 SET llm_provider = 'google',
     llm_model = 'gemini-2.5-flash',
     document_count = 3,
     pydantic_code = 'class Resposta(BaseModel): pass',
-    round_id = (
-      SELECT current_round_id FROM public.projects
-      WHERE id = '7c100000-0000-0000-0000-000000000001'
-    )
+    round_id = '7c300000-0000-0000-0000-000000000001'
 WHERE job_id = '7c200000-0000-0000-0000-000000000001';
 
 DO $$
@@ -115,13 +136,44 @@ BEGIN
     FROM public.llm_runs AS run
     JOIN public.projects AS project ON project.id = run.project_id
     WHERE run.job_id = '7c200000-0000-0000-0000-000000000001'
-      AND run.round_id = project.current_round_id
+      AND run.round_id = '7c300000-0000-0000-0000-000000000001'
+      -- O discriminante: e esta metade que morre se `round_id` sair do SET,
+      -- porque a trigger de (b) deixou a run na rodada corrente.
+      AND run.round_id IS DISTINCT FROM project.current_round_id
       AND run.llm_model = 'gemini-2.5-flash'
       AND run.document_count = 3
   ) THEN
     RAISE EXCEPTION 'FALHOU: snapshot da execucao nao gravou rodada e metadados';
   END IF;
-  RAISE NOTICE 'OK: snapshot da execucao grava a rodada junto dos metadados';
+  RAISE NOTICE 'OK: snapshot da execucao move a run para a rodada que gravou';
+END;
+$$;
+
+-- (c2) A outra metade do contrato de `fill_current_round_id`: valor explicito
+-- nunca e sobrescrito. Sem isso, uma trigger que carimbasse incondicionalmente
+-- passaria em (b) e so quebraria em producao, no INSERT de um cliente
+-- round-aware.
+INSERT INTO public.llm_runs (job_id, project_id, round_id, status, phase)
+VALUES (
+  '7c200000-0000-0000-0000-000000000003',
+  '7c100000-0000-0000-0000-000000000001',
+  '7c300000-0000-0000-0000-000000000001',
+  'running', 'loading'
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.llm_runs AS run
+    JOIN public.projects AS project ON project.id = run.project_id
+    WHERE run.job_id = '7c200000-0000-0000-0000-000000000003'
+      AND run.round_id = '7c300000-0000-0000-0000-000000000001'
+      AND run.round_id IS DISTINCT FROM project.current_round_id
+  ) THEN
+    RAISE EXCEPTION 'FALHOU: INSERT com rodada explicita foi sobrescrito pela trigger';
+  END IF;
+  RAISE NOTICE 'OK: rodada explicita no INSERT sobrevive a trigger';
 END;
 $$;
 


### PR DESCRIPTION
## O problema

Toda execução de LLM em produção falhava com `PGRST204 — Could not find the 'round_id' column of 'llm_runs' in the schema cache`, morrendo em `phase='loading'` antes de processar um único documento.

O #642 deu rodada explícita a `assignments`, `assignment_batches` e `responses` via `20260731120000_explicit_assignment_rounds.sql`. No mesmo commit, `_persist_run_snapshot` (`backend/services/llm_runner.py:226`) passou a gravar `round_id` numa **quarta** tabela, `llm_runs`, que aquela migration não menciona uma única vez. O deploy do backend é automático em merge que toque `backend/**` e rodou no mesmo minuto; migrations são aplicadas à mão. O código subiu sem o schema.

Duas circunstâncias explicam por que isso ficou 11 dias sem aparecer e por que, quando apareceu, foi fatal em vez de degradado. Em primeiro lugar, `backend/tests/test_llm_runner_run_llm.py:344` afirma `snapshot["round_id"] == "round-1"` sobre um `_FakeTable` em memória que aceita qualquer chave sem validar schema, e `frontend/supabase/tests/` não exercitava `llm_runs` — o mock replicava o contrato em vez de verificá-lo. Em segundo lugar, das seis funções que escrevem em `llm_runs`, cinco logam e seguem; `_persist_run_snapshot` re-lança por decisão documentada ("Não engolir erro"), o que converteu coluna faltante em aborto total.

## Diagnóstico medido antes de escrever qualquer linha

| Verificação | Resultado |
|---|---|
| `llm_runs.round_id` existe? | Não — `42703`, erro do Postgres. **Não era cache do PostgREST** |
| Migration do #642 aplicada no remoto? | Sim — `assignments.round_id` e `assignment_batches.round_id` respondiam 200 |
| Alguma migration cria a coluna? | Nenhuma, em nenhum branch, em toda a história do repo |
| Colunas escritas pelo backend × schema real | **40 de 41 existem**; `round_id` era a única lacuna |
| Impacto | 1 run desde o deploy (2026-08-10T21:54:52), falhada. Última bem-sucedida: 2026-07-02 |

## O que muda

Uma migration e uma suíte de teste. **Nada em `backend/`** — o código já escrevia corretamente, faltava o schema (e manter o PR fora de `backend/**` evita disparar o deploy da API, cujo restart mataria run em andamento).

A coluna nasce NOT NULL com backfill e FK composta, como as três tabelas irmãs. As decisões de desenho, com a razão de cada uma:

- **FK composta `(project_id, round_id) → rounds(project_id, id)`**, não `REFERENCES rounds(id)`: a simples aceitaria run de um projeto carimbada com rodada de outro. Ancora na `rounds_project_id_id_key`, que o #642 criou justamente para servir de alvo a essas FKs.
- **Sem `ON DELETE` (NO ACTION)**, deliberado: `llm_runs.project_id` e `rounds.project_id` já cascateiam de `projects`, e a checagem de integridade roda no fim do statement, quando o cascade já removeu a run. `RESTRICT` quebraria a exclusão de projeto. Fixado pela asserção (e) do teste.
- **Reuso de `fill_current_round_id()` sem alteração**: `_persist_run_insert` cria a linha sem `round_id` (a rodada só é lida depois, no background task), então o NOT NULL sem preenchimento automático inverteria o bug — o INSERT passaria a falhar com 23502 e a run ficaria invisível na aba Execuções. Função nova exigiria replicar o `REVOKE` e o `search_path` que a `rls_audit` cobra.
- **Sem índice**: nenhuma query filtra run por rodada, `round_id` é coluna atualizada a cada ~2s pelo save loop, e a própria tabela já dropou um índice especulativo em `20260423000000` com a justificativa "no query filters by status".
- **Sem guarda de imutabilidade** análoga a `enforce_current_response_round_write`: não há policy de UPDATE em `llm_runs` desde `20260423000000` (só SELECT), e a guarda mataria justamente o UPDATE do snapshot que estamos consertando — trocaria PGRST204 por 23514.

## Correções vindas da revisão

**Preflight fail-fast antes do backfill.** O backfill carimba a rodada corrente em toda run histórica, o que só vale sob a premissa do #642 — "a Rodada inicial representa retroativamente todo o histórico". A migration irmã `20260731120000` protegeu essa premissa com um `RAISE EXCEPTION`; aqui ela vinha herdada sem guarda. E deixou de ser automática em `20260804120000`: até ali nenhuma troca de rodada chegava a commitar, e a partir dali passou a commitar. O bloco aborta quando existe run anterior à criação da rodada corrente num projeto que já tem mais de uma rodada.

A cláusula `count(*) > 1` é carga, não decoração: as "Rodada inicial" foram todas criadas pelo backfill do #642 em 2026-07-31, *depois* das runs que representam. Medido contra produção — sem ela o preflight abortaria **8 das 9 runs**; com ela, **nenhuma**. Provado nas duas direções por cenário construído no banco local: projeto multi-rodada com run anterior à corrente **aborta**; projeto de rodada única com run anterior à rodada **fica em silêncio**.

Produção executou a versão sem preflight em 2026-08-11 e os dados de lá estão corretos. A guarda vale para replay: `db reset`, CI, staging, restore de dump.

**A asserção (c) não discriminava a escrita.** A trigger `BEFORE INSERT` já carimbava `round_id = current_round_id` em (b), e o UPDATE do snapshot em (c) gravava o mesmo valor — escrita que repete o valor existente não é observável. Medido: remover `round_id` do `SET` de (c) deixava a suíte **verde**, exatamente a mutação correspondente ao write que quebrou em produção. (c) passa a gravar uma segunda rodada do mesmo projeto, não promovida a corrente, e a afirmar também `round_id IS DISTINCT FROM current_round_id`.

Não é artifício de teste: o INSERT nasce no `POST /api/llm/run` e o snapshot roda depois, no background task, relendo `current_round_id`. Se o coordenador trocar de rodada no intervalo, a run migra — é o que o comentário da migration chama de "o UPDATE do snapshot manda na rodada final". Nada bloqueia esse UPDATE: `enforce_current_response_round_write` protege `responses`, não `llm_runs`.

Entrou junto (c2), a outra metade do contrato de `fill_current_round_id`: valor explícito não é sobrescrito. Sem ela, uma trigger que carimbasse incondicionalmente passaria em (b) e só quebraria em produção.

**Não entrou, virou #687.** A revisão propôs `ALTER TABLE projects ALTER COLUMN current_round_id SET NOT NULL` para tornar irrepresentável o projeto sem rodada corrente. Isso **quebraria a criação de projeto**: `create_initial_project_round` é trigger AFTER INSERT e `NOT NULL` é checado na inserção da tupla, antes de qualquer AFTER trigger. O fallback natural também não existe — em Postgres `CHECK` não aceita `DEFERRABLE`. O caminho é `CONSTRAINT TRIGGER ... DEFERRABLE INITIALLY DEFERRED`, padrão inédito no repo, mais o estreitamento de `setCurrentRound`, que aceita `null` e não tem chamador na UI. Escopo próprio; 0 projetos em produção estão nesse estado hoje.

## Verificação

**Prova do vermelho, no próprio histórico:** o commit do teste vem antes do da migration. Em `192faff0` a suíte falha com `FALHOU: llm_runs.round_id nao existe como uuid NOT NULL`; em `6ac50dac` fica verde.

**Matriz de mutação** — o verde global não prova que cada guarda morde, então mutei uma a uma:

| Mutação | Asserção comportamental que morre | Mensagem da suíte completa |
|---|---|---|
| remover `SET NOT NULL` | (d) "run de projeto sem rodada foi aceita" | `round_id nao existe como uuid NOT NULL` |
| remover a FK composta | (e) "run aceitou rodada de outro projeto" | `nao ancora (project_id, round_id) em rounds` |
| remover o trigger | (b) aborta no INSERT com 23502 | `nao preenche a rodada corrente no INSERT` |
| FK simples `rounds(id)` | (e) "run aceitou rodada de outro projeto" | idem — discrimina composta de simples |
| remover `round_id` do SET de (c) | (c) — **sobrevivia** antes da revisão; hoje morre | `snapshot da execucao nao gravou rodada e metadados` |
| trigger sobrescreve valor explícito | (c2) — cobertura nova | `INSERT com rodada explicita foi sobrescrito pela trigger` |

**Local:** a migration aplica na cadeia completa a partir de `db reset` (última versão registrada = `20260811120000`). Varredura completa: 18 PASS, incluindo `llm_runs_round`. `tsc --noEmit` limpo; vitest 199 arquivos / 2185 testes.

**Produção, depois do `db push`:**

- sonda `llm_runs?select=round_id` passou de **400/42703 para 200**;
- backfill íntegro: 9 runs antes, 9 depois, **0 com `round_id` nulo**;
- **9/9** carimbadas corretamente — agora conferido contra `rounds.created_at`, e não contra `projects.current_round_id`, que é a própria fonte do carimbo e portanto não valida nada. Dos 9 projetos, só o Zolgensma-Judiciário tem duas rodadas; a segunda nasceu em 2026-08-05 e a única run dele começou em 2026-08-10, depois da troca, então a rodada corrente é de fato a certa. As outras 8 runs são de projeto de rodada única;
- **replay do write path pela mesma camada PostgREST que devolvia o erro**: INSERT sem `round_id` → **201** com a rodada herdada pela trigger; UPDATE do snapshot com `round_id` → **204**. O registro de verificação foi removido em seguida (total de volta a 9).

O backfill é o único ponto que nenhum teste local cobre — `db reset` produz `llm_runs` vazia (`UPDATE 0`), então a contagem pré/pós no remoto é a única prova dele. Fica registrado como limite honesto, não como cobertura.

## Gates

Todos os gates de pre-push passam, sem `--no-verify`.

Uma correção de rumo: a versão anterior deste texto atribuía a falha da suíte `auto_review_reconciliation_outbox` a contaminação por fixtures das suítes `dblink`. Isso está errado. Medido em 2026-08-13: depois de `db reset` nesta branch, a suíte passa isolada **duas vezes seguidas**, e a varredura completa passa **duas vezes seguidas** — as duas hipóteses de não-idempotência caem. A causa real é o container local ser compartilhado entre worktrees: ele estava com `20260811130000_auto_review_reconciliation_requires_llm.sql`, do #670, aplicada por uma sessão paralela. Essa migration remove justamente o comportamento que a asserção cobra (enfileirar codificação humana suja sem geração LLM), e o arquivo de teste daquela branch já não contém a string que falhava aqui. Não é defeito de arranjo do `GATE_SUITES` nem regressão deste PR — é estado de outra branch no banco.

## Implantação

**A migration já foi aplicada ao Supabase remoto** — e isso, sozinho, restaurou produção. A ordem normal se inverteu de propósito: o código que escreve a coluna está em produção desde 2026-08-01, então o schema estava atrás do código, não à frente. A migration é compatível nos dois sentidos com o código em voo (o INSERT sem `round_id` passa a ser coberto pela trigger; o UPDATE passa a ser aceito) e o frontend nunca tocou a coluna.

Atenção no merge: este PR **vai redeployar o frontend**, porque `frontend-fly-deploy.yml` filtra `frontend/**`, o que inclui `frontend/supabase/migrations/` e `frontend/scripts/` — ainda que nenhuma linha de `src/` mude. Vale conferir o `check-frontend-fly-machines.sh` pós-deploy. O deploy do backend **não** dispara.

Ref #642.
