### PR TITLE
fix(llm-insights): inclui auto-revisão na taxa de erro e unifica a noção de equivalência

### DIFF
--- a/frontend/src/actions/export.ts
+++ b/frontend/src/actions/export.ts
@@ -6,6 +6,7 @@
 import { createSupabaseServer } from "@/lib/supabase/server";
 import { requireCoordinator } from "@/lib/auth";
 import type { PydanticField } from "@/lib/types";
+import { fetchAllPaged } from "@/lib/supabase/fetch-all-paged";
 import {
   assembleExport,
   type ExportDataset,
@@ -20,33 +21,6 @@ export type GetExportDatasetResult = ExportDataset | { error: string };
 // Sem paginar, um projeto grande teria a exportação truncada SILENCIOSAMENTE —
 // contradizendo a FR-008 ("conjunto completo"). Buscamos por páginas com .range()
 // até uma página vir incompleta. `build()` recria a query a cada página porque um
-// builder do PostgREST é de uso único (o await o executa).
-const EXPORT_PAGE_SIZE = 1000;
-
-async function fetchAllPaged<T>(
-  build: () => {
-    range: (
-      from: number,
-      to: number
-    ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
-  }
-): Promise<{ data: T[]; error: { message: string } | null }> {
-  const all: T[] = [];
-  let from = 0;
-  for (;;) {
-    // await sequencial é da natureza da paginação: só dá para pedir a próxima
-    // página sabendo que a anterior veio cheia.
-    // react-doctor-disable-next-line react-doctor/async-await-in-loop
-    const { data, error } = await build().range(from, from + EXPORT_PAGE_SIZE - 1);
-    if (error) return { data: all, error };
-    const batch = data ?? [];
-    all.push(...batch);
-    if (batch.length < EXPORT_PAGE_SIZE) break;
-    from += EXPORT_PAGE_SIZE;
-  }
-  return { data: all, error: null };
-}
-
 // Retorna o conjunto completo do projeto (documentos + respostas + gabarito)
 // já montado como planilhas de strings. Gate coordinator-only (fail-closed);
 // lê documents.metadata APENAS aqui — nunca na listagem da página. As 4 queries

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -31,13 +31,13 @@ export default async function LlmInsightsPage({
     { data: documents },
     { data: errorResolutions },
     { data: equivalencePairs },
-    { data: finalAnswers },
+    { data: finalAnswers, error: finalAnswersError },
     accessResult,
   ] = await Promise.all([
     supabase
       .from("projects")
       .select(
-        "pydantic_fields, schema_revision",
+        "pydantic_fields, schema_revision, automation_mode",
       )
       .eq("id", id)
       .single(),
@@ -97,6 +97,17 @@ export default async function LlmInsightsPage({
     getProjectAccessContext(id, user),
   ]);
 
+  // A fonte de auto-revisão some sem quebrar a página se a query falhar — o
+  // que aconteceria numa janela de deploy em que o código já subiu mas a
+  // migration que expõe os vereditos em `final_answers` ainda não foi
+  // aplicada. Silêncio aqui seria uma taxa incompleta sem aviso nenhum.
+  if (finalAnswersError) {
+    console.error(
+      `[llm-insights] projeto ${id}: fonte de auto-revisão indisponível, taxa calculada só com a Comparação —`,
+      finalAnswersError.message,
+    );
+  }
+
   // Fail-open em contexto de acesso indisponível (erro transitório de query):
   // não rebaixa um coordenador legítimo a não-coordenador por falha transiente.
   // Seguro aqui porque isCoordinator só liga affordances no LlmInsightsView
@@ -125,6 +136,7 @@ export default async function LlmInsightsPage({
 
   const { errors, reviewedEntries } = computeLlmErrorMetrics({
     fields: allFields,
+    automationMode: project?.automation_mode ?? null,
     documentTitles,
     responses,
     reviews,

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -13,17 +13,14 @@ import {
 } from "@/lib/llm-error-metrics";
 import type { PydanticField } from "@/lib/types";
 
-export default async function LlmInsightsPage({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const [{ id }, user, supabase] = await Promise.all([
-    params,
-    requirePageAuthUser(),
-    createSupabaseServer(),
-  ]);
-
+// Carga de dados da página. Fora do componente porque o RSC fica ilegível com
+// sete queries inline — e porque a lista de colunas é o contrato real com
+// `computeLlmErrorMetrics`.
+async function loadInsightsData(
+  supabase: Awaited<ReturnType<typeof createSupabaseServer>>,
+  id: string,
+  user: Awaited<ReturnType<typeof requirePageAuthUser>>,
+) {
   const [
     { data: project },
     { data: responses },
@@ -97,6 +94,60 @@ export default async function LlmInsightsPage({
     getProjectAccessContext(id, user),
   ]);
 
+  return {
+    project,
+    responses,
+    reviews,
+    documents,
+    errorResolutions,
+    equivalencePairs,
+    finalAnswers,
+    finalAnswersError,
+    accessResult,
+  };
+}
+
+// Documentos que o LLM respondeu e que a métrica ainda não alcançou — o
+// rodapé dos cards avisa que a taxa não cobre o projeto inteiro.
+function buildSummary(
+  responses: MetricsResponse[],
+  reviewedEntries: { documentId: string }[],
+): { totalLlmDocs: number; unreviewedLlmDocs: number } {
+  const llmDocIds = new Set(
+    responses
+      .filter((r) => r.respondent_type === "llm" && r.is_latest)
+      .map((r) => r.document_id),
+  );
+  const measuredDocIds = new Set(reviewedEntries.map((e) => e.documentId));
+  return {
+    totalLlmDocs: llmDocIds.size,
+    unreviewedLlmDocs: [...llmDocIds].filter((id) => !measuredDocIds.has(id)).length,
+  };
+}
+
+export default async function LlmInsightsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const [{ id }, user, supabase] = await Promise.all([
+    params,
+    requirePageAuthUser(),
+    createSupabaseServer(),
+  ]);
+
+  const {
+    project,
+    responses,
+    reviews,
+    documents,
+    errorResolutions,
+    equivalencePairs,
+    finalAnswers,
+    finalAnswersError,
+    accessResult,
+  } = await loadInsightsData(supabase, id, user);
+
   // A fonte de auto-revisão some sem quebrar a página se a query falhar — o
   // que aconteceria numa janela de deploy em que o código já subiu mas a
   // migration que expõe os vereditos em `final_answers` ainda não foi
@@ -124,37 +175,25 @@ export default async function LlmInsightsPage({
     revision: project?.schema_revision ?? 0,
   };
 
-  const documentTitles = new Map(
-    documents?.map((d) => [d.id, d.title || d.external_id || d.id]) || [],
-  );
-  const errorResolutionMap = new Map(
-    errorResolutions?.map((r) => [
-      `${r.document_id}:${r.field_name}`,
-      r.resolved_at,
-    ]) || [],
-  );
-
   const { errors, reviewedEntries } = computeLlmErrorMetrics({
     fields: allFields,
     automationMode: project?.automation_mode ?? null,
-    documentTitles,
+    documentTitles: new Map(
+      documents?.map((d) => [d.id, d.title || d.external_id || d.id]) || [],
+    ),
     responses,
     reviews,
     finalAnswers,
     equivalences: equivalencePairs,
-    errorResolutions: errorResolutionMap,
+    errorResolutions: new Map(
+      errorResolutions?.map((r) => [
+        `${r.document_id}:${r.field_name}`,
+        r.resolved_at,
+      ]) || [],
+    ),
   });
 
-  const llmDocIds = new Set(
-    responses
-      .filter((r) => r.respondent_type === "llm" && r.is_latest)
-      .map((r) => r.document_id),
-  );
-  const totalLlmDocs = llmDocIds.size;
-  const measuredDocIds = new Set(reviewedEntries.map((e) => e.documentId));
-  const unreviewedLlmDocs = [...llmDocIds].filter(
-    (docId) => !measuredDocIds.has(docId),
-  ).length;
+  const summary = buildSummary(responses, reviewedEntries);
 
   // Visible fields for the dropdown filter (same criteria as the error suppression).
   const visibleFields = allFields.filter(
@@ -170,7 +209,7 @@ export default async function LlmInsightsPage({
         fields={visibleFields}
         schemaEditor={{ fields: allFields, baseline: schemaBaseline }}
         isCoordinator={isCoordinator}
-        summary={{ totalLlmDocs, unreviewedLlmDocs }}
+        summary={summary}
       />
     </div>
   );

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -87,7 +87,7 @@ async function loadInsightsData(
       supabase
         .from("final_answers")
         .select(
-          "document_id, field_name, provenance, final_verdict, self_reviewed_at, final_decided_at, human_response_id, llm_response_id, human_answer_snapshot, llm_answer_snapshot",
+          "document_id, field_name, provenance, final_verdict, self_reviewed_at, final_decided_at, human_response_id, llm_response_id, human_answer_snapshot, llm_answer_snapshot, arbitrator_comment",
         )
         .eq("project_id", id),
     ),

--- a/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/reviews/llm-insights/page.tsx
@@ -2,39 +2,16 @@ import { createSupabaseServer } from "@/lib/supabase/server";
 import { getProjectAccessContext } from "@/lib/auth";
 import { requirePageAuthUser } from "@/lib/page-auth";
 import { coordinatorGate } from "@/lib/project-access";
-import { normalizeForComparison } from "@/lib/utils";
 import { LlmInsightsView } from "@/components/stats/LlmInsightsView";
-import { formatAnswer } from "@/lib/reviews/queries";
-import { canonicalPair } from "@/lib/equivalence";
+import { fetchAllPaged } from "@/lib/supabase/fetch-all-paged";
+import {
+  computeLlmErrorMetrics,
+  type MetricsEquivalence,
+  type MetricsFinalAnswer,
+  type MetricsResponse,
+  type MetricsReview,
+} from "@/lib/llm-error-metrics";
 import type { PydanticField } from "@/lib/types";
-
-export interface LlmError {
-  documentId: string;
-  documentTitle: string;
-  fieldName: string;
-  fieldDescription: string;
-  llmAnswer: string;
-  llmJustification: string | null;
-  chosenVerdict: string;
-  reviewerComment: string | null;
-  resolvedAt: string | null;
-  reviewedAt: string;
-  schemaVersion: string | null;
-  llmResponseId: string;
-  chosenResponseId: string | null;
-}
-
-// Every reviewed (doc, field) pair the LLM also answered, after applying the
-// same hidden/equivalent/same-content suppressions used to build `errors`.
-// Used client-side as the denominator so the error rate respects active filters.
-export interface ReviewedEntry {
-  documentId: string;
-  documentTitle: string;
-  fieldName: string;
-  schemaVersion: string | null;
-  reviewedAt: string;
-  isError: boolean;
-}
 
 export default async function LlmInsightsPage({
   params,
@@ -49,11 +26,12 @@ export default async function LlmInsightsPage({
 
   const [
     { data: project },
-    { data: llmResponses },
+    { data: responses },
     { data: reviews },
     { data: documents },
     { data: errorResolutions },
     { data: equivalencePairs },
+    { data: finalAnswers },
     accessResult,
   ] = await Promise.all([
     supabase
@@ -63,21 +41,27 @@ export default async function LlmInsightsPage({
       )
       .eq("id", id)
       .single(),
-    supabase
-      .from("responses")
-      .select(
-        "id, document_id, answers, justifications, respondent_name, schema_version_major, schema_version_minor, schema_version_patch",
-      )
-      .eq("project_id", id)
-      .eq("respondent_type", "llm")
-      .eq("is_latest", true),
-    supabase
-      .from("reviews")
-      .select(
-        "document_id, field_name, verdict, chosen_response_id, comment, created_at",
-      )
-      .eq("project_id", id)
-      .not("chosen_response_id", "is", null),
+    // Todas as responses, de todas as rodadas e dos dois tipos de respondente:
+    // o union-find de equivalência precisa dos dois endpoints de cada par, e
+    // `chosen_response_id` pode apontar para uma resposta que não é mais
+    // `is_latest`. Paginado — um projeto grande passa de 1000 responses.
+    fetchAllPaged<MetricsResponse>(() =>
+      supabase
+        .from("responses")
+        .select(
+          "id, document_id, respondent_type, is_latest, answers, justifications, answer_field_hashes, created_at, schema_version_major, schema_version_minor, schema_version_patch",
+        )
+        .eq("project_id", id),
+    ),
+    fetchAllPaged<MetricsReview>(() =>
+      supabase
+        .from("reviews")
+        .select(
+          "document_id, field_name, verdict, chosen_response_id, comment, created_at",
+        )
+        .eq("project_id", id)
+        .not("chosen_response_id", "is", null),
+    ),
     supabase
       .from("documents")
       .select("id, title, external_id")
@@ -88,11 +72,28 @@ export default async function LlmInsightsPage({
       .from("error_resolutions")
       .select("document_id, field_name, resolved_at")
       .eq("project_id", id),
-    supabase
-      .from("response_equivalences")
-      .select("document_id, field_name, response_a_id, response_b_id")
-      .eq("project_id", id)
-      .is("superseded_at", null),
+    // As colunas de snapshot são obrigatórias: `filterCurrentEquivalencePairs`
+    // é fail-closed e descarta todo par que venha sem elas.
+    fetchAllPaged<MetricsEquivalence>(() =>
+      supabase
+        .from("response_equivalences")
+        .select(
+          "document_id, field_name, response_a_id, response_b_id, response_a_answer_snapshot, response_b_answer_snapshot",
+        )
+        .eq("project_id", id)
+        .is("superseded_at", null),
+    ),
+    // Fonte de veredito do fluxo de auto-revisão. A RPC desse fluxo grava em
+    // `field_reviews` e nunca em `reviews`, então sem esta query os projetos
+    // em `automation_mode = 'auto_review_llm'` não teriam taxa nenhuma.
+    fetchAllPaged<MetricsFinalAnswer>(() =>
+      supabase
+        .from("final_answers")
+        .select(
+          "document_id, field_name, provenance, final_verdict, self_reviewed_at, final_decided_at, human_response_id, llm_response_id, human_answer_snapshot, llm_answer_snapshot",
+        )
+        .eq("project_id", id),
+    ),
     getProjectAccessContext(id, user),
   ]);
 
@@ -112,122 +113,36 @@ export default async function LlmInsightsPage({
     revision: project?.schema_revision ?? 0,
   };
 
-  const fieldMap = new Map(allFields.map((f) => [f.name, f]));
-  const fieldDescMap = new Map(allFields.map((f) => [f.name, f.description]));
-  const docMap = new Map(
+  const documentTitles = new Map(
     documents?.map((d) => [d.id, d.title || d.external_id || d.id]) || [],
   );
-
-  // Build LLM response map: document_id -> response
-  const llmByDoc = new Map<
-    string,
-    {
-      id: string;
-      answers: Record<string, unknown>;
-      justifications: Record<string, string> | null;
-      respondent_name: string | null;
-      schemaVersion: string | null;
-    }
-  >();
-  llmResponses?.forEach((r) => {
-    const v =
-      r.schema_version_major != null && r.schema_version_minor != null && r.schema_version_patch != null
-        ? `${r.schema_version_major}.${r.schema_version_minor}.${r.schema_version_patch}`
-        : null;
-    llmByDoc.set(r.document_id, {
-      id: r.id,
-      answers: r.answers as Record<string, unknown>,
-      justifications: r.justifications as Record<string, string> | null,
-      respondent_name: r.respondent_name,
-      schemaVersion: v,
-    });
-  });
-
-  // Build error resolution map: "docId:fieldName" -> resolved_at
-  const errorResolvedMap = new Map(
+  const errorResolutionMap = new Map(
     errorResolutions?.map((r) => [
       `${r.document_id}:${r.field_name}`,
       r.resolved_at,
     ]) || [],
   );
 
-  // Build equivalence pair set: "docId:fieldName:a|b" (canonical) for direct lookup
-  const equivPairSet = new Set<string>();
-  equivalencePairs?.forEach((p) => {
-    const [a, b] = canonicalPair(p.response_a_id, p.response_b_id);
-    equivPairSet.add(`${p.document_id}:${p.field_name}:${a}|${b}`);
+  const { errors, reviewedEntries } = computeLlmErrorMetrics({
+    fields: allFields,
+    documentTitles,
+    responses,
+    reviews,
+    finalAnswers,
+    equivalences: equivalencePairs,
+    errorResolutions: errorResolutionMap,
   });
 
-  // Compute LLM errors and the parallel list of every reviewed (doc, field)
-  // entry that survived the same suppressions. The client uses
-  // `reviewedEntries` as the denominator so the rate matches the filtered card.
-  const errors: LlmError[] = [];
-  const reviewedEntries: ReviewedEntry[] = [];
-
-  reviews?.forEach((review) => {
-    const llmResp = llmByDoc.get(review.document_id);
-    if (!llmResp) return;
-
-    const field = fieldMap.get(review.field_name);
-    // Skip fields that are hidden from humans (target=none) or LLM-only.
-    // These shouldn't show up as "errors" since coordenador chose to remove
-    // them from the review surface — past reviews would otherwise leak.
-    if (!field || field.target === "none" || field.target === "llm_only") return;
-
-    let isError = false;
-    if (review.chosen_response_id !== llmResp.id) {
-      const llmAnswer = llmResp.answers?.[review.field_name];
-      const sameContent =
-        normalizeForComparison(llmAnswer) ===
-        normalizeForComparison(review.verdict);
-
-      let markedEquivalent = false;
-      if (review.chosen_response_id) {
-        const [a, b] = canonicalPair(llmResp.id, review.chosen_response_id);
-        markedEquivalent = equivPairSet.has(
-          `${review.document_id}:${review.field_name}:${a}|${b}`,
-        );
-      }
-
-      if (!sameContent && !markedEquivalent) {
-        isError = true;
-        errors.push({
-          documentId: review.document_id,
-          documentTitle: docMap.get(review.document_id) || review.document_id,
-          fieldName: review.field_name,
-          fieldDescription:
-            fieldDescMap.get(review.field_name) || review.field_name,
-          llmAnswer: formatAnswer(llmAnswer),
-          llmJustification:
-            llmResp.justifications?.[review.field_name] || null,
-          chosenVerdict: review.verdict,
-          reviewerComment: review.comment,
-          resolvedAt:
-            errorResolvedMap.get(
-              `${review.document_id}:${review.field_name}`,
-            ) || null,
-          reviewedAt: review.created_at,
-          schemaVersion: llmResp.schemaVersion,
-          llmResponseId: llmResp.id,
-          chosenResponseId: review.chosen_response_id,
-        });
-      }
-    }
-
-    reviewedEntries.push({
-      documentId: review.document_id,
-      documentTitle: docMap.get(review.document_id) || review.document_id,
-      fieldName: review.field_name,
-      schemaVersion: llmResp.schemaVersion,
-      reviewedAt: review.created_at,
-      isError,
-    });
-  });
-
-  const totalLlmDocs = llmByDoc.size;
-
-  const reviewedDocIds = new Set(reviews?.map((r) => r.document_id) || []);
-  const unreviewedLlmDocs = [...llmByDoc.keys()].filter((id) => !reviewedDocIds.has(id)).length;
+  const llmDocIds = new Set(
+    responses
+      .filter((r) => r.respondent_type === "llm" && r.is_latest)
+      .map((r) => r.document_id),
+  );
+  const totalLlmDocs = llmDocIds.size;
+  const measuredDocIds = new Set(reviewedEntries.map((e) => e.documentId));
+  const unreviewedLlmDocs = [...llmDocIds].filter(
+    (docId) => !measuredDocIds.has(docId),
+  ).length;
 
   // Visible fields for the dropdown filter (same criteria as the error suppression).
   const visibleFields = allFields.filter(

--- a/frontend/src/components/stats/LlmErrorCard.tsx
+++ b/frontend/src/components/stats/LlmErrorCard.tsx
@@ -14,7 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import { formatDate } from "@/lib/date-format";
 import { formatVerdictDisplay } from "@/lib/verdict-display";
-import type { LlmError } from "@/app/(app)/projects/[id]/reviews/llm-insights/page";
+import type { LlmError } from "@/lib/llm-error-metrics";
 
 interface LlmErrorCardProps {
   error: LlmError;

--- a/frontend/src/components/stats/LlmInsightsView.tsx
+++ b/frontend/src/components/stats/LlmInsightsView.tsx
@@ -19,7 +19,7 @@ import type { PydanticField, SchemaBaselineIdentity } from "@/lib/types";
 import type {
   LlmError,
   ReviewedEntry,
-} from "@/app/(app)/projects/[id]/reviews/llm-insights/page";
+} from "@/lib/llm-error-metrics";
 
 interface LlmInsightsViewProps {
   projectId: string;

--- a/frontend/src/lib/__tests__/llm-error-metrics.test.ts
+++ b/frontend/src/lib/__tests__/llm-error-metrics.test.ts
@@ -88,6 +88,7 @@ function equiv(
 function run(overrides: Partial<LlmErrorMetricsInput> = {}) {
   return computeLlmErrorMetrics({
     fields: [field()],
+    automationMode: "auto_review_llm",
     documentTitles: new Map([["doc1", "Documento 1"]]),
     responses: [],
     reviews: [],
@@ -251,6 +252,54 @@ describe("computeLlmErrorMetrics — fonte Auto-revisão", () => {
     expect(reviewedEntries).toHaveLength(0);
   });
 
+  // O bug que o replay em produção pegou: num projeto de Comparação a view
+  // devolve 'consenso' para a grade inteira, porque `field_reviews` nunca é
+  // materializado ali. Sem este gate o denominador triplicava.
+  it("ignora a fonte inteira fora do modo auto_review_llm", () => {
+    const entrada = {
+      documentTitles: titles,
+      responses: [llmDoc2, humanDoc2],
+      finalAnswers: [finalAnswer({ document_id: "doc2", provenance: "consenso" })],
+    };
+
+    expect(run({ ...entrada, automationMode: "compare_llm" }).reviewedEntries).toHaveLength(0);
+    expect(run({ ...entrada, automationMode: "compare_humans" }).reviewedEntries).toHaveLength(0);
+    expect(run({ ...entrada, automationMode: "none" }).reviewedEntries).toHaveLength(0);
+    expect(run({ ...entrada, automationMode: null }).reviewedEntries).toHaveLength(0);
+    expect(run({ ...entrada, automationMode: "auto_review_llm" }).reviewedEntries).toHaveLength(1);
+  });
+
+  // Espelha `computeBacklogRows`, que só varre codificações completas: num
+  // documento pela metade a ausência de `field_reviews` não prova concordância.
+  it("exige codificação humana COMPLETA para tratar consenso como acerto", () => {
+    const fields = [
+      field({ name: "x", required: true }),
+      field({ name: "y", required: true }),
+    ];
+
+    const incompleta = run({
+      fields,
+      documentTitles: titles,
+      responses: [
+        llmDoc2,
+        response({ id: "rh2", document_id: "doc2", answers: { x: "NI", y: "" } }),
+      ],
+      finalAnswers: [finalAnswer({ document_id: "doc2", provenance: "consenso" })],
+    });
+    expect(incompleta.reviewedEntries).toHaveLength(0);
+
+    const completa = run({
+      fields,
+      documentTitles: titles,
+      responses: [
+        llmDoc2,
+        response({ id: "rh2", document_id: "doc2", answers: { x: "NI", y: "N/A" } }),
+      ],
+      finalAnswers: [finalAnswer({ document_id: "doc2", provenance: "consenso" })],
+    });
+    expect(completa.reviewedEntries).toHaveLength(1);
+  });
+
   it("não conta campo que ainda não existia quando o humano codificou", () => {
     const { reviewedEntries } = run({
       documentTitles: titles,
@@ -359,6 +408,24 @@ describe("computeLlmErrorMetrics — deduplicação entre as fontes", () => {
           final_decided_at: "2026-03-01T00:00:00Z",
           human_response_id: "rh",
           llm_response_id: "rllm",
+        }),
+      ],
+    });
+
+    expect(reviewedEntries).toHaveLength(1);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("colapsa o mesmo campo revisado por vários revisores em uma entrada", () => {
+    const { errors, reviewedEntries } = run({
+      responses: [llmResp, humanResp],
+      reviews: [
+        // Dois revisores, o mesmo (documento, campo): o mais recente decide.
+        review({ verdict: "N/A", created_at: "2026-02-01T00:00:00Z" }),
+        review({
+          verdict: "NI",
+          chosen_response_id: "rllm",
+          created_at: "2026-02-10T00:00:00Z",
         }),
       ],
     });

--- a/frontend/src/lib/__tests__/llm-error-metrics.test.ts
+++ b/frontend/src/lib/__tests__/llm-error-metrics.test.ts
@@ -63,6 +63,7 @@ function finalAnswer(
     llm_response_id: null,
     human_answer_snapshot: null,
     llm_answer_snapshot: null,
+    arbitrator_comment: null,
     ...overrides,
   };
 }
@@ -391,6 +392,24 @@ describe("computeLlmErrorMetrics — fonte Auto-revisão", () => {
       llmResponseId: "rllm2",
       reviewedAt: "2026-03-01T00:00:00Z",
     });
+  });
+
+  it("leva o comentário do arbitrador para o card do erro", () => {
+    const { errors } = run({
+      documentTitles: titles,
+      responses: [llmDoc2, humanDoc2],
+      finalAnswers: [
+        finalAnswer({
+          document_id: "doc2",
+          provenance: "arbitrado",
+          final_verdict: "humano",
+          final_decided_at: "2026-03-01T00:00:00Z",
+          arbitrator_comment: "A nota técnica é explícita no ponto.",
+        }),
+      ],
+    });
+
+    expect(errors[0].reviewerComment).toBe("A nota técnica é explícita no ponto.");
   });
 });
 

--- a/frontend/src/lib/__tests__/llm-error-metrics.test.ts
+++ b/frontend/src/lib/__tests__/llm-error-metrics.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeLlmErrorMetrics,
+  type LlmErrorMetricsInput,
+  type MetricsEquivalence,
+  type MetricsFinalAnswer,
+  type MetricsResponse,
+  type MetricsReview,
+} from "@/lib/llm-error-metrics";
+import type { PydanticField } from "@/lib/types";
+
+function field(overrides: Partial<PydanticField> = {}): PydanticField {
+  return {
+    name: "x",
+    type: "text",
+    options: null,
+    description: "",
+    target: "all",
+    ...overrides,
+  };
+}
+
+function response(overrides: Partial<MetricsResponse> = {}): MetricsResponse {
+  return {
+    id: "r1",
+    document_id: "doc1",
+    respondent_type: "humano",
+    is_latest: true,
+    answers: {},
+    justifications: null,
+    answer_field_hashes: null,
+    created_at: "2026-01-01T00:00:00Z",
+    schema_version_major: 1,
+    schema_version_minor: 0,
+    schema_version_patch: 0,
+    ...overrides,
+  };
+}
+
+function review(overrides: Partial<MetricsReview> = {}): MetricsReview {
+  return {
+    document_id: "doc1",
+    field_name: "x",
+    verdict: "sim",
+    chosen_response_id: "rh",
+    comment: null,
+    created_at: "2026-02-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function finalAnswer(
+  overrides: Partial<MetricsFinalAnswer> = {},
+): MetricsFinalAnswer {
+  return {
+    document_id: "doc1",
+    field_name: "x",
+    provenance: "consenso",
+    final_verdict: null,
+    self_reviewed_at: null,
+    final_decided_at: null,
+    human_response_id: null,
+    llm_response_id: null,
+    human_answer_snapshot: null,
+    llm_answer_snapshot: null,
+    ...overrides,
+  };
+}
+
+function equiv(
+  a: string,
+  b: string,
+  snapA: unknown,
+  snapB: unknown,
+  overrides: Partial<MetricsEquivalence> = {},
+): MetricsEquivalence {
+  return {
+    document_id: "doc1",
+    field_name: "x",
+    response_a_id: a,
+    response_b_id: b,
+    response_a_answer_snapshot: snapA,
+    response_b_answer_snapshot: snapB,
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<LlmErrorMetricsInput> = {}) {
+  return computeLlmErrorMetrics({
+    fields: [field()],
+    documentTitles: new Map([["doc1", "Documento 1"]]),
+    responses: [],
+    reviews: [],
+    finalAnswers: [],
+    equivalences: [],
+    errorResolutions: new Map(),
+    ...overrides,
+  });
+}
+
+// Respostas divergentes no texto: o LLM disse "NI", o humano disse "N/A".
+const llmResp = response({
+  id: "rllm",
+  respondent_type: "llm",
+  answers: { x: "NI" },
+});
+const humanResp = response({ id: "rh", answers: { x: "N/A" } });
+
+describe("computeLlmErrorMetrics — fonte Comparação", () => {
+  it("conta erro quando o gabarito escolhido difere da resposta do LLM", () => {
+    const { errors, reviewedEntries } = run({
+      responses: [llmResp, humanResp],
+      reviews: [review({ verdict: "N/A" })],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].llmAnswer).toBe("NI");
+    expect(errors[0].chosenVerdict).toBe("N/A");
+    expect(reviewedEntries).toHaveLength(1);
+    expect(reviewedEntries[0].isError).toBe(true);
+  });
+
+  it("não conta erro quando a própria resposta do LLM é o gabarito", () => {
+    const { errors, reviewedEntries } = run({
+      responses: [llmResp, humanResp],
+      reviews: [review({ chosen_response_id: "rllm", verdict: "NI" })],
+    });
+
+    expect(errors).toHaveLength(0);
+    expect(reviewedEntries).toHaveLength(1);
+    expect(reviewedEntries[0].isError).toBe(false);
+  });
+
+  // A regressão que este módulo não pode quebrar: "semelhantes" é acerto.
+  it("equivalência marcada suprime o erro e PERMANECE no denominador", () => {
+    const { errors, reviewedEntries } = run({
+      responses: [llmResp, humanResp],
+      reviews: [review({ verdict: "N/A" })],
+      equivalences: [equiv("rh", "rllm", "N/A", "NI")],
+    });
+
+    expect(errors).toHaveLength(0);
+    expect(reviewedEntries).toHaveLength(1);
+    expect(reviewedEntries[0].isError).toBe(false);
+  });
+
+  it("propaga equivalência por transitividade (A≡B, B≡C ⇒ A≡C)", () => {
+    // O par marcado liga o LLM a uma resposta intermediária; o gabarito
+    // escolhido é uma terceira resposta, ligada à intermediária só por texto.
+    const intermediaria = response({ id: "rmid", answers: { x: "nao informado" } });
+    const escolhida = response({ id: "rh2", answers: { x: "Não informado" } });
+
+    const { errors } = run({
+      responses: [llmResp, intermediaria, escolhida],
+      reviews: [review({ chosen_response_id: "rh2", verdict: "Não informado" })],
+      equivalences: [equiv("rllm", "rmid", "NI", "nao informado")],
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("ignora par cujo snapshot não corresponde mais à resposta atual", () => {
+    // A resposta humana foi revisada depois de o par ser criado: a decisão de
+    // equivalência era sobre outro valor e não vale mais.
+    const { errors } = run({
+      responses: [llmResp, humanResp],
+      reviews: [review({ verdict: "N/A" })],
+      equivalences: [equiv("rh", "rllm", "valor antigo", "NI")],
+    });
+
+    expect(errors).toHaveLength(1);
+  });
+
+  it("descarta par sem colunas de snapshot (fail-closed)", () => {
+    const semSnapshot = {
+      document_id: "doc1",
+      field_name: "x",
+      response_a_id: "rh",
+      response_b_id: "rllm",
+    } as unknown as MetricsEquivalence;
+
+    const { errors } = run({
+      responses: [llmResp, humanResp],
+      reviews: [review({ verdict: "N/A" })],
+      equivalences: [semSnapshot],
+    });
+
+    expect(errors).toHaveLength(1);
+  });
+
+  it("cai no texto do veredito quando a resposta escolhida não está no conjunto", () => {
+    // `chosen_response_id` aponta para uma resposta de rodada anterior que não
+    // veio na página; o texto gravado no veredito ainda prova a igualdade.
+    const { errors } = run({
+      responses: [llmResp],
+      reviews: [review({ chosen_response_id: "sumiu", verdict: "NI" })],
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("ignora campos fora da superfície de revisão humana", () => {
+    const { reviewedEntries } = run({
+      fields: [field({ name: "a", target: "none" }), field({ name: "b", target: "llm_only" })],
+      responses: [response({ id: "rllm", respondent_type: "llm", answers: { a: "1", b: "2" } })],
+      reviews: [
+        review({ field_name: "a", verdict: "z" }),
+        review({ field_name: "b", verdict: "z" }),
+      ],
+    });
+
+    expect(reviewedEntries).toHaveLength(0);
+  });
+});
+
+describe("computeLlmErrorMetrics — fonte Auto-revisão", () => {
+  const llmDoc2 = response({
+    id: "rllm2",
+    document_id: "doc2",
+    respondent_type: "llm",
+    answers: { x: "NI" },
+  });
+  const humanDoc2 = response({ id: "rh2", document_id: "doc2", answers: { x: "N/A" } });
+  const titles = new Map([
+    ["doc1", "Documento 1"],
+    ["doc2", "Documento 2"],
+  ]);
+
+  it("consenso conta como acerto quando houve codificação humana", () => {
+    const { errors, reviewedEntries } = run({
+      documentTitles: titles,
+      responses: [llmDoc2, humanDoc2],
+      finalAnswers: [finalAnswer({ document_id: "doc2", provenance: "consenso" })],
+    });
+
+    expect(errors).toHaveLength(0);
+    expect(reviewedEntries).toHaveLength(1);
+    expect(reviewedEntries[0].isError).toBe(false);
+  });
+
+  // A armadilha da view: ela emite 'consenso' para todo documento com resposta
+  // do LLM, inclusive os que ninguém codificou.
+  it("consenso SEM codificação humana fica fora do denominador", () => {
+    const { errors, reviewedEntries } = run({
+      documentTitles: titles,
+      responses: [llmDoc2],
+      finalAnswers: [finalAnswer({ document_id: "doc2", provenance: "consenso" })],
+    });
+
+    expect(errors).toHaveLength(0);
+    expect(reviewedEntries).toHaveLength(0);
+  });
+
+  it("não conta campo que ainda não existia quando o humano codificou", () => {
+    const { reviewedEntries } = run({
+      documentTitles: titles,
+      responses: [
+        llmDoc2,
+        response({
+          id: "rh2",
+          document_id: "doc2",
+          answers: { outro: "v" },
+          answer_field_hashes: { outro: "h1" },
+        }),
+      ],
+      finalAnswers: [finalAnswer({ document_id: "doc2", provenance: "consenso" })],
+    });
+
+    expect(reviewedEntries).toHaveLength(0);
+  });
+
+  it("classifica cada proveniência no balde certo", () => {
+    const cases: Array<{
+      provenance: string;
+      final_verdict?: string | null;
+      esperado: "acerto" | "erro" | "fora";
+    }> = [
+      { provenance: "consenso", esperado: "acerto" },
+      { provenance: "auto_corrigido", esperado: "acerto" },
+      { provenance: "equivalente", esperado: "acerto" },
+      { provenance: "arbitrado", final_verdict: "llm", esperado: "acerto" },
+      { provenance: "arbitrado", final_verdict: "humano", esperado: "erro" },
+      { provenance: "ambiguo", esperado: "fora" },
+      { provenance: "aguarda_auto_revisao", esperado: "fora" },
+      { provenance: "aguarda_arbitragem", esperado: "fora" },
+      { provenance: "aguarda_reconciliacao", esperado: "fora" },
+    ];
+
+    for (const { provenance, final_verdict, esperado } of cases) {
+      const { errors, reviewedEntries } = run({
+        documentTitles: titles,
+        responses: [llmDoc2, humanDoc2],
+        finalAnswers: [
+          finalAnswer({
+            document_id: "doc2",
+            provenance,
+            final_verdict: final_verdict ?? null,
+            human_answer_snapshot: "N/A",
+            llm_answer_snapshot: "NI",
+            final_decided_at: final_verdict ? "2026-03-01T00:00:00Z" : null,
+          }),
+        ],
+      });
+
+      const resumo = { provenance, final_verdict: final_verdict ?? null };
+      if (esperado === "fora") {
+        expect(reviewedEntries, JSON.stringify(resumo)).toHaveLength(0);
+      } else {
+        expect(reviewedEntries, JSON.stringify(resumo)).toHaveLength(1);
+        expect(errors.length, JSON.stringify(resumo)).toBe(
+          esperado === "erro" ? 1 : 0,
+        );
+      }
+    }
+  });
+
+  it("descreve o erro arbitrado pelos snapshots do ciclo", () => {
+    const { errors } = run({
+      documentTitles: titles,
+      responses: [llmDoc2, humanDoc2],
+      finalAnswers: [
+        finalAnswer({
+          document_id: "doc2",
+          provenance: "arbitrado",
+          final_verdict: "humano",
+          final_decided_at: "2026-03-01T00:00:00Z",
+          human_response_id: "rh2",
+          llm_response_id: "rllm2",
+          human_answer_snapshot: "N/A",
+          llm_answer_snapshot: "NI",
+        }),
+      ],
+    });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      documentId: "doc2",
+      documentTitle: "Documento 2",
+      llmAnswer: "NI",
+      chosenVerdict: "N/A",
+      chosenResponseId: "rh2",
+      llmResponseId: "rllm2",
+      reviewedAt: "2026-03-01T00:00:00Z",
+    });
+  });
+});
+
+describe("computeLlmErrorMetrics — deduplicação entre as fontes", () => {
+  it("conta uma vez só, vencendo a decisão mais recente", () => {
+    const { errors, reviewedEntries } = run({
+      responses: [llmResp, humanResp],
+      // Comparação decidiu em fevereiro que o LLM errou...
+      reviews: [review({ verdict: "N/A", created_at: "2026-02-01T00:00:00Z" })],
+      // ...e a arbitragem decidiu em março que o LLM estava certo.
+      finalAnswers: [
+        finalAnswer({
+          provenance: "arbitrado",
+          final_verdict: "llm",
+          final_decided_at: "2026-03-01T00:00:00Z",
+          human_response_id: "rh",
+          llm_response_id: "rllm",
+        }),
+      ],
+    });
+
+    expect(reviewedEntries).toHaveLength(1);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("um veredito explícito vence o consenso, que não é decisão de ninguém", () => {
+    const { errors, reviewedEntries } = run({
+      responses: [llmResp, humanResp],
+      reviews: [review({ verdict: "N/A" })],
+      finalAnswers: [finalAnswer({ provenance: "consenso" })],
+    });
+
+    expect(reviewedEntries).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+  });
+});
+
+describe("computeLlmErrorMetrics — metadados para os filtros da UI", () => {
+  it("preenche schemaVersion e reviewedAt nas duas fontes", () => {
+    const { reviewedEntries } = run({
+      documentTitles: new Map([
+        ["doc1", "Documento 1"],
+        ["doc2", "Documento 2"],
+      ]),
+      responses: [
+        llmResp,
+        humanResp,
+        response({
+          id: "rllm2",
+          document_id: "doc2",
+          respondent_type: "llm",
+          answers: { x: "NI" },
+          created_at: "2026-01-15T00:00:00Z",
+          schema_version_major: 2,
+          schema_version_minor: 1,
+          schema_version_patch: 0,
+        }),
+        response({ id: "rh2", document_id: "doc2", answers: { x: "NI" } }),
+      ],
+      reviews: [review({ verdict: "N/A" })],
+      finalAnswers: [finalAnswer({ document_id: "doc2", provenance: "consenso" })],
+    });
+
+    expect(reviewedEntries).toHaveLength(2);
+    const porDoc = new Map(reviewedEntries.map((e) => [e.documentId, e]));
+    expect(porDoc.get("doc1")).toMatchObject({
+      schemaVersion: "1.0.0",
+      reviewedAt: "2026-02-01T00:00:00Z",
+    });
+    // Consenso não tem instante de decisão: cai na data da resposta do LLM.
+    expect(porDoc.get("doc2")).toMatchObject({
+      schemaVersion: "2.1.0",
+      reviewedAt: "2026-01-15T00:00:00Z",
+    });
+  });
+
+  it("anexa o resolvedAt de erros já resolvidos", () => {
+    const { errors } = run({
+      responses: [llmResp, humanResp],
+      reviews: [review({ verdict: "N/A" })],
+      errorResolutions: new Map([["doc1:x", "2026-04-01T00:00:00Z"]]),
+    });
+
+    expect(errors[0].resolvedAt).toBe("2026-04-01T00:00:00Z");
+  });
+});

--- a/frontend/src/lib/export/assemble.ts
+++ b/frontend/src/lib/export/assemble.ts
@@ -165,6 +165,13 @@ function multiFieldAgrees(
 // Valor concordante de um campo entre as respostas de um documento, ou null se
 // houver divergência. Multi compara conjuntos de opções; demais tipos usam
 // normalizeForComparison.
+//
+// Igualdade LITERAL, de propósito por ora: ao contrário da Comparação e da
+// métrica de erro do LLM — que fundem respostas por union-find sobre pares de
+// `response_equivalences` — aqui duas respostas marcadas como equivalentes
+// ainda contam como divergentes. Fundi-las exigiria decidir QUAL valor vai para
+// a célula, e a saída certa é um dicionário canônico de respostas, não uma
+// escolha arbitrária dentro do grupo. Ver issue bdcdo/dataframeitGUI#702.
 function fieldAgreementValue(
   docResponses: ExportResponse[],
   fieldName: string,

--- a/frontend/src/lib/llm-error-metrics.ts
+++ b/frontend/src/lib/llm-error-metrics.ts
@@ -27,6 +27,7 @@ import {
   type EquivalencePair,
 } from "@/lib/equivalence";
 import { fieldExistedWhenCoded } from "@/lib/answer-staleness";
+import { isCodingComplete } from "@/lib/coding-completeness";
 import { formatAnswer } from "@/lib/reviews/queries";
 import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
 
@@ -105,6 +106,13 @@ export interface MetricsEquivalence extends EquivalencePair {
 
 export interface LlmErrorMetricsInput {
   fields: PydanticField[];
+  /**
+   * `projects.automation_mode`. A fonte de auto-revisão só é lida em
+   * 'auto_review_llm': `field_reviews` não é materializado nos outros modos, e
+   * a view devolveria 'consenso' — que ali significa apenas "este projeto não
+   * usa auto-revisão" — para todo campo de todo documento.
+   */
+  automationMode: string | null;
   documentTitles: Map<string, string>;
   /** Todas as responses do projeto, de todas as rodadas e respondentes. */
   responses: MetricsResponse[];
@@ -192,6 +200,7 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
 } {
   const {
     fields,
+    automationMode,
     documentTitles,
     responses,
     reviews,
@@ -327,7 +336,12 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
   }
 
   /* ── Fonte B: Auto-revisão (view `final_answers`) ── */
-  for (const row of finalAnswers) {
+  // Sem este gate, um projeto de Comparação (`compare_llm`) veria toda a sua
+  // grade documento × campo entrar como acerto: medido no projeto Zolgensma,
+  // o denominador saltava de 898 para 2944 e a taxa despencava de 37% para
+  // 11% — puro ruído de linhas 'consenso' que nunca passaram por auto-revisão.
+  const autoReviewEnabled = automationMode === "auto_review_llm";
+  for (const row of autoReviewEnabled ? finalAnswers : []) {
     const field = fieldMap.get(row.field_name);
     if (!isMeasurableField(field)) continue;
 
@@ -338,6 +352,12 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
     // resposta do LLM, e marca 'consenso' sempre que não há linha em
     // `field_reviews` — inclusive em documentos que ninguém codificou. Sem
     // este gate, não-codificação viraria acerto do LLM e afundaria a taxa.
+    //
+    // O gate espelha `computeBacklogRows` (`auto-review-backlog.ts`), que é
+    // quem MATERIALIZA as linhas de `field_reviews`: ele só varre codificações
+    // humanas COMPLETAS. Um gate mais frouxo aqui leria a ausência de linha
+    // num documento pela metade como concordância, quando ela só significa que
+    // o documento ainda não era elegível ao backlog.
     const humanCoded = (responsesByDoc.get(row.document_id) ?? []).some(
       (response) =>
         response.respondent_type === "humano" &&
@@ -346,7 +366,12 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
           response.answer_field_hashes ?? undefined,
           field.name,
         ) &&
-        isFieldVisible(field, response.answers ?? {}),
+        isFieldVisible(field, response.answers ?? {}) &&
+        isCodingComplete(
+          fields,
+          response.answers ?? {},
+          response.answer_field_hashes ?? undefined,
+        ),
     );
     if (!humanCoded) continue;
 
@@ -398,7 +423,14 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
     });
   }
 
-  /* ── Deduplicação entre as fontes ── */
+  /* ── Deduplicação por (documento, campo) ── */
+  // Vale tanto ENTRE as fontes quanto DENTRO da Comparação: `reviews` é única
+  // por (projeto, doc, campo, revisor), então um campo revisado por três
+  // pessoas rendia três entradas e pesava o triplo na taxa. Uma entrada por
+  // campo é a leitura certa de "quantos campos o LLM errou" — medido no
+  // projeto Zolgensma, o efeito é de menos de 1 ponto percentual (961 reviews
+  // colapsam em 898 campos), mas o peso deixa de depender de quantas pessoas
+  // passaram pelo documento.
   const winners = new Map<string, Candidate>();
   for (const candidate of candidates) {
     const key = `${candidate.documentId}:${candidate.fieldName}`;

--- a/frontend/src/lib/llm-error-metrics.ts
+++ b/frontend/src/lib/llm-error-metrics.ts
@@ -1,0 +1,421 @@
+// Métrica de erro do LLM exibida em LLM Insights: numerador (`errors`) e
+// denominador (`reviewedEntries`) de "taxa de erro".
+//
+// Puro e sem Supabase — recebe linhas cruas e devolve as duas listas — para
+// ser testável fora do runtime do Next, no molde de `compare-divergence.ts`.
+//
+// Há DUAS fontes de veredito sobre acerto/erro do LLM, e as duas contam:
+//
+//   Fonte A — Comparação (`reviews`): o revisor escolheu, entre as respostas
+//   do documento, qual é o gabarito. O LLM acertou se a resposta dele cai na
+//   mesma classe de equivalência da escolhida.
+//
+//   Fonte B — Auto-revisão (`field_reviews`, lida via a view `final_answers`):
+//   o próprio codificador confronta a sua resposta com a do LLM, com
+//   arbitragem quando ele contesta. A RPC desse fluxo nunca escreve em
+//   `reviews`, então antes desta métrica os projetos em `auto_review_llm`
+//   apareciam sem taxa nenhuma.
+//
+// Um projeto que trocou de `automation_mode` tem histórico nas duas tabelas
+// para o mesmo (documento, campo) — não há constraint cruzada impedindo — daí
+// a deduplicação em `pickWinner`.
+import { normalizeForComparison } from "@/lib/utils";
+import { isFieldVisible } from "@/lib/conditional";
+import {
+  buildResponseGroupKeys,
+  filterCurrentEquivalencePairs,
+  type EquivalencePair,
+} from "@/lib/equivalence";
+import { fieldExistedWhenCoded } from "@/lib/answer-staleness";
+import { formatAnswer } from "@/lib/reviews/queries";
+import type { AnswerFieldHashes, PydanticField } from "@/lib/types";
+
+export interface LlmError {
+  documentId: string;
+  documentTitle: string;
+  fieldName: string;
+  fieldDescription: string;
+  llmAnswer: string;
+  llmJustification: string | null;
+  chosenVerdict: string;
+  reviewerComment: string | null;
+  resolvedAt: string | null;
+  reviewedAt: string;
+  schemaVersion: string | null;
+  llmResponseId: string;
+  chosenResponseId: string | null;
+}
+
+// Todo (doc, campo) que o LLM respondeu e que já tem veredito humano — de
+// qualquer das duas fontes — após as mesmas supressões aplicadas a `errors`.
+// A UI usa como denominador, para que a taxa respeite os filtros ativos.
+export interface ReviewedEntry {
+  documentId: string;
+  documentTitle: string;
+  fieldName: string;
+  schemaVersion: string | null;
+  reviewedAt: string;
+  isError: boolean;
+}
+
+/* ── Formatos crus de entrada (colunas do banco, snake_case) ── */
+
+export interface MetricsResponse {
+  id: string;
+  document_id: string;
+  respondent_type: "humano" | "llm";
+  is_latest: boolean;
+  answers: Record<string, unknown> | null;
+  justifications: Record<string, string> | null;
+  answer_field_hashes?: AnswerFieldHashes | null;
+  created_at: string;
+  schema_version_major: number | null;
+  schema_version_minor: number | null;
+  schema_version_patch: number | null;
+}
+
+export interface MetricsReview {
+  document_id: string;
+  field_name: string;
+  verdict: string;
+  chosen_response_id: string | null;
+  comment: string | null;
+  created_at: string;
+}
+
+// Linha da view `final_answers` (uma por documento com LLM × campo do schema).
+export interface MetricsFinalAnswer {
+  document_id: string;
+  field_name: string;
+  provenance: string;
+  final_verdict: string | null;
+  self_reviewed_at: string | null;
+  final_decided_at: string | null;
+  human_response_id: string | null;
+  llm_response_id: string | null;
+  human_answer_snapshot: unknown;
+  llm_answer_snapshot: unknown;
+  arbitrator_comment?: string | null;
+}
+
+export interface MetricsEquivalence extends EquivalencePair {
+  document_id: string;
+  field_name: string;
+}
+
+export interface LlmErrorMetricsInput {
+  fields: PydanticField[];
+  documentTitles: Map<string, string>;
+  /** Todas as responses do projeto, de todas as rodadas e respondentes. */
+  responses: MetricsResponse[];
+  /** Já filtradas por `chosen_response_id IS NOT NULL`. */
+  reviews: MetricsReview[];
+  /** Já filtradas por projeto; vazio quando o projeto não usa auto-revisão. */
+  finalAnswers: MetricsFinalAnswer[];
+  /** Já filtradas por `superseded_at IS NULL`, COM as colunas de snapshot. */
+  equivalences: MetricsEquivalence[];
+  /** "documentId:fieldName" -> resolved_at */
+  errorResolutions: Map<string, string | null>;
+}
+
+// Candidato antes da deduplicação entre as duas fontes.
+interface Candidate {
+  documentId: string;
+  fieldName: string;
+  /** Quando o humano decidiu. `null` em consenso (ninguém decidiu nada). */
+  decidedAt: string | null;
+  isError: boolean;
+  error: LlmError | null;
+  entry: ReviewedEntry;
+}
+
+export function formatSchemaVersion(response: {
+  schema_version_major: number | null;
+  schema_version_minor: number | null;
+  schema_version_patch: number | null;
+}): string | null {
+  const { schema_version_major, schema_version_minor, schema_version_patch } =
+    response;
+  if (
+    schema_version_major == null ||
+    schema_version_minor == null ||
+    schema_version_patch == null
+  )
+    return null;
+  return `${schema_version_major}.${schema_version_minor}.${schema_version_patch}`;
+}
+
+// Campos que o coordenador removeu da superfície de revisão humana nunca são
+// erro: vereditos antigos sobre eles vazariam para a métrica.
+function isMeasurableField(field: PydanticField | undefined): field is PydanticField {
+  return !!field && field.target !== "none" && field.target !== "llm_only";
+}
+
+// "O LLM acertou este campo?" a partir da proveniência da auto-revisão. O mapa
+// espelha a view `final_answers`; 'arbitrado' é o único caso em que
+// `provenance` sozinho não decide.
+function classifyAutoReview(
+  row: MetricsFinalAnswer,
+): "acerto" | "erro" | "pendente" {
+  switch (row.provenance) {
+    // Sem linha em `field_reviews`: humano e LLM concordaram na codificação, e
+    // o campo nunca entrou na fila de auto-revisão.
+    case "consenso":
+    // O codificador reconheceu que errou e o LLM estava certo.
+    case "auto_corrigido":
+    // Respostas diferentes no texto, mesma coisa no conteúdo — o análogo
+    // exato do "semelhantes" da Comparação, e como lá, não é erro do LLM.
+    case "equivalente":
+      return "acerto";
+    case "arbitrado":
+      return row.final_verdict === "humano" ? "erro" : "acerto";
+    // 'ambiguo' é terminal mas não produz gabarito: fica fora do numerador E
+    // do denominador, como já acontece com o veredito "ambiguo" da Comparação.
+    // Os 'aguarda_*' são pendências, não acertos.
+    default:
+      return "pendente";
+  }
+}
+
+// Vence a decisão mais recente. Consenso não é decisão de ninguém e perde para
+// qualquer veredito explícito, de qualquer das fontes; empate mantém o
+// incumbente, o que torna o resultado estável dada a ordem de inserção.
+function beats(candidate: Candidate, incumbent: Candidate): boolean {
+  if (candidate.decidedAt && !incumbent.decidedAt) return true;
+  if (!candidate.decidedAt) return false;
+  return candidate.decidedAt > incumbent.decidedAt!;
+}
+
+export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
+  errors: LlmError[];
+  reviewedEntries: ReviewedEntry[];
+} {
+  const {
+    fields,
+    documentTitles,
+    responses,
+    reviews,
+    finalAnswers,
+    equivalences,
+    errorResolutions,
+  } = input;
+
+  const fieldMap = new Map(fields.map((f) => [f.name, f]));
+  const titleOf = (docId: string) => documentTitles.get(docId) || docId;
+  const resolvedAtOf = (docId: string, fieldName: string) =>
+    errorResolutions.get(`${docId}:${fieldName}`) ?? null;
+
+  const responsesByDoc = new Map<string, MetricsResponse[]>();
+  const llmLatestByDoc = new Map<string, MetricsResponse>();
+  for (const response of responses) {
+    const bucket = responsesByDoc.get(response.document_id);
+    if (bucket) bucket.push(response);
+    else responsesByDoc.set(response.document_id, [response]);
+    if (response.respondent_type === "llm" && response.is_latest) {
+      llmLatestByDoc.set(response.document_id, response);
+    }
+  }
+
+  const equivByDocField = new Map<string, Map<string, MetricsEquivalence[]>>();
+  for (const pair of equivalences) {
+    let byField = equivByDocField.get(pair.document_id);
+    if (!byField) {
+      byField = new Map();
+      equivByDocField.set(pair.document_id, byField);
+    }
+    const bucket = byField.get(pair.field_name);
+    if (bucket) bucket.push(pair);
+    else byField.set(pair.field_name, [pair]);
+  }
+
+  // Classes de equivalência por (documento, campo), memoizadas: um documento
+  // com muitos campos revisados repetiria o union-find à toa.
+  const groupKeyCache = new Map<string, Map<string, string>>();
+  const groupKeysFor = (docId: string, fieldName: string) => {
+    const cacheKey = `${docId}:${fieldName}`;
+    const cached = groupKeyCache.get(cacheKey);
+    if (cached) return cached;
+
+    // Todas as responses do documento entram, inclusive rodadas anteriores:
+    // `chosen_response_id` pode apontar para uma resposta que não é mais a
+    // `is_latest`, e é justamente por essas que o fecho transitivo passa.
+    const items = (responsesByDoc.get(docId) ?? []).map((response) => ({
+      id: response.id,
+      answer: response.answers?.[fieldName],
+    }));
+    const pairs = filterCurrentEquivalencePairs(
+      items,
+      equivByDocField.get(docId)?.get(fieldName) ?? [],
+      (item) => item.answer,
+    );
+    const groupKeys = buildResponseGroupKeys(items, pairs, (item) =>
+      normalizeForComparison(item.answer),
+    );
+    groupKeyCache.set(cacheKey, groupKeys);
+    return groupKeys;
+  };
+
+  const candidates: Candidate[] = [];
+
+  /* ── Fonte A: Comparação (`reviews`) ── */
+  for (const review of reviews) {
+    const llmResponse = llmLatestByDoc.get(review.document_id);
+    if (!llmResponse) continue;
+
+    const field = fieldMap.get(review.field_name);
+    if (!isMeasurableField(field)) continue;
+
+    const llmAnswer = llmResponse.answers?.[review.field_name];
+    let isError = false;
+
+    if (review.chosen_response_id !== llmResponse.id) {
+      // Uma única noção de "mesma resposta": as classes do union-find já fundem
+      // tanto pares marcados como equivalentes pelo revisor quanto respostas de
+      // texto idêntico, e propagam por transitividade (A≡B, B≡C ⇒ A≡C). É a
+      // mesma primitiva que a tela de Comparação usa para decidir divergência.
+      const groupKeys = groupKeysFor(review.document_id, review.field_name);
+      const llmKey = groupKeys.get(llmResponse.id);
+      const chosenKey = review.chosen_response_id
+        ? groupKeys.get(review.chosen_response_id)
+        : undefined;
+
+      if (llmKey !== undefined && chosenKey !== undefined) {
+        isError = llmKey !== chosenKey;
+      } else {
+        // A response escolhida sumiu do conjunto (apagada, ou de um documento
+        // que não veio na página). Resta comparar o texto do veredito, que é
+        // uma cópia do valor escolhido no momento da revisão.
+        isError =
+          normalizeForComparison(llmAnswer) !==
+          normalizeForComparison(review.verdict);
+      }
+    }
+
+    const schemaVersion = formatSchemaVersion(llmResponse);
+    candidates.push({
+      documentId: review.document_id,
+      fieldName: review.field_name,
+      decidedAt: review.created_at,
+      isError,
+      error: isError
+        ? {
+            documentId: review.document_id,
+            documentTitle: titleOf(review.document_id),
+            fieldName: review.field_name,
+            fieldDescription: field.description || review.field_name,
+            llmAnswer: formatAnswer(llmAnswer),
+            llmJustification:
+              llmResponse.justifications?.[review.field_name] || null,
+            chosenVerdict: review.verdict,
+            reviewerComment: review.comment,
+            resolvedAt: resolvedAtOf(review.document_id, review.field_name),
+            reviewedAt: review.created_at,
+            schemaVersion,
+            llmResponseId: llmResponse.id,
+            chosenResponseId: review.chosen_response_id,
+          }
+        : null,
+      entry: {
+        documentId: review.document_id,
+        documentTitle: titleOf(review.document_id),
+        fieldName: review.field_name,
+        schemaVersion,
+        reviewedAt: review.created_at,
+        isError,
+      },
+    });
+  }
+
+  /* ── Fonte B: Auto-revisão (view `final_answers`) ── */
+  for (const row of finalAnswers) {
+    const field = fieldMap.get(row.field_name);
+    if (!isMeasurableField(field)) continue;
+
+    const llmResponse = llmLatestByDoc.get(row.document_id);
+    if (!llmResponse) continue;
+
+    // A view produz uma linha por campo do schema para TODO documento com
+    // resposta do LLM, e marca 'consenso' sempre que não há linha em
+    // `field_reviews` — inclusive em documentos que ninguém codificou. Sem
+    // este gate, não-codificação viraria acerto do LLM e afundaria a taxa.
+    const humanCoded = (responsesByDoc.get(row.document_id) ?? []).some(
+      (response) =>
+        response.respondent_type === "humano" &&
+        response.is_latest &&
+        fieldExistedWhenCoded(
+          response.answer_field_hashes ?? undefined,
+          field.name,
+        ) &&
+        isFieldVisible(field, response.answers ?? {}),
+    );
+    if (!humanCoded) continue;
+
+    const outcome = classifyAutoReview(row);
+    if (outcome === "pendente") continue;
+
+    const isError = outcome === "erro";
+    const decidedAt = row.final_decided_at ?? row.self_reviewed_at ?? null;
+    // Consenso não tem instante de decisão; a data da resposta do LLM é o que
+    // situa a entrada no tempo para o filtro de período.
+    const reviewedAt = decidedAt ?? llmResponse.created_at;
+    const schemaVersion = formatSchemaVersion(llmResponse);
+
+    candidates.push({
+      documentId: row.document_id,
+      fieldName: row.field_name,
+      decidedAt,
+      isError,
+      error: isError
+        ? {
+            documentId: row.document_id,
+            documentTitle: titleOf(row.document_id),
+            fieldName: row.field_name,
+            fieldDescription: field.description || row.field_name,
+            // Os snapshots congelam os valores sobre os quais o veredito foi
+            // dado; a resposta atual pode já ter sido revisada desde então.
+            llmAnswer: formatAnswer(
+              row.llm_answer_snapshot ?? llmResponse.answers?.[row.field_name],
+            ),
+            llmJustification:
+              llmResponse.justifications?.[row.field_name] || null,
+            chosenVerdict: formatAnswer(row.human_answer_snapshot),
+            reviewerComment: row.arbitrator_comment ?? null,
+            resolvedAt: resolvedAtOf(row.document_id, row.field_name),
+            reviewedAt,
+            schemaVersion,
+            llmResponseId: row.llm_response_id ?? llmResponse.id,
+            chosenResponseId: row.human_response_id,
+          }
+        : null,
+      entry: {
+        documentId: row.document_id,
+        documentTitle: titleOf(row.document_id),
+        fieldName: row.field_name,
+        schemaVersion,
+        reviewedAt,
+        isError,
+      },
+    });
+  }
+
+  /* ── Deduplicação entre as fontes ── */
+  const winners = new Map<string, Candidate>();
+  for (const candidate of candidates) {
+    const key = `${candidate.documentId}:${candidate.fieldName}`;
+    const incumbent = winners.get(key);
+    if (!incumbent || beats(candidate, incumbent)) winners.set(key, candidate);
+  }
+
+  // Ordem estável por (documento, campo): a ordem de retorno do Postgres não é
+  // garantida, e a UI exibe esta lista como está quando o sort é "default".
+  const sorted = [...winners.values()].sort((a, b) =>
+    a.documentId === b.documentId
+      ? a.fieldName.localeCompare(b.fieldName)
+      : a.documentId.localeCompare(b.documentId),
+  );
+
+  return {
+    errors: sorted.flatMap((c) => (c.error ? [c.error] : [])),
+    reviewedEntries: sorted.map((c) => c.entry),
+  };
+}

--- a/frontend/src/lib/llm-error-metrics.ts
+++ b/frontend/src/lib/llm-error-metrics.ts
@@ -96,7 +96,8 @@ export interface MetricsFinalAnswer {
   llm_response_id: string | null;
   human_answer_snapshot: unknown;
   llm_answer_snapshot: unknown;
-  arbitrator_comment?: string | null;
+  /** Texto que o arbitrador escreveu ao decidir; exibido como "Comentário do revisor". */
+  arbitrator_comment: string | null;
 }
 
 export interface MetricsEquivalence extends EquivalencePair {
@@ -398,7 +399,7 @@ function buildAutoReviewError(
     ),
     llmJustification: llmResponse.justifications?.[row.field_name] || null,
     chosenVerdict: formatAnswer(row.human_answer_snapshot),
-    reviewerComment: row.arbitrator_comment ?? null,
+    reviewerComment: row.arbitrator_comment,
     resolvedAt: ctx.resolvedAtOf(row.document_id, row.field_name),
     llmResponseId: row.llm_response_id ?? llmResponse.id,
     chosenResponseId: row.human_response_id,

--- a/frontend/src/lib/llm-error-metrics.ts
+++ b/frontend/src/lib/llm-error-metrics.ts
@@ -137,7 +137,7 @@ interface Candidate {
   entry: ReviewedEntry;
 }
 
-export function formatSchemaVersion(response: {
+function formatSchemaVersion(response: {
   schema_version_major: number | null;
   schema_version_minor: number | null;
   schema_version_patch: number | null;
@@ -194,25 +194,19 @@ function beats(candidate: Candidate, incumbent: Candidate): boolean {
   return candidate.decidedAt > incumbent.decidedAt!;
 }
 
-export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
-  errors: LlmError[];
-  reviewedEntries: ReviewedEntry[];
-} {
-  const {
-    fields,
-    automationMode,
-    documentTitles,
-    responses,
-    reviews,
-    finalAnswers,
-    equivalences,
-    errorResolutions,
-  } = input;
+// Contexto derivado uma vez e compartilhado pelas duas fontes.
+interface MetricsContext {
+  fieldMap: Map<string, PydanticField>;
+  titleOf: (docId: string) => string;
+  resolvedAtOf: (docId: string, fieldName: string) => string | null;
+  responsesByDoc: Map<string, MetricsResponse[]>;
+  llmLatestByDoc: Map<string, MetricsResponse>;
+  /** Classes de equivalência por (documento, campo), memoizadas. */
+  groupKeysFor: (docId: string, fieldName: string) => Map<string, string>;
+}
 
-  const fieldMap = new Map(fields.map((f) => [f.name, f]));
-  const titleOf = (docId: string) => documentTitles.get(docId) || docId;
-  const resolvedAtOf = (docId: string, fieldName: string) =>
-    errorResolutions.get(`${docId}:${fieldName}`) ?? null;
+function buildContext(input: LlmErrorMetricsInput): MetricsContext {
+  const { fields, documentTitles, responses, equivalences, errorResolutions } = input;
 
   const responsesByDoc = new Map<string, MetricsResponse[]>();
   const llmLatestByDoc = new Map<string, MetricsResponse>();
@@ -237,8 +231,8 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
     else byField.set(pair.field_name, [pair]);
   }
 
-  // Classes de equivalência por (documento, campo), memoizadas: um documento
-  // com muitos campos revisados repetiria o union-find à toa.
+  // Memoizado: um documento com muitos campos revisados repetiria o union-find
+  // por campo à toa.
   const groupKeyCache = new Map<string, Map<string, string>>();
   const groupKeysFor = (docId: string, fieldName: string) => {
     const cacheKey = `${docId}:${fieldName}`;
@@ -264,43 +258,71 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
     return groupKeys;
   };
 
+  return {
+    fieldMap: new Map(fields.map((f) => [f.name, f])),
+    titleOf: (docId) => documentTitles.get(docId) || docId,
+    resolvedAtOf: (docId, fieldName) =>
+      errorResolutions.get(`${docId}:${fieldName}`) ?? null,
+    responsesByDoc,
+    llmLatestByDoc,
+    groupKeysFor,
+  };
+}
+
+// O LLM errou este campo, na leitura da Comparação? Uma única noção de "mesma
+// resposta": as classes do union-find já fundem tanto pares marcados como
+// equivalentes pelo revisor quanto respostas de texto idêntico, e propagam por
+// transitividade (A≡B, B≡C ⇒ A≡C). É a mesma primitiva que a tela de
+// Comparação usa para decidir divergência.
+function comparisonIsError(
+  review: MetricsReview,
+  llmResponse: MetricsResponse,
+  ctx: MetricsContext,
+): boolean {
+  if (review.chosen_response_id === llmResponse.id) return false;
+
+  const groupKeys = ctx.groupKeysFor(review.document_id, review.field_name);
+  const llmKey = groupKeys.get(llmResponse.id);
+  const chosenKey = review.chosen_response_id
+    ? groupKeys.get(review.chosen_response_id)
+    : undefined;
+
+  if (llmKey !== undefined && chosenKey !== undefined) return llmKey !== chosenKey;
+
+  // A response escolhida sumiu do conjunto (apagada, ou de um documento que não
+  // veio na página). Resta comparar o texto do veredito, que é uma cópia do
+  // valor escolhido no momento da revisão.
+  return (
+    normalizeForComparison(llmResponse.answers?.[review.field_name]) !==
+    normalizeForComparison(review.verdict)
+  );
+}
+
+/* ── Fonte A: Comparação (`reviews`) ── */
+function comparisonCandidates(
+  reviews: MetricsReview[],
+  ctx: MetricsContext,
+): Candidate[] {
   const candidates: Candidate[] = [];
 
-  /* ── Fonte A: Comparação (`reviews`) ── */
   for (const review of reviews) {
-    const llmResponse = llmLatestByDoc.get(review.document_id);
+    const llmResponse = ctx.llmLatestByDoc.get(review.document_id);
     if (!llmResponse) continue;
 
-    const field = fieldMap.get(review.field_name);
+    const field = ctx.fieldMap.get(review.field_name);
     if (!isMeasurableField(field)) continue;
 
     const llmAnswer = llmResponse.answers?.[review.field_name];
-    let isError = false;
+    const isError = comparisonIsError(review, llmResponse, ctx);
 
-    if (review.chosen_response_id !== llmResponse.id) {
-      // Uma única noção de "mesma resposta": as classes do union-find já fundem
-      // tanto pares marcados como equivalentes pelo revisor quanto respostas de
-      // texto idêntico, e propagam por transitividade (A≡B, B≡C ⇒ A≡C). É a
-      // mesma primitiva que a tela de Comparação usa para decidir divergência.
-      const groupKeys = groupKeysFor(review.document_id, review.field_name);
-      const llmKey = groupKeys.get(llmResponse.id);
-      const chosenKey = review.chosen_response_id
-        ? groupKeys.get(review.chosen_response_id)
-        : undefined;
+    const shared = {
+      documentId: review.document_id,
+      documentTitle: ctx.titleOf(review.document_id),
+      fieldName: review.field_name,
+      schemaVersion: formatSchemaVersion(llmResponse),
+      reviewedAt: review.created_at,
+    };
 
-      if (llmKey !== undefined && chosenKey !== undefined) {
-        isError = llmKey !== chosenKey;
-      } else {
-        // A response escolhida sumiu do conjunto (apagada, ou de um documento
-        // que não veio na página). Resta comparar o texto do veredito, que é
-        // uma cópia do valor escolhido no momento da revisão.
-        isError =
-          normalizeForComparison(llmAnswer) !==
-          normalizeForComparison(review.verdict);
-      }
-    }
-
-    const schemaVersion = formatSchemaVersion(llmResponse);
     candidates.push({
       documentId: review.document_id,
       fieldName: review.field_name,
@@ -308,120 +330,154 @@ export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
       isError,
       error: isError
         ? {
-            documentId: review.document_id,
-            documentTitle: titleOf(review.document_id),
-            fieldName: review.field_name,
+            ...shared,
             fieldDescription: field.description || review.field_name,
             llmAnswer: formatAnswer(llmAnswer),
             llmJustification:
               llmResponse.justifications?.[review.field_name] || null,
             chosenVerdict: review.verdict,
             reviewerComment: review.comment,
-            resolvedAt: resolvedAtOf(review.document_id, review.field_name),
-            reviewedAt: review.created_at,
-            schemaVersion,
+            resolvedAt: ctx.resolvedAtOf(review.document_id, review.field_name),
             llmResponseId: llmResponse.id,
             chosenResponseId: review.chosen_response_id,
           }
         : null,
-      entry: {
-        documentId: review.document_id,
-        documentTitle: titleOf(review.document_id),
-        fieldName: review.field_name,
-        schemaVersion,
-        reviewedAt: review.created_at,
-        isError,
-      },
+      entry: { ...shared, isError },
     });
   }
 
-  /* ── Fonte B: Auto-revisão (view `final_answers`) ── */
-  // Sem este gate, um projeto de Comparação (`compare_llm`) veria toda a sua
-  // grade documento × campo entrar como acerto: medido no projeto Zolgensma,
-  // o denominador saltava de 898 para 2944 e a taxa despencava de 37% para
-  // 11% — puro ruído de linhas 'consenso' que nunca passaram por auto-revisão.
-  const autoReviewEnabled = automationMode === "auto_review_llm";
-  for (const row of autoReviewEnabled ? finalAnswers : []) {
-    const field = fieldMap.get(row.field_name);
-    if (!isMeasurableField(field)) continue;
+  return candidates;
+}
 
-    const llmResponse = llmLatestByDoc.get(row.document_id);
-    if (!llmResponse) continue;
+// A view produz uma linha por campo do schema para TODO documento com resposta
+// do LLM, e marca 'consenso' sempre que não há linha em `field_reviews` —
+// inclusive em documentos que ninguém codificou. O gate espelha
+// `computeBacklogRows` (`auto-review-backlog.ts`), que é quem MATERIALIZA as
+// linhas: ele só varre codificações humanas COMPLETAS. Um gate mais frouxo
+// leria a ausência de linha num documento pela metade como concordância,
+// quando ela só significa que o documento ainda não era elegível ao backlog.
+function hasCompleteHumanCoding(
+  docId: string,
+  field: PydanticField,
+  fields: PydanticField[],
+  ctx: MetricsContext,
+): boolean {
+  return (ctx.responsesByDoc.get(docId) ?? []).some(
+    (response) =>
+      response.respondent_type === "humano" &&
+      response.is_latest &&
+      fieldExistedWhenCoded(
+        response.answer_field_hashes ?? undefined,
+        field.name,
+      ) &&
+      isFieldVisible(field, response.answers ?? {}) &&
+      isCodingComplete(
+        fields,
+        response.answers ?? {},
+        response.answer_field_hashes ?? undefined,
+      ),
+  );
+}
 
-    // A view produz uma linha por campo do schema para TODO documento com
-    // resposta do LLM, e marca 'consenso' sempre que não há linha em
-    // `field_reviews` — inclusive em documentos que ninguém codificou. Sem
-    // este gate, não-codificação viraria acerto do LLM e afundaria a taxa.
-    //
-    // O gate espelha `computeBacklogRows` (`auto-review-backlog.ts`), que é
-    // quem MATERIALIZA as linhas de `field_reviews`: ele só varre codificações
-    // humanas COMPLETAS. Um gate mais frouxo aqui leria a ausência de linha
-    // num documento pela metade como concordância, quando ela só significa que
-    // o documento ainda não era elegível ao backlog.
-    const humanCoded = (responsesByDoc.get(row.document_id) ?? []).some(
-      (response) =>
-        response.respondent_type === "humano" &&
-        response.is_latest &&
-        fieldExistedWhenCoded(
-          response.answer_field_hashes ?? undefined,
-          field.name,
-        ) &&
-        isFieldVisible(field, response.answers ?? {}) &&
-        isCodingComplete(
-          fields,
-          response.answers ?? {},
-          response.answer_field_hashes ?? undefined,
-        ),
-    );
-    if (!humanCoded) continue;
+type SharedEntryFields = Omit<ReviewedEntry, "isError">;
 
-    const outcome = classifyAutoReview(row);
-    if (outcome === "pendente") continue;
+// Os snapshots congelam os valores sobre os quais o veredito foi dado; a
+// resposta atual pode já ter sido revisada desde então.
+function buildAutoReviewError(
+  row: MetricsFinalAnswer,
+  field: PydanticField,
+  llmResponse: MetricsResponse,
+  shared: SharedEntryFields,
+  ctx: MetricsContext,
+): LlmError {
+  return {
+    ...shared,
+    fieldDescription: field.description || row.field_name,
+    llmAnswer: formatAnswer(
+      row.llm_answer_snapshot ?? llmResponse.answers?.[row.field_name],
+    ),
+    llmJustification: llmResponse.justifications?.[row.field_name] || null,
+    chosenVerdict: formatAnswer(row.human_answer_snapshot),
+    reviewerComment: row.arbitrator_comment ?? null,
+    resolvedAt: ctx.resolvedAtOf(row.document_id, row.field_name),
+    llmResponseId: row.llm_response_id ?? llmResponse.id,
+    chosenResponseId: row.human_response_id,
+  };
+}
 
-    const isError = outcome === "erro";
-    const decidedAt = row.final_decided_at ?? row.self_reviewed_at ?? null;
+/* ── Fonte B: Auto-revisão (view `final_answers`) ── */
+// `null` quando a linha não é mensurável: campo fora da superfície de revisão,
+// documento sem LLM corrente, codificação humana ausente ou incompleta, ou
+// veredito ainda pendente.
+function autoReviewCandidate(
+  row: MetricsFinalAnswer,
+  fields: PydanticField[],
+  ctx: MetricsContext,
+): Candidate | null {
+  const field = ctx.fieldMap.get(row.field_name);
+  if (!isMeasurableField(field)) return null;
+
+  const llmResponse = ctx.llmLatestByDoc.get(row.document_id);
+  if (!llmResponse) return null;
+  if (!hasCompleteHumanCoding(row.document_id, field, fields, ctx)) return null;
+
+  const outcome = classifyAutoReview(row);
+  if (outcome === "pendente") return null;
+
+  const isError = outcome === "erro";
+  const decidedAt = row.final_decided_at ?? row.self_reviewed_at ?? null;
+  const shared: SharedEntryFields = {
+    documentId: row.document_id,
+    documentTitle: ctx.titleOf(row.document_id),
+    fieldName: row.field_name,
+    schemaVersion: formatSchemaVersion(llmResponse),
     // Consenso não tem instante de decisão; a data da resposta do LLM é o que
     // situa a entrada no tempo para o filtro de período.
-    const reviewedAt = decidedAt ?? llmResponse.created_at;
-    const schemaVersion = formatSchemaVersion(llmResponse);
+    reviewedAt: decidedAt ?? llmResponse.created_at,
+  };
 
-    candidates.push({
-      documentId: row.document_id,
-      fieldName: row.field_name,
-      decidedAt,
-      isError,
-      error: isError
-        ? {
-            documentId: row.document_id,
-            documentTitle: titleOf(row.document_id),
-            fieldName: row.field_name,
-            fieldDescription: field.description || row.field_name,
-            // Os snapshots congelam os valores sobre os quais o veredito foi
-            // dado; a resposta atual pode já ter sido revisada desde então.
-            llmAnswer: formatAnswer(
-              row.llm_answer_snapshot ?? llmResponse.answers?.[row.field_name],
-            ),
-            llmJustification:
-              llmResponse.justifications?.[row.field_name] || null,
-            chosenVerdict: formatAnswer(row.human_answer_snapshot),
-            reviewerComment: row.arbitrator_comment ?? null,
-            resolvedAt: resolvedAtOf(row.document_id, row.field_name),
-            reviewedAt,
-            schemaVersion,
-            llmResponseId: row.llm_response_id ?? llmResponse.id,
-            chosenResponseId: row.human_response_id,
-          }
-        : null,
-      entry: {
-        documentId: row.document_id,
-        documentTitle: titleOf(row.document_id),
-        fieldName: row.field_name,
-        schemaVersion,
-        reviewedAt,
-        isError,
-      },
-    });
-  }
+  return {
+    documentId: row.document_id,
+    fieldName: row.field_name,
+    decidedAt,
+    isError,
+    error: isError
+      ? buildAutoReviewError(row, field, llmResponse, shared, ctx)
+      : null,
+    entry: { ...shared, isError },
+  };
+}
+
+function autoReviewCandidates(
+  finalAnswers: MetricsFinalAnswer[],
+  fields: PydanticField[],
+  ctx: MetricsContext,
+): Candidate[] {
+  return finalAnswers.flatMap((row) => {
+    const candidate = autoReviewCandidate(row, fields, ctx);
+    return candidate ? [candidate] : [];
+  });
+}
+
+export function computeLlmErrorMetrics(input: LlmErrorMetricsInput): {
+  errors: LlmError[];
+  reviewedEntries: ReviewedEntry[];
+} {
+  const ctx = buildContext(input);
+
+  // Sem o gate de modo, um projeto de Comparação (`compare_llm`) veria toda a
+  // sua grade documento × campo entrar como acerto: medido no projeto
+  // Zolgensma, o denominador saltava de 898 para 2944 e a taxa despencava de
+  // 37% para 11% — puro ruído de linhas 'consenso' que nunca passaram por
+  // auto-revisão, porque `field_reviews` não é materializado nesse modo.
+  const autoReviewEnabled = input.automationMode === "auto_review_llm";
+
+  const candidates = [
+    ...comparisonCandidates(input.reviews, ctx),
+    ...(autoReviewEnabled
+      ? autoReviewCandidates(input.finalAnswers, input.fields, ctx)
+      : []),
+  ];
 
   /* ── Deduplicação por (documento, campo) ── */
   // Vale tanto ENTRE as fontes quanto DENTRO da Comparação: `reviews` é única

--- a/frontend/src/lib/supabase/fetch-all-paged.ts
+++ b/frontend/src/lib/supabase/fetch-all-paged.ts
@@ -1,0 +1,31 @@
+// Paginação de leitura do PostgREST. O builder é de uso único (o await o
+// executa), por isso o caller passa uma FÁBRICA de query, não a query pronta.
+//
+// Compartilhado entre o export e a métrica de erro do LLM: os dois varrem
+// tabelas inteiras de um projeto, onde o teto default de 1000 linhas do
+// PostgREST truncaria em silêncio — e truncar aqui não dá erro, dá número errado.
+const PAGE_SIZE = 1000;
+
+export async function fetchAllPaged<T>(
+  build: () => {
+    range: (
+      from: number,
+      to: number,
+    ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>;
+  },
+): Promise<{ data: T[]; error: { message: string } | null }> {
+  const all: T[] = [];
+  let from = 0;
+  for (;;) {
+    // await sequencial é da natureza da paginação: só dá para pedir a próxima
+    // página sabendo que a anterior veio cheia.
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop
+    const { data, error } = await build().range(from, from + PAGE_SIZE - 1);
+    if (error) return { data: all, error };
+    const batch = data ?? [];
+    all.push(...batch);
+    if (batch.length < PAGE_SIZE) break;
+    from += PAGE_SIZE;
+  }
+  return { data: all, error: null };
+}

--- a/frontend/supabase/migrations/20260820120000_final_answers_expose_verdicts.sql
+++ b/frontend/supabase/migrations/20260820120000_final_answers_expose_verdicts.sql
@@ -78,7 +78,12 @@ CROSS JOIN LATERAL (
 WHERE r_llm.respondent_type = 'llm'
   AND r_llm.is_latest = true;
 
-REVOKE SELECT ON public.final_answers FROM anon;
+-- CREATE OR REPLACE VIEW preserva os grants existentes, mas reafirmamos o
+-- estado desejado. REVOKE ALL (e não apenas SELECT) para não reabrir a brecha
+-- fechada em 20260724140000_revoke_anon_from_public_views: `final_answers`
+-- carregava bits de INSERT/UPDATE/DELETE para anon que um REVOKE restrito a
+-- SELECT deixaria intactos.
+REVOKE ALL ON public.final_answers FROM anon;
 GRANT SELECT ON public.final_answers TO authenticated, service_role;
 
 COMMIT;

--- a/frontend/supabase/migrations/20260820120000_final_answers_expose_verdicts.sql
+++ b/frontend/supabase/migrations/20260820120000_final_answers_expose_verdicts.sql
@@ -1,0 +1,84 @@
+-- Expõe em `final_answers` os vereditos crus e os snapshots do ciclo de
+-- auto-revisão, para que a métrica de erro do LLM (LLM Insights) possa
+-- classificar cada (documento, campo) sem reimplementar em TypeScript o mapa
+-- de proveniência que já vive nesta view — inclusive o estado
+-- `aguarda_reconciliacao`, derivado de `is_auto_review_reconciliation_pending`.
+--
+-- `provenance` sozinho não basta: 'arbitrado' cobre tanto "o LLM errou"
+-- (final_verdict = 'humano') quanto "o LLM acertou" (final_verdict = 'llm'),
+-- e a métrica precisa separar os dois. Os timestamps servem à deduplicação
+-- contra a tabela `reviews`, que registra o veredito do fluxo de Comparação —
+-- um projeto que trocou de `automation_mode` tem histórico nas duas tabelas
+-- para o mesmo (documento, campo), sem constraint cruzada que o impeça.
+--
+-- Os snapshots são os valores exatos sobre os quais o veredito foi dado, e por
+-- isso descrevem o erro melhor que a resposta atual, que pode ter sido
+-- revisada depois. São NULL em 'consenso' (não há linha em `field_reviews`),
+-- caso que nunca é erro.
+--
+-- Colunas são acrescentadas ao FINAL: é o que CREATE OR REPLACE VIEW permite
+-- sem DROP, preservando os grants e quaisquer dependências existentes.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.final_answers
+WITH (security_invoker = true) AS
+SELECT
+  r_llm.project_id,
+  r_llm.document_id,
+  fld.field_name,
+  CASE
+    WHEN reconciliation.pending THEN NULL
+    WHEN fr.id IS NULL THEN r_llm.answers -> fld.field_name
+    WHEN fr.self_verdict IS NULL THEN NULL
+    WHEN fr.self_verdict = 'admite_erro' THEN fr.llm_answer_snapshot
+    WHEN fr.self_verdict = 'equivalente' THEN fr.human_answer_snapshot
+    WHEN fr.self_verdict = 'ambiguo' THEN NULL
+    WHEN fr.final_verdict IS NULL THEN NULL
+    WHEN fr.final_verdict = 'humano' THEN fr.human_answer_snapshot
+    WHEN fr.final_verdict = 'llm' THEN fr.llm_answer_snapshot
+    ELSE NULL
+  END AS answer,
+  CASE
+    WHEN reconciliation.pending THEN 'aguarda_reconciliacao'
+    WHEN fr.id IS NULL THEN 'consenso'
+    WHEN fr.self_verdict IS NULL THEN 'aguarda_auto_revisao'
+    WHEN fr.self_verdict = 'admite_erro' THEN 'auto_corrigido'
+    WHEN fr.self_verdict = 'equivalente' THEN 'equivalente'
+    WHEN fr.self_verdict = 'ambiguo' THEN 'ambiguo'
+    WHEN fr.final_verdict IS NULL THEN 'aguarda_arbitragem'
+    ELSE 'arbitrado'
+  END AS provenance,
+  fr.id AS field_review_id,
+  fr.changed_after_justification,
+  fr.cycle_no,
+  fr.self_verdict,
+  fr.final_verdict,
+  fr.self_reviewed_at,
+  fr.final_decided_at,
+  fr.human_response_id,
+  fr.llm_response_id,
+  fr.human_answer_snapshot,
+  fr.llm_answer_snapshot
+FROM public.responses AS r_llm
+JOIN public.projects AS project ON project.id = r_llm.project_id
+CROSS JOIN LATERAL pg_catalog.jsonb_array_elements(
+  COALESCE(project.pydantic_fields, '[]'::JSONB)
+) AS field_raw
+CROSS JOIN LATERAL (SELECT field_raw->>'name' AS field_name) AS fld
+LEFT JOIN public.field_reviews AS fr
+  ON fr.document_id = r_llm.document_id
+  AND fr.field_name = fld.field_name
+  AND fr.superseded_at IS NULL
+CROSS JOIN LATERAL (
+  SELECT public.is_auto_review_reconciliation_pending(
+    r_llm.project_id, r_llm.document_id, r_llm.id
+  ) AS pending
+) AS reconciliation
+WHERE r_llm.respondent_type = 'llm'
+  AND r_llm.is_latest = true;
+
+REVOKE SELECT ON public.final_answers FROM anon;
+GRANT SELECT ON public.final_answers TO authenticated, service_role;
+
+COMMIT;

--- a/frontend/supabase/migrations/20260820130000_final_answers_expose_arbitrator_comment.sql
+++ b/frontend/supabase/migrations/20260820130000_final_answers_expose_arbitrator_comment.sql
@@ -1,0 +1,83 @@
+-- Acrescenta `arbitrator_comment` a `final_answers`.
+--
+-- A 20260820120000 expôs os vereditos do ciclo de auto-revisão para a métrica
+-- de erro do LLM, mas deixou de fora o comentário que o arbitrador escreve ao
+-- decidir (`field_reviews.arbitrator_comment`, gravado em
+-- `submit_final_verdicts` e nas RPCs de arbitragem). O consumidor já o lia, e
+-- por isso todo erro vindo da auto-revisão chegava à UI com "Comentário do
+-- revisor" vazio mesmo havendo texto no banco — perda silenciosa de contexto
+-- justamente no caso em que houve desacordo entre humano e LLM.
+--
+-- Migration separada, e não edição da anterior, porque aquela já foi aplicada
+-- no remoto: reescrever um arquivo de migration já registrado não o reaplica.
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.final_answers
+WITH (security_invoker = true) AS
+SELECT
+  r_llm.project_id,
+  r_llm.document_id,
+  fld.field_name,
+  CASE
+    WHEN reconciliation.pending THEN NULL
+    WHEN fr.id IS NULL THEN r_llm.answers -> fld.field_name
+    WHEN fr.self_verdict IS NULL THEN NULL
+    WHEN fr.self_verdict = 'admite_erro' THEN fr.llm_answer_snapshot
+    WHEN fr.self_verdict = 'equivalente' THEN fr.human_answer_snapshot
+    WHEN fr.self_verdict = 'ambiguo' THEN NULL
+    WHEN fr.final_verdict IS NULL THEN NULL
+    WHEN fr.final_verdict = 'humano' THEN fr.human_answer_snapshot
+    WHEN fr.final_verdict = 'llm' THEN fr.llm_answer_snapshot
+    ELSE NULL
+  END AS answer,
+  CASE
+    WHEN reconciliation.pending THEN 'aguarda_reconciliacao'
+    WHEN fr.id IS NULL THEN 'consenso'
+    WHEN fr.self_verdict IS NULL THEN 'aguarda_auto_revisao'
+    WHEN fr.self_verdict = 'admite_erro' THEN 'auto_corrigido'
+    WHEN fr.self_verdict = 'equivalente' THEN 'equivalente'
+    WHEN fr.self_verdict = 'ambiguo' THEN 'ambiguo'
+    WHEN fr.final_verdict IS NULL THEN 'aguarda_arbitragem'
+    ELSE 'arbitrado'
+  END AS provenance,
+  fr.id AS field_review_id,
+  fr.changed_after_justification,
+  fr.cycle_no,
+  fr.self_verdict,
+  fr.final_verdict,
+  fr.self_reviewed_at,
+  fr.final_decided_at,
+  fr.human_response_id,
+  fr.llm_response_id,
+  fr.human_answer_snapshot,
+  fr.llm_answer_snapshot,
+  fr.arbitrator_comment
+FROM public.responses AS r_llm
+JOIN public.projects AS project ON project.id = r_llm.project_id
+CROSS JOIN LATERAL pg_catalog.jsonb_array_elements(
+  COALESCE(project.pydantic_fields, '[]'::JSONB)
+) AS field_raw
+CROSS JOIN LATERAL (SELECT field_raw->>'name' AS field_name) AS fld
+LEFT JOIN public.field_reviews AS fr
+  ON fr.document_id = r_llm.document_id
+  AND fr.field_name = fld.field_name
+  AND fr.superseded_at IS NULL
+CROSS JOIN LATERAL (
+  SELECT public.is_auto_review_reconciliation_pending(
+    r_llm.project_id, r_llm.document_id, r_llm.id
+  ) AS pending
+) AS reconciliation
+WHERE r_llm.respondent_type = 'llm'
+  AND r_llm.is_latest = true;
+
+-- CREATE OR REPLACE VIEW preserva os grants existentes, mas reafirmamos o
+-- estado desejado. REVOKE ALL (e não apenas SELECT) para não reabrir a brecha
+-- fechada em 20260724140000_revoke_anon_from_public_views: `final_answers`
+-- carregava bits de INSERT/UPDATE/DELETE para anon que um REVOKE restrito a
+-- SELECT deixaria intactos.
+-- Mesmo racional de grants da 20260820120000: REVOKE ALL, não apenas SELECT.
+REVOKE ALL ON public.final_answers FROM anon;
+GRANT SELECT ON public.final_answers TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
## Contexto

A pergunta que originou o PR foi se a taxa de concordância do LLM leva em conta o "semelhantes" dos revisores. Levava — mas a investigação expôs dois problemas na métrica de **Taxa de erro** (`/projects/[id]/reviews/llm-insights`).

**1. A auto-revisão era invisível.** `submit_auto_review_verdicts` grava em `field_reviews` e nunca em `reviews`, e a página só lia `reviews`. Em projetos com `automation_mode = 'auto_review_llm'`, `admite_erro` e `contesta_llm` — que são precisamente os vereditos sobre acerto e erro do LLM — não entravam na conta.

**2. Havia três noções incompatíveis de "duas respostas dizem a mesma coisa".** A Comparação, o sync, a auto-comparação e o backlog usam union-find sobre pares validados por snapshot (`equivalence.ts` + `compare-divergence.ts`). A página de LLM Insights usava um `Set` de par canônico **sem** validação de snapshot, combinado com uma comparação valor-contra-texto-do-veredito. O export usa igualdade literal — este PR não mexe nele, ver mais abaixo.

## O que muda

**Unificação da equivalência.** A pergunta passa a ser "a resposta do LLM e a escolhida caem na mesma classe de equivalência?", com as primitivas que o resto do app já usa. Três efeitos: vale o fecho transitivo (A≡B, B≡C ⇒ A≡C), que o lookup de par direto perdia; pares cujo snapshot não corresponde mais à resposta atual deixam de valer; e a comparação passa a ser resposta-contra-resposta, o que corrige de quebra o caso em que o revisor escolheu uma resposta LLM de rodada anterior.

**Auto-revisão entra na métrica**, lida pela view `final_answers`. Consenso, `auto_corrigido` e `equivalente` contam como acerto; `final_verdict = 'humano'` conta como erro; `ambiguo` e os `aguarda_*` ficam fora do numerador e do denominador. Note a simetria: `equivalente` na auto-revisão é o análogo exato do "semelhantes" da Comparação, e como lá, não é erro.

**Deduplicação por (documento, campo)**, necessária porque um projeto que trocou de `automation_mode` tem histórico nas duas tabelas. Ela também colapsa o mesmo campo revisado por vários revisores, que antes pesava uma vez por revisor — medido no Zolgensma, 961 reviews viram 898 campos e a taxa não se move (37% nas duas políticas), mas o peso deixa de depender de quantas pessoas passaram pelo documento.

**Migration**: `final_answers` passa a expor `self_verdict`, `final_verdict`, os timestamps de decisão e os snapshots do ciclo. Colunas acrescentadas ao final, via `CREATE OR REPLACE VIEW`. A view continua sendo a fonte única do mapa de proveniência — inclusive do estado `aguarda_reconciliacao`, que depende de `is_auto_review_reconciliation_pending` e que replicar em TypeScript seria drift garantido. O `REVOKE ALL ON ... FROM anon` (e não apenas `REVOKE SELECT`) preserva o hardening de `20260724140000_revoke_anon_from_public_views`.

A lógica saiu de `page.tsx` para `frontend/src/lib/llm-error-metrics.ts`, puro e testável — antes deste PR não havia **nenhum** teste cobrindo a métrica.

## Dois gates que o replay em produção obrigou a acrescentar

A view emite `provenance = 'consenso'` para toda a grade documento × campo sempre que não há linha em `field_reviews`. Isso não significa concordância em dois casos:

- **Fora do modo `auto_review_llm`**, onde `field_reviews` nunca é materializado. Sem o gate, o denominador do Zolgensma saltava de 898 para 2944 e a taxa despencava de 37% para 11%, puro ruído.
- **Em codificação humana incompleta**, porque `computeBacklogRows` — quem cria as linhas — só varre codificações completas. O gate agora usa o mesmo `isCodingComplete`, de modo que a métrica espelha exatamente quem materializa as linhas que ela lê.

Os dois casos viraram teste.

## Achado da revisão independente

A revisão pegou um bug que os testes não cobriam: `arbitrator_comment` não estava na view nem no SELECT, mas o consumidor já o lia — então todo erro vindo da auto-revisão chegaria à UI com "Comentário do revisor" vazio, mesmo havendo texto gravado em `field_reviews`. Perda silenciosa de contexto justamente no caso em que houve desacordo entre humano e LLM. Corrigido numa **segunda migration** (`20260820130000`), e não por edição da primeira, porque aquela já havia sido aplicada no remoto — reescrever um arquivo de migration já registrado não o reaplica. Coberto por teste, com prova do vermelho.

## Verificação

- `vitest`: suíte completa verde; 20 casos novos em `llm-error-metrics.test.ts`.
- **Prova do vermelho por mutação**: quebrar o gate de codificação humana, o de `automation_mode`, o union-find de equivalência e a deduplicação derruba exatamente — e apenas — os testes que os cobrem.
- `tsc --noEmit` e `eslint` (padrão e type-checked) limpos.
- `npm run invariants`: 17/17 contra produção.
- **Replay com dados de produção** (`harness/`, descartável): no Zolgensma a taxa vai de 375/961 = 39% para 328/898 = 37%. As 20 chaves que deixaram de ser erro são todas fusões por equivalência que o lookup de par direto não enxergava; nenhuma chave nova virou erro.

**Limitação declarada**: a fonte de auto-revisão **não pôde ser verificada contra dados reais** — nenhum projeto em produção tem hoje `field_reviews` vivos e resposta LLM `is_latest`. Ela está coberta só por teste unitário, incluindo os dois gates acima. Vale um olho na primeira vez que um projeto de auto-revisão acumular vereditos.

## Fora de escopo

O export continua calculando concordância por igualdade literal, ignorando as equivalências. Corrigir depende de decidir **qual** valor representa um grupo fundido, o que pede um dicionário canônico de respostas. Registrado em #702, com ponteiro em comentário no `assemble.ts`.
