### PR TITLE
fix(comparação): rascunho nunca submetido deixa de contar como codificação (#678)

### DIFF
--- a/frontend/scripts/invariants/check-invariants.ts
+++ b/frontend/scripts/invariants/check-invariants.ts
@@ -364,6 +364,53 @@ const invariants: Invariant[] = [
     },
   },
   {
+    name: "comparacao-apoiada-so-em-rascunho",
+    motivation:
+      "#678: `is_partial` humano significa 'nunca submetida', mas sorteio e comparação usavam `is_latest` como proxy de 'codificou' — 21 dos 194 documentos ativos do Zolgensma entraram na fila de comparação apoiados numa codificação que o pesquisador nunca enviou. Corrigido em duas fronteiras (view lottery_doc_stats e regra 2 de responseQualifiesForVersion); FAIL aqui = alguma delas voltou a contar rascunho, ou um canal de escrita novo criou comparação sem checar submissão",
+    run: async () => {
+      const active = await activeDocIds();
+      const [assignments, responses] = await Promise.all([
+        fetchAll<{ id: string; document_id: string }>(
+          "assignments",
+          "id, document_id",
+          (q) => q.eq("type", "comparacao"),
+        ),
+        fetchAll<{ document_id: string; respondent_id: string | null; is_partial: boolean | null }>(
+          "responses",
+          "document_id, respondent_id, is_partial",
+          (q) => q.eq("respondent_type", "humano").eq("is_latest", true),
+        ),
+      ]);
+      // Conta, por documento, quantas codificações humanas SUBMETIDAS existem.
+      // `is_partial === true` é o único estado excluído: `null` é linha legada
+      // sem o sinal e conta como submetida, mesma escolha conservadora de
+      // 'codificacao-concluida-response-so-rascunho' — não falso-positivar sem
+      // prova de rascunho.
+      const submittedByDoc = new Map<string, number>();
+      const draftOnlyByDoc = new Map<string, number>();
+      for (const r of responses) {
+        const bucket = r.is_partial === true ? draftOnlyByDoc : submittedByDoc;
+        bucket.set(r.document_id, (bucket.get(r.document_id) ?? 0) + 1);
+      }
+      // Violação: existe comparação para o documento, mas NENHUMA codificação
+      // humana submetida a sustenta — e há ao menos um rascunho, que é o que
+      // explica a comparação ter sido criada. Sem essa segunda condição a
+      // invariante também pegaria comparação órfã por response apagada, que é
+      // outra família (e outra invariante).
+      return assignments
+        .filter(
+          (a) =>
+            active.has(a.document_id) &&
+            (submittedByDoc.get(a.document_id) ?? 0) === 0 &&
+            (draftOnlyByDoc.get(a.document_id) ?? 0) > 0,
+        )
+        .map((a) => ({
+          key: a.id,
+          detail: `comparação apoiada só em rascunho: doc ${a.document_id} tem ${draftOnlyByDoc.get(a.document_id)} codificação(ões) humana(s) nunca submetida(s) e nenhuma submetida`,
+        }));
+    },
+  },
+  {
     name: "versao-carimbada-tem-hash-da-propria-epoca",
     motivation:
       "família #529/#573 (medição #574/#579): antes do #573, o auto-save promovia schema_version_* sem revisão. Sob o critério do #573, carimbar a versão V no save ao vivo exige revisão real sob V — que grava ao menos um hash de V em answer_field_hashes. Uma response live_save cujo carimbo não é sustentado por NENHUM hash da própria época foi promovida por canal que pulou essa regra (ou o log de versões foi reescrito sob os pés dela — também vale investigação)",

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -592,6 +592,11 @@ describe("saveResponse — gravação pelo envio explícito", () => {
     const versioned: VersionedResponse = {
       respondent_type: "humano",
       is_latest: true,
+      // Derivado do payload, não fixado: assim o caso também prova que um
+      // submit grava `is_partial: false` e portanto passa pela regra 2 do
+      // predicado (#678). Fixar `false` aqui tornaria a asserção vácua quanto
+      // a isso.
+      is_partial: payload.is_partial as boolean,
       pydantic_hash: payload.pydantic_hash as string,
       schema_version_major: payload.schema_version_major as number,
       schema_version_minor: payload.schema_version_minor as number,

--- a/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/compare/page.tsx
@@ -71,7 +71,7 @@ export default async function ComparePageRoute({
       // `documents!inner` + filtro excluded_at: documentos arquivados não
       // entram na fila de comparação (consistente com a contagem de B4).
       .select(
-        "id, document_id, respondent_type, respondent_name, respondent_id, answers, justifications, is_latest, pydantic_hash, answer_field_hashes, schema_version_major, schema_version_minor, schema_version_patch, created_at, documents!inner(id, title, external_id)",
+        "id, document_id, respondent_type, respondent_name, respondent_id, answers, justifications, is_latest, is_partial, pydantic_hash, answer_field_hashes, schema_version_major, schema_version_minor, schema_version_patch, created_at, documents!inner(id, title, external_id)",
       )
       .eq("project_id", id)
       .is("documents.excluded_at", null)

--- a/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.integration.test.tsx
@@ -108,6 +108,7 @@ function resp(
     answers,
     justifications: null,
     is_latest: true,
+    is_partial: false,
     pydantic_hash: null,
     answer_field_hashes: null,
     schema_version_major: null,

--- a/frontend/src/components/compare/__tests__/ComparePage.test.tsx
+++ b/frontend/src/components/compare/__tests__/ComparePage.test.tsx
@@ -271,6 +271,7 @@ function resp(
     answers,
     justifications: null,
     is_latest: true,
+    is_partial: false,
     pydantic_hash: null,
     answer_field_hashes: null,
     schema_version_major: null,

--- a/frontend/src/components/compare/compare-types.ts
+++ b/frontend/src/components/compare/compare-types.ts
@@ -21,6 +21,10 @@ export interface CompareResponse {
   answers: Record<string, unknown>;
   justifications: Record<string, string> | null;
   is_latest: boolean;
+  // Rascunho nunca submetido. Trafega até a fila porque
+  // `responseQualifiesForVersion` decide sobre o dado, não sobre o WHERE da
+  // query — ver regra 2 do predicado e #678.
+  is_partial: boolean;
   pydantic_hash: string | null;
   answer_field_hashes: AnswerFieldHashes;
   schema_version_major: number | null;

--- a/frontend/src/lib/__tests__/compare-queue.test.ts
+++ b/frontend/src/lib/__tests__/compare-queue.test.ts
@@ -41,6 +41,7 @@ function response(overrides: Partial<CompareQueueResponse> = {}): CompareQueueRe
     answers: { a: "x" },
     justifications: null,
     is_latest: true,
+    is_partial: false,
     pydantic_hash: "hash1",
     answer_field_hashes: {},
     schema_version_major: null,

--- a/frontend/src/lib/__tests__/compare-version.test.ts
+++ b/frontend/src/lib/__tests__/compare-version.test.ts
@@ -29,6 +29,7 @@ function resp(overrides: Partial<VersionedResponse>): VersionedResponse {
   return {
     respondent_type: "llm",
     is_latest: true,
+    is_partial: false,
     pydantic_hash: "hash-atual",
     schema_version_major: 0,
     schema_version_minor: 20,
@@ -128,6 +129,53 @@ describe("responseQualifiesForVersion", () => {
     expect(
       responseQualifiesForVersion(
         resp({ respondent_type: "humano", is_latest: false }),
+        floor,
+        proj,
+      ),
+    ).toBe(false);
+  });
+  // Regra 2 (#678): rascunho nunca submetido não conta como codificação.
+  // Antes desta regra, `is_latest` fazia as vezes de "codificou" e um
+  // auto-save tirava o documento da fila do pesquisador e o empurrava para a
+  // Comparação — 21 dos 194 documentos ativos do Zolgensma.
+  it("descarta rascunho humano (is_partial=true) mesmo sendo is_latest", () => {
+    expect(
+      responseQualifiesForVersion(
+        resp({ respondent_type: "humano", is_partial: true }),
+        floor,
+        proj,
+      ),
+    ).toBe(false);
+  });
+  it("descarta rascunho humano mesmo sem filtro de versão (minVersion null)", () => {
+    // Discrimina a regra 2 da regra 3: sem piso, o predicado retornaria true
+    // logo após o gate de is_latest se o rascunho não fosse barrado antes.
+    expect(
+      responseQualifiesForVersion(
+        resp({ respondent_type: "humano", is_partial: true }),
+        null,
+        proj,
+      ),
+    ).toBe(false);
+  });
+  it("aceita resposta humana submetida (is_partial=false)", () => {
+    // O par positivo da regra 2: sem ele, um predicado que devolvesse `false`
+    // para tudo passaria nos dois casos acima.
+    expect(
+      responseQualifiesForVersion(
+        resp({ respondent_type: "humano", is_partial: false }),
+        floor,
+        proj,
+      ),
+    ).toBe(true);
+  });
+  it("descarta rascunho LLM — redundante com a CHECK do banco, mas não confia nela", () => {
+    // `responses_partial_llm_not_latest` já impede LLM parcial de ser
+    // is_latest; a regra vale como defesa em profundidade se a constraint for
+    // relaxada ou se a linha vier de fixture/backfill.
+    expect(
+      responseQualifiesForVersion(
+        resp({ respondent_type: "llm", is_partial: true }),
         floor,
         proj,
       ),
@@ -239,6 +287,7 @@ describe("fecho espelha o filtro default da UI (#217/#218/#247)", () => {
     answers,
     respondent_type: "humano",
     is_latest: true,
+    is_partial: false,
     pydantic_hash: "hash-atual",
     schema_version_major: 0,
     schema_version_minor: 20,

--- a/frontend/src/lib/auto-comparison.ts
+++ b/frontend/src/lib/auto-comparison.ts
@@ -51,6 +51,11 @@ interface ResponseRow {
   // Campos de versão: necessários para aplicar o piso `latest_major` (#247),
   // o MESMO que a fila (compare/page.tsx) e o fecho (compare-sync.ts) usam.
   is_latest?: boolean;
+  // Rascunho nunca submetido; entra na regra 2 de `responseQualifiesForVersion`
+  // (#678). Opcional aqui porque o shape descreve a linha crua vinda do
+  // PostgREST; `toVersioned` é quem normaliza para o campo obrigatório de
+  // `VersionedResponse`.
+  is_partial?: boolean;
   pydantic_hash?: string | null;
   schema_version_major?: number | null;
   schema_version_minor?: number | null;
@@ -72,8 +77,12 @@ function toResponseLike(r: ResponseRow) {
 // (superseded → fora) ser defesa REAL no dado, não só uma garantia implícita do
 // WHERE: se um caller futuro relaxar/copiar a query sem o filtro, o predicado
 // ainda exclui superseded em vez de contá-los (regressão #213).
+// `is_partial` entra pelo mesmo motivo que `is_latest`: a regra 2 do predicado
+// (rascunho → fora) precisa decidir sobre o dado, e nenhuma das queries abaixo
+// filtra por ela no WHERE. Trazê-la aqui é o que faz o #678 ficar corrigido nas
+// cinco queries de uma vez, em vez de exigir a cláusula repetida em cada uma.
 const RESPONSE_VERSION_COLS =
-  "is_latest, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch";
+  "is_latest, is_partial, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch";
 
 // Monta o shape `VersionedResponse` a partir de uma linha de `responses`.
 // `is_latest` vem do SELECT (ver RESPONSE_VERSION_COLS), mas a coluna é
@@ -85,6 +94,7 @@ function toVersioned(
   r: Pick<
     ResponseRow,
     | "is_latest"
+    | "is_partial"
     | "pydantic_hash"
     | "schema_version_major"
     | "schema_version_minor"
@@ -95,6 +105,11 @@ function toVersioned(
   return {
     respondent_type: respondentType,
     is_latest: r.is_latest ?? true,
+    // `responses.is_partial` é NOT NULL DEFAULT false desde a migration
+    // 20260425, então o `??` só cobre o caso de a coluna não ter sido pedida no
+    // select — que o campo obrigatório em `VersionedResponse` já barra em tempo
+    // de compilação. O default espelha o do banco (#678).
+    is_partial: r.is_partial ?? false,
     pydantic_hash: r.pydantic_hash ?? null,
     schema_version_major: r.schema_version_major ?? null,
     schema_version_minor: r.schema_version_minor ?? null,
@@ -555,6 +570,7 @@ interface ComparisonProjectRow extends ComparisonProjectSettings {
 interface HumanResponseMeta extends Pick<
   ResponseRow,
   | "is_latest"
+  | "is_partial"
   | "pydantic_hash"
   | "schema_version_major"
   | "schema_version_minor"

--- a/frontend/src/lib/compare-sync.ts
+++ b/frontend/src/lib/compare-sync.ts
@@ -186,7 +186,7 @@ export async function syncCompareAssignment(
     supabase
       .from("responses")
       .select(
-        "id, respondent_type, is_latest, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch, answers, answer_field_hashes",
+        "id, respondent_type, is_latest, is_partial, pydantic_hash, schema_version_major, schema_version_minor, schema_version_patch, answers, answer_field_hashes",
       )
       .eq("project_id", projectId)
       .eq("document_id", documentId),

--- a/frontend/src/lib/compare-version.ts
+++ b/frontend/src/lib/compare-version.ts
@@ -44,9 +44,16 @@ export interface SchemaVersion {
 // Campos mínimos de uma resposta necessários para decidir se ela qualifica sob
 // um piso de versão. Tanto `CompareResponse` (página) quanto a linha buscada em
 // compare-sync.ts satisfazem este shape.
+//
+// `is_partial` é obrigatório de propósito (não opcional): é o que obriga cada
+// caller a trazer a coluna do banco. Antes do #678 ela não era pedida em lugar
+// nenhum da comparação, e o resultado foi contar rascunho como codificação em
+// 21 dos 194 documentos ativos do Zolgensma. Tornar o campo opcional aqui
+// reabriria exatamente esse buraco, agora em silêncio.
 export interface VersionedResponse {
   respondent_type: "humano" | "llm";
   is_latest: boolean;
+  is_partial: boolean;
   pydantic_hash: string | null;
   schema_version_major: number | null;
   schema_version_minor: number | null;
@@ -175,13 +182,25 @@ export function versionGate(project: ProjectVersionRow): {
 //      mais recente no dedup de documentos, ou após unificação de membros) tem
 //      is_latest=false e não deve reaparecer como segundo card / inflar a
 //      contagem. Antes a cláusula mantinha humano por engano;
-//   2. sem filtro de versão (minVersion null = filtro "all"), qualifica;
-//   3. respostas pré-versionamento (pydantic_hash NULL, gravadas antes da
+//   2. rascunhos (is_partial=true) ficam de fora. Para humano, `is_partial`
+//      significa "nunca submetida" — o valor sai do botão, não do
+//      preenchimento (`actions/responses.ts`, `isAutoSave`), com cliquet: uma
+//      vez enviada, auto-save posterior não rebaixa o sinal. Para LLM
+//      significa "cobertura abaixo do limiar", e a CHECK
+//      `responses_partial_llm_not_latest` já garante que parcial nunca seja
+//      is_latest — logo esta regra é redundante para LLM e load-bearing para
+//      humano. Sem ela, `is_latest` virava proxy de "codificou" e um rascunho
+//      auto-salvo tirava o documento da fila do próprio pesquisador e o
+//      empurrava para a Comparação (#678). A auto-revisão já exigia
+//      `is_partial = false` em seis camadas; a comparação era a metade do
+//      sistema que não aplicava a regra;
+//   3. sem filtro de versão (minVersion null = filtro "all"), qualifica;
+//   4. respostas pré-versionamento (pydantic_hash NULL, gravadas antes da
 //      migration 20260420) são descartadas com filtro ativo — não há como
 //      situá-las;
-//   4. com semver gravado (fonte de verdade), a versão da resposta precisa ser
+//   5. com semver gravado (fonte de verdade), a versão da resposta precisa ser
 //      >= o piso;
-//   5. SEM semver gravado: as respostas LLM nascem com schema_version NULL
+//   6. SEM semver gravado: as respostas LLM nascem com schema_version NULL
 //      porque o backend não popula esses campos no insert (o B1 deste PR passa
 //      a popular, mas só nos inserts futuros; as respostas legadas seguem NULL
 //      até um backfill). Para não esvaziar a comparação, usamos o
@@ -196,6 +215,7 @@ export function responseQualifiesForVersion(
   project: ProjectVersionContext,
 ): boolean {
   if (!r.is_latest) return false;
+  if (r.is_partial) return false;
   if (!minVersion) return true;
   if (r.pydantic_hash === null) return false;
   if (r.schema_version_major !== null) {

--- a/frontend/supabase/migrations/20260813120000_lottery_doc_stats_ignora_rascunho.sql
+++ b/frontend/supabase/migrations/20260813120000_lottery_doc_stats_ignora_rascunho.sql
@@ -1,0 +1,89 @@
+-- #678: `lottery_doc_stats.human_coding_count` contava rascunho nunca
+-- submetido como codificação.
+--
+-- `is_partial` tem duas semânticas conforme o respondente. Para humano
+-- significa "nunca submetida": o valor sai do botão, não do preenchimento
+-- (`actions/responses.ts`, `isAutoSave`), com cliquet — uma vez enviada,
+-- auto-save posterior não rebaixa o sinal. Para LLM significa "cobertura
+-- abaixo do limiar da run", e a CHECK `responses_partial_llm_not_latest` já
+-- garante que uma resposta LLM parcial nunca seja `is_latest`.
+--
+-- Daí a assimetria que produziu o defeito: `is_latest` equivale a "publicada"
+-- para LLM, mas para humano significa apenas "a mais recente", submetida ou
+-- não. A LATERAL abaixo usava `is_latest` como proxy de "codificou", então um
+-- auto-save bastava para o documento sair da fila de codificação (o sorteio o
+-- considerava coberto) e entrar na de comparação. Medido em 2026-08-10 sobre
+-- dump de produção: 21 dos 194 documentos ativos do projeto Zolgensma.
+--
+-- A regra correta já existia no projeto — a auto-revisão exige
+-- `is_partial = false` em seis camadas independentes. Era a comparação/sorteio
+-- que não a aplicava.
+--
+-- O predicado equivalente no lado TypeScript é a regra 2 de
+-- `responseQualifiesForVersion` (`lib/compare-version.ts`), que este PR
+-- introduz na mesma passagem. São duas cópias da mesma regra em fronteiras
+-- diferentes (SQL e TS), então cada uma tem teste próprio — prática 4 de
+-- `docs/VERIFICATION.md`.
+--
+-- Único delta em relação a 20260803204000: a cláusula `is_partial = false` na
+-- LATERAL de responses. O filtro atinge as duas agregações da LATERAL, mas é
+-- no-op para `has_llm_response`, porque a CHECK acima impede que exista linha
+-- LLM com `is_latest = true AND is_partial = true`.
+
+CREATE OR REPLACE VIEW public.lottery_doc_stats
+WITH (security_invoker = true) AS
+WITH canonical AS (
+  SELECT
+    document.id,
+    document.project_id,
+    document.external_id,
+    document.title,
+    COALESCE(response_stats.human_coding_count, 0)::integer AS human_coding_count,
+    COALESCE(response_stats.has_llm_response, false) AS has_llm_response,
+    COALESCE(assignment_stats.active_codificacao, 0)::integer AS active_codificacao,
+    COALESCE(assignment_stats.active_comparacao, 0)::integer AS active_comparacao,
+    COALESCE(assignment_stats.has_assignment_in_current_round, false)
+      AS has_assignment_in_current_round,
+    COALESCE(assignment_stats.batch_ids, ARRAY[]::uuid[]) AS batch_ids
+  FROM public.documents AS document
+  JOIN public.projects AS project ON project.id = document.project_id
+  LEFT JOIN LATERAL (
+    SELECT
+      count(DISTINCT response.respondent_id)
+        FILTER (WHERE response.respondent_type = 'humano') AS human_coding_count,
+      bool_or(response.respondent_type = 'llm') AS has_llm_response
+    FROM public.responses AS response
+    WHERE response.document_id = document.id
+      AND response.project_id = document.project_id
+      AND response.round_id = project.current_round_id
+      AND response.is_latest = true
+      AND response.is_partial = false
+  ) AS response_stats ON true
+  LEFT JOIN LATERAL (
+    SELECT
+      count(*) FILTER (
+        WHERE assignment.type = 'codificacao'
+          AND assignment.status IN ('pendente', 'em_andamento')
+      ) AS active_codificacao,
+      count(*) FILTER (
+        WHERE assignment.type = 'comparacao'
+          AND assignment.status IN ('pendente', 'em_andamento')
+      ) AS active_comparacao,
+      count(*) > 0 AS has_assignment_in_current_round,
+      array_agg(DISTINCT assignment.batch_id)
+        FILTER (WHERE assignment.batch_id IS NOT NULL) AS batch_ids
+    FROM public.assignments AS assignment
+    WHERE assignment.document_id = document.id
+      AND assignment.project_id = document.project_id
+      AND assignment.round_id = project.current_round_id
+  ) AS assignment_stats ON true
+  WHERE document.excluded_at IS NULL
+    AND document.exclusion_pending_at IS NULL
+)
+SELECT
+  canonical.*,
+  canonical.has_assignment_in_current_round AS has_any_assignment_ever
+FROM canonical;
+
+REVOKE ALL ON public.lottery_doc_stats FROM PUBLIC, anon;
+GRANT SELECT ON public.lottery_doc_stats TO authenticated, service_role;


### PR DESCRIPTION
Corrige o defeito medido na #678: **21 dos 194 documentos ativos** do Zolgensma entravam na elegibilidade de comparação apoiados numa codificação que o pesquisador nunca enviou — saindo da fila do próprio pesquisador no caminho.

## A assimetria que produzia o defeito

`is_partial` tem duas semânticas conforme o respondente:

- **humano** — "nunca submetida". O valor sai do botão, não do preenchimento (`actions/responses.ts`, `isAutoSave`), com cliquet: uma vez enviada, auto-save posterior não rebaixa o sinal.
- **LLM** — "cobertura abaixo do limiar da run", e a CHECK `responses_partial_llm_not_latest` garante que LLM parcial nunca seja `is_latest`.

Logo `is_latest` equivale a "publicada" para LLM, mas para humano significa apenas "a mais recente, submetida ou não". Todo consumidor que usava `is_latest` como proxy de "codificou" contava rascunho.

A regra correta já existia no projeto: a auto-revisão exige `is_partial = false` em **seis camadas independentes**. Era a comparação/sorteio que não a aplicava — metade do sistema seguindo a regra, metade não, sem comentário, teste ou migration registrando a ausência como intencional.

## Correção — duas fronteiras, nenhuma cópia nova

A #678 alerta que filtrar em cada consumidor acrescentaria a quarta e a quinta cópia de uma regra já duplicada. Este PR corrige nos dois pontos que **já eram fonte única** da sua camada:

**TypeScript** — regra 2 de `responseQualifiesForVersion` (`lib/compare-version.ts`), o predicado que `compare-queue` (fila), `compare-sync` (fecho) e `auto-comparison` (gatilho) já compartilhavam. Um ponto, três consumidores.

`is_partial` entra como campo **obrigatório** de `VersionedResponse`. Essa é a parte que impede a reincidência: o compilador passa a exigir a coluna de cada caller, em vez de depender de alguém lembrar de pedi-la. Foi o `tsc` que apontou os quatro pontos que não a traziam.

**SQL** — `lottery_doc_stats.human_coding_count`, que alimenta o sorteio. Delta único sobre a `20260803204000`: a cláusula `is_partial = false` na LATERAL. É no-op para `has_llm_response`, porque a CHECK impede linha LLM com `is_latest = true AND is_partial = true`.

`RESPONSE_VERSION_COLS` passa a trazer `is_partial`, corrigindo as cinco queries de `auto-comparison` de uma vez.

## Verificação

**Prova do vermelho** — mutei a guarda `if (r.is_partial) return false;` no predicado. As 3 asserções de rejeição falham sem ela; a positiva ("aceita resposta humana submetida") **continua verde**, que é o par discriminante impedindo um predicado degenerado (`return false` para tudo) de passar. Guarda restaurada, 31/31.

| Gate | Resultado |
|---|---|
| Vitest (suíte completa) | 2189/2189 |
| `tsc --noEmit` | limpo |
| Playwright e2e smoke | passou |
| fallow / semgrep / lint:types | passou |
| `test:db` (contrato SQL) | passou |

## Ressalva importante: a invariante nasce vermelha

A invariante nova `comparacao-apoiada-so-em-rascunho` detecta **19 violações vivas** em produção. Elas são o **dano pré-existente** — este PR impede que cresça, mas não repara o que já está lá. `npm run invariants` é comando manual e não gateia push, então nada quebra no fluxo de ninguém; mas quem rodar vai ver vermelho até o reparo.

O reparo dos 19 é trabalho de dado, não de produto, e por isso não entra aqui — segue em issue própria, conforme a convenção de `pipeline-processos/`.

Nota: a invariante conta *assignments de comparação* apoiados só em rascunho (19), enquanto a #678 contava *documentos elegíveis* (21) — medidas vizinhas, não idênticas.

Closes #678