### PR TITLE
feat(llm): Gemini 3.7 Flash como default + canário contra modelo recusado pelo provider

### DIFF
--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -17,6 +17,13 @@ from datetime import datetime, timedelta, timezone
 
 import pandas as pd
 
+# Importado no topo (e não junto do `from dataframeit import dataframeit` que
+# vive dentro de _run_dataframeit_batches) porque os testes substituem
+# sys.modules["dataframeit"] por um SimpleNamespace sem submódulos: resolver a
+# tupla em import-time do módulo mantém esses testes válidos sem que eles
+# precisem conhecer este import.
+from dataframeit.errors import NON_RECOVERABLE_ERRORS
+
 from services.auto_review_reconciliation import wake_auto_review_reconciliation
 from services.condition_evaluator import evaluate_condition, extract_field_conditions
 from services.pydantic_compiler import build_model_from_code, extract_json_schema_extra
@@ -839,6 +846,38 @@ def _expected_llm_fields(model_class) -> set[str]:
     return expected_llm_fields
 
 
+def _fatal_provider_error(frame: pd.DataFrame) -> str | None:
+    """Erro de configuração do provider (modelo inexistente, chave inválida,
+    permissão) visível já no canário — a mensagem, ou None se não houver.
+
+    Só classifica como fatal o que o próprio dataframeit marcou como sem
+    retry: `NON_RECOVERABLE_ERRORS` é a mesma tupla que ele consulta em
+    `is_recoverable_error` para decidir não tentar de novo, então não há um
+    segundo critério aqui para desatualizar quando a lib mudar o dela.
+
+    A distinção importa: um erro que esgotou retries num documento específico
+    (rate limit, timeout) continua indo para a via estatística de
+    `_raise_if_run_compromised`. Matar a run inteira por ele confundiria azar
+    pontual com configuração errada.
+
+    Exige que TODAS as linhas do frame tenham falhado assim — o sinal é "o
+    provider recusou tudo que viu", não "uma linha falhou".
+    """
+    if frame.empty:
+        return None
+    first_error: str | None = None
+    for _, row in frame.iterrows():
+        _, dfi_error = _extract_dataframeit_error(row)
+        if dfi_error is None:
+            return None
+        lowered = dfi_error.lower()
+        if not any(pattern.lower() in lowered for pattern in NON_RECOVERABLE_ERRORS):
+            return None
+        if first_error is None:
+            first_error = dfi_error
+    return first_error
+
+
 def _run_dataframeit_batches(
     *,
     sb,
@@ -855,7 +894,22 @@ def _run_dataframeit_batches(
     from dataframeit import dataframeit
 
     batch_size = max(1, config.parallel_requests)
-    batches = [df.iloc[i : i + batch_size] for i in range(0, len(df), batch_size)]
+    # A primeira batch leva um documento só, como canário. O dataframeit não
+    # propaga erro do provider: ele grava o erro na célula e devolve o frame
+    # normalmente, então um modelo inexistente ou uma chave inválida só
+    # apareceria em _raise_if_run_compromised — depois de gastar uma chamada por
+    # documento e de _process_and_save_rows ter publicado uma resposta vazia
+    # para cada um. Com o canário o pior caso é uma chamada e nenhuma escrita.
+    batches = [
+        batch
+        for batch in [
+            df.iloc[0:1],
+            *(df.iloc[i : i + batch_size] for i in range(1, len(df), batch_size)),
+        ]
+        # Partição vazia não é batch: sem o filtro, um df sem linhas produziria
+        # uma "primeira batch" vazia e o provider seria chamado à toa.
+        if not batch.empty
+    ]
     jobs_state.update(phase="processing", total_batches=len(batches))
 
     result_frames = []
@@ -876,6 +930,20 @@ def _run_dataframeit_batches(
             resume=False,
             **config.dfi_kwargs,
         )
+        if idx == 0:
+            fatal = _fatal_provider_error(batch_result)
+            if fatal:
+                # A afirmação "nenhuma resposta foi gravada" depende de esta
+                # função rodar inteira antes de _process_and_save_rows, que é
+                # quem publica (ver run_llm). Mover a publicação para dentro do
+                # loop de batches tornaria a mensagem mentirosa.
+                raise RuntimeError(
+                    f"O provider recusou o modelo '{llm_provider}/{llm_model}' "
+                    f"no primeiro dos {len(df)} documentos, então a run foi "
+                    f"abortada e nenhuma resposta foi gravada. Confira o nome "
+                    f"do modelo e a chave de API. "
+                    f"Erro do provider: {fatal}"
+                )
         result_frames.append(batch_result)
         processed = sum(len(f) for f in result_frames)
         jobs_state["progress"] = processed

--- a/backend/tests/test_llm_runner_response_row.py
+++ b/backend/tests/test_llm_runner_response_row.py
@@ -13,7 +13,7 @@ def _run(**overrides) -> _RunMetadata:
         project_id="proj-1",
         round_id="round-1",
         llm_provider="google_genai",
-        llm_model="gemini-3-flash-preview",
+        llm_model="gemini-3.7-flash",
         pydantic_hash="3c5e901f76547135",
         answer_field_hashes={"q1": "h1"},
         schema_version_major=0,
@@ -66,7 +66,7 @@ def test_campos_basicos_preservados():
     row = _build_llm_response_row(**_kwargs())
     assert row["respondent_type"] == "llm"
     assert "respondent_id" not in row
-    assert row["respondent_name"] == "google_genai/gemini-3-flash-preview"
+    assert row["respondent_name"] == "google_genai/gemini-3.7-flash"
     assert row["pydantic_hash"] == "3c5e901f76547135"
     assert row["llm_job_id"] == "job-1"
     assert row["llm_error"] is None

--- a/backend/tests/test_llm_runner_run_llm.py
+++ b/backend/tests/test_llm_runner_run_llm.py
@@ -202,12 +202,22 @@ def _docs(n: int) -> list[dict]:
     ]
 
 
-def _make_fake_dataframeit(row_specs: dict[str, dict], calls: list[dict] | None = None):
+def _make_fake_dataframeit(
+    row_specs: dict[str, dict],
+    calls: list[dict] | None = None,
+    errors: dict[str, str] | None = None,
+):
     """row_specs: {doc_id: {field: value}}.
 
     Campos ausentes do spec de um doc simulam resposta incompleta do
     provider (o dataframeit real também não garante 100% de cobertura).
+
+    errors: {doc_id: mensagem de _error_details}. Espelha o ponto central do
+    dataframeit real — ele NÃO propaga exceção do provider: marca a linha com
+    `_dataframeit_status='error'`, escreve a mensagem em `_error_details` e
+    devolve o frame como se tivesse dado certo.
     """
+    errors = errors or {}
 
     def _fake(batch_df, model_class, prompt_template, **kwargs):
         if calls is not None:
@@ -224,8 +234,10 @@ def _make_fake_dataframeit(row_specs: dict[str, dict], calls: list[dict] | None 
             out[field] = [
                 row_specs.get(doc_id, {}).get(field) for doc_id in batch_df["id"]
             ]
-        out["_dataframeit_status"] = "processed"
-        out["_error_details"] = None
+        out["_dataframeit_status"] = [
+            "error" if doc_id in errors else "processed" for doc_id in batch_df["id"]
+        ]
+        out["_error_details"] = [errors.get(doc_id) for doc_id in batch_df["id"]]
         return out
 
     return _fake
@@ -256,13 +268,16 @@ def _run_llm_sync(
     *,
     dataframeit_calls: list[dict] | None = None,
     wakeup_calls: list[bool] | None = None,
+    dataframeit_errors: dict[str, str] | None = None,
 ) -> None:
     monkeypatch.setattr("services.llm_runner.get_supabase", lambda: sb)
     monkeypatch.setitem(
         sys.modules,
         "dataframeit",
         SimpleNamespace(
-            dataframeit=_make_fake_dataframeit(row_specs, dataframeit_calls)
+            dataframeit=_make_fake_dataframeit(
+                row_specs, dataframeit_calls, dataframeit_errors
+            )
         ),
     )
 
@@ -431,9 +446,11 @@ def test_run_llm_processes_multiple_batches_and_tracks_progress(monkeypatch):
 
     _run_llm_sync(monkeypatch, sb, row_specs, dataframeit_calls=dataframeit_calls)
 
+    # A primeira batch leva um documento só (canário do erro de provider); as
+    # demais seguem o parallel_requests configurado.
     assert [call["document_ids"] for call in dataframeit_calls] == [
-        ["doc-0", "doc-1"],
-        ["doc-2"],
+        ["doc-0"],
+        ["doc-1", "doc-2"],
     ]
     assert _jobs[JOB_ID]["current_batch"] == 2
     assert _jobs[JOB_ID]["total_batches"] == 2
@@ -443,8 +460,10 @@ def test_run_llm_processes_multiple_batches_and_tracks_progress(monkeypatch):
         "doc-1",
         "doc-2",
     }
+    # Heartbeat persistido no fim da primeira batch — que agora é o canário,
+    # de um documento.
     assert any(
-        update.get("progress") == 2 for update in sb.table("llm_runs").update_calls
+        update.get("progress") == 1 for update in sb.table("llm_runs").update_calls
     )
 
 
@@ -604,6 +623,89 @@ def test_run_llm_compromised_run_raises_runtime_error(monkeypatch):
     error_update = _last_update_where(sb.table("llm_runs"), status="error")
     assert error_update is not None
     assert "Run comprometida" in error_update["error_message"]
+
+
+# Erro determinístico de configuração: o provider recusa o modelo em toda
+# linha. Texto copiado do incidente que motivou o canário (gemini-3-flash, um
+# ID que nunca existiu na API).
+_MODEL_NOT_FOUND = (
+    "[Erro não-recuperável] ChatGoogleGenerativeAIError: Error calling model "
+    "'gemini-3-flash' (NOT_FOUND): 404 NOT_FOUND. models/gemini-3-flash is not "
+    "found for API version v1beta"
+)
+# Erro pontual daquele documento, que o dataframeit já tentou de novo e
+# desistiu. Não contém nenhum padrão de NON_RECOVERABLE_ERRORS.
+_RATE_LIMIT_EXHAUSTED = (
+    "[Falhou após 3 tentativa(s)] ResourceExhausted: 429 rate limit exceeded"
+)
+
+
+def test_run_llm_canary_aborts_before_publishing_when_provider_rejects_model(
+    monkeypatch,
+):
+    # 26 documentos: a escala do incidente real, em que as 26 chamadas foram
+    # gastas e 26 respostas vazias publicadas antes de alguém perceber o 404.
+    docs = _docs(26)
+    row_specs = {doc["id"]: {} for doc in docs}
+    dataframeit_calls: list[dict] = []
+    sb = _build_supabase(_project_row(llm_model="gemini-3-flash"), docs)
+
+    _run_llm_sync(
+        monkeypatch,
+        sb,
+        row_specs,
+        dataframeit_calls=dataframeit_calls,
+        dataframeit_errors={doc["id"]: _MODEL_NOT_FOUND for doc in docs},
+    )
+
+    assert _jobs[JOB_ID]["status"] == "error"
+    assert _jobs[JOB_ID]["error_type"] == "RuntimeError"
+    message = _jobs[JOB_ID]["errors"][0]
+    # A mensagem tem de nomear o modelo: o diagnóstico antigo falava em
+    # cobertura baixa e mandava o usuário procurar defeito no schema.
+    assert "google/gemini-3-flash" in message
+    assert "404 NOT_FOUND" in message
+    assert "Run comprometida" not in message
+
+    # O que a guarda existe para evitar. Sem a asserção das chamadas, o teste
+    # passaria mesmo se o abort acontecesse só no fim, depois de gastar as 26.
+    assert [call["document_ids"] for call in dataframeit_calls] == [["doc-0"]]
+    assert _published_responses(sb) == []
+
+    error_update = _last_update_where(sb.table("llm_runs"), status="error")
+    assert error_update is not None
+    assert "404 NOT_FOUND" in error_update["error_message"]
+
+
+def test_run_llm_canary_lets_recoverable_error_reach_the_statistical_path(
+    monkeypatch,
+):
+    # Mesma forma do teste acima — todo documento falhando já no canário — mas
+    # com erro recuperável. É o discriminante: uma guarda que abortasse em
+    # qualquer falha do primeiro documento passaria no teste anterior e
+    # quebraria aqui, matando a run inteira por azar pontual.
+    docs = _docs(4)
+    row_specs = {doc["id"]: {} for doc in docs}
+    dataframeit_calls: list[dict] = []
+    sb = _build_supabase(_project_row(), docs)
+
+    _run_llm_sync(
+        monkeypatch,
+        sb,
+        row_specs,
+        dataframeit_calls=dataframeit_calls,
+        dataframeit_errors={doc["id"]: _RATE_LIMIT_EXHAUSTED for doc in docs},
+    )
+
+    # Todas as batches rodaram e as respostas foram publicadas (parciais, com
+    # is_latest=false) — só então o caminho estatístico reprovou a run.
+    assert [call["document_ids"] for call in dataframeit_calls] == [
+        ["doc-0"],
+        ["doc-1", "doc-2", "doc-3"],
+    ]
+    assert len(_published_responses(sb)) == 4
+    assert _jobs[JOB_ID]["status"] == "error"
+    assert "Run comprometida" in _jobs[JOB_ID]["errors"][0]
 
 
 def test_run_llm_unhandled_exception_is_persisted(monkeypatch):

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -26,7 +26,7 @@ CREATE TABLE projects (
   pydantic_fields JSONB,
   prompt_template TEXT,
   llm_provider    TEXT DEFAULT 'google_genai',
-  llm_model       TEXT DEFAULT 'gemini-3-flash-preview',
+  llm_model       TEXT DEFAULT 'gemini-3.7-flash',
   llm_kwargs      JSONB DEFAULT '{"temperature": 1.0, "thinking_level": "medium"}',
   resolution_rule              TEXT DEFAULT 'majority',
   min_responses_for_comparison INTEGER DEFAULT 2,

--- a/frontend/src/actions/__tests__/schema.test.ts
+++ b/frontend/src/actions/__tests__/schema.test.ts
@@ -507,11 +507,65 @@ describe("savePrompt / saveLlmConfig", () => {
     await expect(savePrompt("p1", "prompt")).resolves.toMatchObject({
       error: expect.stringMatching(/salvar o prompt/i),
     });
+    // Config válida de propósito: com provider ou modelo fora do registry a
+    // action recusa antes de tocar no banco, e este teste passaria a medir a
+    // validação em vez do caminho de RLS que ele existe para cobrir.
     state.tables = { projects: { data: [] } };
     await expect(saveLlmConfig("p1", {
-      llm_provider: "google",
-      llm_model: "gemini",
+      llm_provider: "google_genai",
+      llm_model: "gemini-3.7-flash",
       llm_kwargs: {},
     })).resolves.toMatchObject({ error: expect.stringMatching(/configuração do LLM/i) });
+  });
+
+  // A coluna `llm_model` ia crua ao provider, sem validação em ponto algum do
+  // caminho: foi um ID inexistente gravado aqui que queimou 26 chamadas em
+  // produção. Recusar na escrita torna o valor ruim impossível de persistir.
+  it("recusa provider fora do registry sem tocar no banco", async () => {
+    const result = await saveLlmConfig("p1", {
+      llm_provider: "google",
+      llm_model: "gemini-3.7-flash",
+      llm_kwargs: {},
+    });
+    expect(result.error).toMatch(/provedor de llm desconhecido/i);
+    expect(state.writes).toEqual([]);
+  });
+
+  it("recusa modelo que o provider não oferece sem tocar no banco", async () => {
+    const result = await saveLlmConfig("p1", {
+      llm_provider: "google_genai",
+      llm_model: "gemini-3-flash",
+      llm_kwargs: {},
+    });
+    // A mensagem nomeia as opções válidas: quem cair aqui está com uma UI
+    // dessincronizada do registry e precisa saber para onde ir.
+    expect(result.error).toMatch(/gemini-3-flash/);
+    expect(result.error).toMatch(/gemini-3\.7-flash/);
+    expect(state.writes).toEqual([]);
+  });
+
+  it("descarta o kwarg que o modelo escolhido não aceita", async () => {
+    // Cenário real: o projeto trocou de um Gemini 3.x para o 2.5 Flash Lite.
+    // `buildKwargsForCapabilities` só roda nos handlers de troca da UI, nunca
+    // no mount, então sem esta limpeza o thinking_level herdado sobreviveria na
+    // coluna e o provider responderia 400 em todo documento da run.
+    state.tables = { projects: { data: [{ id: "p1" }] } };
+    const result = await saveLlmConfig("p1", {
+      llm_provider: "google_genai",
+      llm_model: "gemini-2.5-flash-lite",
+      llm_kwargs: { thinking_level: "high", include_justifications: true },
+    });
+    expect(result.error).toBeUndefined();
+    expect(state.writes).toEqual([
+      {
+        table: "projects",
+        op: "update",
+        payload: {
+          llm_provider: "google_genai",
+          llm_model: "gemini-2.5-flash-lite",
+          llm_kwargs: { include_justifications: true, temperature: 1.0 },
+        },
+      },
+    ]);
   });
 });

--- a/frontend/src/actions/schema.ts
+++ b/frontend/src/actions/schema.ts
@@ -23,6 +23,12 @@ import {
   parseSaveablePydanticFields,
 } from "@/lib/pydantic-field";
 import {
+  buildKwargsForCapabilities,
+  getModelCapabilities,
+  getModelsForProvider,
+  isProvider,
+} from "@/lib/model-registry";
+import {
   classifyLogEntries,
   reconstructSnapshotsByVersion,
   matchResponsesToVersions,
@@ -833,6 +839,17 @@ export async function toggleLlmField(
   return persistSchema(projectId, fields, expectedBaseline, loaded);
 }
 
+/**
+ * Único escritor de `projects.llm_provider` / `llm_model` / `llm_kwargs` no
+ * sistema — o backend só lê essas colunas. É por isso que a validação mora
+ * aqui: é a fronteira onde dá para tornar o estado ruim inconstruível, em vez
+ * de detectá-lo depois, na run, quando o provider já recusou.
+ *
+ * O `llm_model` gravado ia cru para o provider, sem validação em ponto algum do
+ * caminho — foi assim que um ID inexistente queimou 26 chamadas em produção.
+ * Recusar o que não está no registry, em vez de sanear em silêncio, mantém o
+ * erro visível: `RunCard` já aborta a run quando esta action devolve `error`.
+ */
 export async function saveLlmConfig(
   projectId: string,
   config: {
@@ -841,9 +858,34 @@ export async function saveLlmConfig(
     llm_kwargs: Record<string, unknown>;
   }
 ): Promise<{ error?: string }> {
+  const { llm_provider, llm_model, llm_kwargs } = config;
+  if (!isProvider(llm_provider)) {
+    return { error: `Provedor de LLM desconhecido: "${llm_provider}".` };
+  }
+  const known = getModelsForProvider(llm_provider).map((m) => m.model);
+  if (!known.includes(llm_model)) {
+    return {
+      error:
+        `O modelo "${llm_model}" não é oferecido por ${llm_provider}. ` +
+        `Escolha um destes: ${known.join(", ")}.`,
+    };
+  }
+  // Higieniza os kwargs pela mesma regra que a UI aplica ao trocar de modelo.
+  // Sem isto, um `thinking_level` herdado de outro modelo sobrevive na coluna:
+  // `buildKwargsForCapabilities` só roda nos handlers de troca, nunca no mount,
+  // então config antiga nunca passaria por limpeza nenhuma.
+  const sanitized = {
+    llm_provider,
+    llm_model,
+    llm_kwargs: buildKwargsForCapabilities(
+      llm_kwargs,
+      getModelCapabilities(llm_provider, llm_model)
+    ),
+  };
+
   const supabase = await createSupabaseServer();
   try {
-    await updateOrThrow(supabase, "projects", config, { id: projectId }, {
+    await updateOrThrow(supabase, "projects", sanitized, { id: projectId }, {
       message:
         "Não foi possível salvar a configuração do LLM: sem permissão para alterar este projeto.",
     });

--- a/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
@@ -1,5 +1,6 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { LlmConfigurePane } from "@/components/llm/LlmConfigurePane";
+import { defaultModelForProvider, type Provider } from "@/lib/model-registry";
 import type { PydanticField } from "@/lib/types";
 
 // fallow-ignore-next-line complexity -- esta mudança só propaga a revisão do schema; a composição preexistente da página permanece fora deste refactor.
@@ -43,14 +44,21 @@ export default async function LlmConfigurePage({
     new Set(llmResponses?.map((response) => response.document_id)).size,
   );
 
+  // Projeto que nunca teve o modelo tocado na UI cai neste fallback. Ele tem
+  // de ser o mesmo default do registry: quando divergiam, a página abria num
+  // modelo que o próprio registry não conhecia e, por cair em
+  // DEFAULT_CAPABILITIES, escondia o select de raciocínio enquanto seguia
+  // mandando thinking_level nos kwargs.
+  const provider = (project?.llm_provider || "google_genai") as Provider;
+
   return (
     <LlmConfigurePane
       projectId={id}
       promptTemplate={project?.prompt_template ?? ""}
       projectDescription={project?.description ?? ""}
       config={{
-        llm_provider: project?.llm_provider || "google_genai",
-        llm_model: project?.llm_model || "gemini-3-flash-preview",
+        llm_provider: provider,
+        llm_model: project?.llm_model || defaultModelForProvider(provider),
         llm_kwargs:
           (project?.llm_kwargs as Record<string, unknown>) || {
             temperature: 1.0,

--- a/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/llm/configure/page.tsx
@@ -1,6 +1,6 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { LlmConfigurePane } from "@/components/llm/LlmConfigurePane";
-import { defaultModelForProvider, type Provider } from "@/lib/model-registry";
+import { defaultModelForProvider, isProvider } from "@/lib/model-registry";
 import type { PydanticField } from "@/lib/types";
 
 // fallow-ignore-next-line complexity -- esta mudança só propaga a revisão do schema; a composição preexistente da página permanece fora deste refactor.
@@ -49,7 +49,13 @@ export default async function LlmConfigurePage({
   // modelo que o próprio registry não conhecia e, por cair em
   // DEFAULT_CAPABILITIES, escondia o select de raciocínio enquanto seguia
   // mandando thinking_level nos kwargs.
-  const provider = (project?.llm_provider || "google_genai") as Provider;
+  //
+  // `llm_provider` é TEXT livre no banco; o guard é a fronteira que converte a
+  // string persistida no tipo `Provider`. Um cast no lugar dele deixaria um
+  // valor desconhecido render `""` em defaultModelForProvider.
+  const provider = isProvider(project?.llm_provider)
+    ? project.llm_provider
+    : "google_genai";
 
   return (
     <LlmConfigurePane

--- a/frontend/src/components/llm/ModelConfigCard.tsx
+++ b/frontend/src/components/llm/ModelConfigCard.tsx
@@ -22,7 +22,7 @@ import { toast } from "sonner";
 import { toggleLlmField } from "@/actions/schema";
 import { LLM_AMBIGUITIES_FIELD } from "@/lib/standard-questions";
 import {
-  getModelsForProvider,
+  defaultModelForProvider,
   getModelCapabilities,
   type ModelCapabilities,
   type Provider,
@@ -93,12 +93,11 @@ export function ModelConfigCard({
   };
 
   const handleChangeProvider = (provider: string) => {
-    const models = getModelsForProvider(provider as Provider);
-    const firstModel = models[0]?.model ?? "";
-    const caps = getModelCapabilities(provider as Provider, firstModel);
+    const defaultModel = defaultModelForProvider(provider as Provider);
+    const caps = getModelCapabilities(provider as Provider, defaultModel);
     setConfig({
       llm_provider: provider,
-      llm_model: firstModel,
+      llm_model: defaultModel,
       llm_kwargs: buildKwargsForCapabilities(config.llm_kwargs, caps),
     });
   };

--- a/frontend/src/components/llm/ModelConfigCard.tsx
+++ b/frontend/src/components/llm/ModelConfigCard.tsx
@@ -22,9 +22,10 @@ import { toast } from "sonner";
 import { toggleLlmField } from "@/actions/schema";
 import { LLM_AMBIGUITIES_FIELD } from "@/lib/standard-questions";
 import {
+  buildKwargsForCapabilities,
   defaultModelForProvider,
   getModelCapabilities,
-  type ModelCapabilities,
+  PROVIDERS,
   type Provider,
 } from "@/lib/model-registry";
 import { ModelCombobox } from "./ModelCombobox";
@@ -39,18 +40,6 @@ interface ModelConfigCardProps {
   schemaBaseline: SchemaBaselineIdentity;
 }
 
-function buildKwargsForCapabilities(
-  currentKwargs: Record<string, unknown>,
-  caps: ModelCapabilities,
-): Record<string, unknown> {
-  const newKwargs = { ...currentKwargs };
-  if (!caps.supportsTemperature) delete newKwargs.temperature;
-  else if (newKwargs.temperature == null) newKwargs.temperature = 1.0;
-  if (!caps.supportsThinkingLevel) delete newKwargs.thinking_level;
-  else if (!newKwargs.thinking_level) newKwargs.thinking_level = "medium";
-  return newKwargs;
-}
-
 export function ModelConfigCard({
   projectId,
   config,
@@ -59,7 +48,7 @@ export function ModelConfigCard({
   schemaBaseline,
 }: ModelConfigCardProps) {
   const capabilities = getModelCapabilities(
-    config.llm_provider as Provider,
+    config.llm_provider,
     config.llm_model,
   );
 
@@ -84,7 +73,7 @@ export function ModelConfigCard({
   };
 
   const handleSelectModel = (model: string) => {
-    const caps = getModelCapabilities(config.llm_provider as Provider, model);
+    const caps = getModelCapabilities(config.llm_provider, model);
     setConfig((c) => ({
       ...c,
       llm_model: model,
@@ -92,9 +81,11 @@ export function ModelConfigCard({
     }));
   };
 
-  const handleChangeProvider = (provider: string) => {
-    const defaultModel = defaultModelForProvider(provider as Provider);
-    const caps = getModelCapabilities(provider as Provider, defaultModel);
+  // O parâmetro é `Provider` porque as opções do Select saem de PROVIDERS; o
+  // cast fica na fronteira do Radix, cujo onValueChange é sempre `string`.
+  const handleChangeProvider = (provider: Provider) => {
+    const defaultModel = defaultModelForProvider(provider);
+    const caps = getModelCapabilities(provider, defaultModel);
     setConfig({
       llm_provider: provider,
       llm_model: defaultModel,
@@ -151,15 +142,17 @@ export function ModelConfigCard({
             <Label className="text-sm">Provedor</Label>
             <Select
               value={config.llm_provider}
-              onValueChange={handleChangeProvider}
+              onValueChange={(v) => handleChangeProvider(v as Provider)}
             >
               <SelectTrigger className="w-full">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="google_genai">Google GenAI</SelectItem>
-                <SelectItem value="openai">OpenAI</SelectItem>
-                <SelectItem value="anthropic">Anthropic</SelectItem>
+                {PROVIDERS.map((p) => (
+                  <SelectItem key={p.provider} value={p.provider}>
+                    {p.label}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/frontend/src/components/llm/__tests__/LlmConfigurePane.degradation.test.tsx
+++ b/frontend/src/components/llm/__tests__/LlmConfigurePane.degradation.test.tsx
@@ -50,7 +50,7 @@ const baseProps = {
   promptTemplate: "",
   projectDescription: "",
   config: {
-    llm_provider: "anthropic",
+    llm_provider: "anthropic" as const,
     llm_model: "claude-test",
     llm_kwargs: {},
   },

--- a/frontend/src/components/llm/__tests__/ModelConfigCard.test.tsx
+++ b/frontend/src/components/llm/__tests__/ModelConfigCard.test.tsx
@@ -20,7 +20,7 @@ import { LLM_AMBIGUITIES_FIELD } from "@/lib/standard-questions";
 const baseProps = {
   projectId: "p1",
   config: {
-    llm_provider: "anthropic",
+    llm_provider: "anthropic" as const,
     llm_model: "claude-test",
     llm_kwargs: {},
   },

--- a/frontend/src/components/llm/__tests__/RunCard.test.tsx
+++ b/frontend/src/components/llm/__tests__/RunCard.test.tsx
@@ -56,7 +56,7 @@ import { RunCard } from "@/components/llm/RunCard";
 const props = {
   projectId: "00000000-0000-4000-8000-000000000001",
   config: {
-    llm_provider: "openai",
+    llm_provider: "openai" as const,
     llm_model: "test-model",
     llm_kwargs: {},
   },

--- a/frontend/src/lib/__tests__/model-registry.test.ts
+++ b/frontend/src/lib/__tests__/model-registry.test.ts
@@ -2,14 +2,17 @@ import { describe, it, expect } from "vitest";
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
+  buildKwargsForCapabilities,
   defaultModelForProvider,
   getModelCapabilities,
   getModelsForProvider,
-  type Provider,
+  isProvider,
+  PROVIDERS,
+  type ModelCapabilities,
 } from "../model-registry";
 
 const MIGRATIONS = join(__dirname, "..", "..", "..", "supabase", "migrations");
-const PROVIDERS: Provider[] = ["google_genai", "openai", "anthropic"];
+const PROVIDER_IDS = PROVIDERS.map((p) => p.provider);
 
 /** O DEFAULT vigente de `projects.llm_model`, lido das migrations.
  *
@@ -45,7 +48,7 @@ describe("registry de modelos", () => {
   it("todo provider declara ao menos um modelo, e o default é um deles", () => {
     // defaultModelForProvider devolve "" para provider sem modelo — o combobox
     // abriria vazio e o backend mandaria string vazia ao provider.
-    for (const provider of PROVIDERS) {
+    for (const provider of PROVIDER_IDS) {
       const models = getModelsForProvider(provider);
       expect(models.length).toBeGreaterThan(0);
       expect(models.map((m) => m.model)).toContain(
@@ -57,7 +60,7 @@ describe("registry de modelos", () => {
   it("não repete id de modelo dentro de um provider", () => {
     // Duplicata daria duas entradas no combobox e tornaria indeterminado qual
     // label/capabilities getModelCapabilities devolve.
-    for (const provider of PROVIDERS) {
+    for (const provider of PROVIDER_IDS) {
       const ids = getModelsForProvider(provider).map((m) => m.model);
       expect(ids).toEqual([...new Set(ids)]);
     }
@@ -66,12 +69,134 @@ describe("registry de modelos", () => {
   it("todo modelo do registry se encontra por getModelCapabilities", () => {
     // Fecha a volta provider+model: uma entrada com o provider errado no campo
     // `provider` sairia na lista de um provider e não seria achada por ele.
-    for (const provider of PROVIDERS) {
+    for (const provider of PROVIDER_IDS) {
       for (const model of getModelsForProvider(provider)) {
         expect(getModelCapabilities(provider, model.model).label).toBe(
           model.label,
         );
       }
     }
+  });
+});
+
+/** Veredito da API do Gemini para cada modelo, medido em 2026-08-13.
+ *
+ * Cada linha é uma chamada real (`ChatGoogleGenerativeAI(...).invoke`) feita da
+ * máquina do Fly, onde vive a única GOOGLE_API_KEY. Não dá para reproduzir isso
+ * num teste unitário — o que este arquivo trava é a transcrição da medição para
+ * o registry, que é onde a divergência causa dano.
+ *
+ * `thinking_level` não é "toda a linha Gemini": a 2.5 responde
+ * `400 INVALID_ARGUMENT: 'Thinking level is not supported for this model.'`.
+ * Só a linha 3.x aceita o parâmetro.
+ */
+const THINKING_LEVEL_NA_API: Record<string, boolean> = {
+  "gemini-3.7-flash": true,
+  "gemini-3.6-flash": true,
+  "gemini-3.5-flash": true,
+  "gemini-3.5-flash-lite": true,
+  "gemini-2.5-flash": false,
+  "gemini-2.5-flash-lite": false,
+};
+
+describe("capabilities conferidas contra a API", () => {
+  it("supportsThinkingLevel do google_genai reproduz a medição", () => {
+    // O dano de errar aqui não é cosmético: a UI injeta thinking_level="medium"
+    // ao selecionar o modelo, o backend repassa o kwarg cru ao provider, e o
+    // 400 resultante nem sequer aciona o canário — 'INVALID_ARGUMENT' não casa
+    // com o padrão 'InvalidArgument' de NON_RECOVERABLE_ERRORS por causa do
+    // underscore. O dataframeit trata como recuperável, gasta 3 retries por
+    // documento e a run morre em "Run comprometida".
+    for (const model of getModelsForProvider("google_genai")) {
+      expect(THINKING_LEVEL_NA_API).toHaveProperty(model.model);
+      expect({
+        model: model.model,
+        supportsThinkingLevel: model.supportsThinkingLevel,
+      }).toEqual({
+        model: model.model,
+        supportsThinkingLevel: THINKING_LEVEL_NA_API[model.model],
+      });
+    }
+  });
+
+  it("não oferece modelo que a API recusa para esta chave", () => {
+    // gemini-2.5-pro responde "This model models/gemini-2.5-pro is no longer
+    // available to new users" — e, ao contrário de gemini-3-flash, ele APARECE
+    // no ListModels. Conferir o catálogo não basta; só a chamada revela.
+    const ids = getModelsForProvider("google_genai").map((m) => m.model);
+    expect(ids).not.toContain("gemini-2.5-pro");
+  });
+});
+
+describe("isProvider", () => {
+  it("aceita os providers do registry e recusa o resto", () => {
+    // A coluna projects.llm_provider é TEXT livre. Este guard é o que separa
+    // o valor persistido do tipo Provider — sem ele o cast `as Provider` deixa
+    // um valor desconhecido chegar a getModelsForProvider, que devolve [] e
+    // faz defaultModelForProvider render "".
+    for (const provider of PROVIDER_IDS) expect(isProvider(provider)).toBe(true);
+    for (const bogus of ["google", "gemini", "", "GOOGLE_GENAI"]) {
+      expect(isProvider(bogus)).toBe(false);
+    }
+    expect(isProvider(null)).toBe(false);
+    expect(isProvider(undefined)).toBe(false);
+  });
+});
+
+describe("buildKwargsForCapabilities", () => {
+  const caps = (over: Partial<ModelCapabilities>): ModelCapabilities => ({
+    provider: "google_genai",
+    model: "m",
+    label: "M",
+    supportsTemperature: true,
+    supportsThinkingLevel: true,
+    category: "reasoning",
+    ...over,
+  });
+
+  it("remove o kwarg que o modelo não aceita", () => {
+    // O caso que queimou a run: kwargs herdados de um modelo 3.x seguindo para
+    // um 2.5 que recusa o parâmetro.
+    expect(
+      buildKwargsForCapabilities(
+        { thinking_level: "medium", temperature: 0.7 },
+        caps({ supportsThinkingLevel: false }),
+      ),
+    ).toEqual({ temperature: 0.7 });
+    expect(
+      buildKwargsForCapabilities(
+        { thinking_level: "high", temperature: 0.7 },
+        caps({ supportsTemperature: false }),
+      ),
+    ).toEqual({ thinking_level: "high" });
+  });
+
+  it("preenche o default só quando o modelo aceita e o valor falta", () => {
+    expect(buildKwargsForCapabilities({}, caps({}))).toEqual({
+      temperature: 1.0,
+      thinking_level: "medium",
+    });
+  });
+
+  it("não sobrescreve valor já escolhido, inclusive temperatura zero", () => {
+    // `temperature: 0` é falsy: um teste de presença por truthiness o
+    // substituiria por 1.0 e mudaria o resultado da run em silêncio.
+    expect(
+      buildKwargsForCapabilities(
+        { temperature: 0, thinking_level: "high" },
+        caps({}),
+      ),
+    ).toEqual({ temperature: 0, thinking_level: "high" });
+  });
+
+  it("preserva os kwargs que não são de capability", () => {
+    // include_justifications, parallel_requests e os thresholds de run passam
+    // por aqui e não podem ser descartados na higienização.
+    expect(
+      buildKwargsForCapabilities(
+        { include_justifications: true, parallel_requests: 8 },
+        caps({ supportsTemperature: false, supportsThinkingLevel: false }),
+      ),
+    ).toEqual({ include_justifications: true, parallel_requests: 8 });
   });
 });

--- a/frontend/src/lib/__tests__/model-registry.test.ts
+++ b/frontend/src/lib/__tests__/model-registry.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  defaultModelForProvider,
+  getModelCapabilities,
+  getModelsForProvider,
+  type Provider,
+} from "../model-registry";
+
+const MIGRATIONS = join(__dirname, "..", "..", "..", "supabase", "migrations");
+const PROVIDERS: Provider[] = ["google_genai", "openai", "anthropic"];
+
+/** O DEFAULT vigente de `projects.llm_model`, lido das migrations.
+ *
+ * Vale a última declaração em ordem de nome de arquivo — que é a ordem em que
+ * o Postgres as aplica. Casa as duas formas em que o default aparece: a coluna
+ * nascendo no CREATE TABLE (001) e o ALTER COLUMN que a redefine depois.
+ */
+function llmModelDefaultInSql(): string {
+  const declaration =
+    /llm_model\s+TEXT\s+DEFAULT\s+'([^']+)'|ALTER\s+COLUMN\s+llm_model\s+SET\s+DEFAULT\s+'([^']+)'/gi;
+  let latest: string | null = null;
+  for (const file of readdirSync(MIGRATIONS).sort()) {
+    const sql = readFileSync(join(MIGRATIONS, file), "utf8");
+    for (const match of sql.matchAll(declaration)) {
+      latest = match[1] ?? match[2];
+    }
+  }
+  if (latest === null) {
+    throw new Error("nenhuma migration declara o DEFAULT de projects.llm_model");
+  }
+  return latest;
+}
+
+describe("registry de modelos", () => {
+  it("o default do google_genai é o mesmo DEFAULT da coluna projects.llm_model", () => {
+    // O SQL não deriva do TypeScript, então esta é a única amarra entre os
+    // dois. Quando divergiram, a página de configuração abria num modelo que o
+    // próprio registry não conhecia: caía em DEFAULT_CAPABILITIES, escondia o
+    // select de raciocínio e seguia mandando thinking_level nos kwargs.
+    expect(llmModelDefaultInSql()).toBe(defaultModelForProvider("google_genai"));
+  });
+
+  it("todo provider declara ao menos um modelo, e o default é um deles", () => {
+    // defaultModelForProvider devolve "" para provider sem modelo — o combobox
+    // abriria vazio e o backend mandaria string vazia ao provider.
+    for (const provider of PROVIDERS) {
+      const models = getModelsForProvider(provider);
+      expect(models.length).toBeGreaterThan(0);
+      expect(models.map((m) => m.model)).toContain(
+        defaultModelForProvider(provider),
+      );
+    }
+  });
+
+  it("não repete id de modelo dentro de um provider", () => {
+    // Duplicata daria duas entradas no combobox e tornaria indeterminado qual
+    // label/capabilities getModelCapabilities devolve.
+    for (const provider of PROVIDERS) {
+      const ids = getModelsForProvider(provider).map((m) => m.model);
+      expect(ids).toEqual([...new Set(ids)]);
+    }
+  });
+
+  it("todo modelo do registry se encontra por getModelCapabilities", () => {
+    // Fecha a volta provider+model: uma entrada com o provider errado no campo
+    // `provider` sairia na lista de um provider e não seria achada por ele.
+    for (const provider of PROVIDERS) {
+      for (const model of getModelsForProvider(provider)) {
+        expect(getModelCapabilities(provider, model.model).label).toBe(
+          model.label,
+        );
+      }
+    }
+  });
+});

--- a/frontend/src/lib/model-registry.ts
+++ b/frontend/src/lib/model-registry.ts
@@ -1,4 +1,27 @@
-export type Provider = "google_genai" | "openai" | "anthropic";
+/**
+ * Providers oferecidos pela UI, com o rótulo do select. A união `Provider`
+ * deriva desta lista: declarar as duas coisas em separado é a forma de drift
+ * que este arquivo existe para evitar — o `<Select>` de provedor chegou a
+ * repetir estes três valores em JSX.
+ */
+export const PROVIDERS = [
+  { provider: "google_genai", label: "Google GenAI" },
+  { provider: "openai", label: "OpenAI" },
+  { provider: "anthropic", label: "Anthropic" },
+] as const;
+
+export type Provider = (typeof PROVIDERS)[number]["provider"];
+
+/**
+ * `projects.llm_provider` é TEXT livre, então todo valor vindo do banco entra
+ * como `string`. Este guard é a única fronteira entre esse valor e o tipo
+ * `Provider`; sem ele, um cast deixa um provider desconhecido chegar a
+ * `getModelsForProvider`, que devolve `[]` — e aí `defaultModelForProvider`
+ * rende `""` e a página abre sem modelo.
+ */
+export function isProvider(value: string | null | undefined): value is Provider {
+  return PROVIDERS.some((p) => p.provider === value);
+}
 
 export interface ModelCapabilities {
   provider: Provider;
@@ -6,10 +29,20 @@ export interface ModelCapabilities {
   label: string;
   supportsTemperature: boolean;
   /**
-   * Aceita `thinking_level` nos kwargs. Independente de `category`: os
-   * Flash-Lite entram no grupo "Padrão" pelo porte, mas aceitam o parâmetro.
-   * O select da UI só oferece low/medium/high — subconjunto que vale para
-   * toda a linha Gemini (os 3.5/3.6 também aceitam `minimal`).
+   * Aceita `thinking_level` nos kwargs. Independente de `category`: o
+   * `gemini-3.5-flash-lite` entra no grupo "Padrão" pelo porte e aceita o
+   * parâmetro. A divisão real é por geração — a linha Gemini 2.5 responde
+   * `400 INVALID_ARGUMENT: 'Thinking level is not supported for this model.'`,
+   * a 3.x aceita. O select da UI oferece low/medium/high (a 3.x também aceita
+   * `minimal`).
+   *
+   * Declarar `true` para um modelo que recusa não é engano cosmético: a UI
+   * injeta `thinking_level: "medium"` ao selecionar, o backend repassa o kwarg
+   * cru, e o 400 resultante nem aciona o canário de `llm_runner` — o texto
+   * `INVALID_ARGUMENT` não casa com o padrão `InvalidArgument` de
+   * `NON_RECOVERABLE_ERRORS` por causa do underscore, então o dataframeit o
+   * trata como recuperável e gasta os retries de cada documento antes de a run
+   * morrer em "Run comprometida".
    */
   supportsThinkingLevel: boolean;
   /** Só agrupa a lista do combobox por porte do modelo. */
@@ -21,10 +54,15 @@ export interface ModelCapabilities {
  * `defaultModelForProvider`. Trocar o default é reordenar esta lista, não
  * manter uma tabela provider→modelo em paralelo.
  *
- * IDs conferidos em https://ai.google.dev/gemini-api/docs/models. Um ID que
- * não exista lá vira 404 no provider e queima a run inteira (foi o que
- * aconteceu com `gemini-3-flash`, que nunca existiu: o preview chamava-se
- * `gemini-3-flash-preview`).
+ * Entradas conferidas em 2026-08-13 por chamada real à API, a partir da máquina
+ * do Fly (onde vive a chave). Consultar o catálogo — a doc ou o `ListModels` —
+ * NÃO basta: `gemini-2.5-pro` aparece listado e mesmo assim responde "no longer
+ * available to new users", então só a chamada distingue catálogo de acesso. Um
+ * modelo indisponível queima a run inteira, como aconteceu com `gemini-3-flash`
+ * (que nunca existiu: o preview chamava-se `gemini-3-flash-preview`).
+ *
+ * As entradas de `openai` e `anthropic` seguem não medidas — não há chave
+ * desses providers no ambiente. Ver issue de follow-up.
  */
 const MODEL_REGISTRY: ModelCapabilities[] = [
   // --- Google GenAI ---
@@ -57,17 +95,12 @@ const MODEL_REGISTRY: ModelCapabilities[] = [
     model: "gemini-2.5-flash",
     label: "Gemini 2.5 Flash",
     supportsTemperature: true,
-    supportsThinkingLevel: true,
+    supportsThinkingLevel: false,
     category: "reasoning",
   },
-  {
-    provider: "google_genai",
-    model: "gemini-2.5-pro",
-    label: "Gemini 2.5 Pro",
-    supportsTemperature: true,
-    supportsThinkingLevel: true,
-    category: "reasoning",
-  },
+  // `gemini-2.5-pro` saiu daqui: a API responde "This model models/gemini-2.5-pro
+  // is no longer available to new users". Nenhuma resposta gravada usou o
+  // modelo, então remover não degrada rótulo de histórico nenhum.
   {
     provider: "google_genai",
     model: "gemini-3.5-flash-lite",
@@ -81,7 +114,7 @@ const MODEL_REGISTRY: ModelCapabilities[] = [
     model: "gemini-2.5-flash-lite",
     label: "Gemini 2.5 Flash Lite",
     supportsTemperature: true,
-    supportsThinkingLevel: true,
+    supportsThinkingLevel: false,
     category: "standard",
   },
 
@@ -203,6 +236,31 @@ export function getModelCapabilities(
   );
   if (found) return found;
   return { ...DEFAULT_CAPABILITIES, provider, model, label: model };
+}
+
+/**
+ * Ajusta os kwargs ao que o modelo aceita: descarta o parâmetro que ele recusa
+ * e preenche o default do que ele aceita e ainda não tem valor. As demais
+ * chaves (`include_justifications`, `parallel_requests`, os thresholds de run)
+ * passam intactas.
+ *
+ * Mora aqui, e não no componente, porque a mesma regra vale na escrita: a UI a
+ * aplica ao trocar de modelo, e `saveLlmConfig` a reaplica antes de gravar. Uma
+ * segunda cópia divergiria — e é justamente a divergência que manda ao provider
+ * um kwarg que o modelo recusa.
+ */
+export function buildKwargsForCapabilities(
+  currentKwargs: Record<string, unknown>,
+  caps: ModelCapabilities
+): Record<string, unknown> {
+  const newKwargs = { ...currentKwargs };
+  if (!caps.supportsTemperature) delete newKwargs.temperature;
+  // `== null` de propósito: `temperature: 0` é um valor escolhido, e um teste
+  // por truthiness o trocaria por 1.0 mudando o resultado da run em silêncio.
+  else if (newKwargs.temperature == null) newKwargs.temperature = 1.0;
+  if (!caps.supportsThinkingLevel) delete newKwargs.thinking_level;
+  else if (!newKwargs.thinking_level) newKwargs.thinking_level = "medium";
+  return newKwargs;
 }
 
 /**

--- a/frontend/src/lib/model-registry.ts
+++ b/frontend/src/lib/model-registry.ts
@@ -5,24 +5,49 @@ export interface ModelCapabilities {
   model: string;
   label: string;
   supportsTemperature: boolean;
+  /**
+   * Aceita `thinking_level` nos kwargs. Independente de `category`: os
+   * Flash-Lite entram no grupo "Padrão" pelo porte, mas aceitam o parâmetro.
+   * O select da UI só oferece low/medium/high — subconjunto que vale para
+   * toda a linha Gemini (os 3.5/3.6 também aceitam `minimal`).
+   */
   supportsThinkingLevel: boolean;
+  /** Só agrupa a lista do combobox por porte do modelo. */
   category: "standard" | "reasoning";
 }
 
+/**
+ * O PRIMEIRO modelo de cada provider é o default dele — ver
+ * `defaultModelForProvider`. Trocar o default é reordenar esta lista, não
+ * manter uma tabela provider→modelo em paralelo.
+ *
+ * IDs conferidos em https://ai.google.dev/gemini-api/docs/models. Um ID que
+ * não exista lá vira 404 no provider e queima a run inteira (foi o que
+ * aconteceu com `gemini-3-flash`, que nunca existiu: o preview chamava-se
+ * `gemini-3-flash-preview`).
+ */
 const MODEL_REGISTRY: ModelCapabilities[] = [
   // --- Google GenAI ---
   {
     provider: "google_genai",
-    model: "gemini-3-flash",
-    label: "Gemini 3 Flash",
+    model: "gemini-3.7-flash",
+    label: "Gemini 3.7 Flash",
     supportsTemperature: true,
     supportsThinkingLevel: true,
     category: "reasoning",
   },
   {
     provider: "google_genai",
-    model: "gemini-3.1-pro-preview",
-    label: "Gemini 3.1 Pro",
+    model: "gemini-3.6-flash",
+    label: "Gemini 3.6 Flash",
+    supportsTemperature: true,
+    supportsThinkingLevel: true,
+    category: "reasoning",
+  },
+  {
+    provider: "google_genai",
+    model: "gemini-3.5-flash",
+    label: "Gemini 3.5 Flash",
     supportsTemperature: true,
     supportsThinkingLevel: true,
     category: "reasoning",
@@ -45,10 +70,18 @@ const MODEL_REGISTRY: ModelCapabilities[] = [
   },
   {
     provider: "google_genai",
+    model: "gemini-3.5-flash-lite",
+    label: "Gemini 3.5 Flash Lite",
+    supportsTemperature: true,
+    supportsThinkingLevel: true,
+    category: "standard",
+  },
+  {
+    provider: "google_genai",
     model: "gemini-2.5-flash-lite",
     label: "Gemini 2.5 Flash Lite",
     supportsTemperature: true,
-    supportsThinkingLevel: false,
+    supportsThinkingLevel: true,
     category: "standard",
   },
 
@@ -139,6 +172,19 @@ const MODEL_REGISTRY: ModelCapabilities[] = [
 
 export function getModelsForProvider(provider: Provider): ModelCapabilities[] {
   return MODEL_REGISTRY.filter((m) => m.provider === provider);
+}
+
+/**
+ * Modelo default de um provider: o primeiro que ele declara no registry.
+ * Usado tanto ao trocar de provider na UI quanto como fallback para projeto
+ * cuja coluna `llm_model` veio vazia.
+ *
+ * O DEFAULT da coluna `projects.llm_model` precisa acompanhar este valor para
+ * `google_genai` — o SQL não deriva do TypeScript, então a migration que troca
+ * um lado tem de trocar o outro.
+ */
+export function defaultModelForProvider(provider: Provider): string {
+  return getModelsForProvider(provider)[0]?.model ?? "";
 }
 
 const DEFAULT_CAPABILITIES: Omit<ModelCapabilities, "provider" | "model"> = {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,4 +1,5 @@
 import type { PydanticField } from "./pydantic-field";
+import type { Provider } from "./model-registry";
 
 export interface Profile {
   id: string;
@@ -237,7 +238,11 @@ export interface SchemaChangeEntry {
 // `ModelConfigCard`/`RunCard` — tipo único aqui evita drift ao adicionar um
 // kwarg estrutural novo.
 export interface LlmConfig {
-  llm_provider: string;
+  // `Provider`, e não `string`: enquanto era string, cada consumidor refazia um
+  // `as Provider` por conta própria e nenhum deles validava nada. Com a união
+  // aqui, o compilador exige `isProvider` na única fronteira que lê a coluna
+  // (a página de configure) e os casts somem.
+  llm_provider: Provider;
   llm_model: string;
   llm_kwargs: Record<string, unknown>;
 }

--- a/frontend/supabase/migrations/20260813120000_default_llm_model_gemini_3_7_flash.sql
+++ b/frontend/supabase/migrations/20260813120000_default_llm_model_gemini_3_7_flash.sql
@@ -1,0 +1,35 @@
+-- projects.llm_model: default passa a ser gemini-3.7-flash (GA) e os projetos
+-- que apontavam para a linha Gemini 3 preview sao migrados junto.
+--
+-- Motivacao: uma run de producao gastou 26 chamadas e gravou 26 respostas
+-- vazias antes de estourar "Run comprometida: 26/26 docs (100%)". O provider
+-- respondeu 404 NOT_FOUND para `models/gemini-3-flash` — um ID que nunca
+-- existiu na API. O registry do frontend oferecia "Gemini 3 Flash" apontando
+-- para `gemini-3-flash`, quando o preview real chamava-se
+-- `gemini-3-flash-preview` (o proprio default desta coluna desde a 001).
+-- Selecionar aquela opcao gravava o ID morto aqui, e o backend passava a
+-- string crua ao provider sem validacao em ponto algum do caminho.
+--
+-- Censo antes desta migration (9 projetos, todos google_genai):
+--   1x gemini-3-flash          -- inexistente, e o que estourou
+--   8x gemini-3-flash-preview  -- existe, mas ja e preview legado
+--
+-- O valor tem de acompanhar `defaultModelForProvider("google_genai")` em
+-- frontend/src/lib/model-registry.ts — o SQL nao deriva do TypeScript, entao a
+-- proxima troca de default precisa mexer nos dois lados.
+--
+-- Respostas ja gravadas nao sao tocadas: `responses.respondent_name` guarda o
+-- modelo historico de cada run, e `publish_latest_llm_response` desmarca
+-- is_latest por documento sem olhar respondent_name. Trocar o modelo do projeto
+-- substitui a resposta LLM corrente no proximo run, como um re-run comum — nao
+-- cria respondente paralelo nem par de comparacao novo.
+
+ALTER TABLE public.projects
+  ALTER COLUMN llm_model SET DEFAULT 'gemini-3.7-flash';
+
+-- Escopo restrito a google_genai para nao tocar projeto que tenha migrado de
+-- provider e por acaso carregue um destes nomes.
+UPDATE public.projects
+   SET llm_model = 'gemini-3.7-flash'
+ WHERE llm_provider = 'google_genai'
+   AND llm_model IN ('gemini-3-flash', 'gemini-3-flash-preview');


### PR DESCRIPTION
## Contexto

Uma run de produção gastou 26 chamadas e publicou 26 respostas vazias antes de estourar `RuntimeError: Run comprometida: 26/26 docs (100%)`. O diagnóstico falava em cobertura baixa e listava campos faltantes — mandando procurar defeito no schema. O problema era outro: o provider devolveu `404 NOT_FOUND` para `models/gemini-3-flash`.

**Esse ID nunca existiu.** O preview real chamava-se `gemini-3-flash-preview` — que é, aliás, o default desta coluna desde a `001`. O registry oferecia "Gemini 3 Flash" apontando para o nome errado; selecionar aquela opção gravava o ID morto em `projects.llm_model`, e como o modelo não trafega no body do `/run` (o backend relê do banco em `llm_runner.py`), a string ia crua ao `dataframeit` sem validação em ponto algum do caminho.

Em paralelo, saiu o Gemini 3.7 Flash. O PR resolve as duas coisas, em duas metades independentes.

## Verificado contra a API real

Chamadas de dentro da máquina do Fly, com a `GOOGLE_API_KEY` de produção — sem gravar nada:

| ID | resultado |
|---|---|
| `gemini-3.7-flash` | **HTTP 200** |
| `gemini-3-flash` | **404** — a causa raiz |
| `gemini-3-flash-preview` | HTTP 200 — os 8 projetos de fato funcionavam |

## Metade 1 — modelo e registry (f413eaa)

- registry Google refeito com os IDs de [ai.google.dev](https://ai.google.dev/gemini-api/docs/models): 3.7/3.6/3.5 Flash, 3.5 e 2.5 Flash Lite, 2.5 Flash/Pro. Saem `gemini-3-flash` (inexistente) e `gemini-3.1-pro-preview` (preview legado).
- os Flash-Lite passam a declarar `supportsThinkingLevel` — a doc confirma que aceitam o parâmetro. `category` deixa de ser sinônimo disso e fica só com o agrupamento por porte no combobox.
- `defaultModelForProvider` deriva o default do primeiro item do registry, em vez de uma tabela provider→modelo paralela à ordem (que `handleChangeProvider` já usava de fato). A página de configuração passa a usá-lo no lugar do ID hardcoded, que divergia do registry e por isso escondia o select de raciocínio em projeto nunca-tocado.
- migration troca o `DEFAULT` da coluna e migra os 9 projetos existentes. **Já aplicada em produção**: censo passou de `1× gemini-3-flash` + `8× gemini-3-flash-preview` para `9× gemini-3.7-flash`. Respostas gravadas não são tocadas — `publish_latest_llm_response` desmarca `is_latest` por documento sem olhar `respondent_name`, então trocar o modelo substitui a resposta corrente no próximo run como um re-run comum, sem criar respondente paralelo.
- teste novo amarra o default do registry ao `DEFAULT` da migration: a duplicação TS↔SQL não dá para derivar, então vira gate.

## Metade 2 — canário (edf17b5)

O `dataframeit` não propaga erro do provider. `is_recoverable_error` classifica 404/401/403 como sem retry, mas em vez de levantar a exceção ele grava `_dataframeit_status='error'` na célula e devolve o frame como se tivesse dado certo. Por isso o 404 só aparecia em `_raise_if_run_compromised` — depois de gastar uma chamada por documento e de `_process_and_save_rows` ter publicado uma resposta vazia para cada um.

A primeira batch passa a levar um documento só. Se ele voltar com erro que a própria lib marcou como não-recuperável, a run aborta ali, antes de qualquer publicação. **O pior caso vai de 26 chamadas + 26 linhas mortas para 1 chamada e nenhuma escrita**, e a mensagem nomeia provider e modelo.

O canário não desperdiça chamada: o frame de uma linha entra no `pd.concat` final como qualquer outra batch. A classificação importa `NON_RECOVERABLE_ERRORS` de `dataframeit.errors` — a mesma tupla que a lib consulta — em vez de copiar para cá a string do prefixo.

## Verificação

- **Prova do vermelho**: rodados contra o runner anterior, os testes novos falham produzindo literalmente a mensagem do incidente (`Run comprometida: 26/26 docs (100%)`); a asserção que cai é a de nomear o modelo.
- **Discriminante**: o caso do 429 é idêntico ao do 404 em tudo menos a classe do erro, e exige que a run siga até o fim. É o que separa esta guarda de um "aborta em qualquer falha do primeiro documento" — que passaria no primeiro teste e mataria runs por azar pontual.
- O teste do 404 exige zero publicações **e** uma única chamada ao `dataframeit`; sem a segunda asserção ele passaria mesmo com o abort chegando tarde demais.
- **UI**: combobox com as 7 opções nos grupos certos, trigger mostrando o label e não o ID, select de raciocínio visível. Com o ID removido no lugar, o card degrada exatamente como no bug antigo (ID cru + select sumindo) — o vermelho da UI também foi provado.
- Gates: pytest 286, vitest 2190, typecheck, lint:types, mypy, fallow new-only (0/0/0), semgrep, e2e-smoke e test:db — todos verdes no pre-push.
- `npm run invariants`: 16/17. O `FAIL` é o resíduo conhecido da #623 (2 casos de 2026-07-27, contagem inalterada), sem relação com `llm_model`.

## Não coberto

A run real fim-a-fim não foi disparada: ela publicaria respostas e desmarcaria as anteriores em documentos de um projeto real. O teste direto contra a API cobre o que ela provaria sobre o modelo.