### PR TITLE
fix(llm): divide o schema em lotes quando o provider recusa o modelo inteiro

### DIFF
--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -22,7 +22,7 @@ import pandas as pd
 # sys.modules["dataframeit"] por um SimpleNamespace sem submódulos: resolver a
 # tupla em import-time do módulo mantém esses testes válidos sem que eles
 # precisem conhecer este import.
-from dataframeit.errors import NON_RECOVERABLE_ERRORS
+from dataframeit.errors import RECOVERABLE_ERRORS
 
 from services.auto_review_reconciliation import wake_auto_review_reconciliation
 from services.condition_evaluator import evaluate_condition, extract_field_conditions
@@ -846,22 +846,21 @@ def _expected_llm_fields(model_class) -> set[str]:
     return expected_llm_fields
 
 
-def _fatal_provider_error(frame: pd.DataFrame) -> str | None:
-    """Erro de configuração do provider (modelo inexistente, chave inválida,
-    permissão) visível já no canário — a mensagem, ou None se não houver.
+def _canary_provider_error(frame: pd.DataFrame) -> str | None:
+    """A mensagem de erro do provider se TODAS as linhas do frame falharam.
 
-    Só classifica como fatal o que o próprio dataframeit marcou como sem
-    retry: `NON_RECOVERABLE_ERRORS` é a mesma tupla que ele consulta em
-    `is_recoverable_error` para decidir não tentar de novo, então não há um
-    segundo critério aqui para desatualizar quando a lib mudar o dela.
+    Só constata a falha; não a classifica. A classificação — configuração
+    errada versus azar naquele documento — é feita por experimento em
+    `_probe_schema`, porque nenhuma leitura do texto do erro dá a resposta.
 
-    A distinção importa: um erro que esgotou retries num documento específico
-    (rate limit, timeout) continua indo para a via estatística de
-    `_raise_if_run_compromised`. Matar a run inteira por ele confundiria azar
-    pontual com configuração errada.
-
-    Exige que TODAS as linhas do frame tenham falhado assim — o sinal é "o
-    provider recusou tudo que viu", não "uma linha falhou".
+    O critério textual que existia aqui consultava `NON_RECOVERABLE_ERRORS` do
+    dataframeit, e errava nos dois sentidos (ver issue #692). Deixava passar a
+    recusa de schema medida em produção, porque `INVALID_ARGUMENT` não casa
+    com o padrão `InvalidArgument` por causa do underscore; e, na direção
+    oposta, teria matado a run inteira por um `BadRequestError` de um único
+    documento — a tupla responde "vale repetir esta linha?", uma pergunta por
+    documento, e estava sendo usada para decidir "a run está mal
+    configurada?", uma pergunta sobre a run.
     """
     if frame.empty:
         return None
@@ -870,12 +869,194 @@ def _fatal_provider_error(frame: pd.DataFrame) -> str | None:
         _, dfi_error = _extract_dataframeit_error(row)
         if dfi_error is None:
             return None
-        lowered = dfi_error.lower()
-        if not any(pattern.lower() in lowered for pattern in NON_RECOVERABLE_ERRORS):
-            return None
         if first_error is None:
             first_error = dfi_error
     return first_error
+
+
+# Sonda: um documento sintético, curto e sem particularidade nenhuma. O id não
+# colide com uuid de documento real, e o frame da sonda nunca chega a
+# _process_and_save_rows — é descartado assim que o erro é lido.
+_PROBE_DOC_ID = "__schema_probe__"
+_PROBE_TEXT = "Documento de teste."
+
+
+def _is_transient(message: str) -> bool:
+    """O provider declarou falha passageira (429, timeout, 5xx)?
+
+    Consulta `RECOVERABLE_ERRORS` para a pergunta que essa tupla de fato
+    responde — "isto é transitório?" — e exige casamento **explícito**. O
+    default do `is_recoverable_error` é otimista: erro que não casa com lista
+    nenhuma é tratado como recuperável, e foi por aí que a recusa de schema
+    ganhou o prefixo "[Falhou após 3 tentativa(s)]" apesar de determinística.
+    Aqui o silêncio das duas listas significa "não sei", não "passageiro".
+
+    Serve para não martelar um provider que já está recusando: sob rate limit
+    a sonda falha igual à chamada real, e sem esta porta a bisseção abortaria
+    a run inteira por uma falha que costuma passar sozinha.
+    """
+    lowered = message.lower()
+    return any(pattern.lower() in lowered for pattern in RECOVERABLE_ERRORS)
+
+
+def _field_group_key(model_class, name: str) -> str:
+    """Chave do grupo de campos que precisam viajar na mesma chamada.
+
+    Dois vínculos são semânticos e não podem ser quebrados por uma divisão:
+
+    - campo e sua justificativa gerada. Separados, o modelo escreveria a
+      justificativa numa chamada em que a resposta correspondente não foi
+      decidida — justificaria uma resposta que ele não deu;
+    - subcampos achatados de um mesmo pai (`pai__sub`), que são uma pergunta
+      só, quebrada em colunas por `_flatten_nested_basemodels`.
+
+    A justificativa é reconhecida pelo conjunto que o próprio
+    `_extend_model_with_justifications` registrou, não pelo sufixo: um campo
+    do coordenador pode terminar em `_justification` sem ser gerado.
+    """
+    if name in _generated_justification_fields(model_class):
+        name = name[: -len(_JUSTIFICATION_FIELD_SUFFIX)]
+    return name.split(_NESTED_FLATTEN_SEP, 1)[0]
+
+
+def _field_groups(model_class) -> list[list[str]]:
+    """Campos agrupados por `_field_group_key`, na ordem de declaração."""
+    groups: dict[str, list[str]] = {}
+    for name in model_class.model_fields:
+        groups.setdefault(_field_group_key(model_class, name), []).append(name)
+    return list(groups.values())
+
+
+def _submodel(model_class, names: list[str]):
+    """Modelo com o subconjunto de campos, preservando cada `FieldInfo`.
+
+    Devolve o próprio modelo quando o subconjunto é o total: além de evitar
+    reconstrução à toa, preserva os atributos que `_expected_llm_fields` e
+    `_extract_answers_from_row` leem do modelo completo.
+    """
+    if len(names) == len(model_class.model_fields):
+        return model_class
+    from pydantic import create_model
+
+    fields = {
+        name: (
+            model_class.model_fields[name].annotation,
+            model_class.model_fields[name],
+        )
+        for name in names
+    }
+    return create_model(f"{model_class.__name__}Chunk", **fields)
+
+
+def _merge_chunk_frames(frames: list[pd.DataFrame]) -> pd.DataFrame:
+    """Funde os frames dos lotes de campos de um mesmo conjunto de documentos.
+
+    Cada lote traz suas colunas de resposta mais as duas de controle. A regra
+    de fusão do controle é "erro em qualquer lote marca a linha": sem ela um
+    lote que falhou sozinho desapareceria, o documento sairia como resposta
+    parcial e o erro do provider nunca chegaria ao usuário.
+    """
+    if len(frames) == 1:
+        return frames[0]
+    control = {"_dataframeit_status", "_error_details"}
+    normalized = [f.reset_index(drop=True) for f in frames]
+    merged = normalized[0].copy()
+    for frame in normalized[1:]:
+        for column in frame.columns:
+            if column not in control and column not in merged.columns:
+                merged[column] = frame[column]
+
+    statuses: list[str] = []
+    details: list[str | None] = []
+    for i in range(len(merged)):
+        messages: list[str] = []
+        failed = False
+        for frame in normalized:
+            status, message = _extract_dataframeit_error(frame.iloc[i])
+            if status == "error":
+                failed = True
+            if message is not None:
+                messages.append(message)
+        statuses.append("error" if failed else "processed")
+        # dict.fromkeys deduplica preservando ordem: quando a recusa atinge
+        # todos os lotes, a mesma mensagem chegaria repetida.
+        details.append(" | ".join(dict.fromkeys(messages)) or None)
+    merged["_dataframeit_status"] = statuses
+    merged["_error_details"] = details
+    return merged
+
+
+def _probe_schema(call, model_class, names: list[str]) -> str | None:
+    """Roda o modelo contra um texto trivial. A mensagem de erro, ou None.
+
+    É este experimento que responde a pergunta que o texto do erro não
+    responde: *o erro depende de qual documento é?* Se o texto trivial também
+    falha, o documento não é a variável.
+    """
+    frame = pd.DataFrame([{"id": _PROBE_DOC_ID, "texto": _PROBE_TEXT}])
+    result = call(frame, _submodel(model_class, names))
+    if result.empty:
+        return None
+    _, message = _extract_dataframeit_error(result.iloc[0])
+    return message
+
+
+def _fit_chunks(probe, groups: list[list[str]], llm_provider, llm_model):
+    """Maior subdivisão que o provider aceita, achada por bisseção.
+
+    Sem número mágico: o limite de schema do provider é opaco (medi que não é
+    contagem de campos, nem propriedades+valores de enum, nem tamanho em chars
+    — cada métrica tem contraexemplo), então ele é descoberto perguntando.
+    Schema que já cabe não paga nada, porque a primeira pergunta é o modelo
+    inteiro.
+
+    Recursão em profundidade pela esquerda, levantando no primeiro lote de um
+    grupo só que ainda falhe: um erro que atinge tudo aborta em ~log2(n)
+    sondas, em vez de varrer a árvore inteira martelando um provider que já
+    está recusando.
+    """
+    names = [name for group in groups for name in group]
+    message = probe(names)
+    if message is None:
+        return [names]
+    if len(groups) == 1:
+        # Sem diagnóstico embutido: a mensagem relata o que foi tentado e
+        # deixa o erro do provider falar. Dizer "o schema é grande demais"
+        # aqui seria mentira sempre que a causa for outra.
+        raise RuntimeError(
+            f"O provider recusou toda chamada a '{llm_provider}/{llm_model}', "
+            f"inclusive com texto trivial e um único campo no schema, então "
+            f"a run foi abortada sem gravar resposta alguma. "
+            f"Erro do provider: {message}"
+        )
+    middle = len(groups) // 2
+    return _fit_chunks(probe, groups[:middle], llm_provider, llm_model) + _fit_chunks(
+        probe, groups[middle:], llm_provider, llm_model
+    )
+
+
+def _chunks_after_canary_failure(
+    probe, model_class, chunks: list[list[str]], llm_provider, llm_model
+) -> list[list[str]] | None:
+    """Lotes novos quando o canário falhou, ou None para seguir sem dividir.
+
+    Três desfechos, e a ordem entre eles importa. Sonda passa: o erro era
+    daquele documento, a run segue e a via estatística julga. Sonda falha com
+    erro transitório: também segue, porque abortar por rate limit desperdiça
+    uma run que costuma passar depois. Sonda falha de outro jeito: é a
+    configuração, e só aí vale dividir.
+    """
+    probe_error = probe(chunks[0])
+    if probe_error is None or _is_transient(probe_error):
+        return None
+    split = _fit_chunks(probe, _field_groups(model_class), llm_provider, llm_model)
+    logger.warning(
+        "Schema recusado inteiro por %s/%s; dividido em %d lotes de campos.",
+        llm_provider,
+        llm_model,
+        len(split),
+    )
+    return split
 
 
 def _run_dataframeit_batches(
@@ -912,14 +1093,10 @@ def _run_dataframeit_batches(
     ]
     jobs_state.update(phase="processing", total_batches=len(batches))
 
-    result_frames = []
-    proc_start = time.time()
-    last_proc_heartbeat = 0.0
-    for idx, batch_df in enumerate(batches):
-        jobs_state["current_batch"] = idx + 1
-        batch_result = dataframeit(
-            batch_df,
-            model_class,
+    def _call(frame: pd.DataFrame, model):
+        return dataframeit(
+            frame,
+            model,
             prompt_template,
             text_column="texto",
             provider=llm_provider,
@@ -930,20 +1107,33 @@ def _run_dataframeit_batches(
             resume=False,
             **config.dfi_kwargs,
         )
-        if idx == 0:
-            fatal = _fatal_provider_error(batch_result)
-            if fatal:
-                # A afirmação "nenhuma resposta foi gravada" depende de esta
-                # função rodar inteira antes de _process_and_save_rows, que é
-                # quem publica (ver run_llm). Mover a publicação para dentro do
-                # loop de batches tornaria a mensagem mentirosa.
-                raise RuntimeError(
-                    f"O provider recusou o modelo '{llm_provider}/{llm_model}' "
-                    f"no primeiro dos {len(df)} documentos, então a run foi "
-                    f"abortada e nenhuma resposta foi gravada. Confira o nome "
-                    f"do modelo e a chave de API. "
-                    f"Erro do provider: {fatal}"
-                )
+
+    def _call_chunks(frame: pd.DataFrame, chunks: list[list[str]]) -> pd.DataFrame:
+        return _merge_chunk_frames(
+            [_call(frame, _submodel(model_class, names)) for names in chunks]
+        )
+
+    def _probe(names: list[str]) -> str | None:
+        return _probe_schema(_call, model_class, names)
+
+    chunks: list[list[str]] = [list(model_class.model_fields)]
+    result_frames = []
+    proc_start = time.time()
+    last_proc_heartbeat = 0.0
+    for idx, batch_df in enumerate(batches):
+        jobs_state["current_batch"] = idx + 1
+        batch_result = _call_chunks(batch_df, chunks)
+        if idx == 0 and _canary_provider_error(batch_result):
+            # A afirmação "nenhuma resposta foi gravada" nas mensagens de abort
+            # depende de esta função rodar inteira antes de
+            # _process_and_save_rows, que é quem publica (ver run_llm).
+            split = _chunks_after_canary_failure(
+                _probe, model_class, chunks, llm_provider, llm_model
+            )
+            if split is not None:
+                chunks = split
+                # Refaz o canário para que a run comece com o resultado bom.
+                batch_result = _call_chunks(batch_df, chunks)
         result_frames.append(batch_result)
         processed = sum(len(f) for f in result_frames)
         jobs_state["progress"] = processed

--- a/backend/services/llm_runner.py
+++ b/backend/services/llm_runner.py
@@ -861,12 +861,16 @@ def _canary_provider_error(frame: pd.DataFrame) -> str | None:
     documento — a tupla responde "vale repetir esta linha?", uma pergunta por
     documento, e estava sendo usada para decidir "a run está mal
     configurada?", uma pergunta sobre a run.
+
+    Quem responde "esta linha falhou?" é `_row_error`, pelo status: a
+    presença de `_error_details` não basta, porque sucesso após retry também
+    a preenche.
     """
     if frame.empty:
         return None
     first_error: str | None = None
     for _, row in frame.iterrows():
-        _, dfi_error = _extract_dataframeit_error(row)
+        dfi_error = _row_error(row)
         if dfi_error is None:
             return None
         if first_error is None:
@@ -972,10 +976,9 @@ def _merge_chunk_frames(frames: list[pd.DataFrame]) -> pd.DataFrame:
         messages: list[str] = []
         failed = False
         for frame in normalized:
-            status, message = _extract_dataframeit_error(frame.iloc[i])
-            if status == "error":
-                failed = True
+            message = _row_error(frame.iloc[i])
             if message is not None:
+                failed = True
                 messages.append(message)
         statuses.append("error" if failed else "processed")
         # dict.fromkeys deduplica preservando ordem: quando a recusa atinge
@@ -997,8 +1000,23 @@ def _probe_schema(call, model_class, names: list[str]) -> str | None:
     result = call(frame, _submodel(model_class, names))
     if result.empty:
         return None
-    _, message = _extract_dataframeit_error(result.iloc[0])
-    return message
+    return _row_error(result.iloc[0])
+
+
+class _TransientProbeError(Exception):
+    """A sonda esbarrou numa falha passageira, não num veredito sobre o schema.
+
+    Sobe de qualquer nível da bisseção, e não só da primeira pergunta: a
+    divisão dispara sondas em sequência logo depois de `parallel_requests`
+    chamadas, que é justamente quando um 429 é mais provável. Sem esta
+    distinção, um rate limit no meio da recursão faria a bisseção concluir
+    "não cabe" sobre um lote que cabe — over-split permanente no caso leve, e
+    no caso pior a run abortaria no piso culpando o schema.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.provider_message = message
 
 
 def _fit_chunks(probe, groups: list[list[str]], llm_provider, llm_model):
@@ -1008,7 +1026,9 @@ def _fit_chunks(probe, groups: list[list[str]], llm_provider, llm_model):
     contagem de campos, nem propriedades+valores de enum, nem tamanho em chars
     — cada métrica tem contraexemplo), então ele é descoberto perguntando.
     Schema que já cabe não paga nada, porque a primeira pergunta é o modelo
-    inteiro.
+    inteiro — e é essa mesma pergunta que serve de discriminante entre erro do
+    documento e erro de configuração, motivo pelo qual ela não é feita duas
+    vezes (ver `_chunks_after_canary_failure`).
 
     Recursão em profundidade pela esquerda, levantando no primeiro lote de um
     grupo só que ainda falhe: um erro que atinge tudo aborta em ~log2(n)
@@ -1019,14 +1039,22 @@ def _fit_chunks(probe, groups: list[list[str]], llm_provider, llm_model):
     message = probe(names)
     if message is None:
         return [names]
+    if _is_transient(message):
+        raise _TransientProbeError(message)
     if len(groups) == 1:
-        # Sem diagnóstico embutido: a mensagem relata o que foi tentado e
-        # deixa o erro do provider falar. Dizer "o schema é grande demais"
-        # aqui seria mentira sempre que a causa for outra.
+        # O piso é um GRUPO, não um campo: campo mais a justificativa dele, ou
+        # um campo aninhado com todos os subcampos (ver `_field_group_key`).
+        #
+        # A dica sobre modelo e chave não afirma causa — afirmar "o schema é
+        # grande demais" aqui seria mentira sempre que a causa for outra. Ela
+        # aponta o que conferir, porque um modelo inexistente ou uma chave
+        # inválida (o caso da #691) recusa exatamente assim: tudo, até o
+        # menor pedido possível. O erro do provider vem junto e fala por si.
         raise RuntimeError(
             f"O provider recusou toda chamada a '{llm_provider}/{llm_model}', "
-            f"inclusive com texto trivial e um único campo no schema, então "
-            f"a run foi abortada sem gravar resposta alguma. "
+            f"inclusive com texto trivial e um único grupo de campos no "
+            f"schema, então a run foi abortada sem gravar resposta alguma. "
+            f"Confira o nome do modelo e a chave de API. "
             f"Erro do provider: {message}"
         )
     middle = len(groups) // 2
@@ -1036,20 +1064,35 @@ def _fit_chunks(probe, groups: list[list[str]], llm_provider, llm_model):
 
 
 def _chunks_after_canary_failure(
-    probe, model_class, chunks: list[list[str]], llm_provider, llm_model
+    probe, model_class, llm_provider, llm_model
 ) -> list[list[str]] | None:
     """Lotes novos quando o canário falhou, ou None para seguir sem dividir.
 
-    Três desfechos, e a ordem entre eles importa. Sonda passa: o erro era
-    daquele documento, a run segue e a via estatística julga. Sonda falha com
-    erro transitório: também segue, porque abortar por rate limit desperdiça
-    uma run que costuma passar depois. Sonda falha de outro jeito: é a
-    configuração, e só aí vale dividir.
+    Três desfechos. Sonda passa: o erro era daquele documento, a run segue e a
+    via estatística julga. Sonda falha com erro transitório: também segue,
+    porque abortar por rate limit desperdiça uma run que costuma passar
+    depois. Sonda falha de outro jeito: é a configuração, e só aí vale
+    dividir.
+
+    Os três saem da mesma bisseção em vez de uma sonda de entrada seguida de
+    outra idêntica: a primeira pergunta de `_fit_chunks` já é o modelo
+    inteiro, e "cabe inteiro" é o mesmo fato que "o erro era do documento".
+    Perguntar de novo era uma chamada paga ao provider em toda decisão de
+    divisão.
     """
-    probe_error = probe(chunks[0])
-    if probe_error is None or _is_transient(probe_error):
+    try:
+        split = _fit_chunks(probe, _field_groups(model_class), llm_provider, llm_model)
+    except _TransientProbeError as exc:
+        logger.warning(
+            "Sonda de schema barrada por erro transitório em %s/%s; a run "
+            "segue sem dividir. Erro do provider: %s",
+            llm_provider,
+            llm_model,
+            exc.provider_message,
+        )
         return None
-    split = _fit_chunks(probe, _field_groups(model_class), llm_provider, llm_model)
+    if len(split) == 1:
+        return None
     logger.warning(
         "Schema recusado inteiro por %s/%s; dividido em %d lotes de campos.",
         llm_provider,
@@ -1095,7 +1138,15 @@ def _run_dataframeit_batches(
 
     def _call(frame: pd.DataFrame, model):
         return dataframeit(
-            frame,
+            # Cópia, e não o frame recebido: o dataframeit escreve as colunas
+            # do modelo e as de controle **no objeto do chamador** (`to_pandas`
+            # devolve o mesmo DataFrame e `_setup_columns` é in-place) e, num
+            # frame que já as tenha, desiste em silêncio — avisa "Colunas [...]
+            # já existem" e devolve sem chamar o provider. Chamar duas vezes
+            # sobre o mesmo frame é justamente o que o refazer do canário
+            # abaixo faz. Copiar aqui torna esse estado inconstruível, em vez
+            # de obrigar cada chamador a lembrar da regra.
+            frame.copy(),
             model,
             prompt_template,
             text_column="texto",
@@ -1128,11 +1179,16 @@ def _run_dataframeit_batches(
             # depende de esta função rodar inteira antes de
             # _process_and_save_rows, que é quem publica (ver run_llm).
             split = _chunks_after_canary_failure(
-                _probe, model_class, chunks, llm_provider, llm_model
+                _probe, model_class, llm_provider, llm_model
             )
             if split is not None:
                 chunks = split
                 # Refaz o canário para que a run comece com o resultado bom.
+                # Depende de `_call` copiar o frame: sem isso a chamada aqui
+                # reencontraria as colunas que a primeira gravou em batch_df,
+                # devolveria o frame da falha sem chamar o provider, e este
+                # documento sairia vazio — abaixo do run_failure_threshold e,
+                # portanto, sem nem reprovar a run.
                 batch_result = _call_chunks(batch_df, chunks)
         result_frames.append(batch_result)
         processed = sum(len(f) for f in result_frames)
@@ -1241,6 +1297,25 @@ def _extract_dataframeit_error(row) -> tuple[object, str | None]:
         else None
     )
     return dfi_status, dfi_error
+
+
+def _row_error(row) -> str | None:
+    """A mensagem da linha **só quando ela de fato falhou**.
+
+    O dataframeit usa `_error_details` para duas coisas diferentes: em falha
+    grava o erro com `_dataframeit_status='error'`, mas em sucesso que passou
+    por retry grava `"Sucesso após N retry(s)"` mantendo o status
+    `'processed'` (`core.py`, tanto no caminho sequencial quanto no
+    paralelo). Quem lê só a mensagem confunde um sucesso com uma recusa de
+    schema — e, no canário, um único retry passaria a disparar a bisseção
+    inteira.
+
+    É por isso que este predicado existe em vez de `_error_details is not
+    None` repetido em cada chamador: a regra é uma só, e o status é quem a
+    decide.
+    """
+    status, message = _extract_dataframeit_error(row)
+    return message if status == "error" else None
 
 
 def _reconstruct_nested_answers(

--- a/backend/tests/test_llm_runner_run_llm.py
+++ b/backend/tests/test_llm_runner_run_llm.py
@@ -15,7 +15,7 @@ import asyncio
 import sys
 from types import SimpleNamespace
 
-from services.llm_runner import _jobs, init_job, run_llm
+from services.llm_runner import _PROBE_DOC_ID, _jobs, init_job, run_llm
 
 JOB_ID = "job-1"
 PROJECT_ID = "proj-1"
@@ -233,6 +233,8 @@ def _make_fake_dataframeit(
     errors: dict[str, str] | None = None,
     error_always: str | None = None,
     max_schema_fields: int | None = None,
+    retry_success: bool = False,
+    probe_errors: list[str | None] | None = None,
 ):
     """row_specs: {doc_id: {field: value}}.
 
@@ -255,10 +257,35 @@ def _make_fake_dataframeit(
       abaixo disso — é a recusa de schema medida em produção contra o Gemini
       (`400 INVALID_ARGUMENT`), que não depende do documento nem do modelo,
       só do tamanho do que se pediu.
+
+    `retry_success` não é um modo de erro: é **sucesso** que passou por retry.
+    A lib real escreve `"Sucesso após N retry(s)"` em `_error_details`
+    mantendo o status `'processed'`, e reproduzir isso é o que permite testar
+    que ninguém confunda a mensagem com uma recusa.
+
+    `probe_errors` roteia as sondas de texto trivial, em ordem: cada elemento
+    é a mensagem daquela sonda (ou None para passar), e depois que a lista
+    acaba a sonda volta ao comportamento normal. Serve para escrever o que os
+    outros modos não conseguem — um provider que muda de resposta entre uma
+    sonda e a seguinte, como acontece quando um 429 cai no meio da bisseção.
+
+    Duas fidelidades a mais, ambas atrás de bug encontrado em revisão:
+
+    - o frame recebido é mutado **in-place**, como faz o dataframeit
+      (`to_pandas` devolve o mesmo objeto e `_setup_columns` escreve nele);
+    - num frame que já tenha as colunas do modelo, a lib avisa e devolve
+      **sem chamar o provider**. Sem esse ramo aqui, um chamador que rode duas
+      vezes sobre o mesmo frame parece funcionar no teste e perde o documento
+      em produção.
     """
     errors = errors or {}
+    sondas_restantes = list(probe_errors or [])
 
     def _fake(batch_df, model_class, prompt_template, **kwargs):
+        ja_processado = [c for c in model_class.model_fields if c in batch_df.columns]
+        if ja_processado and not kwargs.get("resume"):
+            # Nem registra em `calls`: nenhuma chamada ao provider aconteceu.
+            return batch_df.copy()
         if calls is not None:
             calls.append(
                 {
@@ -272,13 +299,13 @@ def _make_fake_dataframeit(
             max_schema_fields is not None
             and len(model_class.model_fields) > max_schema_fields
         )
-        out = batch_df.copy()
-        for field in model_class.model_fields:
-            out[field] = [
-                row_specs.get(doc_id, {}).get(field) for doc_id in batch_df["id"]
-            ]
+
+        e_sonda = list(batch_df["id"]) == [_PROBE_DOC_ID]
+        sonda_roteada = e_sonda and sondas_restantes
 
         def _erro(doc_id):
+            if sonda_roteada:
+                return sondas_restantes.pop(0)
             if error_always:
                 return error_always
             if schema_recusado:
@@ -286,11 +313,26 @@ def _make_fake_dataframeit(
             return errors.get(doc_id)
 
         detalhes = [_erro(doc_id) for doc_id in batch_df["id"]]
-        out["_dataframeit_status"] = [
+        # Linha que falhou não ganha resposta nenhuma: no dataframeit real a
+        # exceção sobe antes da escrita das colunas, que ficam com o None que
+        # `_setup_columns` criou. Preencher aqui apesar do erro faria um
+        # documento perdido parecer completo — o teste mediria a contagem de
+        # chamadas e não o dano.
+        for field in model_class.model_fields:
+            batch_df[field] = [
+                None if erro is not None else row_specs.get(doc_id, {}).get(field)
+                for doc_id, erro in zip(batch_df["id"], detalhes, strict=True)
+            ]
+        batch_df["_dataframeit_status"] = [
             "error" if d is not None else "processed" for d in detalhes
         ]
-        out["_error_details"] = detalhes
-        return out
+        batch_df["_error_details"] = [
+            d
+            if d is not None
+            else ("Sucesso após 1 retry(s)" if retry_success else None)
+            for d in detalhes
+        ]
+        return batch_df.copy()
 
     return _fake
 
@@ -323,6 +365,8 @@ def _run_llm_sync(
     dataframeit_errors: dict[str, str] | None = None,
     dataframeit_error_always: str | None = None,
     max_schema_fields: int | None = None,
+    retry_success: bool = False,
+    probe_errors: list[str | None] | None = None,
 ) -> None:
     monkeypatch.setattr("services.llm_runner.get_supabase", lambda: sb)
     monkeypatch.setitem(
@@ -335,6 +379,8 @@ def _run_llm_sync(
                 dataframeit_errors,
                 dataframeit_error_always,
                 max_schema_fields,
+                retry_success,
+                probe_errors,
             )
         ),
     )
@@ -933,8 +979,178 @@ def test_run_llm_aborta_quando_nem_um_campo_sozinho_e_aceito(monkeypatch):
 
     assert _jobs[JOB_ID]["status"] == "error"
     assert _published_responses(sb) == []
-    assert "INVALID_ARGUMENT" in _jobs[JOB_ID]["errors"][0]
+    erro = _jobs[JOB_ID]["errors"][0]
+    assert "INVALID_ARGUMENT" in erro
     assert _doc_batches(calls) == [["doc-0"]]
+    # A unidade do piso é o GRUPO (campo + justificativa, ou aninhado com os
+    # subcampos), não o campo: dizer "um único campo" mandaria o usuário
+    # procurar um schema de um campo que a bisseção nunca chega a pedir.
+    assert "um único grupo de campos" in erro
+    # E a dica que a #691 dava continua chegando: recusar até o menor pedido
+    # possível é como um modelo inexistente ou uma chave inválida se
+    # manifestam, e a bisseção não pode custar ao usuário essa orientação.
+    assert "Confira o nome do modelo e a chave de API" in erro
+
+
+def _sondas(calls: list[dict]) -> list[set[str]]:
+    """Os campos pedidos em cada sonda de texto trivial, na ordem."""
+    return [
+        call["model_fields"]
+        for call in calls
+        if call["document_ids"] == [_PROBE_DOC_ID]
+    ]
+
+
+def test_run_llm_refaz_o_canario_de_verdade_depois_de_dividir(monkeypatch):
+    # O documento do canário é processado ANTES de a divisão ser conhecida,
+    # então a run precisa refazê-lo com os lotes novos. O dataframeit grava
+    # as colunas no frame que recebe e, num frame que já as tenha, devolve
+    # sem chamar o provider — se o refazer reaproveitar o frame do canário,
+    # este documento sai vazio.
+    #
+    # São 5 documentos de propósito: com 1 perdido em 5, a cobertura baixa
+    # fica em 0,2, abaixo do run_failure_threshold de 0,3. A run reporta
+    # "completed" e o documento some sem ninguém ser avisado — que é
+    # exatamente a forma do dano em produção (1 em 26).
+    docs = _docs(5)
+    campos = ["campo_a", "campo_b", "campo_c", "campo_d"]
+    todos = campos + [f"{c}_justification" for c in campos]
+    row_specs = {doc["id"]: {c: f"v-{c}" for c in todos} for doc in docs}
+    sb = _build_supabase(
+        _project_row(
+            pydantic_code=SPLIT_PYDANTIC_CODE,
+            llm_kwargs={"include_justifications": True},
+        ),
+        docs,
+    )
+
+    _run_llm_sync(monkeypatch, sb, row_specs, max_schema_fields=4)
+
+    assert _jobs[JOB_ID]["status"] == "completed"
+    por_doc = {r["document_id"]: r for r in _published_responses(sb)}
+    assert set(por_doc) == {d["id"] for d in docs}
+    # A asserção que importa é sobre o documento do canário, não sobre a
+    # média: os outros quatro nunca passaram pelo caminho do refazer.
+    assert set(por_doc["doc-0"]["answers"]) == set(campos)
+
+
+def test_run_llm_sucesso_apos_retry_no_canario_nao_dispara_divisao(monkeypatch):
+    # O dataframeit escreve "Sucesso após N retry(s)" em `_error_details`
+    # mantendo o status 'processed'. Quem lê só a mensagem toma um documento
+    # bem-sucedido por uma recusa de schema — e, no canário, um único retry
+    # (banal sob rate limit do Gemini) bastaria para dividir um schema que
+    # cabe, dobrando o custo da run inteira.
+    docs = _docs(3)
+    campos = ["campo_a", "campo_b", "campo_c"]
+    row_specs = {doc["id"]: {c: f"v-{c}" for c in campos} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(_project_row(), docs)
+
+    _run_llm_sync(
+        monkeypatch, sb, row_specs, dataframeit_calls=calls, retry_success=True
+    )
+
+    assert _jobs[JOB_ID]["status"] == "completed"
+    # Nenhuma sonda: o canário não foi lido como falha, então não houve o que
+    # discriminar. Contar sondas é o discriminante — o resultado final é o
+    # mesmo com ou sem a divisão espúria, só o custo muda.
+    assert _sondas(calls) == []
+    assert all(lote == set(campos) for lote in _campos_por_lote(calls, "doc-0"))
+
+
+def test_run_llm_sucesso_apos_retry_na_sonda_nao_conta_como_recusa(monkeypatch):
+    # Mesma confusão, agora na sonda: aqui ela é pior, porque "Sucesso após 1
+    # retry(s)" não casa com RECOVERABLE_ERRORS e portanto nem a porta de
+    # transitório o barra. A bisseção leria "não cabe" a cada nível e mataria
+    # no piso uma run que o provider nunca recusou.
+    #
+    # Cinco documentos porque o canário falha de verdade aqui: 1 perdido em 5
+    # fica abaixo do run_failure_threshold, então a run só termina em "error"
+    # se a sonda for mal lida — que é justamente o que se quer medir.
+    docs = _docs(5)
+    campos = ["campo_a", "campo_b", "campo_c"]
+    row_specs = {doc["id"]: {c: f"v-{c}" for c in campos} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(_project_row(), docs)
+
+    _run_llm_sync(
+        monkeypatch,
+        sb,
+        row_specs,
+        dataframeit_calls=calls,
+        # O canário falha de verdade (erro daquele documento), então a sonda
+        # é consultada; ela responde com sucesso-após-retry.
+        dataframeit_errors={"doc-0": "[Erro não-recuperável] BadRequestError: 400"},
+        retry_success=True,
+    )
+
+    assert _jobs[JOB_ID]["status"] == "completed"
+    # Uma sonda só, e ela encerrou a questão: o schema inteiro passou.
+    assert _sondas(calls) == [set(campos)]
+    assert len(_published_responses(sb)) == 5
+
+
+def test_run_llm_sonda_transitoria_no_meio_da_bissecao_nao_vira_veredito(
+    monkeypatch,
+):
+    # A bisseção dispara sondas em sequência logo depois de parallel_requests
+    # chamadas — é ali que um 429 é mais provável. Sem distinguir "não cabe"
+    # de "não deu para perguntar", o rate limit vira veredito sobre o schema:
+    # a recursão desce até o piso e aborta a run com uma mensagem que culpa o
+    # tamanho do pedido.
+    docs = _docs(3)
+    campos = ["campo_a", "campo_b", "campo_c"]
+    row_specs = {doc["id"]: {c: f"v-{c}" for c in campos} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(_project_row(), docs)
+
+    _run_llm_sync(
+        monkeypatch,
+        sb,
+        row_specs,
+        dataframeit_calls=calls,
+        dataframeit_error_always=_SCHEMA_RECUSADO,
+        # 1ª sonda: o modelo inteiro é recusado, a bisseção começa.
+        # 2ª sonda: 429 no meio do caminho.
+        probe_errors=[
+            _SCHEMA_RECUSADO,
+            "[Falhou após 3 tentativa(s)] ResourceExhausted: 429 quota",
+        ],
+    )
+
+    erro = _jobs[JOB_ID]["errors"][0]
+    # A run termina denunciando o erro que o provider de fato deu, e não
+    # inventando um veredito sobre o schema a partir de um rate limit.
+    assert "INVALID_ARGUMENT" in erro
+    assert "um único grupo de campos" not in erro
+    # E parou de martelar o provider: duas sondas, não a árvore inteira.
+    assert len(_sondas(calls)) == 2
+
+
+def test_run_llm_pergunta_pelo_schema_inteiro_uma_vez_so(monkeypatch):
+    # A sonda de entrada e a primeira pergunta da bisseção são a mesma:
+    # "o modelo inteiro cabe?". Fazê-las separadamente custava uma chamada
+    # paga ao provider em toda decisão de divisão.
+    docs = _docs(1)
+    campos = ["campo_a", "campo_b", "campo_c", "campo_d"]
+    todos = campos + [f"{c}_justification" for c in campos]
+    row_specs = {doc["id"]: {c: f"v-{c}" for c in todos} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(
+        _project_row(
+            pydantic_code=SPLIT_PYDANTIC_CODE,
+            llm_kwargs={"include_justifications": True},
+        ),
+        docs,
+    )
+
+    _run_llm_sync(
+        monkeypatch, sb, row_specs, dataframeit_calls=calls, max_schema_fields=4
+    )
+
+    sondas = _sondas(calls)
+    assert [len(s) for s in sondas] == [8, 4, 4]
+    assert sondas[0] == set(todos)
 
 
 def test_run_llm_marca_o_documento_quando_um_dos_lotes_falha(monkeypatch):

--- a/backend/tests/test_llm_runner_run_llm.py
+++ b/backend/tests/test_llm_runner_run_llm.py
@@ -37,6 +37,31 @@ class Analysis(BaseModel):
     q5: Doenca = Field(description="Q5")
 """
 
+SPLIT_PYDANTIC_CODE = """from pydantic import BaseModel, Field
+
+class Analysis(BaseModel):
+    campo_a: str = Field(description="Campo A")
+    campo_b: str = Field(description="Campo B")
+    campo_c: str = Field(description="Campo C")
+    campo_d: str = Field(description="Campo D")
+"""
+
+# Texto do 400 que o Gemini devolve quando o schema é grande demais. Medido
+# contra a API real em 2026-08-13 com o schema de 62 campos do projeto
+# Zolgensma-Judiciário; o mesmo schema com 31 campos responde 200.
+#
+# Duas propriedades importam e estão preservadas na cópia: a mensagem não diz
+# o que está errado ("Request contains an invalid argument"), e o texto
+# `INVALID_ARGUMENT` NÃO casa com o padrão `InvalidArgument` de
+# NON_RECOVERABLE_ERRORS por causa do underscore — por isso o dataframeit a
+# trata como recuperável e o prefixo é "[Falhou após ...]".
+_SCHEMA_RECUSADO = (
+    "[Falhou após 3 tentativa(s)] ChatGoogleGenerativeAIError: Error calling "
+    "model 'gemini-3.7-flash' (INVALID_ARGUMENT): 400 INVALID_ARGUMENT. "
+    "{'error': {'code': 400, 'message': 'Request contains an invalid "
+    "argument.', 'status': 'INVALID_ARGUMENT'}}"
+)
+
 
 class _FakeQuery:
     """Fake do query builder do Supabase.
@@ -206,6 +231,8 @@ def _make_fake_dataframeit(
     row_specs: dict[str, dict],
     calls: list[dict] | None = None,
     errors: dict[str, str] | None = None,
+    error_always: str | None = None,
+    max_schema_fields: int | None = None,
 ):
     """row_specs: {doc_id: {field: value}}.
 
@@ -216,6 +243,18 @@ def _make_fake_dataframeit(
     dataframeit real — ele NÃO propaga exceção do provider: marca a linha com
     `_dataframeit_status='error'`, escreve a mensagem em `_error_details` e
     devolve o frame como se tivesse dado certo.
+
+    Os três modos de erro são distintos de propósito, porque é justamente
+    entre eles que o canário precisa discriminar:
+
+    - `errors` falha em documentos nomeados e **passa** em qualquer outro
+      texto — é o erro que depende do documento (azar pontual);
+    - `error_always` falha em toda linha, seja qual for o texto — é o erro de
+      configuração (modelo inexistente, chave inválida);
+    - `max_schema_fields` falha quando o schema passa de N campos e passa
+      abaixo disso — é a recusa de schema medida em produção contra o Gemini
+      (`400 INVALID_ARGUMENT`), que não depende do documento nem do modelo,
+      só do tamanho do que se pediu.
     """
     errors = errors or {}
 
@@ -229,15 +268,28 @@ def _make_fake_dataframeit(
                     "kwargs": kwargs,
                 }
             )
+        schema_recusado = (
+            max_schema_fields is not None
+            and len(model_class.model_fields) > max_schema_fields
+        )
         out = batch_df.copy()
         for field in model_class.model_fields:
             out[field] = [
                 row_specs.get(doc_id, {}).get(field) for doc_id in batch_df["id"]
             ]
+
+        def _erro(doc_id):
+            if error_always:
+                return error_always
+            if schema_recusado:
+                return _SCHEMA_RECUSADO
+            return errors.get(doc_id)
+
+        detalhes = [_erro(doc_id) for doc_id in batch_df["id"]]
         out["_dataframeit_status"] = [
-            "error" if doc_id in errors else "processed" for doc_id in batch_df["id"]
+            "error" if d is not None else "processed" for d in detalhes
         ]
-        out["_error_details"] = [errors.get(doc_id) for doc_id in batch_df["id"]]
+        out["_error_details"] = detalhes
         return out
 
     return _fake
@@ -269,6 +321,8 @@ def _run_llm_sync(
     dataframeit_calls: list[dict] | None = None,
     wakeup_calls: list[bool] | None = None,
     dataframeit_errors: dict[str, str] | None = None,
+    dataframeit_error_always: str | None = None,
+    max_schema_fields: int | None = None,
 ) -> None:
     monkeypatch.setattr("services.llm_runner.get_supabase", lambda: sb)
     monkeypatch.setitem(
@@ -276,7 +330,11 @@ def _run_llm_sync(
         "dataframeit",
         SimpleNamespace(
             dataframeit=_make_fake_dataframeit(
-                row_specs, dataframeit_calls, dataframeit_errors
+                row_specs,
+                dataframeit_calls,
+                dataframeit_errors,
+                dataframeit_error_always,
+                max_schema_fields,
             )
         ),
     )
@@ -633,8 +691,10 @@ _MODEL_NOT_FOUND = (
     "'gemini-3-flash' (NOT_FOUND): 404 NOT_FOUND. models/gemini-3-flash is not "
     "found for API version v1beta"
 )
-# Erro pontual daquele documento, que o dataframeit já tentou de novo e
-# desistiu. Não contém nenhum padrão de NON_RECOVERABLE_ERRORS.
+# Falha passageira que o dataframeit já tentou de novo e desistiu. Casa
+# explicitamente com RECOVERABLE_ERRORS ('ResourceExhausted', '429'), e é esse
+# casamento — não o prefixo — que a distingue da recusa de schema em
+# _SCHEMA_RECUSADO, que carrega o mesmo prefixo e não casa com lista nenhuma.
 _RATE_LIMIT_EXHAUSTED = (
     "[Falhou após 3 tentativa(s)] ResourceExhausted: 429 rate limit exceeded"
 )
@@ -650,12 +710,16 @@ def test_run_llm_canary_aborts_before_publishing_when_provider_rejects_model(
     dataframeit_calls: list[dict] = []
     sb = _build_supabase(_project_row(llm_model="gemini-3-flash"), docs)
 
+    # `error_always`, e não `errors` por documento: um modelo inexistente
+    # falha para qualquer texto, inclusive o texto trivial que o canário usa
+    # para sondar. Com o erro amarrado aos ids dos documentos, a sonda passaria
+    # e o teste mediria o oposto do que promete.
     _run_llm_sync(
         monkeypatch,
         sb,
         row_specs,
         dataframeit_calls=dataframeit_calls,
-        dataframeit_errors={doc["id"]: _MODEL_NOT_FOUND for doc in docs},
+        dataframeit_error_always=_MODEL_NOT_FOUND,
     )
 
     assert _jobs[JOB_ID]["status"] == "error"
@@ -667,9 +731,15 @@ def test_run_llm_canary_aborts_before_publishing_when_provider_rejects_model(
     assert "404 NOT_FOUND" in message
     assert "Run comprometida" not in message
 
-    # O que a guarda existe para evitar. Sem a asserção das chamadas, o teste
-    # passaria mesmo se o abort acontecesse só no fim, depois de gastar as 26.
-    assert [call["document_ids"] for call in dataframeit_calls] == [["doc-0"]]
+    # O que a guarda existe para evitar: o abort acontece com um documento
+    # gasto, não com 26. As chamadas extras são as sondas de texto trivial —
+    # nenhuma delas carrega documento do projeto.
+    doc_calls = [
+        call["document_ids"]
+        for call in dataframeit_calls
+        if any(str(i).startswith("doc-") for i in call["document_ids"])
+    ]
+    assert doc_calls == [["doc-0"]]
     assert _published_responses(sb) == []
 
     error_update = _last_update_where(sb.table("llm_runs"), status="error")
@@ -684,6 +754,11 @@ def test_run_llm_canary_lets_recoverable_error_reach_the_statistical_path(
     # com erro recuperável. É o discriminante: uma guarda que abortasse em
     # qualquer falha do primeiro documento passaria no teste anterior e
     # quebraria aqui, matando a run inteira por azar pontual.
+    #
+    # `error_always` é a forma fiel: rate limit não escolhe documento, e falha
+    # na sonda de texto trivial exatamente como falha na chamada real. Amarrar
+    # o erro aos ids faria a sonda passar e o teste mediria outra coisa — é a
+    # porta de `_is_transient` que precisa segurar aqui, não a sonda.
     docs = _docs(4)
     row_specs = {doc["id"]: {} for doc in docs}
     dataframeit_calls: list[dict] = []
@@ -694,18 +769,210 @@ def test_run_llm_canary_lets_recoverable_error_reach_the_statistical_path(
         sb,
         row_specs,
         dataframeit_calls=dataframeit_calls,
-        dataframeit_errors={doc["id"]: _RATE_LIMIT_EXHAUSTED for doc in docs},
+        dataframeit_error_always=_RATE_LIMIT_EXHAUSTED,
     )
 
     # Todas as batches rodaram e as respostas foram publicadas (parciais, com
-    # is_latest=false) — só então o caminho estatístico reprovou a run.
-    assert [call["document_ids"] for call in dataframeit_calls] == [
+    # is_latest=false) — só então o caminho estatístico reprovou a run. E
+    # nenhuma divisão foi tentada: o schema nunca foi a variável.
+    assert _doc_batches(dataframeit_calls) == [
         ["doc-0"],
         ["doc-1", "doc-2", "doc-3"],
     ]
+    assert all(
+        call["model_fields"] == {"campo_a", "campo_b", "campo_c"}
+        for call in dataframeit_calls
+    )
     assert len(_published_responses(sb)) == 4
     assert _jobs[JOB_ID]["status"] == "error"
     assert "Run comprometida" in _jobs[JOB_ID]["errors"][0]
+
+
+def _doc_batches(calls: list[dict]) -> list[list[str]]:
+    """Só as chamadas que carregam documento do projeto, na ordem.
+
+    As sondas de texto trivial também passam pelo fake; separá-las é o que
+    permite afirmar quantos documentos a run gastou.
+    """
+    return [
+        call["document_ids"]
+        for call in calls
+        if any(str(i).startswith("doc-") for i in call["document_ids"])
+    ]
+
+
+def _campos_por_lote(calls: list[dict], doc_id: str) -> list[set[str]]:
+    """Os conjuntos de campos pedidos nas chamadas que levaram `doc_id`."""
+    return [call["model_fields"] for call in calls if doc_id in call["document_ids"]]
+
+
+def test_run_llm_divide_o_schema_quando_o_provider_recusa_o_modelo_inteiro(
+    monkeypatch,
+):
+    # Forma do incidente de 2026-08-13: o schema com justificativas dobra de
+    # tamanho e o provider recusa o modelo inteiro, sem dizer por quê. Aqui
+    # são 4 campos + 4 justificativas = 8, com o provider aceitando no máximo
+    # 4 — o que obriga a partir em dois lotes de 2 campos e 2 justificativas.
+    docs = _docs(3)
+    campos = ["campo_a", "campo_b", "campo_c", "campo_d"]
+    todos = campos + [f"{c}_justification" for c in campos]
+    row_specs = {doc["id"]: {c: f"v-{c}" for c in todos} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(
+        _project_row(
+            pydantic_code=SPLIT_PYDANTIC_CODE,
+            llm_kwargs={"include_justifications": True},
+        ),
+        docs,
+    )
+
+    _run_llm_sync(
+        monkeypatch, sb, row_specs, dataframeit_calls=calls, max_schema_fields=4
+    )
+
+    # A run completa: dividir é transparente para quem só olha o resultado.
+    assert _jobs[JOB_ID]["status"] == "completed"
+    respostas = _published_responses(sb)
+    assert len(respostas) == 3
+
+    # E entrega o schema INTEIRO. Sem a fusão dos frames, cada documento
+    # sairia só com os campos do último lote — uma resposta parcial que a via
+    # estatística reprovaria, e o motivo verdadeiro ficaria invisível.
+    for r in respostas:
+        assert set(r["answers"]) == set(campos)
+
+    lotes = _campos_por_lote(calls, "doc-0")
+    # A primeira chamada é o modelo inteiro: schema que já cabe não paga
+    # nada, e só quando ele é recusado é que a bisseção começa.
+    assert lotes[0] == set(todos)
+    aceitos = [lote for lote in lotes[1:] if len(lote) <= 4]
+    assert len(aceitos) == 2
+    assert set().union(*aceitos) == set(todos)
+
+
+def test_run_llm_mantem_cada_justificativa_no_lote_do_campo_que_ela_justifica(
+    monkeypatch,
+):
+    # Invariante semântica, não cosmética: separados, o modelo produziria a
+    # justificativa numa chamada em que a resposta correspondente não foi
+    # decidida — justificaria uma resposta que ele não deu. Um split ingênuo
+    # por índice quebra isto, e é a regressão silenciosa mais provável aqui.
+    docs = _docs(1)
+    campos = ["campo_a", "campo_b", "campo_c", "campo_d"]
+    todos = campos + [f"{c}_justification" for c in campos]
+    row_specs = {doc["id"]: {c: f"v-{c}" for c in todos} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(
+        _project_row(
+            pydantic_code=SPLIT_PYDANTIC_CODE,
+            llm_kwargs={"include_justifications": True},
+        ),
+        docs,
+    )
+
+    # Limite de 2 força o lote mínimo — um campo e a justificativa dele.
+    _run_llm_sync(
+        monkeypatch, sb, row_specs, dataframeit_calls=calls, max_schema_fields=2
+    )
+
+    assert _jobs[JOB_ID]["status"] == "completed"
+    lotes = [lote for lote in _campos_por_lote(calls, "doc-0") if len(lote) <= 2]
+    assert len(lotes) == 4
+    for lote in lotes:
+        for nome in lote:
+            if nome.endswith("_justification"):
+                assert nome.removesuffix("_justification") in lote
+
+
+def test_run_llm_nao_divide_quando_o_erro_e_do_documento(monkeypatch):
+    # O discriminante que faltava: erro que falha NAQUELE documento e passa em
+    # qualquer outro texto não é configuração. A tupla de strings não
+    # distingue os dois casos — a sonda com texto trivial distingue.
+    docs = _docs(4)
+    row_specs = {doc["id"]: {} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(_project_row(), docs)
+
+    _run_llm_sync(
+        monkeypatch,
+        sb,
+        row_specs,
+        dataframeit_calls=calls,
+        # Casa com NON_RECOVERABLE_ERRORS ('BadRequestError'), então o critério
+        # antigo mataria a run inteira por um documento só.
+        dataframeit_errors={
+            "doc-0": "[Erro não-recuperável] BadRequestError: 400 context length exceeded"
+        },
+    )
+
+    # Nenhuma divisão: os campos pedidos são sempre o schema inteiro.
+    assert all(
+        lote == {"campo_a", "campo_b", "campo_c"}
+        for lote in _campos_por_lote(calls, "doc-0")
+    )
+    # E a run seguiu até o fim, deixando a via estatística julgar.
+    assert _doc_batches(calls) == [["doc-0"], ["doc-1", "doc-2", "doc-3"]]
+    assert len(_published_responses(sb)) == 4
+
+
+def test_run_llm_aborta_quando_nem_um_campo_sozinho_e_aceito(monkeypatch):
+    # Piso da bisseção. Se o provider recusa até o lote de um campo, o
+    # problema não é tamanho e continuar partindo seria laço infinito.
+    docs = _docs(3)
+    row_specs = {doc["id"]: {} for doc in docs}
+    calls: list[dict] = []
+    sb = _build_supabase(_project_row(), docs)
+
+    _run_llm_sync(
+        monkeypatch,
+        sb,
+        row_specs,
+        dataframeit_calls=calls,
+        max_schema_fields=0,
+    )
+
+    assert _jobs[JOB_ID]["status"] == "error"
+    assert _published_responses(sb) == []
+    assert "INVALID_ARGUMENT" in _jobs[JOB_ID]["errors"][0]
+    assert _doc_batches(calls) == [["doc-0"]]
+
+
+def test_run_llm_marca_o_documento_quando_um_dos_lotes_falha(monkeypatch):
+    # Fusão dos frames: um lote que erra sozinho não pode desaparecer. Sem a
+    # regra "erro em qualquer lote marca a linha", o documento sairia como
+    # resposta parcial silenciosa e o erro do provider nunca chegaria ao
+    # usuário.
+    import pandas as pd
+
+    from services.llm_runner import _merge_chunk_frames
+
+    a = pd.DataFrame(
+        [
+            {
+                "id": "doc-0",
+                "campo_a": "x",
+                "_dataframeit_status": "processed",
+                "_error_details": None,
+            }
+        ]
+    )
+    b = pd.DataFrame(
+        [
+            {
+                "id": "doc-0",
+                "campo_b": None,
+                "_dataframeit_status": "error",
+                "_error_details": "boom",
+            }
+        ]
+    )
+
+    merged = _merge_chunk_frames([a, b])
+    linha = merged.iloc[0]
+    assert linha["campo_a"] == "x"
+    assert "campo_b" in merged.columns
+    assert linha["_dataframeit_status"] == "error"
+    assert "boom" in linha["_error_details"]
 
 
 def test_run_llm_unhandled_exception_is_persisted(monkeypatch):


### PR DESCRIPTION
Closes #692

## O incidente

A run de 2026-08-13 22:19 do projeto Zolgensma-Judiciário falhou em 26/26 documentos com `400 INVALID_ARGUMENT: 'Request contains an invalid argument.'` e terminou em "Run comprometida", mandando o usuário procurar defeito no schema.

Reproduzi **byte a byte** contra a API real, da máquina do Fly. A causa é `include_justifications`, que dobra o schema:

| variante | campos | veredito |
|---|---|---|
| `include_justifications: false` | 31 | **200** |
| `include_justifications: true` | 62 | **400 INVALID_ARGUMENT** |

## O que não é a causa

Cada um refutado por medição, não por leitura:

- **Não foi o #691.** O `gemini-3-flash-preview`, que rodava antes, recusa o mesmo schema de 62 campos hoje.
- **Não é limite global.** O Zolgensma (52 campos com justificativas) continua passando nos dois modelos.
- **Não escapa por outro método.** `json_schema`, `function_calling` e `json_mode` dão o mesmo 400.
- **Não é campo patológico.** Remover `q15`, `q17` ou `q28` isoladamente não resolve — é cumulativo.
- **Não são as chaves internas.** Sete chaves nossas vazam inline no schema (issue à parte), mas removê-las mantém o 400.
- **Não é métrica simples.** Contagem de campos: o Judiciário falha em 42, o Zolgensma passa em 78. Propriedades + valores de enum: falha em 147 num schema, passa em 148 no outro. Tamanho em chars: 20 mil falha, 37 mil passa.

O limite do provider é opaco. A correção não pode conhecê-lo — precisa **descobri-lo**.

## A correção

**Sonda discriminante.** Quando o canário falha, uma chamada com texto trivial responde a pergunta que o texto do erro não responde: *o erro depende de qual documento é?* Três desfechos — sonda passa (erro do documento, segue e a via estatística julga); sonda falha com erro transitório (segue, porque abortar por rate limit desperdiça uma run que costuma passar depois); sonda falha de outro jeito (é a configuração, divide).

**Bisseção.** O modelo é partido ao meio recursivamente até cada lote ser aceito. Schema que já cabe não paga nada, porque a primeira pergunta é o modelo inteiro. Medido contra o schema real: **62 campos viram 2 lotes (32 + 30) em 3 sondas**, cobrindo todos os campos.

**Vínculos preservados.** Campo e sua justificativa viajam no mesmo lote, assim como subcampos achatados de um mesmo pai. Separados, o modelo escreveria a justificativa numa chamada em que a resposta correspondente não foi decidida — justificaria uma resposta que ele não deu.

**Fusão dos frames.** Erro em qualquer lote marca a linha, com as mensagens concatenadas. Sem isso um lote que falhou sozinho desapareceria e o documento sairia como resposta parcial silenciosa.

## Por que isso fecha a #692

O critério textual anterior consultava `NON_RECOVERABLE_ERRORS`, que responde *"vale a pena repetir esta linha?"* — pergunta por documento — e era usado para decidir *"a run está mal configurada?"*. Errava nos dois sentidos: deixou passar esta recusa, porque `INVALID_ARGUMENT` não casa com `InvalidArgument` por causa do underscore, e teria matado a run por um `BadRequestError` de um documento só.

`RECOVERABLE_ERRORS` continua consultada, mas para a pergunta que ela de fato responde — *é transitório?* — e com casamento explícito, porque o default da lib é otimista e foi por ele que a recusa determinística ganhou o prefixo `[Falhou após 3 tentativa(s)]`.

A #692 tinha mecanismo confirmado e cenário hipotético. Este PR traz o caso real e o teste discriminante que faltava.

## Correções da revisão (commit `3d613f44`)

A revisão em nível `high` apontou sete pontos; cinco se confirmaram contra o `dataframeit` instalado, e um deles por experimento executado, não por leitura. Os três primeiros são regressões que este PR tinha introduzido e que a versão anterior não tinha.

**O refazer do canário não chamava o provider.** `to_pandas` devolve o próprio frame do chamador e `_setup_columns` escreve nele, então a primeira chamada deixa as colunas gravadas em `batch_df`; a segunda reencontra essas colunas, avisa `Colunas [...] já existem` e devolve sem falar com o provider. Rodei o caso ponta a ponta contra a lib real: a segunda chamada não gerava requisição nenhuma e o frame continuava sendo o da falha. O documento do canário saía vazio e, a 1 em 26, ficava abaixo do `run_failure_threshold` — a run reportava "completed" e o documento sumia calado. `_call` passa a copiar o frame por dentro, o que torna esse estado inconstruível em vez de deixá-lo por conta da memória de cada chamador.

**Sucesso após retry era lido como falha.** A lib grava `"Sucesso após N retry(s)"` em `_error_details` mantendo o status `processed`; o canário e a sonda liam só a mensagem. Um único retry — banal sob rate limit do Gemini — passava a dividir um schema que cabe, e uma sonda com retry podia matar no piso uma run que o provider nunca recusou, já que essa string não casa com `RECOVERABLE_ERRORS`. O filtro `NON_RECOVERABLE_ERRORS` que este PR removeu era também o que barrava essa string. A regra passa a viver em `_row_error`, que decide pelo status, e os três chamadores derivam dela.

**A porta de transitório só existia na entrada.** `_fit_chunks` tratava qualquer mensagem como "não cabe", inclusive um 429 — mais provável justamente ali, com sondas em sequência logo depois de `parallel_requests` chamadas. `_TransientProbeError` sobe de qualquer nível e a run segue sem dividir, em vez de abortar culpando o schema.

Mais dois, menores. A sonda de entrada e a primeira pergunta da bisseção eram a mesma — "o modelo inteiro cabe?" — e custavam duas chamadas em toda decisão de divisão; agora saem da mesma bisseção. E a mensagem do piso dizia "um único campo" quando a unidade real é o grupo (campo mais justificativa, ou aninhado com os subcampos), além de ter perdido a dica sobre modelo e chave que a #691 dava e que é exatamente o caso que chega ali.

Refutei um ponto: a revisão atribuía também um vazamento de colunas entre lotes. O copy-on-write do pandas isola o frame já devolvido e `_merge_chunk_frames` usa o primeiro como base, então não há corrupção entre lotes — o dano era só no refazer do canário.

## Verificação

- 296 testes do backend verdes (291 + 5 novos).
- **Mutação, 5 novas:** remover o `.copy()` de `_call`; fazer `_row_error` ignorar o status; remover o `raise` de transitório; ressuscitar a sonda dupla; desfazer a mensagem do piso. Cada uma morre com o teste que descreve aquela guarda, e nenhuma outra.
- **O fake dos testes divergia da lib** justamente onde os bugs viviam: copiava o frame em vez de mutá-lo, não tinha o ramo "colunas já existem" e preenchia respostas em linha que falhou — o que fazia um documento perdido parecer completo. Agora espelha os três, e por isso o teste de divisão que já existia passou a medir o dano em vez da contagem de chamadas.
- **Contra a lib real, com o código corrigido:** duas chamadas sobre o mesmo frame produzem duas requisições, o frame do chamador fica intacto e o lote seguinte não herda coluna do anterior.
- 5 testes novos, todos falhando antes da correção (a suíte carrega e falha na asserção, não no import).

## Nota de custo

Dividir multiplica as chamadas por documento pelo número de lotes. No Judiciário são 2, então 26 documentos passam a custar 52 chamadas. Projetos cujo schema já cabe não mudam de custo.

O custo da decisão em si são **3 sondas** para o schema de 62 campos que vira 2 lotes. Antes da correção da sonda dupla eram 4 — a contagem que este texto afirmava não valia para o código medido, e agora há teste fixando o número.
