### PR TITLE
fix(rounds): UPDATE de manutenção deixa de ser impossível em rodada encerrada

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,7 @@
     "test:db:responses-human-latest": "npm run test:db:psql -- supabase/tests/responses_one_latest_human.test.sql",
     "test:db:responses-human-concurrency": "npm run test:db:psql -- supabase/tests/responses_latest_human_concurrency.test.sql",
     "test:db:response-round-serialization": "npm run test:db:psql -- supabase/tests/response_round_serialization.test.sql",
+    "test:db:round-write-maintenance": "npm run test:db:psql -- supabase/tests/round_write_maintenance.test.sql",
     "test:db:remove-member": "npm run test:db:psql -- supabase/tests/remove_project_member_self_identity.test.sql",
     "test:db:unmark-equivalence": "npm run test:db:psql -- supabase/tests/unmark_equivalence_atomic.test.sql",
     "test:db:arbitration-reopen": "npm run test:db:psql -- supabase/tests/arbitration_reopen.test.sql",

--- a/frontend/scripts/run-db-tests.sh
+++ b/frontend/scripts/run-db-tests.sh
@@ -49,6 +49,7 @@ GATE_SUITES=(
   auto_review_assignment_sync
   atomic_replace_rpcs
   explicit_assignment_rounds
+  round_write_maintenance
   llm_rate_limit
   llm_runs_round
   member_permission_rpcs

--- a/frontend/src/actions/__tests__/responses.test.ts
+++ b/frontend/src/actions/__tests__/responses.test.ts
@@ -788,10 +788,15 @@ describe("saveResponse — unicidade da resposta corrente (#609)", () => {
     expect(state.existingReadCount).toBe(1);
   });
 
+  // O SQLSTATE aqui é contrato, não detalhe: 40001 (serialization_failure) faz
+  // drivers e schedulers retentarem sozinhos, e esta condição só sai do lugar
+  // quando alguém recarrega a página. Em 2026-08-20 essa promessa falsa
+  // saturou os 2 vCPU do banco com ~1.700 transações/s, 99,9% em rollback.
+  // Se este teste voltar a aceitar 40001, o loop volta junto.
   it("rodada alterada atomicamente no banco devolve mensagem de recarga", async () => {
     state.existingResponse = null;
     state.responseInsertErrorQueue = [
-      { code: "40001", message: "a rodada atual mudou; recarregue o formulario" },
+      { code: "P0R01", message: "a rodada atual mudou; recarregue o formulario" },
     ];
     const saveResponse = await loadSaveResponse();
     const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
@@ -801,6 +806,17 @@ describe("saveResponse — unicidade da resposta corrente (#609)", () => {
       error: "A rodada mudou enquanto este formulário estava aberto. Recarregue a página.",
     });
     expect(state.assignmentUpdatePayload).toBeNull();
+  });
+
+  it("40001 deixa de significar rodada alterada e propaga como erro cru", async () => {
+    state.existingResponse = null;
+    state.responseInsertErrorQueue = [
+      { code: "40001", message: "could not serialize access" },
+    ];
+    const saveResponse = await loadSaveResponse();
+    const r = await saveResponse("proj-1", "doc-1", { q1: "a" });
+
+    expect(r).toEqual({ success: false, error: "could not serialize access" });
   });
 
   it("conflito nas DUAS tentativas devolve erro explícito, sem girar", async () => {

--- a/frontend/src/actions/responses.ts
+++ b/frontend/src/actions/responses.ts
@@ -257,6 +257,14 @@ type PersistOutcome =
 // unicidade que a tabela venha a ter.
 const HUMAN_LATEST_UNIQUE_INDEX = "responses_one_latest_human_per_document";
 
+// SQLSTATE que `enforce_current_response_round_write` reserva para "a rodada
+// fechou enquanto este formulário estava aberto". Deliberadamente NÃO é 40001:
+// aquele código promete que repetir pode dar certo, e schedulers e drivers
+// retentam nele sozinhos — o que aqui nunca converge, porque a condição só sai
+// do lugar quando alguém recarrega a página. Fonte: a migration
+// 20260820170000_round_write_allows_maintenance.sql.
+const ROUND_CHANGED_SQLSTATE = "P0R01";
+
 // Escrita idempotente sobre a CHAVE LÓGICA (#609). O UPDATE filtra pela chave
 // — não por `id` — e o rowcount que ele devolve é quem decide se havia linha
 // corrente; a leitura de `existing` deixou de ser o árbitro dessa decisão e
@@ -496,7 +504,7 @@ async function runSaveAttempt({
     return {
       success: false,
       error:
-        outcome.code === "40001"
+        outcome.code === ROUND_CHANGED_SQLSTATE
           ? "A rodada mudou enquanto este formulário estava aberto. Recarregue a página."
           : outcome.error,
     };

--- a/frontend/supabase/migrations/20260820170000_round_write_allows_maintenance.sql
+++ b/frontend/supabase/migrations/20260820170000_round_write_allows_maintenance.sql
@@ -1,0 +1,92 @@
+-- Corrige um bloqueio que tornava linhas de rodada encerrada irreparáveis.
+--
+-- `enforce_current_response_round_write` já trata `round_id` como imutável em
+-- UPDATE (23514 abaixo). Logo, num UPDATE a comparação seguinte não confrontava
+-- o destino da escrita com a rodada corrente: confrontava a rodada DA PRÓPRIA
+-- LINHA. Toda linha de rodada passada passou a falhar em qualquer UPDATE — e o
+-- estado era irreparável por construção, porque consertá-la exigia justamente o
+-- UPDATE que o trigger recusava.
+--
+-- Medido em produção em 2026-08-20: 101.580 erros em 20 minutos, todos deste
+-- RAISE, vindos de `UPDATE responses SET is_latest = ...` — manutenção de flag,
+-- não gravação de resposta. O cliente retentava sem convergir (ver o ERRCODE
+-- abaixo) e o banco ficou com 2 vCPU saturados por ~1.700 transações/s das
+-- quais 99,9% eram rollback.
+--
+-- A invariante que o trigger existe para proteger — nenhuma RESPOSTA nova entra
+-- em rodada fechada — é sobre conteúdo. Por isso o discriminador passa a ser o
+-- conteúdo (`answers`/`justifications`), não a operação: manutenção de
+-- `is_latest`, `respondent_*` e afins segue permitida em linha histórica;
+-- alterar conteúdo continua exigindo rodada corrente. INSERT não muda em nada.
+--
+-- Efeito colateral desejado: o caminho de manutenção deixa de tomar o
+-- `FOR SHARE` em `projects` a cada linha. Esse lock respondia por dezenas de
+-- milhões de varreduras numa tabela de 9 linhas.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.enforce_current_response_round_write()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_current_round_id uuid;
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.project_id IS DISTINCT FROM OLD.project_id
+       OR NEW.round_id IS DISTINCT FROM OLD.round_id
+    THEN
+      RAISE EXCEPTION 'project_id e round_id da response sao imutaveis'
+        USING ERRCODE = '23514';
+    END IF;
+
+    -- Manutenção sai antes de olhar a rodada: é o que mantém reparável a linha
+    -- que já ficou para trás. `answers`/`justifications` inalterados definem
+    -- "não é conteúdo de resposta" — as demais colunas derivadas (hashes,
+    -- schema_version_*) só mudam acompanhando esses dois.
+    IF NEW.answers IS NOT DISTINCT FROM OLD.answers
+       AND NEW.justifications IS NOT DISTINCT FROM OLD.justifications
+    THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  -- Toda escrita de conteúdo se lineariza com a troca de rodada pelo mesmo row
+  -- lock de projects. FOR SHARE permite saves concorrentes, mas conflita com o
+  -- FOR UPDATE de apply_lottery_assignments. Assim, ou o save termina antes da
+  -- ativação, ou observa a nova rodada e falha; nunca grava no histórico depois.
+  SELECT project.current_round_id INTO v_current_round_id
+  FROM public.projects AS project
+  WHERE project.id = NEW.project_id
+  FOR SHARE;
+
+  IF NOT FOUND OR v_current_round_id IS NULL THEN
+    RAISE EXCEPTION 'projeto sem rodada atual' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Compatibilidade com a release imediatamente anterior. Clientes round-aware
+  -- sempre enviam o id exibido e, portanto, passam pela comparacao abaixo.
+  IF NEW.round_id IS NULL THEN
+    NEW.round_id := v_current_round_id;
+  ELSIF NEW.round_id IS DISTINCT FROM v_current_round_id THEN
+    -- SQLSTATE próprio, não 40001. `40001` (serialization_failure) promete ao
+    -- cliente que repetir a operação pode dar certo, e drivers e schedulers
+    -- retentam nele por padrão. Esta condição não é transitória: só sai do
+    -- lugar quando um humano recarrega o formulário. Foi essa promessa falsa
+    -- que transformou um erro correto em loop de retry infinito. `P0R01` é
+    -- dedicado a ela — P0001 é o default de todo RAISE e não discriminaria.
+    -- O consumidor é ROUND_CHANGED_SQLSTATE em src/actions/responses.ts.
+    RAISE EXCEPTION 'a rodada atual mudou; recarregue o formulario'
+      USING ERRCODE = 'P0R01';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enforce_current_response_round_write()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+COMMIT;

--- a/frontend/supabase/migrations/20260820170000_round_write_allows_maintenance.sql
+++ b/frontend/supabase/migrations/20260820170000_round_write_allows_maintenance.sql
@@ -89,4 +89,111 @@ $$;
 REVOKE ALL ON FUNCTION public.enforce_current_response_round_write()
   FROM PUBLIC, anon, authenticated, service_role;
 
+-- A guarda de rodada da publicacao LLM tinha o mesmo contrato quebrado: recusa
+-- permanente anunciada como conflito transitorio. Recriada a partir da
+-- 20260731120000, que e a definicao viva desta funcao — so o ERRCODE muda.
+CREATE OR REPLACE FUNCTION public.publish_latest_llm_response(
+  p_response jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_project_id uuid;
+  v_document_id uuid;
+  v_round_id uuid;
+  v_current_round_id uuid;
+  v_document_project_id uuid;
+  v_response_id uuid;
+  v_is_partial boolean;
+BEGIN
+  IF p_response IS NULL OR pg_catalog.jsonb_typeof(p_response) <> 'object' THEN
+    RAISE EXCEPTION 'p_response must be a JSON object';
+  END IF;
+  IF pg_catalog.jsonb_typeof(p_response->'answers') <> 'object'
+     OR (
+       p_response->'justifications' IS NOT NULL
+       AND p_response->'justifications' <> 'null'::jsonb
+       AND pg_catalog.jsonb_typeof(p_response->'justifications') <> 'object'
+     )
+     OR (
+       p_response->'answer_field_hashes' IS NOT NULL
+       AND p_response->'answer_field_hashes' <> 'null'::jsonb
+       AND pg_catalog.jsonb_typeof(p_response->'answer_field_hashes') <> 'object'
+     ) THEN
+    RAISE EXCEPTION 'LLM response answers, justifications, and field hashes must be JSON objects';
+  END IF;
+
+  v_project_id := (p_response->>'project_id')::uuid;
+  v_document_id := (p_response->>'document_id')::uuid;
+  v_round_id := NULLIF(p_response->>'round_id', '')::uuid;
+  v_is_partial := COALESCE((p_response->>'is_partial')::boolean, false);
+
+  IF v_round_id IS NULL THEN
+    RAISE EXCEPTION 'LLM response round_id is required' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT project.current_round_id INTO v_current_round_id
+  FROM public.projects AS project
+  WHERE project.id = v_project_id
+  FOR SHARE;
+
+  IF NOT FOUND OR v_current_round_id IS DISTINCT FROM v_round_id THEN
+    -- Mesma razao do P0R01 no trigger: a rodada da resposta nao volta a ser
+    -- a corrente sozinha, entao 40001 so servia para o publicador retentar em
+    -- laco. O llm_runner e justamente quem chama esta RPC em loop por linha.
+    RAISE EXCEPTION 'LLM response round is no longer current'
+      USING ERRCODE = 'P0R01';
+  END IF;
+
+  SELECT document.project_id INTO v_document_project_id
+  FROM public.documents AS document
+  WHERE document.id = v_document_id
+  FOR UPDATE;
+
+  IF v_document_project_id IS NULL
+     OR v_document_project_id IS DISTINCT FROM v_project_id THEN
+    RAISE EXCEPTION 'LLM response document does not belong to project';
+  END IF;
+
+  DELETE FROM public.auto_review_reconciliation_requests AS request
+  WHERE request.document_id = v_document_id;
+
+  UPDATE public.responses AS response
+  SET is_latest = false
+  WHERE response.project_id = v_project_id
+    AND response.round_id = v_round_id
+    AND response.document_id = v_document_id
+    AND response.respondent_type = 'llm'
+    AND response.is_latest = true;
+
+  INSERT INTO public.responses (
+    project_id, document_id, respondent_id, respondent_type, respondent_name,
+    answers, justifications, is_latest, is_partial, pydantic_hash,
+    answer_field_hashes, llm_job_id, llm_error, schema_version_major,
+    schema_version_minor, schema_version_patch, version_inferred_from, round_id
+  ) VALUES (
+    v_project_id, v_document_id, NULL, 'llm', p_response->>'respondent_name',
+    COALESCE(p_response->'answers', '{}'::jsonb),
+    NULLIF(p_response->'justifications', 'null'::jsonb),
+    NOT v_is_partial, v_is_partial, p_response->>'pydantic_hash',
+    NULLIF(p_response->'answer_field_hashes', 'null'::jsonb),
+    NULLIF(p_response->>'llm_job_id', '')::uuid, p_response->>'llm_error',
+    COALESCE((p_response->>'schema_version_major')::integer, 0),
+    COALESCE((p_response->>'schema_version_minor')::integer, 1),
+    COALESCE((p_response->>'schema_version_patch')::integer, 0),
+    p_response->>'version_inferred_from', v_round_id
+  )
+  RETURNING id INTO v_response_id;
+
+  RETURN v_response_id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.publish_latest_llm_response(jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_latest_llm_response(jsonb)
+  TO service_role;
+
 COMMIT;

--- a/frontend/supabase/tests/explicit_assignment_rounds.test.sql
+++ b/frontend/supabase/tests/explicit_assignment_rounds.test.sql
@@ -564,7 +564,10 @@ BEGIN
         'is_partial', false
       )
     );
-  EXCEPTION WHEN serialization_failure THEN
+  -- P0R01, nao serialization_failure: a recusa por rodada encerrada e terminal.
+  -- 40001 faria drivers e schedulers retentarem sozinhos, e a condicao so sai
+  -- do lugar quando alguem recarrega a pagina (ver 20260820170000).
+  EXCEPTION WHEN SQLSTATE 'P0R01' THEN
     v_rejected := true;
   END;
 
@@ -593,7 +596,10 @@ BEGIN
       '72000000-0000-0000-0000-000000000001',
       'humano', '{}'::jsonb, true, true, v_old_round
     );
-  EXCEPTION WHEN serialization_failure THEN
+  -- P0R01, nao serialization_failure: a recusa por rodada encerrada e terminal.
+  -- 40001 faria drivers e schedulers retentarem sozinhos, e a condicao so sai
+  -- do lugar quando alguem recarrega a pagina (ver 20260820170000).
+  EXCEPTION WHEN SQLSTATE 'P0R01' THEN
     v_rejected := true;
   END;
 

--- a/frontend/supabase/tests/response_round_serialization.test.sql
+++ b/frontend/supabase/tests/response_round_serialization.test.sql
@@ -59,7 +59,8 @@ SELECT extensions.dblink_exec(
         '{"q1":"stale"}'::jsonb, true, true, v_old_round
       );
       RETURN 'unexpected-success';
-    EXCEPTION WHEN serialization_failure THEN
+    -- P0R01: recusa terminal, nao conflito transitorio (20260820170000).
+    EXCEPTION WHEN SQLSTATE 'P0R01' THEN
       RETURN 'rejected-stale-round';
     END;
     $fn$;$$

--- a/frontend/supabase/tests/round_write_maintenance.test.sql
+++ b/frontend/supabase/tests/round_write_maintenance.test.sql
@@ -1,0 +1,143 @@
+-- Contrato do trigger enforce_current_response_round_write apos a migration
+-- 20260820170000.
+--
+-- O bug que este teste fixa: como o trigger ja trata round_id como imutavel em
+-- UPDATE, a comparacao com projects.current_round_id passava a confrontar a
+-- rodada DA PROPRIA LINHA. Toda linha de rodada encerrada falhava em qualquer
+-- UPDATE, inclusive manutencao de is_latest — e o estado era irreparavel, pois
+-- consertar exigia justamente o UPDATE recusado. Em producao (2026-08-20) isso
+-- rendeu 101.580 erros em 20 minutos e 2 vCPU saturados por retry que nunca
+-- convergia.
+--
+-- Como rodar (apos `npx supabase start` e `npx supabase db reset`):
+--   bash scripts/run-sql-test.sh supabase/tests/round_write_maintenance.test.sql
+--
+-- Validar pelo exit code, nao por contar OKs na saida.
+-- Roda inteiro em BEGIN ... ROLLBACK; nao deixa fixtures no banco local.
+
+BEGIN;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('7a000000-0000-0000-0000-000000000001', 'round-maintenance@example.test');
+
+INSERT INTO public.clerk_user_mapping
+  (clerk_user_id, supabase_user_id, access_sync_version)
+VALUES
+  ('7a000000-0000-0000-0000-000000000001',
+   '7a000000-0000-0000-0000-000000000001', 1);
+
+INSERT INTO public.projects (id, name, created_by, pydantic_fields) VALUES
+  ('7a100000-0000-0000-0000-000000000001', 'round maintenance',
+   '7a000000-0000-0000-0000-000000000001', '[{"name":"q1"}]');
+
+INSERT INTO public.documents (id, project_id, title, text, text_hash) VALUES
+  ('7a200000-0000-0000-0000-000000000001',
+   '7a100000-0000-0000-0000-000000000001', 'doc', 'texto',
+   'round-maintenance-doc');
+
+INSERT INTO public.rounds (id, project_id, label) VALUES
+  ('7a300000-0000-0000-0000-000000000001',
+   '7a100000-0000-0000-0000-000000000001', 'Rodada antiga'),
+  ('7a300000-0000-0000-0000-000000000002',
+   '7a100000-0000-0000-0000-000000000001', 'Rodada corrente');
+
+-- A resposta nasce na rodada antiga, enquanto ela ainda e a corrente.
+UPDATE public.projects
+SET current_round_id = '7a300000-0000-0000-0000-000000000001'
+WHERE id = '7a100000-0000-0000-0000-000000000001';
+
+INSERT INTO public.responses
+  (id, project_id, document_id, respondent_id, respondent_type,
+   answers, is_latest, round_id)
+VALUES
+  ('7a400000-0000-0000-0000-000000000001',
+   '7a100000-0000-0000-0000-000000000001',
+   '7a200000-0000-0000-0000-000000000001',
+   '7a000000-0000-0000-0000-000000000001', 'humano',
+   '{"q1":"antiga"}'::jsonb, true,
+   '7a300000-0000-0000-0000-000000000001');
+
+-- A rodada vira. A linha acima passa a ser historico.
+UPDATE public.projects
+SET current_round_id = '7a300000-0000-0000-0000-000000000002'
+WHERE id = '7a100000-0000-0000-0000-000000000001';
+
+-- ========== 1. Manutencao em linha historica PASSA (o bug) ==========
+DO $$
+BEGIN
+  UPDATE public.responses
+  SET is_latest = false
+  WHERE id = '7a400000-0000-0000-0000-000000000001';
+
+  IF (SELECT is_latest FROM public.responses
+      WHERE id = '7a400000-0000-0000-0000-000000000001') THEN
+    RAISE EXCEPTION 'FALHOU: is_latest nao foi arquivado';
+  END IF;
+  RAISE NOTICE 'OK: arquivar is_latest em rodada encerrada e permitido';
+EXCEPTION
+  WHEN SQLSTATE 'P0R01' THEN
+    RAISE EXCEPTION
+      'FALHOU: manutencao de is_latest ainda bloqueada em rodada encerrada';
+END;
+$$;
+
+-- ========== 2. Conteudo em linha historica CONTINUA bloqueado ==========
+DO $$
+DECLARE
+  v_state text;
+BEGIN
+  BEGIN
+    UPDATE public.responses
+    SET answers = '{"q1":"editada-fora-de-rodada"}'::jsonb
+    WHERE id = '7a400000-0000-0000-0000-000000000001';
+    RAISE EXCEPTION 'FALHOU: editar conteudo de rodada encerrada foi aceito';
+  EXCEPTION
+    WHEN SQLSTATE 'P0R01' THEN
+      RAISE NOTICE 'OK: conteudo em rodada encerrada continua recusado';
+    WHEN SQLSTATE '40001' THEN
+      RAISE EXCEPTION
+        'FALHOU: recusa voltou a usar 40001, que faz o cliente retentar';
+  END;
+END;
+$$;
+
+-- ========== 3. round_id segue imutavel ==========
+DO $$
+BEGIN
+  BEGIN
+    UPDATE public.responses
+    SET round_id = '7a300000-0000-0000-0000-000000000002'
+    WHERE id = '7a400000-0000-0000-0000-000000000001';
+    RAISE EXCEPTION 'FALHOU: round_id deixou de ser imutavel';
+  EXCEPTION
+    WHEN SQLSTATE '23514' THEN
+      RAISE NOTICE 'OK: round_id continua imutavel';
+  END;
+END;
+$$;
+
+-- ========== 4. INSERT em rodada encerrada recusado, e nao com 40001 ==========
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.responses
+      (project_id, document_id, respondent_id, respondent_type,
+       answers, is_latest, round_id)
+    VALUES
+      ('7a100000-0000-0000-0000-000000000001',
+       '7a200000-0000-0000-0000-000000000001',
+       '7a000000-0000-0000-0000-000000000001', 'humano',
+       '{"q1":"nova"}'::jsonb, true,
+       '7a300000-0000-0000-0000-000000000001');
+    RAISE EXCEPTION 'FALHOU: resposta nova entrou em rodada encerrada';
+  EXCEPTION
+    WHEN SQLSTATE 'P0R01' THEN
+      RAISE NOTICE 'OK: INSERT em rodada encerrada recusado com codigo terminal';
+    WHEN SQLSTATE '40001' THEN
+      RAISE EXCEPTION
+        'FALHOU: INSERT recusado com 40001 — o cliente vai retentar sem fim';
+  END;
+END;
+$$;
+
+ROLLBACK;


### PR DESCRIPTION
## O problema

O Supabase alertou em 20/08 que o banco de produção passou de 80% de CPU. Não era crescimento orgânico: o banco tem 35 MB, 1.299 responses e 9 projetos, mas gastava os dois vCPU do compute Micro em **1.695 transações por segundo que abortavam sem efeito nenhum**, contra 0,2 commit por segundo de tráfego real. O acumulado chegou a 31,4 milhões de rollbacks, e `projects` — uma tabela de 9 linhas — somou 16 milhões de sequential scans.

Os logs do Postgres deram o ponto exato. As 101.580 falhas registradas numa janela de 20 minutos eram todas a mesma:

```
QUERY:   UPDATE "public"."responses" SET "is_latest" = ...
CONTEXT: PL/pgSQL function public.enforce_current_response_round_write() line 28 at RAISE
STATE:   40001
```

## Causa raiz

`enforce_current_response_round_write` já tratava `round_id` como imutável em UPDATE. Diante disso, num UPDATE a comparação seguinte não confrontava o destino da escrita com a rodada corrente — confrontava a rodada **da própria linha**. Toda linha de rodada encerrada passou a falhar em qualquer UPDATE, e o estado era irreparável por construção: consertá-lo exigia justamente o UPDATE que o trigger recusava.

O agravante estava no código de erro. `40001` é `serialization_failure`, que por convenção significa "conflito transitório, pode retentar". Aqui a condição nunca deixava de valer, então qualquer camada de retry — presente ou futura — entrava em laço por construção. Foi o que aconteceu.

Um detalhe da medição em produção ajuda a ver o tamanho do problema: as 185 linhas em rodada não-corrente já estavam com `is_latest = false`. O UPDATE em laço era `SET is_latest = false` numa linha que já estava `false`, isto é, um no-op semântico. Um trigger `BEFORE UPDATE` dispara pela operação, não pelo efeito, então ele avaliava a guarda, encontrava a divergência de rodada e abortava. O banco sangrava pela impossibilidade de reafirmar um estado que já estava correto.

## A correção

O discriminador deixa de ser a **operação** e passa a ser o **conteúdo**. Se `answers` e `justifications` não mudam, o trigger retorna antes de olhar a rodada — manutenção de `is_latest` e afins volta a ser possível em linha histórica. Alterar conteúdo continua exigindo rodada corrente, com o mesmo `FOR SHARE` em `projects` linearizando a troca de rodada. INSERT não muda em nada, de modo que a invariante que o trigger existe para proteger, nenhuma resposta nova em rodada fechada, permanece intacta.

O `ERRCODE` do caso "a rodada mudou" passa de `40001` para `P0R01`, na classe `P0`, que nenhuma camada de retry interpreta como retentável. A troca vale em `enforce_current_response_round_write` e em `publish_latest_llm_response` — esta última é a RPC que o `llm_runner` chama uma vez por documento, exatamente onde o retry cego vira laço. Os casos de conflito genuinamente transitório em `apply_lottery_assignments` seguem com `40001`, que ali está correto.

Efeito colateral desejado: o caminho de manutenção deixa de tomar o `FOR SHARE` em `projects` a cada linha, que era a origem das dezenas de milhões de varreduras na tabela de 9 linhas.

## Verificação

Segui a prova do vermelho descrita em `docs/VERIFICATION.md`. O teste novo `round_write_maintenance.test.sql` roda inteiro dentro de `BEGIN … ROLLBACK` e cobre quatro asserções: arquivar `is_latest` em linha de rodada encerrada passa; editar `answers` na mesma linha continua recusado; `round_id` segue imutável com `23514`; e INSERT em rodada fechada é recusado com `P0R01`, falhando explicitamente se vier `40001`. Contra a função antiga ele reproduz o erro de produção com CONTEXT idêntico; contra a nova, passa.

A suíte de contrato SQL fecha em **PASS=20 / FAIL=0**, e o pre-push passou em todos os estágios — typecheck, vitest completo, e2e smoke, lint type-checked, fallow audit e semgrep.

Os testes existentes que capturavam a recusa por `EXCEPTION WHEN serialization_failure` foram atualizados para `SQLSTATE 'P0R01'`, com comentário fixando que o código é contrato e não detalhe de implementação. No lado do cliente, `responses.ts` passa a reconhecer `P0R01` e um teste novo garante que `40001` deixou de significar "rodada alterada" e propaga como erro cru.

## Estado em produção

A migration **já foi aplicada em produção** em 20/08, antes deste merge, para interromper o incidente — decisão do Bruno diante do consumo contínuo dos dois vCPU. Antes de aplicar, comparei a definição viva de `publish_latest_llm_response` com a que esta migration instala e confirmei que diferem apenas pelo `ERRCODE` e por um comentário, sem regredir as migrations `20260820120000` e `20260820130000` da branch `fix/llm-error-metrics-auto-revisao`, que já estavam lá e tocam somente a view `final_answers`.

Medição depois da aplicação:

| Métrica | Antes | Depois |
|---|---|---|
| Rollbacks/s | 1.695,5 | **0,0** |
| Commits/s | 0,2 | 1,3 |
| `node_load1` | 7,78 | **1,21** |

A migration é idempotente, então reaplicá-la no deploy do merge é inócuo. Um ponto de atenção: o registro em `supabase_migrations.schema_migrations` não pôde ser gravado por essa via, de modo que o `db push` do merge deve tentar aplicá-la de novo — sem efeito prático, mas convém saber.

## O que este PR não faz

Duas frentes ficaram de fora, deliberadamente, e seguem em aberto.

Primeiro, o gerador do estado inválido. `createRound(setAsCurrent)` e `setCurrentRound`, em `src/actions/rounds.ts`, trocam `projects.current_round_id` com um UPDATE direto, sem arquivar antes as respostas da rodada que sai — ao contrário da RPC `start_project_round`, cujo próprio comentário registra que a ordem é load-bearing. Segundo, o amplificador: a query de `assignments` em `analyze/code/page.tsx` traz `documents.text` de toda a fila sem paginação e respondia por 126 dos 214 segundos de CPU medidos por janela.

Relacionado: #99, cujo item E ("upgrade para Pro") foi feito no plano de faturamento enquanto o compute add-on nunca saiu de Micro.
