### PR TITLE
perf(coding): texto do documento sai da fila e passa a vir sob demanda

### DIFF
--- a/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
+++ b/frontend/src/app/(app)/projects/[id]/analyze/code/page.tsx
@@ -95,7 +95,11 @@ export default async function CodePage({
   const [{ data: assignments }, { data: responses }] = await Promise.all([
     supabase
       .from("assignments")
-      .select("id, status, document_id, round_id, documents!inner(id, external_id, title, text)")
+      // Sem `text`: a fila é metadado. O texto do documento aberto vem por
+      // `getDocumentText` (ver `AssignedCodingView`). Trazê-lo aqui serializava
+      // o texto de TODOS os atribuídos no payload RSC e respondia por 126s dos
+      // 214s de CPU de query medidos em produção em 2026-08-20.
+      .select("id, status, document_id, round_id, documents!inner(id, external_id, title)")
       .eq("project_id", id)
       .eq("user_id", queueUserId)
       .eq("type", "codificacao")

--- a/frontend/src/components/coding/AssignedCodingView.tsx
+++ b/frontend/src/components/coding/AssignedCodingView.tsx
@@ -5,6 +5,8 @@ import {
   ResizablePanel,
   ResizableHandle,
 } from "@/components/ui/resizable";
+import { Button } from "@/components/ui/button";
+import { useDocumentText } from "@/hooks/useDocumentText";
 import { DocumentReader } from "./DocumentReader";
 import { QuestionsPanel, type QuestionsPanelProps } from "./QuestionsPanel";
 import { FullscreenNav } from "./FullscreenNav";
@@ -17,6 +19,8 @@ interface AssignedCodingViewProps
   /** Doc atribuído atual — `undefined` quando não há nenhum a mostrar
    *  (lista vazia ou filtro de rodada sem pendências). */
   doc: AssignedDoc | undefined;
+  /** Projeto do doc — o texto não vem mais na fila; é buscado por id. */
+  projectId: string;
   title: string;
   docIndex: number;
   total: number;
@@ -42,6 +46,7 @@ interface AssignedCodingViewProps
  */
 export function AssignedCodingView({
   doc,
+  projectId,
   title,
   docIndex,
   total,
@@ -63,6 +68,12 @@ export function AssignedCodingView({
   hasAssignments,
   roundFilter,
 }: AssignedCodingViewProps) {
+  // Antes de qualquer early-return: a ordem dos hooks precisa ser estável entre
+  // os estados da cascata abaixo. `useDocumentText` aceita id nulo, então
+  // `doc?.id` cobre os casos allDone/sem-doc sem disparar busca.
+  const { text, loading: textLoading, error: textError, retry: retryText } =
+    useDocumentText(projectId, doc?.id);
+
   // Diferente do container anterior (#389), este componente agora fica montado
   // o tempo todo em mode==="assigned" — a cascata abaixo decide o retorno via
   // early-return, em vez de o pai desmontar/remontar `AssignedCodingView` entre
@@ -101,7 +112,26 @@ export function AssignedCodingView({
       )}
       <ResizablePanelGroup className="flex-1">
         <ResizablePanel defaultSize={55} minSize={25}>
-          <DocumentReader text={doc.text} />
+          {/* Só este painel alterna entre carregando/erro/texto. O
+              QuestionsPanel ao lado fica montado de propósito: ele guarda o
+              rascunho em andamento, e um early-return da tela inteira o
+              desmontaria a cada navegação entre documentos. */}
+          {textLoading ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Carregando documento…
+            </div>
+          ) : textError ? (
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+              <p className="text-sm text-muted-foreground">
+                Não foi possível carregar o documento.
+              </p>
+              <Button variant="outline" size="sm" onClick={retryText}>
+                Tentar novamente
+              </Button>
+            </div>
+          ) : (
+            <DocumentReader text={text ?? ""} />
+          )}
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={45} minSize={25}>

--- a/frontend/src/components/coding/AssignedCodingView.tsx
+++ b/frontend/src/components/coding/AssignedCodingView.tsx
@@ -6,7 +6,6 @@ import {
   ResizableHandle,
 } from "@/components/ui/resizable";
 import { Button } from "@/components/ui/button";
-import { useDocumentText } from "@/hooks/useDocumentText";
 import { DocumentReader } from "./DocumentReader";
 import { QuestionsPanel, type QuestionsPanelProps } from "./QuestionsPanel";
 import { FullscreenNav } from "./FullscreenNav";
@@ -19,8 +18,14 @@ interface AssignedCodingViewProps
   /** Doc atribuído atual — `undefined` quando não há nenhum a mostrar
    *  (lista vazia ou filtro de rodada sem pendências). */
   doc: AssignedDoc | undefined;
-  /** Projeto do doc — o texto não vem mais na fila; é buscado por id. */
-  projectId: string;
+  /** Texto do doc aberto — buscado por id, já que a fila só traz metadado.
+   *  Vem do container, não daqui: este componente desmonta ao trocar para o
+   *  modo Explorar, e um cache local morreria junto (espelha o par
+   *  `browseDocLoading`/`onRetryDoc` de `BrowseCodingView`). */
+  text: string | undefined;
+  textLoading: boolean;
+  textError: boolean;
+  onRetryText: () => void;
   title: string;
   docIndex: number;
   total: number;
@@ -46,7 +51,10 @@ interface AssignedCodingViewProps
  */
 export function AssignedCodingView({
   doc,
-  projectId,
+  text,
+  textLoading,
+  textError,
+  onRetryText,
   title,
   docIndex,
   total,
@@ -68,12 +76,6 @@ export function AssignedCodingView({
   hasAssignments,
   roundFilter,
 }: AssignedCodingViewProps) {
-  // Antes de qualquer early-return: a ordem dos hooks precisa ser estável entre
-  // os estados da cascata abaixo. `useDocumentText` aceita id nulo, então
-  // `doc?.id` cobre os casos allDone/sem-doc sem disparar busca.
-  const { text, loading: textLoading, error: textError, retry: retryText } =
-    useDocumentText(projectId, doc?.id);
-
   // Diferente do container anterior (#389), este componente agora fica montado
   // o tempo todo em mode==="assigned" — a cascata abaixo decide o retorno via
   // early-return, em vez de o pai desmontar/remontar `AssignedCodingView` entre
@@ -125,7 +127,7 @@ export function AssignedCodingView({
               <p className="text-sm text-muted-foreground">
                 Não foi possível carregar o documento.
               </p>
-              <Button variant="outline" size="sm" onClick={retryText}>
+              <Button variant="outline" size="sm" onClick={onRetryText}>
                 Tentar novamente
               </Button>
             </div>

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -530,6 +530,7 @@ function CodingPageInner({
       {mode === "assigned" && (
         <AssignedCodingView
           doc={assigned.currentDoc}
+          projectId={projectId}
           title={assignedTitle}
           docIndex={assigned.docIndex}
           total={documents.length}

--- a/frontend/src/components/coding/CodingPage.tsx
+++ b/frontend/src/components/coding/CodingPage.tsx
@@ -5,6 +5,7 @@ import { applyFieldOrder } from "@/lib/field-order";
 import { sortByRecent } from "@/lib/coding-sort";
 import type { DocRoundStatus } from "@/lib/rounds";
 import { useUrlState } from "@/hooks/useUrlState";
+import { useDocumentText } from "@/hooks/useDocumentText";
 import { useFieldOrder } from "@/hooks/useFieldOrder";
 import { useFullscreen } from "@/hooks/useFullscreen";
 import { useDirtyDocs, useDirtyDocsCount } from "@/hooks/useDirtyDocs";
@@ -24,6 +25,12 @@ import { BrowseCodingView } from "./BrowseCodingView";
 import { useAssignedCoding } from "./useAssignedCoding";
 import { useBrowseCoding } from "./useBrowseCoding";
 import type { OutOfScopeConfig } from "./QuestionsPanel";
+
+/** Quantos textos de doc atribuído ficam em cache por sessão. Espelha o
+ *  `MAX_CACHED_DOCS` do modo Explorar: a fila é percorrida em sequência, então
+ *  um teto baixo cobre o ir-e-voltar entre vizinhos sem reter o texto integral
+ *  da fila inteira no heap — 145 docs a ~16 KB na maior fila medida. */
+const MAX_CACHED_ASSIGNED_TEXTS = 5;
 import type {
   PydanticField,
   AssignedDoc,
@@ -304,6 +311,19 @@ function CodingPageInner({
     setParams,
   });
 
+  // Aqui, e não dentro de `AssignedCodingView`: aquele componente é montado
+  // condicionalmente (`mode === "assigned"`), então alternar para a aba
+  // Explorar o desmontaria e levaria o cache junto — o mesmo documento seria
+  // rebuscado ao voltar. O container sobrevive à troca de modo.
+  // O teto acompanha `MAX_CACHED_DOCS` do modo Explorar: a navegação na fila é
+  // sequencial (anterior/próximo), então poucas entradas cobrem o ir-e-voltar
+  // sem reter o texto integral de uma fila inteira (145 docs na maior medida).
+  const assignedText = useDocumentText(
+    projectId,
+    mode === "assigned" ? (assigned.currentDoc?.id ?? null) : null,
+    MAX_CACHED_ASSIGNED_TEXTS,
+  );
+
   const browse = useBrowseCoding({
     projectId,
     currentRoundId: roundFilter?.currentRoundKey ?? "",
@@ -530,7 +550,10 @@ function CodingPageInner({
       {mode === "assigned" && (
         <AssignedCodingView
           doc={assigned.currentDoc}
-          projectId={projectId}
+          text={assignedText.text}
+          textLoading={assignedText.loading}
+          textError={assignedText.error}
+          onRetryText={assignedText.retry}
           title={assignedTitle}
           docIndex={assigned.docIndex}
           total={documents.length}

--- a/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
@@ -107,8 +107,20 @@ vi.mock("@/components/coding/DocumentPicker", () => ({
   DocumentPicker: () => <div data-testid="picker" />,
 }));
 vi.mock("@/components/coding/CodingHeader", () => ({
-  CodingHeader: ({ mode }: { mode: string }) => (
-    <div data-testid="hdr-mode">{mode}</div>
+  // `onModeChange` exposto como botão: é por ele que o teste de cache alterna
+  // para o modo Explorar e volta, que é o que desmontava `AssignedCodingView`.
+  CodingHeader: ({
+    mode,
+    onModeChange,
+  }: {
+    mode: string;
+    onModeChange: (m: "assigned" | "browse") => void;
+  }) => (
+    <div>
+      <div data-testid="hdr-mode">{mode}</div>
+      <button onClick={() => onModeChange("assigned")}>to-assigned</button>
+      <button onClick={() => onModeChange("browse")}>to-browse</button>
+    </div>
   ),
 }));
 vi.mock("@/components/coding/FullscreenNav", () => ({
@@ -493,5 +505,38 @@ describe("texto do documento vem sob demanda, não na fila", () => {
     // A segunda chamada cai no default do beforeEach, que resolve.
     await user.click(botao);
     expect((await screen.findByTestId("doc-reader")).textContent).toBe("texto-a1");
+  });
+});
+
+describe("cache do texto sobrevive à troca de aba", () => {
+  const DOIS = [assignedDoc("a1"), assignedDoc("a2")];
+
+  it("ir ao Explorar e voltar não rebusca o texto do documento aberto", async () => {
+    // O fetch vive no container (`CodingPage`), não em `AssignedCodingView`.
+    // Aquele componente é montado sob `mode === "assigned"`, então guardar o
+    // cache nele o faria morrer a cada visita à outra aba — e o mesmo documento
+    // seria rebuscado ao voltar. Espelha a guarda que o modo Explorar já tem
+    // sobre `getDocumentForCoding`.
+    const user = userEvent.setup();
+    render(
+      <CodingPage
+        roundFilter={ROUND_FILTER}
+        userId="user-teste"
+        projectId="p1"
+        documents={DOIS}
+        fields={FIELDS}
+        existingAnswers={{}}
+        hasAssignments
+      />,
+    );
+
+    expect((await screen.findByTestId("doc-reader")).textContent).toBe("texto-a1");
+    expect(getDocumentText).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByText("to-browse"));
+    await user.click(screen.getByText("to-assigned"));
+
+    expect((await screen.findByTestId("doc-reader")).textContent).toBe("texto-a1");
+    expect(getDocumentText).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.assigned.test.tsx
@@ -3,16 +3,25 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import type { PydanticField, Document } from "@/lib/types";
+import type { PydanticField, AssignedDoc } from "@/lib/types";
 import type { DocRoundStatus } from "@/lib/rounds";
 
 // Caracterização do modo Atribuídos ANTES do refactor da issue #389 (extração
 // da cascata allDone/no-doc/view de CodingPageInner para AssignedCodingView).
 // Serve de rede de segurança: os contratos observáveis aqui não podem mudar.
-const { saveResponse, getDocumentsForBrowse, urlParams, submitVerdict } = vi.hoisted(
+const {
+  saveResponse,
+  getDocumentsForBrowse,
+  getDocumentText,
+  urlParams,
+  submitVerdict,
+} = vi.hoisted(
   () => ({
     saveResponse: vi.fn(),
     getDocumentsForBrowse: vi.fn(),
+    // Exposto (em vez de inline no factory) para os testes de carregamento e
+    // de falha poderem controlar QUANDO a promessa resolve.
+    getDocumentText: vi.fn(),
     urlParams: { current: {} as Record<string, string | null> },
     // O que o container devolveu ao painel no último Enviar. É por este valor de
     // retorno — e não por um canal de estado — que o veredito do servidor chega
@@ -27,6 +36,8 @@ vi.mock("@/actions/responses", () => ({ saveResponse }));
 vi.mock("@/actions/documents", () => ({
   getDocumentsForBrowse,
   getDocumentForCoding: vi.fn(),
+  // O texto do doc aberto vem por aqui, não mais na fila de assignments.
+  getDocumentText,
 }));
 // `warning` junto de `success`/`error`: um envio que grava com obrigatória em
 // aberto avisa por ele (`notifySaved`). Mock incompleto não falha no typecheck —
@@ -117,13 +128,12 @@ const FIELDS: PydanticField[] = [
   { name: "q1", type: "text", options: null, description: "" },
 ];
 
-function assignedDoc(id: string): Document {
+function assignedDoc(id: string): AssignedDoc {
   return {
     id,
     project_id: "p1",
     external_id: `ext-${id}`,
     title: `Assigned ${id}`,
-    text: `texto-${id}`,
     metadata: null,
     created_at: "2026-01-01",
     excluded_at: null,
@@ -138,6 +148,12 @@ beforeEach(() => {
   submitVerdict.current = undefined;
   Element.prototype.scrollTo = vi.fn();
   getDocumentsForBrowse.mockResolvedValue([]);
+  // Default: resolve com o mesmo `texto-${id}` que os fixtures da fila traziam
+  // antes de o texto sair de lá. Os testes que exercitam carregamento/falha
+  // sobrescrevem este mock.
+  getDocumentText.mockImplementation((_projectId: string, id: string) =>
+    Promise.resolve({ text: `texto-${id}`, title: `Doc ${id}` }),
+  );
 });
 afterEach(() => {
   cleanup();
@@ -413,5 +429,69 @@ describe("CodingPage — modo Atribuídos (integração)", () => {
         }),
       ),
     );
+  });
+});
+
+describe("texto do documento vem sob demanda, não na fila", () => {
+  // A fila de atribuídos passou a trazer só metadado: o `text` saiu do select
+  // de `assignments` porque serializava o texto de TODOS os documentos no
+  // payload RSC — até ~2,3 MB na maior fila medida em produção (145 docs x
+  // ~16 KB), para exibir um. Estes testes fixam o contrato do caminho novo;
+  // sem eles, reintroduzir o campo passaria despercebido.
+  const DOIS = [assignedDoc("a1"), assignedDoc("a2")];
+
+  const renderFila = (documents = DOIS) =>
+    render(
+      <CodingPage
+        roundFilter={ROUND_FILTER}
+        userId="user-teste"
+        projectId="p1"
+        documents={documents}
+        fields={FIELDS}
+        existingAnswers={{}}
+        hasAssignments
+      />,
+    );
+
+  it("busca o texto apenas do documento aberto, não de toda a fila", async () => {
+    renderFila();
+
+    expect((await screen.findByTestId("doc-reader")).textContent).toBe("texto-a1");
+    // O ponto do refactor: dois documentos na fila, uma única busca.
+    expect(getDocumentText).toHaveBeenCalledTimes(1);
+    expect(getDocumentText).toHaveBeenCalledWith("p1", "a1");
+  });
+
+  it("enquanto o texto não chega, avisa que está carregando", async () => {
+    // Promessa que não resolve: congela o estado de carregamento para observá-lo.
+    getDocumentText.mockImplementation(() => new Promise(() => {}));
+    renderFila();
+
+    expect(await screen.findByText("Carregando documento…")).toBeTruthy();
+    expect(screen.queryByTestId("doc-reader")).toBeNull();
+  });
+
+  it("o painel de perguntas fica montado enquanto o texto carrega", async () => {
+    // Load-bearing: o painel guarda o rascunho em andamento. Um early-return da
+    // tela inteira no carregamento o desmontaria a cada navegação entre
+    // documentos, levando junto o que a pesquisadora digitou e ainda não enviou.
+    getDocumentText.mockImplementation(() => new Promise(() => {}));
+    renderFila();
+
+    expect(await screen.findByText("Carregando documento…")).toBeTruthy();
+    expect(screen.getByTestId("qp-answers")).toBeTruthy();
+  });
+
+  it("falha no fetch oferece retry, e o retry recupera o texto", async () => {
+    const user = userEvent.setup();
+    getDocumentText.mockRejectedValueOnce(new Error("rede caiu"));
+    renderFila();
+
+    const botao = await screen.findByRole("button", { name: "Tentar novamente" });
+    expect(screen.queryByTestId("doc-reader")).toBeNull();
+
+    // A segunda chamada cai no default do beforeEach, que resolve.
+    await user.click(botao);
+    expect((await screen.findByTestId("doc-reader")).textContent).toBe("texto-a1");
   });
 });

--- a/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.browse.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import type { PydanticField, Document } from "@/lib/types";
+import type { PydanticField, AssignedDoc } from "@/lib/types";
 
 // Spies/estado controláveis. `urlParams` é o backing store do useUrlState mockado
 // (stateful: `set` muta e força re-render, como o router faria).
@@ -32,7 +32,16 @@ const {
 }));
 
 vi.mock("@/actions/responses", () => ({ saveResponse }));
-vi.mock("@/actions/documents", () => ({ getDocumentsForBrowse, getDocumentForCoding }));
+vi.mock("@/actions/documents", () => ({
+  getDocumentsForBrowse,
+  getDocumentForCoding,
+  // O texto do doc aberto vem por aqui, não mais na fila de assignments.
+  // Devolve o mesmo `texto-${id}` que os fixtures traziam, para as asserções
+  // continuarem valendo — agora sobre o caminho de fetch sob demanda.
+  getDocumentText: vi.fn((_projectId: string, id: string) =>
+    Promise.resolve({ text: `texto-${id}`, title: `Doc ${id}` }),
+  ),
+}));
 // `warning` incluído: é por ele que `notifySaved` avisa a pendência. Mock
 // incompleto não falha no typecheck e só aparece como rejeição não tratada.
 vi.mock("sonner", () => ({
@@ -176,13 +185,12 @@ function codingResult(id: string, answers: Record<string, unknown> | null) {
   };
 }
 
-function assignedDoc(id: string): Document {
+function assignedDoc(id: string): AssignedDoc {
   return {
     id,
     project_id: "p1",
     external_id: `ext-${id}`,
     title: `Assigned ${id}`,
-    text: `texto-${id}`,
     metadata: null,
     created_at: "2026-01-01",
     excluded_at: null,

--- a/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
+++ b/frontend/src/components/coding/__tests__/CodingPage.draft.test.tsx
@@ -14,7 +14,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { render, screen, waitFor, cleanup, act, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
-import type { PydanticField, Document } from "@/lib/types";
+import type { PydanticField, AssignedDoc } from "@/lib/types";
 
 const { saveResponse, getDocumentsForBrowse, urlParams } = vi.hoisted(() => ({
   saveResponse: vi.fn(),
@@ -26,6 +26,12 @@ vi.mock("@/actions/responses", () => ({ saveResponse }));
 vi.mock("@/actions/documents", () => ({
   getDocumentsForBrowse,
   getDocumentForCoding: vi.fn(),
+  // O texto do doc aberto vem por aqui, não mais na fila de assignments.
+  // Devolve o mesmo `texto-${id}` que os fixtures traziam, para as asserções
+  // continuarem valendo — agora sobre o caminho de fetch sob demanda.
+  getDocumentText: vi.fn((_projectId: string, id: string) =>
+    Promise.resolve({ text: `texto-${id}`, title: `Doc ${id}` }),
+  ),
 }));
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
@@ -111,13 +117,12 @@ const FIELDS: PydanticField[] = [
   { name: "q1", type: "text", options: null, description: "Qual o medicamento?" },
 ];
 
-function assignedDoc(id: string): Document {
+function assignedDoc(id: string): AssignedDoc {
   return {
     id,
     project_id: PROJECT,
     external_id: `ext-${id}`,
     title: `Assigned ${id}`,
-    text: `texto-${id}`,
     metadata: null,
     created_at: "2026-01-01",
     excluded_at: null,
@@ -129,7 +134,7 @@ function assignedDoc(id: string): Document {
 
 function renderPage(
   existingAnswers: Record<string, Record<string, unknown>> = {},
-  documents: Document[] = [assignedDoc(DOC)],
+  documents: AssignedDoc[] = [assignedDoc(DOC)],
 ) {
   return render(
     <CodingPage

--- a/frontend/src/hooks/useDocumentText.ts
+++ b/frontend/src/hooks/useDocumentText.ts
@@ -34,19 +34,33 @@ const LOAD_ERROR = "(Erro ao carregar o documento)";
  * está em voo. O refetch é imperativo de propósito: `failed` não está nas deps
  * do effect, então só limpar a marca não re-dispararia a busca.
  *
- * Cobre os três consumidores do texto de documento: `DocumentPreview`,
- * `CommentsSplitView` e `MyVerdictsView`.
+ * Cobre os consumidores do texto de documento: `DocumentPreview`,
+ * `CommentsSplitView`, `MyVerdictsView` e o modo Atribuídos da tela Codificar.
+ *
+ * `maxEntries` (opt-in) limita o cache por despejo FIFO — mesma razão do
+ * `MAX_CACHED_DOCS` de `useDocumentForCoding`: sem teto, o cache reteria o
+ * texto integral de todo doc visitado pelo tempo de vida do componente. Quem
+ * abre um documento por vez (preview, veredito) não precisa; quem percorre uma
+ * fila deve passar um teto.
  */
 export function useDocumentText(
   projectId: string,
   documentId: string | null | undefined,
+  maxEntries?: number,
 ): {
   text: string | undefined;
   loading: boolean;
   error: boolean;
   retry: () => void;
 } {
-  const [cache, setCache] = useState<Record<string, string>>({});
+  // `order` acompanha `entries` para o despejo FIFO quando há `maxEntries`.
+  // Reabrir uma chave já em cache NÃO renova sua posição — não é LRU por
+  // acesso, que exigiria escrita em tempo de render. O custo é um eventual
+  // refetch de chave reaberta após despejo; o ganho é o heap limitado.
+  const [cache, setCache] = useState<{
+    entries: Record<string, string>;
+    order: string[];
+  }>({ entries: {}, order: [] });
   const [failed, setFailed] = useState<Record<string, true>>({});
 
   // Busca compartilhada pelo effect (carga inicial / auto-retry ao renavegar) e
@@ -58,7 +72,16 @@ export function useDocumentText(
       getDocumentText(projectId, id)
         .then((result) => {
           if (cancelled) return;
-          setCache((prev) => ({ ...prev, [id]: result?.text ?? NOT_FOUND }));
+          setCache((prev) => {
+            const entries = { ...prev.entries, [id]: result?.text ?? NOT_FOUND };
+            let order = prev.order.includes(id) ? prev.order : [...prev.order, id];
+            if (maxEntries && order.length > maxEntries) {
+              const evicted = order.slice(0, order.length - maxEntries);
+              order = order.slice(order.length - maxEntries);
+              for (const k of evicted) delete entries[k];
+            }
+            return { entries, order };
+          });
         })
         .catch(() => {
           if (cancelled) return;
@@ -68,11 +91,11 @@ export function useDocumentText(
         cancelled = true;
       };
     },
-    [projectId],
+    [projectId, maxEntries],
   );
 
   useEffect(() => {
-    if (!documentId || documentId in cache) return;
+    if (!documentId || documentId in cache.entries) return;
     return fetchText(documentId);
   }, [documentId, cache, fetchText]);
 
@@ -89,11 +112,12 @@ export function useDocumentText(
   }, [documentId, fetchText]);
 
   const text = documentId
-    ? (cache[documentId] ?? (documentId in failed ? LOAD_ERROR : undefined))
+    ? (cache.entries[documentId] ??
+      (documentId in failed ? LOAD_ERROR : undefined))
     : undefined;
   const loading =
-    !!documentId && !(documentId in cache) && !(documentId in failed);
+    !!documentId && !(documentId in cache.entries) && !(documentId in failed);
   const error =
-    !!documentId && documentId in failed && !(documentId in cache);
+    !!documentId && documentId in failed && !(documentId in cache.entries);
   return { text, loading, error, retry };
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -197,8 +197,14 @@ export interface Assignment {
  * modo Atribuídos usa (id + status). Fonte única consumida por `CodingPage`,
  * `useAssignedCoding` e `useBrowseCoding` (evita redefinir o mesmo tipo em cada
  * arquivo).
+ *
+ * `text` sai do tipo de propósito: a fila é metadado, e o texto do documento
+ * ABERTO é buscado sob demanda por `useDocumentText`. Trazê-lo na listagem
+ * serializava o texto de todos os atribuídos no payload RSC — até ~2,3 MB na
+ * maior fila medida (145 docs x ~16 KB) — para exibir um só. O `Omit` é o que
+ * faz o compilador recusar uma reintrodução acidental.
  */
-export type AssignedDoc = Document & {
+export type AssignedDoc = Omit<Document, "text"> & {
   assignment?: Pick<Assignment, "id" | "status">;
 };
 


### PR DESCRIPTION
> Empilhado sobre #706 (`fix/round-trigger-update-loop`). O diff próprio é o commit `5ead599f`; mergear #706 antes.

## O problema

A investigação do incidente de CPU de 20/08 mediu, em `pg_stat_statements`, que a query de `assignments` da tela Codificar respondia por **126 dos 214 segundos de CPU de query por janela — 59% do total**, a 58 ms por execução em 2.178 execuções.

A causa é o select:

```ts
.select("id, status, document_id, round_id, documents!inner(id, external_id, title, text)")
```

O `text` vem de **todos** os documentos atribuídos, sem paginação, e é serializado inteiro no payload RSC para exibir um documento. Medindo os textos em produção: média de 16.145 caracteres, máximo de 54.361, e a maior fila de codificação tem 145 documentos. No pior caso são cerca de 2,3 MB de texto trafegados por render.

## Por que dava para tirar

Rastreei o consumo do campo. Ele tem **um único leitor**: `AssignedCodingView.tsx`, em `<DocumentReader text={doc.text} />`, e só para o documento aberto. Nada mais na cadeia usa o texto — nem `useAssignedCoding`, nem `useBrowseCoding`, nem `sortByRecent`, nem o rascunho local, que trabalham todos com `id`. Também não há busca client-side sobre o texto, contagem de caracteres, prefetch para navegação ou export que dependa da fila inteira; o export lê `documents` por conta própria em `src/lib/export/`.

## A correção

Fetch em duas fases, que é o padrão prescrito no `CLAUDE.md` em "Performance — Regras de Arquitetura" e que o **modo Explorar da mesma tela já pratica**: `getDocumentsForBrowse` seleciona sem `text` e `getDocumentForCoding` busca por id.

Nada de infraestrutura nova. A fila passa a trazer metadado, e o texto do documento aberto vem de `getDocumentText` através de `useDocumentText` — o mesmo par que `DocumentPreview`, `CommentsSplitView` e `MyVerdictsView` já usam, com cache por id, `loading`, `error` e `retry` prontos.

Duas decisões de desenho merecem registro.

Primeiro, `AssignedDoc` perde `text` via `Omit<Document, "text">`. Isso não é cosmético: é o que faz o compilador recusar uma reintrodução acidental do campo na query, em vez de deixá-la voltar como regressão silenciosa de performance.

Segundo, só o painel do leitor alterna entre carregando, erro e texto. O `QuestionsPanel` ao lado permanece montado de propósito. O modo Explorar faz early-return da tela inteira no carregamento, mas copiar isso aqui desmontaria o painel a cada navegação entre documentos — e é ele que guarda o rascunho em andamento. Há teste fixando esse comportamento, justamente porque a alternativa é sutil e destrutiva.

## Sobre o teto de cache — correção após revisão

A primeira versão deste PR não limitava o cache, justificando com a política documentada em `useCachedResource` ("ok para conjuntos limitados como docs atribuídos"). **Essa justificativa estava errada**, e a revisão independente pegou: `useDocumentText` não usa aquele genérico — implementa cache próprio com `useState`, sem teto. O docstring de `useCachedResource` se declara compartilhado por ele e está desatualizado; citei a política sem conferir o código.

O precedente correto é o oposto do que argumentei. `useDocumentForCoding.ts:21-25` fixa `MAX_CACHED_DOCS = 3` exatamente por este motivo: *"sem teto, o cache reteria o `text` integral de todo doc visitado pelo tempo de vida do `CodingPage`"*. O modo Atribuídos corre o mesmo risco — 145 documentos a ~16 KB retidos no heap pela sessão inteira, que é o mesmo volume que este PR tirou da rede.

Corrigido em `869df171`: `useDocumentText` ganha `maxEntries` opcional com despejo FIFO, e a tela Codificar passa 5. A navegação na fila é sequencial, então poucas entradas cobrem o ir-e-voltar entre vizinhos.

## Regressão de cache entre abas — também corrigida na revisão

O fetch morava em `AssignedCodingView`, que o `CodingPage` monta sob `mode === "assigned"`. Alternar para a aba Explorar desmontava o componente e levava o cache junto, de modo que voltar para Atribuídos rebuscava o texto de um documento lido segundos antes. Antes deste PR isso não acontecia — o texto vinha inteiro no payload —, então era regressão introduzida aqui.

O hook subiu para o container, que sobrevive à troca de modo, e a view passou a receber `text`/`textLoading`/`textError`/`onRetryText` por prop, espelhando o par `browseDocLoading`/`onRetryDoc` que `BrowseCodingView` já usa.

O teste que fixa isso foi verificado contra o código anterior antes de ser aceito: falha com "expected 1 times, but got 2 times", que é exatamente o refetch indevido.

## Verificação

Quatro testes novos em `CodingPage.assigned.test.tsx` fixam o contrato: o texto é buscado **uma vez, só do documento aberto**, com dois na fila; o estado de carregamento aparece; o painel de perguntas continua montado durante o carregamento; e uma falha de fetch oferece retry que recupera o texto.

Os fixtures da fila deixaram de carregar `text` e passaram a ser tipados como `AssignedDoc`, enquanto o mock de `getDocumentText` devolve o mesmo `texto-${id}` de antes. As asserções existentes sobre o conteúdo renderizado continuam valendo — agora sobre o caminho novo.

Suíte completa verde: typecheck, vitest, e2e smoke, lint type-checked, fallow audit e semgrep passaram no pre-push.

O efeito é medível depois do deploy pelo `mean_exec_time` dessa query em `pg_stat_statements`: 58 ms hoje, poucos milissegundos esperados.
